### PR TITLE
Test harness: snapshot oracle replaces per-test CRuby spawns for single-code tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ coverage_html
 rustc-ice-*.txt
 # nextest scratch files (TMPDIR=.tmp); the tracked .tmp/suite.log is kept
 .tmp/.tmp*
+# ruby-oracle side files (the .tsv itself is tracked)
+monoruby/tests/ruby_oracle.tsv.lock
+monoruby/tests/ruby_oracle.tsv.tmp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -430,12 +430,29 @@ bin/test
 **Test harness** (`tests.rs`):
 
 ```rust
-run_test(code)       // runs code 25× (JIT warms up), compares result with CRuby
-run_test_once(code)  // runs code once, compares result with CRuby
-run_tests(codes)     // runs multiple expressions, compares each with CRuby
+run_test(code)       // runs code 25× (JIT warms up), compares result with the CRuby oracle
+run_test_once(code)  // runs code once, compares result with the CRuby oracle
+run_tests(codes)     // runs multiple expressions, compares each with a live CRuby
 ```
 
-All test helpers invoke CRuby via `ruby` in `PATH` and assert output equality.
+**Snapshot oracle** — the single-code helpers (`run_test`, `run_test_once`,
+`run_test2`, `run_test_with_prelude`) do **not** spawn CRuby per call.
+Expected outputs are memoized in the checked-in file
+`monoruby/tests/ruby_oracle.tsv` (`code-hash → p-output line`, key-sorted,
+flock-serialized for concurrent nextest processes); a live `ruby` in `PATH`
+is only invoked on a cache miss (the fresh entry is recorded back into the
+file — commit it). The batched helpers (`run_tests`, `run_tests2`, and the
+binop/unop generators on top of them) always spawn a live CRuby, since their
+auto-generated code strings churn too much to snapshot.
+
+Modes via `MONORUBY_TEST_ORACLE`:
+
+- unset / `snapshot` (default): replay stored entries; spawn + record on miss.
+  `rm monoruby/tests/ruby_oracle.tsv && cargo test` regenerates the file from
+  scratch (dropping orphaned entries).
+- `ruby`: always spawn CRuby and refresh stale entries in place — use this
+  after bumping the reference CRuby version to re-verify the whole suite
+  against the new Ruby.
 
 ### Cargo Features
 
@@ -608,7 +625,7 @@ run `bin/refresh-prism-vendored` (rebuilds and force-pushes
 
 1. **Nightly only**: Attempting to build with stable Rust will fail. The toolchain is pinned in `rust-toolchain.toml`.
 2. **Architecture-specific backends**: The VM and JIT emit machine code directly per `target_arch` (`codegen/arch/{x86_64,aarch64}/`). Both backends lower the full AsmInst set; aarch64 never bails (large immediates go through scratch registers, so the `bool` "decline" return is vestigial — see `doc/arch_difference.md`). Adding/altering low-level codegen usually means touching both backends. Use `bin/test-aarch64` / `bin/setup-aarch64-cross` for the aarch64 path.
-3. **Ruby in PATH**: Tests compare output against a system `ruby` binary matching the vendored pin (`4.0.2`, see `vendor/ruby-stdlib/.ruby-version`). Ensure Ruby is installed and the binary is accessible.
+3. **Ruby in PATH**: Tests compare output against a system `ruby` binary matching the vendored pin (`4.0.2`, see `vendor/ruby-stdlib/.ruby-version`). The single-code helpers replay the checked-in snapshot oracle (`monoruby/tests/ruby_oracle.tsv`) and only spawn `ruby` on a cache miss, but the batched helpers (`run_tests` etc.) and several integration tests still invoke it directly — keep a matching Ruby installed for full-suite runs, and use `MONORUBY_TEST_ORACLE=ruby` after a version bump to refresh the oracle.
 4. **optcarrot**: The full CI test requires optcarrot cloned at `../optcarrot` relative to the repo root.
 5. **Library path**: `build.rs` does **not** invoke a host `ruby` for `$LOAD_PATH` / `RUBY_VERSION` (those come from the vendored snapshot). Host-installed *non-default* gems are discovered at run time by `src/ruby_probe.rs`, which invokes a host `ruby` once if present and caches `~/.monoruby/{library_path,gem_path}`. If no host Ruby is found, those caches stay empty and a warning is printed at startup, but the vendored stdlib still loads from the per-version install root (`~/.monoruby/v<version>/lib`).
 6. **gc-stress in tests**: `gc-stress` is **opt-in** — `export GC_STRESS=1` before `bin/test` and it applies to **every** phase (nextest *and* the benchmark binary, so optcarrot / ruby-spec are stressed too). Since the true-stress restoration this means a collection at **every safepoint**, so a `GC_STRESS=1` run of the full scope is an hours-scale job. Nothing enables it implicitly, so the automatic CI never pays it; run the manual `gc-stress` workflow instead. Tests whose loop counts exist only to reach the JIT thresholds should shrink them under `cfg!(feature = "gc-stress")` (see `tests/method_call.rs`) — otherwise they blow past nextest's per-test cap.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -445,6 +445,19 @@ file — commit it). The batched helpers (`run_tests`, `run_tests2`, and the
 binop/unop generators on top of them) always spawn a live CRuby, since their
 auto-generated code strings churn too much to snapshot.
 
+**Environment-dependent tests** must use `run_test_live` /
+`run_test_once_live`: same warmup/comparison, but always against a live
+CRuby, never the oracle. Use these whenever the expected value varies per
+host or OS — `Dir.home`/`Dir.pwd` (HOME/cwd), absolute checkout paths
+(`require`/`load` fixtures returning `__FILE__`), `~user` expansion
+(`/root` vs macOS `/var/root`), and anything comparing `Dir.pwd`/`realpath`
+results under `/tmp` (a symlink to `/private/tmp` on macOS). As a safety
+net for not-yet-identified cases, a cached entry that disagrees with
+monoruby's result is re-verified against a live CRuby before failing
+("heal": one spawn, never re-recorded) — grep test output for
+`re-verifying against a live ruby` to find tests that should be moved to
+the `_live` helpers.
+
 Modes via `MONORUBY_TEST_ORACLE`:
 
 - unset / `snapshot` (default): replay stored entries; spawn + record on miss.

--- a/monoruby/src/builtins/dir.rs
+++ b/monoruby/src/builtins/dir.rs
@@ -1216,7 +1216,8 @@ mod tests {
     fn dir_pwd_binary_names() {
         // mkdir/chdir/pwd round-trip raw non-ASCII bytes; pwd tags the
         // result UTF-8 when it decodes.
-        run_test_once(
+        // /tmp resolves through /private on macOS — live CRuby.
+        run_test_once_live(
             r##"(base="/tmp/mono_pwd_#{Process.pid}"; Dir.mkdir(base); name="#{base}/あ".dup.force_encoding(Encoding::BINARY); Dir.mkdir(name); r=Dir.chdir(name) { [Dir.pwd.encoding.name, Dir.pwd.force_encoding("binary") == name] }; Dir.rmdir(name); Dir.rmdir(base); r)"##,
         );
     }
@@ -1235,7 +1236,9 @@ mod tests {
         // Dir.home(user) via getpwnam (+ ArgumentError for an unknown user),
         // Dir.foreach's no-block Enumerator (size == nil), Dir.fchdir's tagged
         // SystemCallError message, and the trailing `**` glob == `*` behaviour.
-        run_test_once(
+        // Dir.home("root") is OS-dependent (/root on Linux, /var/root on
+        // macOS): verify against a live CRuby, not the oracle.
+        run_test_once_live(
             r##"(a=Dir.home("root"); b=(begin; Dir.home("no_such_user_zzq"); rescue => e; e.class; end); c=Dir.foreach("/").is_a?(Enumerator); d=Dir.foreach("/").size; e2=(begin; Dir.fchdir(-1); rescue => x; [x.class, x.message]; end); f=(Dir.glob("**").sort==Dir.glob("*").sort); [a,b,c,d,e2,f])"##,
         );
     }
@@ -1316,14 +1319,17 @@ mod tests {
 
     #[test]
     fn home() {
-        run_test(r#"Dir.home"#);
+        // Host-dependent value: verify against a live CRuby, not the oracle.
+        run_test_live(r#"Dir.home"#);
     }
 
     #[test]
     fn pwd() {
-        run_test(r#"Dir.pwd"#);
-        run_test(r#"Dir.getwd"#);
-        run_test(
+        // Host-dependent values (absolute cwd paths): verify against a live
+        // CRuby, not the oracle.
+        run_test_live(r#"Dir.pwd"#);
+        run_test_live(r#"Dir.getwd"#);
+        run_test_live(
             r##"
         $x = []
         $x << Dir.getwd
@@ -1501,7 +1507,8 @@ mod tests {
 
     #[test]
     fn dir_inst_chdir_with_block() {
-        run_test_once(
+        // Dir.pwd inside /tmp differs on macOS (/private/tmp) — live CRuby.
+        run_test_once_live(
             r##"
             before = Dir.pwd
             d = Dir.new("/tmp")
@@ -1530,7 +1537,8 @@ mod tests {
 
     #[test]
     fn dir_fchdir() {
-        run_test_once(
+        // Dir.pwd inside /tmp differs on macOS (/private/tmp) — live CRuby.
+        run_test_once_live(
             r##"
             before = Dir.pwd
             d = Dir.new("/tmp")

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -3161,7 +3161,8 @@ mod tests {
     fn file_expand_path_slashes_and_tilde() {
         // Leading slash runs survive verbatim, interior runs squeeze,
         // ~user expands via getpwnam, mid-path ~ stays literal.
-        run_test_once(
+        // ~root is OS-dependent (/root vs /var/root) — live CRuby.
+        run_test_once_live(
             r##"[File.expand_path("////some/path"), File.expand_path("//some/path"), File.expand_path("/some////path"), File.expand_path("/a/./b/../c//d/"), File.expand_path("~root/x"), File.expand_path("/~root/a"), File.expand_path("a", "/"), File.expand_path("../../bin", "/tmp/x"), (begin; File.expand_path("~no_such_user_zzq"); rescue => e; [e.class, e.message]; end)]"##,
         );
     }
@@ -3171,7 +3172,8 @@ mod tests {
         // dir/file/../ resolves lexically (no ENOTDIR); a missing
         // intermediate component reports CRuby's realpath error message;
         // a self-referential symlink is ELOOP.
-        run_test_once(
+        // /tmp resolves through /private on macOS — live CRuby.
+        run_test_once_live(
             r##"(d="/tmp/mono_rp_#{Process.pid}"; Dir.mkdir(d); File.write("#{d}/file", ""); a=(File.realpath("#{d}/file/../")==d); b=(begin; File.realpath("/no_such_dir_zzq/x"); rescue => e; [e.class, e.message]; end); File.symlink("#{d}/self", "#{d}/self"); c=(begin; File.realpath("#{d}/self"); rescue => e; e.class; end); c2=(begin; File.realdirpath("#{d}/self"); rescue => e; e.class; end); File.unlink("#{d}/self"); File.unlink("#{d}/file"); Dir.rmdir(d); [a,b,c,c2])"##,
         );
     }
@@ -3180,7 +3182,8 @@ mod tests {
     fn file_realdirpath_dangling_symlinks() {
         // The final component may be absent; a dangling symlink resolves
         // to its (absent) target; a missing intermediate dir is ENOENT.
-        run_test_once(
+        // /tmp resolves through /private on macOS — live CRuby.
+        run_test_once_live(
             r##"(d="/tmp/mono_rdp_#{Process.pid}"; Dir.mkdir(d); a=(File.realdirpath("#{d}/missing") == "#{d}/missing"); File.symlink("#{d}/absent_file", "#{d}/link"); b=(File.realdirpath("#{d}/link") == "#{d}/absent_file"); c=(begin; File.realdirpath("#{d}/no_dir/file"); rescue => e; [e.class, e.message.sub(d, "")]; end); File.unlink("#{d}/link"); Dir.rmdir(d); [a, b, c])"##,
         );
     }
@@ -3361,9 +3364,11 @@ mod tests {
 
     #[test]
     fn expand_path() {
-        run_test(r##"File.expand_path("..")"##);
+        // ".." (cwd) and "~" (HOME) are host-dependent: verify against a
+        // live CRuby, not the oracle.
+        run_test_live(r##"File.expand_path("..")"##);
         run_test(r##"File.expand_path("..", "/tmp")"##);
-        run_test(r##"File.expand_path("~")"##);
+        run_test_live(r##"File.expand_path("~")"##);
     }
 
     #[test]
@@ -3434,11 +3439,13 @@ mod tests {
 
     #[test]
     fn realpath() {
-        run_test(r##"File.realpath(".")"##);
-        run_test(r##"File.realpath("./../../../")"##);
-        run_test(r##"File.realpath("../monoruby")"##);
-        run_test(r##"File.realpath("..", "/tmp")"##);
-        run_test(r##"File.realpath("tmp", "/")"##);
+        // All host/OS-dependent (cwd-relative, and /tmp resolves through the
+        // /private symlink on macOS): verify against a live CRuby.
+        run_test_live(r##"File.realpath(".")"##);
+        run_test_live(r##"File.realpath("./../../../")"##);
+        run_test_live(r##"File.realpath("../monoruby")"##);
+        run_test_live(r##"File.realpath("..", "/tmp")"##);
+        run_test_live(r##"File.realpath("tmp", "/")"##);
     }
 
     #[test]

--- a/monoruby/src/tests.rs
+++ b/monoruby/src/tests.rs
@@ -27,7 +27,31 @@ pub fn run_test(code: &str) {
     eprintln!("{}", wrapped);
     let mut globals = Globals::new_test();
     let interp_val = run_test_main(&mut globals, &wrapped);
-    let ruby_res = run_ruby(&mut globals, code);
+    let ruby_res = run_ruby(&mut globals, code, interp_val);
+
+    Value::assert_eq(&globals, interp_val, ruby_res);
+}
+
+/// Like [`run_test`], but always verifies against a live CRuby and never
+/// touches the snapshot oracle. Use for environment-dependent expressions
+/// (e.g. `Dir.home`, `Dir.pwd`) whose expected value varies per host, so a
+/// recorded snapshot would only be correct on the machine that recorded it.
+pub fn run_test_live(code: &str) {
+    let wrapped = format!(
+        r##"
+      __res = ({0})
+      for __i in 0..24 do
+          __res2 = ({0})
+          __assert(__res, __res2)
+      end
+      ({0})
+  "##,
+        code
+    );
+    eprintln!("{}", wrapped);
+    let mut globals = Globals::new_test();
+    let interp_val = run_test_main(&mut globals, &wrapped);
+    let ruby_res = run_ruby_live(&mut globals, code);
 
     Value::assert_eq(&globals, interp_val, ruby_res);
 }
@@ -42,7 +66,24 @@ pub fn run_test_once(code: &str) {
     eprintln!("{}", wrapped);
     let mut globals = Globals::new_test();
     let interp_val = run_test_main(&mut globals, &wrapped);
-    let ruby_res = run_ruby(&mut globals, code);
+    let ruby_res = run_ruby(&mut globals, code, interp_val);
+
+    Value::assert_eq(&globals, interp_val, ruby_res);
+}
+
+/// Like [`run_test_once`], but always verifies against a live CRuby and
+/// never touches the snapshot oracle. See [`run_test_live`].
+pub fn run_test_once_live(code: &str) {
+    let wrapped = format!(
+        r##"
+      ({0})
+  "##,
+        code
+    );
+    eprintln!("{}", wrapped);
+    let mut globals = Globals::new_test();
+    let interp_val = run_test_main(&mut globals, &wrapped);
+    let ruby_res = run_ruby_live(&mut globals, code);
 
     Value::assert_eq(&globals, interp_val, ruby_res);
 }
@@ -140,7 +181,7 @@ pub fn run_test_with_prelude(code: &str, prelude: &str) {
     eprintln!("{}", wrapped);
     let mut globals = Globals::new_test();
     let interp_val = run_test_main(&mut globals, &wrapped);
-    let ruby_res = run_ruby(&mut globals, &format!("{prelude}\n{code}"));
+    let ruby_res = run_ruby(&mut globals, &format!("{prelude}\n{code}"), interp_val);
 
     Value::assert_eq(&globals, interp_val, ruby_res);
 }
@@ -148,7 +189,7 @@ pub fn run_test_with_prelude(code: &str, prelude: &str) {
 pub fn run_test2(code: &str) {
     let mut globals = Globals::new_test();
     let interp_val = run_test_main(&mut globals, code);
-    let ruby_res = run_ruby(&mut globals, code);
+    let ruby_res = run_ruby(&mut globals, code, interp_val);
 
     Value::assert_eq(&globals, interp_val, ruby_res);
 }
@@ -220,10 +261,26 @@ fn run_test_main(globals: &mut Globals, code: &str) -> Value {
 /// a cache miss (the fresh entry is then recorded into the oracle file), or
 /// always when `MONORUBY_TEST_ORACLE=ruby` is exported — the mode to use
 /// after a CRuby version bump to re-verify / refresh the stored snapshots.
-fn run_ruby(globals: &mut Globals, code: &str) -> Value {
+///
+/// **Heal path**: when a *cached* entry disagrees with monoruby's own result
+/// (`interp_val`), the answer is re-derived from a live CRuby before
+/// declaring failure. Environment-dependent expressions (e.g. `Dir.home`,
+/// whose value differs between the recording host and CI runners) thus
+/// degrade to the old one-spawn behavior instead of failing spuriously,
+/// while a genuine monoruby regression still fails — the live CRuby agrees
+/// with the snapshot. The healed value is deliberately **not** recorded:
+/// it is host-specific, so rewriting the entry would make the checked-in
+/// file flip-flop between hosts.
+fn run_ruby(globals: &mut Globals, code: &str, interp_val: Value) -> Value {
     let (inspect, from_cache) = oracle::expected_inspect(code, || spawn_ruby(code));
     let label = if from_cache { "ruby(oracle)" } else { "ruby" };
-    value_from_inspect(globals, &inspect, label)
+    let ruby_res = value_from_inspect(globals, &inspect, label);
+    if from_cache && !Value::test_eq(&globals.store, interp_val, ruby_res) {
+        eprintln!("oracle: snapshot mismatch — re-verifying against a live ruby");
+        let live = spawn_ruby(code);
+        return value_from_inspect(globals, &live, "ruby(live)");
+    }
+    ruby_res
 }
 
 /// Reference result for `code`, always obtained from a live CRuby process.

--- a/monoruby/src/tests.rs
+++ b/monoruby/src/tests.rs
@@ -68,7 +68,7 @@ pub fn run_tests<S: AsRef<str>>(codes: &[S]) {
     eprintln!("{}", wrapped);
     let mut globals = Globals::new_test();
     let interp_val = run_test_main(&mut globals, &wrapped).as_array();
-    let ruby_res = run_ruby(&mut globals, &code).as_array();
+    let ruby_res = run_ruby_live(&mut globals, &code).as_array();
 
     for i in 0..codes.len() {
         let interp_elem = interp_val.get(i).unwrap();
@@ -167,7 +167,7 @@ pub fn run_tests2<S: AsRef<str>>(codes: &[S]) {
     eprintln!("{code}");
     let mut globals = Globals::new_test();
     let interp_val = run_test_main(&mut globals, &code).as_array();
-    let ruby_res = run_ruby(&mut globals, &code).as_array();
+    let ruby_res = run_ruby_live(&mut globals, &code).as_array();
 
     for i in 0..codes.len() {
         let interp_elem = interp_val.get(i).unwrap();
@@ -215,7 +215,43 @@ fn run_test_main(globals: &mut Globals, code: &str) -> Value {
     res
 }
 
+/// Reference result for `code`, served from the checked-in snapshot oracle
+/// (`tests/ruby_oracle.tsv`) when possible. A live CRuby is spawned only on
+/// a cache miss (the fresh entry is then recorded into the oracle file), or
+/// always when `MONORUBY_TEST_ORACLE=ruby` is exported — the mode to use
+/// after a CRuby version bump to re-verify / refresh the stored snapshots.
 fn run_ruby(globals: &mut Globals, code: &str) -> Value {
+    let (inspect, from_cache) = oracle::expected_inspect(code, || spawn_ruby(code));
+    let label = if from_cache { "ruby(oracle)" } else { "ruby" };
+    value_from_inspect(globals, &inspect, label)
+}
+
+/// Reference result for `code`, always obtained from a live CRuby process.
+/// Used by the batched helpers ([`run_tests`], [`run_tests2`]): their
+/// auto-generated concatenated code strings are huge and churn with every
+/// tweak of the combination tables, so snapshotting them would bloat the
+/// oracle file for no stable benefit.
+fn run_ruby_live(globals: &mut Globals, code: &str) -> Value {
+    let inspect = spawn_ruby(code);
+    value_from_inspect(globals, &inspect, "ruby")
+}
+
+/// Reconstruct a [`Value`] from a CRuby `p` output line (either freshly
+/// captured or replayed from the oracle file).
+fn value_from_inspect(globals: &mut Globals, inspect: &str, label: &str) -> Value {
+    let nodes = crate::parser::parse_program(inspect.to_string(), PathBuf::new())
+        .unwrap()
+        .node;
+
+    let res = Value::from_ast(&nodes, globals);
+
+    eprintln!("{label}: {}", res.inspect(&globals.store));
+    res
+}
+
+/// Run `code` under the reference CRuby and return the final `p` output
+/// line (the single-line `inspect` of the expression's value).
+fn spawn_ruby(code: &str) -> String {
     let code = format!(
         r#"
             ____a = ({});
@@ -238,7 +274,7 @@ fn run_ruby(globals: &mut Globals, code: &str) -> Value {
     let res = match std::process::Command::new(&*RUBY)
         .arg("-E")
         .arg("UTF-8")
-        // Skip rubygems boot (~5x faster startup across ~4000 differential
+        // Skip rubygems boot (~5x faster startup across the differential
         // spawns) and ignore any ambient RUBYOPT for hermeticity.
         .arg("--disable=gems,rubyopt")
         .arg(tmpfile.path())
@@ -250,15 +286,7 @@ fn run_ruby(globals: &mut Globals, code: &str) -> Value {
         }
     };
 
-    let res = res.trim_end().split('\n').last().unwrap();
-    let nodes = crate::parser::parse_program(res.to_string(), PathBuf::new())
-        .unwrap()
-        .node;
-
-    let res = Value::from_ast(&nodes, globals);
-
-    eprintln!("ruby: {}", res.inspect(&globals.store));
-    res
+    res.trim_end().split('\n').last().unwrap().to_string()
 }
 
 /// Minimum CRuby version the test harness compares output against.
@@ -318,9 +346,245 @@ fn find_ruby() -> String {
     "ruby".to_string() // last resort — will fail with a clear error message
 }
 
+/// Snapshot oracle: a checked-in cache of CRuby reference outputs.
+///
+/// Spawning a CRuby subprocess for every `run_test`-family call dominates
+/// suite wall-clock and memory, yet the answer for a given code string never
+/// changes for a given CRuby version. This module memoizes the mapping
+/// `code → last p-output line` in `monoruby/tests/ruby_oracle.tsv` so the
+/// suite compares monoruby against the recorded string instead of a live
+/// process.
+///
+/// Modes, selected by the `MONORUBY_TEST_ORACLE` environment variable:
+///
+/// - unset / `snapshot` (default): serve hits from the file with **no** Ruby
+///   spawn; on a miss spawn CRuby once and record the fresh entry back into
+///   the file (so `rm tests/ruby_oracle.tsv && cargo test` regenerates it
+///   from scratch, dropping any orphaned entries).
+/// - `ruby`: always spawn CRuby and use its live answer, refreshing any
+///   stale stored entry. Use this after bumping the reference CRuby version
+///   to re-verify the whole suite against the new Ruby and rewrite the
+///   snapshots in place.
+///
+/// File format: one entry per line, `key TAB output TAB snippet`, where
+/// `key` is a truncated SHA-256 of the code string, `output` is the escaped
+/// `p` line, and `snippet` is an escaped prefix of the code (human context
+/// only — ignored on load). Entries are kept key-sorted so regeneration and
+/// incremental additions produce clean diffs. Concurrent writers (nextest
+/// runs one process per test) serialize on an flock'd side file and each
+/// re-reads + rewrites the file atomically, so parallel misses merge instead
+/// of clobbering each other.
+mod oracle {
+    use std::collections::{BTreeMap, HashMap};
+    use std::io::Write;
+    use std::os::fd::AsRawFd;
+    use std::path::PathBuf;
+    use std::sync::{LazyLock, Mutex};
+
+    const HEADER: &str = "# monoruby ruby-oracle v1 — CRuby reference outputs for the run_test harness.\n\
+                          # Maintenance: `rm` this file and run `cargo test` to regenerate from a live Ruby;\n\
+                          # `MONORUBY_TEST_ORACLE=ruby cargo test` re-verifies/refreshes entries in place.";
+
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Mode {
+        /// Default: replay stored entries; spawn + record only on miss.
+        Snapshot,
+        /// Always spawn CRuby; refresh stale entries (version-bump mode).
+        Ruby,
+    }
+
+    fn mode() -> Mode {
+        match std::env::var("MONORUBY_TEST_ORACLE") {
+            Err(_) => Mode::Snapshot,
+            Ok(s) if s == "snapshot" => Mode::Snapshot,
+            Ok(s) if s == "ruby" => Mode::Ruby,
+            Ok(s) => panic!("MONORUBY_TEST_ORACLE={s:?} — expected \"snapshot\" or \"ruby\""),
+        }
+    }
+
+    fn oracle_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/ruby_oracle.tsv")
+    }
+
+    /// In-process view of the oracle file, loaded once. Misses recorded by
+    /// other concurrent processes after this load are simply re-derived
+    /// live (and re-recorded, idempotently) — correctness never depends on
+    /// seeing them.
+    static CACHE: LazyLock<Mutex<HashMap<String, String>>> = LazyLock::new(|| {
+        let mut map = HashMap::new();
+        if let Ok(text) = std::fs::read_to_string(oracle_path()) {
+            for (key, output_esc, _) in parse_lines(&text) {
+                map.insert(key.to_string(), unescape(output_esc));
+            }
+        }
+        Mutex::new(map)
+    });
+
+    /// Returns the expected `p` output line for `code` and whether it came
+    /// from the snapshot cache (`true`) or a live CRuby spawn (`false`).
+    pub(super) fn expected_inspect(code: &str, spawn: impl FnOnce() -> String) -> (String, bool) {
+        let key = key_of(code);
+        match mode() {
+            Mode::Snapshot => {
+                if let Some(hit) = CACHE.lock().unwrap().get(&key).cloned() {
+                    return (hit, true);
+                }
+                let live = spawn();
+                record(&key, code, &live);
+                (live, false)
+            }
+            Mode::Ruby => {
+                let live = spawn();
+                let stale = CACHE.lock().unwrap().get(&key) != Some(&live);
+                if stale {
+                    eprintln!("oracle: refreshing entry {key}");
+                    record(&key, code, &live);
+                }
+                (live, false)
+            }
+        }
+    }
+
+    /// 128-bit truncated SHA-256 of the code string. The `v1\n` prefix ties
+    /// the key to the harness wrapper (`____a = (..); puts; p(____a)` +
+    /// CRuby flags): if that wrapper ever changes in an output-affecting
+    /// way, bump the prefix to invalidate every stored entry at once.
+    fn key_of(code: &str) -> String {
+        use sha2::{Digest, Sha256};
+        hex::encode(&Sha256::digest(format!("v1\n{code}").as_bytes())[..16])
+    }
+
+    /// Merge one entry into the oracle file (read-modify-rewrite under an
+    /// exclusive flock so concurrent test processes don't drop each other's
+    /// additions). Best-effort: a read-only checkout only loses the caching,
+    /// not the test.
+    fn record(key: &str, code: &str, output: &str) {
+        CACHE
+            .lock()
+            .unwrap()
+            .insert(key.to_string(), output.to_string());
+        if let Err(err) = try_rewrite(key, code, output) {
+            eprintln!("oracle: failed to record entry (non-fatal): {err}");
+        }
+    }
+
+    fn try_rewrite(key: &str, code: &str, output: &str) -> std::io::Result<()> {
+        let path = oracle_path();
+        let lock_path = path.with_extension("tsv.lock");
+        let lock = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(&lock_path)?;
+        // SAFETY: flock on an fd we own; released when `lock` drops (close).
+        let rc = unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX) };
+        if rc != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        // Re-read under the lock: another process may have appended entries
+        // since our startup load.
+        let mut entries: BTreeMap<String, (String, String)> = BTreeMap::new();
+        if let Ok(text) = std::fs::read_to_string(&path) {
+            for (k, out_esc, snip_esc) in parse_lines(&text) {
+                entries.insert(k.to_string(), (out_esc.to_string(), snip_esc.to_string()));
+            }
+        }
+        let snippet: String = code.chars().take(80).collect();
+        entries.insert(
+            key.to_string(),
+            (escape(output), escape(snippet.trim_start())),
+        );
+
+        let tmp_path = path.with_extension("tsv.tmp");
+        {
+            let mut tmp = std::fs::File::create(&tmp_path)?;
+            writeln!(tmp, "{HEADER}")?;
+            for (k, (out_esc, snip_esc)) in &entries {
+                writeln!(tmp, "{k}\t{out_esc}\t{snip_esc}")?;
+            }
+            tmp.sync_all()?;
+        }
+        std::fs::rename(&tmp_path, &path)
+    }
+
+    /// Yields `(key, escaped_output, escaped_snippet)` for each entry line,
+    /// skipping comments/blank lines and tolerating a missing snippet field.
+    fn parse_lines(text: &str) -> impl Iterator<Item = (&str, &str, &str)> {
+        text.lines().filter_map(|line| {
+            if line.is_empty() || line.starts_with('#') {
+                return None;
+            }
+            let mut fields = line.splitn(3, '\t');
+            let key = fields.next()?;
+            let output = fields.next()?;
+            let snippet = fields.next().unwrap_or("");
+            Some((key, output, snippet))
+        })
+    }
+
+    /// The stored output is a single `p` line, but escape defensively so the
+    /// TSV framing can never be broken by exotic inspect output.
+    pub(super) fn escape(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        for c in s.chars() {
+            match c {
+                '\\' => out.push_str("\\\\"),
+                '\t' => out.push_str("\\t"),
+                '\n' => out.push_str("\\n"),
+                '\r' => out.push_str("\\r"),
+                c => out.push(c),
+            }
+        }
+        out
+    }
+
+    pub(super) fn unescape(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut chars = s.chars();
+        while let Some(c) = chars.next() {
+            if c != '\\' {
+                out.push(c);
+                continue;
+            }
+            match chars.next() {
+                Some('\\') => out.push('\\'),
+                Some('t') => out.push('\t'),
+                Some('n') => out.push('\n'),
+                Some('r') => out.push('\r'),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => out.push('\\'),
+            }
+        }
+        out
+    }
+}
+
 #[cfg(test)]
 mod harness_tests {
     use super::*;
+
+    #[test]
+    fn oracle_escape_roundtrip() {
+        // The TSV framing must survive any inspect output: tabs/newlines/CRs
+        // are escaped on write and restored on load, and escaped forms never
+        // contain a literal field or line separator.
+        for s in [
+            "",
+            "plain",
+            "tab\there",
+            "line\nbreak\r\n",
+            r"back\slash",
+            "mixed\\t not-a-tab \\n literal\t\n\\",
+            "日本語\tと\\改行\n",
+        ] {
+            let esc = oracle::escape(s);
+            assert!(!esc.contains('\t') && !esc.contains('\n') && !esc.contains('\r'));
+            assert_eq!(oracle::unescape(&esc), s);
+        }
+    }
 
     #[test]
     fn nonfinite_floats_reconstruct() {

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -587,10 +587,14 @@ impl Value {
 }
 
 impl Value {
-    /// This function is only used for system assertion.
-    pub(crate) fn assert_eq(store: &Store, lhs: Self, rhs: Self) {
+    /// Structural equality as used by the differential test harness: bit
+    /// equality, sign/payload-insensitive NaN equality, or deep RValue
+    /// comparison. Non-panicking; [`Self::assert_eq`] builds on it, and the
+    /// snapshot-oracle heal path in `tests.rs` uses it to decide whether a
+    /// stored entry disagrees with monoruby's own result.
+    pub(crate) fn test_eq(store: &Store, lhs: Self, rhs: Self) -> bool {
         if lhs == rhs {
-            return;
+            return true;
         }
         // NaNs of any sign/payload count as equal for assertion purposes:
         // e.g. x86's 0.0/0.0 yields a negative quiet NaN while a
@@ -599,17 +603,19 @@ impl Value {
             && a.is_nan()
             && b.is_nan()
         {
-            return;
+            return true;
         }
         match (lhs.try_rvalue(), rhs.try_rvalue()) {
-            (Some(lhs), Some(rhs)) => {
-                if RValue::eq(store, lhs, rhs) {
-                    return;
-                }
-            }
-            _ => {}
+            (Some(lhs), Some(rhs)) => RValue::eq(store, lhs, rhs),
+            _ => false,
         }
-        panic!("{} != {}", lhs.inspect(store), rhs.inspect(store))
+    }
+
+    /// This function is only used for system assertion.
+    pub(crate) fn assert_eq(store: &Store, lhs: Self, rhs: Self) {
+        if !Self::test_eq(store, lhs, rhs) {
+            panic!("{} != {}", lhs.inspect(store), rhs.inspect(store))
+        }
     }
 }
 

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -2257,13 +2257,11 @@ impl RValue {
                 (ObjTy::ARRAY, ObjTy::ARRAY) => {
                     let lhs = lhs.as_array();
                     let rhs = rhs.as_array();
-                    if lhs.len() != rhs.len() {
-                        return false;
-                    }
-                    lhs.iter().zip(rhs.iter()).for_each(|(lhs, rhs)| {
-                        Value::assert_eq(store, *lhs, *rhs);
-                    });
-                    true
+                    lhs.len() == rhs.len()
+                        && lhs
+                            .iter()
+                            .zip(rhs.iter())
+                            .all(|(lhs, rhs)| Value::test_eq(store, *lhs, *rhs))
                 }
                 (ObjTy::RANGE, ObjTy::RANGE) => {
                     // Compare the endpoints structurally: a heap Float
@@ -2271,21 +2269,18 @@ impl RValue {
                     // must match by value, not by object identity.
                     let l = lhs.as_range();
                     let r = rhs.as_range();
-                    Value::assert_eq(store, l.start(), r.start());
-                    Value::assert_eq(store, l.end(), r.end());
-                    l.exclude_end() == r.exclude_end()
+                    Value::test_eq(store, l.start(), r.start())
+                        && Value::test_eq(store, l.end(), r.end())
+                        && l.exclude_end() == r.exclude_end()
                 }
                 (ObjTy::HASH, ObjTy::HASH) => {
                     let lhs = lhs.as_hashmap();
                     let rhs = rhs.as_hashmap();
-                    if lhs.len() != rhs.len() {
-                        return false;
-                    }
-                    lhs.iter().zip(rhs.iter()).for_each(|(lhs, rhs)| {
-                        Value::assert_eq(store, lhs.0, rhs.0);
-                        Value::assert_eq(store, lhs.1, rhs.1);
-                    });
-                    true
+                    lhs.len() == rhs.len()
+                        && lhs.iter().zip(rhs.iter()).all(|(lhs, rhs)| {
+                            Value::test_eq(store, lhs.0, rhs.0)
+                                && Value::test_eq(store, lhs.1, rhs.1)
+                        })
                 }
                 _ => false,
             }

--- a/monoruby/tests/require.rs
+++ b/monoruby/tests/require.rs
@@ -3,7 +3,9 @@ use monoruby::tests::*;
 
 #[test]
 fn require() {
-    run_test(
+    // C::D is the fixture's __FILE__ (absolute checkout path): host-dependent,
+    // so verify against a live CRuby, not the oracle.
+    run_test_live(
         r#"
         require File.expand_path("a")
         C::D
@@ -25,7 +27,8 @@ fn require_bundler_resolves_host_copy() {
 
 #[test]
 fn require_relative() {
-    run_test(
+    // Host-dependent (absolute checkout path) — live CRuby.
+    run_test_live(
         r#"
         require File.expand_path("./b")
         C::D
@@ -35,7 +38,8 @@ fn require_relative() {
 
 #[test]
 fn load() {
-    run_test(
+    // Host-dependent (absolute checkout path) — live CRuby.
+    run_test_live(
         r#"
         load "b.rb"
         load "b.rb"
@@ -62,7 +66,8 @@ fn load_priv() {
 
 #[test]
 fn module_autoload() {
-    run_test(
+    // Host-dependent (absolute checkout path) — live CRuby.
+    run_test_live(
         r#"
         class C
           autoload :D, File.expand_path("j")
@@ -204,7 +209,9 @@ fn autoload_const_source_location() {
 // referenced`.
 #[test]
 fn autoload_private_constant_carries_through_load() {
-    run_test_once(
+    // autoload?(:Bar) reports the registered absolute path — host-dependent,
+    // so verify against a live CRuby, not the oracle.
+    run_test_once_live(
         r#"
         # `c.rb` defines `Foo::Bar = 20`. Register it as an autoload
         # under `Foo` and immediately mark it private. After the

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -1,0 +1,10 @@
+# monoruby ruby-oracle v1 — CRuby reference outputs for the run_test harness.
+# Maintenance: `rm` this file and run `cargo test` to regenerate from a live Ruby;
+# `MONORUBY_TEST_ORACLE=ruby cargo test` re-verifies/refreshes entries in place.
+09a6b149f6b260242237a6443ffcf622	Infinity..Infinity	(1.0 / 0.0)..(1.0 / 0.0)
+59a6ce8e2915130ae9576712b5a0f444	[1.0, Infinity]	[1.0, 1.0 / 0.0]
+6a746985c7bc6408f83085340479fbf6	[1.0, NaN]	[1.0, 0.0 / 0.0]
+9f1a90eeaa16fa36daa6ad13a43b2591	{a: Infinity, b: -Infinity}	{ a: 1.0 / 0.0, b: -1.0 / 0.0 }
+b9f8172cb8555b07f17ee7e3934a585e	[Infinity, -Infinity]	[Float::INFINITY, -Float::INFINITY]
+bf421e316fb7533cb8d9a80876438745	[[Infinity], {x: -Infinity}]	[[Float::INFINITY], { x: -Float::INFINITY }]
+ea07ecaa90c2d393514090eaf2eb6009	[1.0, -Infinity]	[1.0, -1.0 / 0.0]

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -1,10 +1,2931 @@
 # monoruby ruby-oracle v1 — CRuby reference outputs for the run_test harness.
 # Maintenance: `rm` this file and run `cargo test` to regenerate from a live Ruby;
 # `MONORUBY_TEST_ORACLE=ruby cargo test` re-verifies/refreshes entries in place.
+000b5e794755bba07796a83c37aa8f43	[7, 11, [:v, :w]]	c = class A\n          def f(x,y)\n            @v = x\n            @w = y\n
+001050afbce6ec6fe7f1f90a76f69707	[[]]	def m; [[1, 2]].map { _1 + _2; local_variables }; end; m
+0018d217ed7a86e77c0861bbaea94d33	[4, 10, 14, 20, 4.4, 14, 18]	class Array\n          def iich\n            for i in 0...self.size\n     
+002fe84a0a39b2e22de0f0a75e6bb957	[false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, true]	res = []\n        s = "abc"\n        30.times { res << (s == nil) << (s !
+00495be3e6ab60f683d55fd854017c80	["a", "b", "c", "", ""]	class C; def to_str; ","; end; end; o = C.new\na = []; "a,b,c,,".split(o, -1) {|p
+006bbb768ca783db96f5a98ba4efe2f2	[[:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], [:a, 1, 100, 77], [:b, 2, 100, 77], 51]	E = 100\n        def foo(&block)\n          a = 1\n          loop do\n     
+006cbb5c93191446bd13dd53c59df3c2	[111, 111]	class BopBase; def calc(a, b); a + b; end; end\n        class BopS1 < Bo
+00768e413c6aa6efc4bb0147b364bb6e	["US-ASCII", "UTF-8", "EUC-JP", "Windows-31J", "US-ASCII"]	x = "a"\n               [ /#{x}/n, /#{x}/u, /#{x}/e, /#{x}/s, /#{x}/ ]\n          
+0078399bb4942990861616abd67b61e3	5	key = Object.new\n            def key.to_str = "kk"\n            Fibe
+00907d9d39ba895181d61ddf1aafce1d	[true, true, false]	def f\n          $x << block_given?\n        end\n        \n\n        $x = [
+00aea899d7eb7dfdfb9142024674e4ff	"UTF-8"	[__ENCODING__].first.name
+00f536a3f6de04483c755254d3feae05	"hey"	m = Module.new\n            [m].map { |mod| mod.module_eval "def gre
+011026a7d4f1d0d0b50ee061ef9ddb92	"self"	begin\n              Thread.current.raise(ArgumentError, "self")\n   
+0112f3cbf1571b4d98d96e426138a425	[["x", "y"]]	cls = Class.new(Hash) do\n              def each\n                sup
+01171a0960b1271e3af32fab59377ba0	[]	class P\n              def foo; end\n              undef_method :foo\n
+011e3a767663769a41763822af96c4c2	"foo"	def m\n              a = 42\n              1.times { /(?<a>foo)/ =~ "
+01285d5502da85e38cd005e70dcfe4ac	["hello Fred", "bye Fred"]	def get_binding(str)\n            binding\n        end\n        str = "hel
+013365e50f318e63be4522e4d94c3ff4	nil	puts 100\n        
+0142f6a78c90261818a919df5e34508a	true	define_method(:boom) { :bam }\n            Object.method_defined?(:b
+01443549f3178fa419efc8dfabeb3d03	[1, 4, 5]	class MyAry; def to_ary; [4,5]; end; end\nobj = MyAry.new\na = [1]; a.concat(obj);
+0157b6a817ac1fed2a62196ed525d722	["a.rb:1: Some runtime error (RuntimeError)\\n\\tfrom b.rb:2\\n", "Traceback (most recent call last):\\n\\t1: from b.rb:2\\na.rb:1: Some runtime error (RuntimeError)\\n", "a.rb:1: \\e[1mSome runtime error (\\e[1;4mRuntimeError\\e[m\\e[1m)\\e[m\\n\\tfrom b.rb:2\\n", "\\e[1mTraceback\\e[m (most recent call last):\\n\\t1: from b.rb:2\\na.rb:1: \\e[1mSome runtime error (\\e[1;4mRuntimeError\\e[m\\e[1m)\\e[m\\n"]	e = RuntimeError.new("Some runtime error")\n        e.set_backtrace(["a.
+015d950e92f84266477f809be2d52ad7	"my_temp"	m = Module.new\n            m.set_temporary_name("my_temp")\n        
+0181411f6f14be38811bc49fd1ac2c8f	[false, true, true, false, false, false, false]	[!true, !false, !nil, !0, !"", ![], !:sym]\n        
+0198f55071323ce6b7b0f303a1e8dd25	"abc"	"abc\\n".chomp
+019bf093e71a4a7e2b8d464eb4c68b93	true	path = "/tmp/monoruby_test_trunc_neg_#{Process.pid}_#{rand(100000)}
+019f3f3fddb9ec21b42090ce2f080bff	["0.314e1", "0.123456e3", "0.0", "-0.0", "0.1e11", "0.15e-2", "NaN", "Infinity", "-Infinity", "0.42e2", "-0.42e2", "0.0"]	require "rubygems"\n        require "bigdecimal"\n        res = []\n      
+01b3a348f0e8e6ad19db70506365aae2	nil	Thread.pass
+01b52241af84af43c90dfc38ff2da6ba	["x1", "x2"]	body = proc { "x#{Thread.current[:n]}" =~ /(x\\d)/; $1 }\n           
+01c4e0473295f086423b12e2cc1c13d8	"dd"	"foo" =~ /(o+)/\n            Enumerator.new { |y| "dd" =~ /(d+)/; y 
+01c75784b17e927119a6f718cf196d83	"missing keyword: :x"	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; def m(x:)
+01cdf73be52a73b5c8a772cfd2975bf0	[:pub, "Method", :priv_err, :prot_err, :missing_err]	class PubMethSpec\n              def pub; :pub; end\n              pr
+01db1c6b4f58aff12e2dbade8652decf	"2.5e+00"	class HasToF; def to_f; 2.5; end; end\n            sprintf("%.1e", H
+01f5957c8d7059b4dc6d1a49e6890469	[:a, [:a, :b]]	m = Module.new do\n              def a; end\n              def b; end
+02383c606eb753dd897479b98e6e993a	[1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987]	fib = Enumerator::Generator.new do |y|\n                a = b = 1\n  
+02421a6c19cfcd2074a6839ee5f9c5eb	[true, true, false, false, false]	class Foo\n              def respond_to_missing?(name, ia); true; en
+02478a618a64d101a41487bb382f82e9	[:a, :b, :propagated]	class E1 < StandardError; end\n            class E2 < StandardError;
+02514ab3efd67e221f849da3b743bbb3	"US-ASCII"	"\\x01".unpack("H")[0].encoding.to_s
+026464d2e8ce39f792e1d0f696b61ee1	true	Process.groups.all? { |g| g.is_a?(Integer) }
+029c362ef9c620f171fc24ead7134c52	[["alpha\\n", "beta\\n", "gamma\\n"], nil]	path = "/tmp/monoruby_io_gets_#{Process.pid}_#{rand(100000)}"\n     
+029c3ebe189781d0b649df411808dfee	[[[:a, 1], 0], [[:b, 2], 1]]	r = []; ({a: 1, b: 2}).each.with_index { |v, i| r << [v, i] }; r
+02a7d510f273964ead93e757431a554c	[3, 2, 1]	base = Class.new { def foo(ary); ary << 1; end }\n            child 
+02c396b429bf65fdf9a120d44cc103f5	true	src = Module.new { def t1; end }\n            m = Module.new do\n    
+02c6f5d297eadcc0a5026d7c20a2e18c	["a", {b: "b"}]	T = Struct.new(:a, :b)\n            \n\n            s = T.new("a", b: 
+02cb9b2aa7a2eb9ebb2690e1cb412b25	200000	io = IO.popen("sleep 0.05; cat > /dev/null", "w")\n            t = T
+02d10182dd5ce63811bf0f343d4007e4	4	def f(a = ($x = 4)); end\n        f\n        $x\n        
+02dd41c47817eb7298fab84529b2c28f	"bar"	class Foo\n              def bar; "bar"; end\n              alias baz
+02ed8a6811a8cf3f58bc7331a3e21d85	"3/4"	0.75.to_r.to_s
+02ffb95da7747bbaa6cd1574881e0f79	["prepended:C"]	$res = []\n        module M\n          def self.prepended(base)\n         
+031288d7e4e5b4e470138e25f3481834	[:dest_req, :dest_req]	require "socket"\n            s = Socket.new(:INET, :DGRAM)\n        
+0314ce7239f180c37dacc23fb9132d85	[99.5, 1.0]	class Foo; def to_f; 99.5; end; end\n        \n1.coerce(Foo.new)
+0324b81d611aaf41f40336b6e6cfc324	[1, 2, 3, 4, 5, 6, 7, 8]	class C\n          attr_reader :a, :b, :c, :d, :e, :f, :g, :h\n          
+0328a628714e073c1fac1d7db99f0db5	["hit", "dflt", "hit", "blk:MONORUBY_COV_ABSENT", "hit", "block wins", KeyError]	ENV["MONORUBY_COV_FETCH"] = "hit"\n            res = [\n             
+03503f8bcb4632cbd04e4701371caab5	["File::Stat", 8, true]	path = "/tmp/monoruby_test_instat_#{Process.pid}_#{rand(100000)}"\n 
+035d992920dc2f7cc38dee107378052b	true	'he[[o'.gsub('[', ']'); $~.regexp == /\\[/
+0365d874d3091255ffafa6a537178e6a	nil	a=Object.new; a.instance_variable_get(:@i)
+0379b90699980103ce98cdf1fd4b6457	[42, false, true]	class Foo\n          def !\n            42\n          end\n        end\n    
+03add114cdd6e1fb8f694172fc12ba42	[["method", "method"], [:se, :se]]	$dlog = []\n            def dse; $dlog << :se; 1; end\n            [[
+04053dc491e488a586338fcc5eed81e2	"hi"	c = Class.new\n            [1].each do |_|\n              c.class_eva
+040e6a190fdcb22a07dee211c3713d43	"US-ASCII"	"HELLO".encode("US-ASCII").downcase.encoding.to_s
+0417499cdc3487266e491725b65dcd89	[43, 42]	f = Fiber.new(storage: {life: 42}) do\n              inner = Fiber.n
+042067cf8df83644b7cd370ce04a55db	100	class C\n            class D\n              E = 1\n              def sel
+042531956d7a960e0bfee8fa3360dc99	["ASCII-8BIT", true]	begin\n              begin\n                File.stat("/missing\\xE3E4
+0459d7cb4f158e142736bf52fff36347	[Hash, {x: 1}, false]	sub = Class.new(Hash)\n            o = sub.new\n            o[:x] = 1
+046110996c8a0ca3802aa257c29bd814	["class variable", true]	class DefCV\n              @@v = 1\n              def t; [defined?(@@
+04960a654db6978cf6c1b2b82065abdf	[1, 2, 3, 4, 5, 6, 7, 8]	class C < Array\n          attr_reader :a, :b, :c, :d, :e, :f, :g, :h\n  
+04bc3e73fd691534c5f67d6cff6c0117	true	o = Object.new\n            o.singleton_class\n            Marshal.lo
+04cd443314c532007660c17ebab3d577	[-4, 1, 2, 5, 7, 10, 12]	class Integer\n              alias old_spaceship <=>\n              d
+050ae4a7c397fbd32b0bd2bb968461d6	[[:a, 0], [:a, 1], [:a, 2], [:b, 0], [:b, 1], [:b, 2]]	log = []\n            t1 = Thread.new { 3.times { |i| log << [:a, i]
+051c6c1a4febd93666a6dd7af8fec314	true	Class.new.method_defined?(:hash)\n            
+0529c3b994259a346f88054c03aff90d	[[Encoding::InvalidByteSequenceError, "\\"\\\\xF1\\" followed by \\"a\\" on UTF-8"], [:invalid_byte_sequence, "UTF-8", "ISO-8859-1", "\\xF1", "a"], Encoding::InvalidByteSequenceError, Encoding::UndefinedConversionError, true, "", [Encoding::InvalidByteSequenceError, "incomplete \\"\\\\xA4\\" on EUC-JP"], [:incomplete_input, "EUC-JP", "UTF-8", "\\xA4", ""], [["US-ASCII", "UTF-8"]], [["US-ASCII", "UTF-8"], ["UTF-8", "Big5"]], "crlf_newline", "crlf_newline", nil]	(t=lambda{|&b| begin; b.call; rescue Exception => e; [e.class, e.message]; end};
+055f890657b797cbf39b10ff47a602e6	"hello"	class Bar\n              class_variable_set(:@@val, "hello")\n       
+059105186c8c7fcaa5b946c1c71b007a	"hello\\n"	r, w = IO.pipe\n            t = Thread.new { r.gets }\n            w.
+05950871938fb64822a955fd038dac97	["included:C"]	$res = []\n        module M\n          def self.included(base)\n          
+059f2e066a6a22fbabc5151c1605ddbe	[18000, 1700000000, -32401, 18000, 0, 1700000000, 500]	t = 1_700_000_000\n            a = Time.at(t, in: "+05:00")\n        
+05a71640804c40648923d410749f1c98	:puts	method(:puts).name
+05ba98f1d4beb06be92e32569f86f319	[false, false, false]	s = "abc"\n              [s.ljust(2).equal?(s), s.rjust(2).equal?(
+05bbb0c3d15dc87a5d509b5e40f01863	"Encoding::CompatibilityError"	(Regexp.new("".dup.force_encoding("UTF-16LE"), Regexp::FIXEDENCODING) =~ " ".enc
+05bebba3f7ecc9b53acb11fcf8edd8ef	"ss"	"ß".downcase(:fold)
+05cf68e37e12ea3ba8361e1c672a7ea0	[["ISO-8859-1", [225], true], ["ISO-8859-2", [225], true], ["ISO-8859-3", [225], true], ["ISO-8859-4", [225], true], ["ISO-8859-5", [225], true], ["ISO-8859-6", [225], true], ["ISO-8859-7", [225], true], ["ISO-8859-8", [225], true], ["ISO-8859-9", [225], true], ["ISO-8859-10", [225], true], ["ISO-8859-11", [225], true], ["ISO-8859-13", [225], true], ["ISO-8859-14", [225], true], ["ISO-8859-15", [225], true], ["ISO-8859-16", [225], true]]	%w[ISO-8859-1 ISO-8859-2 ISO-8859-3 ISO-8859-4 ISO-8859-5\n                 ISO-8
+05f9f4947bb616ee98f8b5b527a50fb4	[["constant", 10, "constant"], ["constant", 11, "constant"], ["constant", 10, "constant"], ["constant", 11, "constant"], ["constant", 10, "constant"], ["constant", 11, "constant"], ["constant", 10, "constant"], ["constant", 11, "constant"], ["constant", 10, "constant"], ["constant", 11, "constant"], ["constant", 10, "constant"], ["constant", 11, "constant"], ["constant", 10, "constant"], ["constant", 11, "constant"], ["constant", 10, "constant"], ["constant", 11, "constant"], ["constant", 10, "constant"], ["constant", 11, "constant"], ["constant", 10, "constant"], ["constant", 11, "constant"], :a, :b, :a, :b, :a, :b, :a, :b, :a, :b, :a, :b, :a, :b, :a, :b, :a, :b, :a, :b, :a, :b, [100, "constant"], [101, "constant"], [100, "constant"], [101, "constant"], [100, "constant"], [101, "constant"], [100, "constant"], [101, "constant"], [100, "constant"], [101, "constant"], [100, "constant"], [101, "constant"], [100, "constant"], [101, "constant"], [100, "constant"], [101, "constant"], [100, "constant"], [101, "constant"], [100, "constant"], [101, "constant"], true, :q, :q, :q, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true]	$r = []\n        TOPC9 = :top\n        # defined?(CONST) resolves through
+0600c545eb8ea8eab3868af35cea60cf	[0, 0, 10, 0]	require "rubygems"\n        require "bigdecimal"\n        res = []\n      
+061bdd061f147a5d9f44958903cc9221	"hi\\n"	require "open3"; Open3.capture2("echo", "hi").first
+0639fd7a5d2bbe9305ea95f45248e727	[[nil], [:v], [[1, 2]]]	[Enumerator.new { |y| y.yield },\n                Enumerator.new { |y| y.yield :v
+0645bcf03de3613af42e57886acd5057	"ClassKwOuter::ClassKwInner"	class ClassKwOuter\n              class ClassKwInner; end\n          
+066265d0228305a399c4298d3fde2292	[[0, 1, 2, 3, 4], true, nil]	q = Queue.new\n            prod = Thread.new { 5.times { |i| q.push 
+067076632d9bbfc6687c8a1ec746a38b	[:a, :b]	c = Class.new { attr :a, :b }\n            c.instance_methods(false)
+0671dc386fe22ac136194d005bfa5d9e	[:foo]	$res = []\n            class C\n              def self.method_undefin
+0691611dde38293b7701c47f3487d59e	[10, 10, 10, 10, 10, 20, 20, 20, 20, 20]	class C\n          def foo; 10; end\n        end\n        c = C.new\n      
+069eae9fbb818fee75b130337a249e6c	[6765, 6765, 0.0, nil]	def fib(n) = n < 2 ? n : fib(n-1) + fib(n-2)\n            res = [fib
+06a5555617326eb4ebb8f42c49df0364	[{1 => :b, 0 => :c}, 2, {1.5 => 1, 2.5 => 0}, {nil => 1, true => 2, sym: 0}, 2, {1 => :c}, 1, {1.5 => 1, 2.5 => 1}, {nil => 1, true => 2, sym: 1}, 2, {1 => :b, 2 => :c}, 2, {1.5 => 1, 2.5 => 2}, {nil => 1, true => 2, sym: 2}, 2, {1 => :b, 3 => :c}, 2, {1.5 => 1, 2.5 => 3}, {nil => 1, true => 2, sym: 3}, 2, {1 => :b, 4 => :c}, 2, {1.5 => 1, 2.5 => 4}, {nil => 1, true => 2, sym: 4}, 2, {1 => :b, 5 => :c}, 2, {1.5 => 1, 2.5 => 5}, {nil => 1, true => 2, sym: 5}, 2, {1 => :b, 6 => :c}, 2, {1.5 => 1, 2.5 => 6}, {nil => 1, true => 2, sym: 6}, 2, {1 => :b, 7 => :c}, 2, {1.5 => 1, 2.5 => 7}, {nil => 1, true => 2, sym: 7}, 2, {1 => :b, 8 => :c}, 2, {1.5 => 1, 2.5 => 8}, {nil => 1, true => 2, sym: 8}, 2, {1 => :b, 9 => :c}, 2, {1.5 => 1, 2.5 => 9}, {nil => 1, true => 2, sym: 9}, 2, {1 => :b, 10 => :c}, 2, {1.5 => 1, 2.5 => 10}, {nil => 1, true => 2, sym: 10}, 2, {1 => :b, 11 => :c}, 2, {1.5 => 1, 2.5 => 11}, {nil => 1, true => 2, sym: 11}, 2, {1 => :b, 12 => :c}, 2, {1.5 => 1, 2.5 => 12}, {nil => 1, true => 2, sym: 12}, 2, {1 => :b, 13 => :c}, 2, {1.5 => 1, 2.5 => 13}, {nil => 1, true => 2, sym: 13}, 2, {1 => :b, 14 => :c}, 2, {1.5 => 1, 2.5 => 14}, {nil => 1, true => 2, sym: 14}, 2, {1 => :b, 15 => :c}, 2, {1.5 => 1, 2.5 => 15}, {nil => 1, true => 2, sym: 15}, 2, {1 => :b, 16 => :c}, 2, {1.5 => 1, 2.5 => 16}, {nil => 1, true => 2, sym: 16}, 2, {1 => :b, 17 => :c}, 2, {1.5 => 1, 2.5 => 17}, {nil => 1, true => 2, sym: 17}, 2, {1 => :b, 18 => :c}, 2, {1.5 => 1, 2.5 => 18}, {nil => 1, true => 2, sym: 18}, 2, {1 => :b, 19 => :c}, 2, {1.5 => 1, 2.5 => 19}, {nil => 1, true => 2, sym: 19}, 2]	x = 1\n        r = []\n        20.times do |i|\n            d = {x => :a, 
+06a627d4aec78b84be750bb045039a58	:OVERRIDDEN	class Array; def [](i); :OVERRIDDEN; end; end; [1,2][0]
+06af6a2097c13550baec901ab71edb0a	100	class A\n          X = 100\n          def test\n            instance_eval(
+06bafaf0a06979cf3370c2fa3a7cb0be	["true", false, "false", true]	res = []\n        50.times do |i|\n          v = (i % 2 == 0)\n          r
+06c98d0ea6dabbd83254f585fdff8d01	"hello"	path = "/tmp/mr_mode_rw.txt"\n            r = File.open(path, "w+") 
+06c9dd57c05cab60ddd6dda0a3401d90	{a: 1, b: 2}	class C; def to_hash; {b: 2}; end; end; o = C.new\n{a: 1}.merge(o)
+06c9ffd7bb14ce02cb3c3cce8547821a	2100	class Object\n          def tag = 7\n        end\n        \n\n        res = 
+06d5ce8d7704e2c7b8595804a919e835	42	def call_with_block\n          p = Proc.new { yield }\n          p.call\n 
+06eda79790808d518cb2c8f486881d9b	[:tl_top, true]	module TlWrap\n              class Cont; class Child; end; end\n     
+06f393f3daee699b0b3292d44f67b8c4	["test", [1, :foo, nil]]	class Baz\n              attr_accessor :name, :items\n              d
+06ff673b8d713741ffee6676d97d749b	[nil, "1234!"]	s = "1234!".dup\n              [s.upcase!, s]\n            
+070a1e1b086a7a10ee821e9b12bfc70a	["name", "Template['foo.rb']", "a::B", "A::b", "A::B::", "A="]	m = Module.new\n            results = []\n            results << m.se
+071650ec93f915a34dff9e18041b0a1b	false	def foo; end\n            public :foo\n            Object.private_met
+072525d9f9be127994b409c1f5b247e4	["a\\r\\nb\\r\\nc", "a\\rb", "a\\nb\\nc\\n", "a\\r\\nb", [97, 0, 13, 0, 10, 0, 98, 0]]	(a="a\\nb\\nc".encode("UTF-8", crlf_newline: true); b="a\\nb".encode("UTF-8", cr_ne
+0736de5b921b47f8e9e27ca56c6c9b35	{A: 1, b: 2}	def drive(n)\n              r = nil\n              n.times { r = yiel
+07499214dbe1866c9cba9612dd1f4909	["a", nil, "bc", true, nil, 2, nil, "bar", 7, true, "foo bar", 7]	require "strscan"\n        r = []\n        s = StringScanner.new("abc")\n 
+0750b259ae197e8b437459f5cfaa246a	{}	/(foo)(bar)/.match("foobar").deconstruct_keys(nil)
+075794323ea386fc27f4ad61a4164ace	4	obj = Object.new\n            def (obj).qux; 4; end\n            obj.
+078a80c14641af84738f69e79b6f4d43	:OVERRIDDEN	class Complex; def -@; :OVERRIDDEN; end; end; -(Complex(1,2))
+078daf4fd77243c21d945dee4f1f3c8a	[1, 1, 20, 1, 100]	class C\n            def foo\n                1\n            end\n         
+07949d484137fbc2f7b3dc559cdc9ccf	:nme	class Integer; def +(o); super(o) * 10; end; end\n                begin; 1 + 2; r
+07955b63ba38d4cd83594a1c65d6ce2e	[1, 2]	File.write('/tmp/monoruby_resync.rb', "$resync_counter = ($resync_c
+07ae3460afd871d9e296a49f2d2affb1	"a"	class MyStr\n                  def to_str; "abc"; end\n          
+07b1d4b32547d6f6624dc2c846950ab0	[true, true]	t = Thread.new { :x }\n            t.join\n            [t.kill == t, 
+07d3d8701aafb106b630434fe110bc28	[8, 7]	inc = proc { |n| n + 1 }\n        d = Object.new\n        def d.call(n); 
+07db4a045facdc21787ed0ef44cb050c	["class or module required for rescue clause", "class or module required for rescue clause", "class or module required for rescue clause"]	res = []\n        rescuer = 42\n        3.times do\n          begin\n      
+080f42d888ea5e1a7eb7a4c43d6b5064	"US-ASCII"	"Hello".encode("US-ASCII").swapcase.encoding.to_s
+080f929287fc4ac492b6fb2c6fb2aaac	[:interrupted]	def run_masked(timing, blocking = true)\n              klass = Class
+082c922854391d30efbd21f4e18518c3	true	File.writable?("/tmp")
+082f54363bbaa6f37b522a29ab6c1e74	true	f = File.new("Cargo.toml", "r")\n            result = f.read(10).is_
+082ffdcafa629eb9c1ce2f11988484e1	[0, "A1", 2, "A1\\n", "A2\\n", "B1\\n", "B1\\n", "no stream to tell", "no stream to seek", "no stream to rewind", "no stream", "closed stream"]	require 'tmpdir'\n            f1 = File.join(Dir.tmpdir, "argf_t1_#{
+08380397571bab4325905bd08954dab7	5	f = ->{ _1 }; f.call(5)
+086bebb78a0ca379f395d0e5f49578e9	2500	a=1;\n            b=while a<2500 do\n                a=a+1\n          
+08996866cb8b785802b6b9956c01496d	true	Process.getrlimit("CORE").is_a?(Array) && Process.getrlimit("CORE").size == 2
+08afdef663fa588e146ea15e587897fc	[false, true, true, true, [1, 2, 3, 4, 5, 6], [], false, true, true, true, [1, 2, 3, 4, 5, 6], [], false, true, true, true, [1, 2, 3, 4, 5, 6], [], false, true, true, true, [1, 2, 3, 4, 5, 6], [], false, true, true, true, [1, 2, 3, 4, 5, 6], [], false, true, true, true, [1, 2, 3, 4, 5, 6], [], false, true, true, true, [1, 2, 3, 4, 5, 6], [], false, true, true, true, [1, 2, 3, 4, 5, 6], [], false, true, true, true, [1, 2, 3, 4, 5, 6], [], false, true, true, true, [1, 2, 3, 4, 5, 6], [], false, true, true, true, [1, 2, 3, 4, 5, 6], [], false, true, true, true, [1, 2, 3, 4, 5, 6], [], false, true, true, true, [1, 2, 3, 4, 5, 6], [], false, true, true, true, [1, 2, 3, 4, 5, 6], [], false, true, true, true, [1, 2, 3, 4, 5, 6], [], false, true, true, true, [1, 2, 3, 4, 5, 6], [], false, true, true, true, [1, 2, 3, 4, 5, 6], [], false, true, true, true, [1, 2, 3, 4, 5, 6], [], false, true, true, true, [1, 2, 3, 4, 5, 6], [], false, true, true, true, [1, 2, 3, 4, 5, 6], []]	def m = []\n        r = []\n        20.times do\n            a = m\n       
+08b7202003237b5589f045034e865e7b	{a: 10, b: 20, c: 30}	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \ns.to_
+08d5901aeb4f2144e9a820f898cbcd1e	[false]	r = []; Enumerator.new { |y| y << caller.empty? }.with_index { |v, i| r << v }; 
+08fc54bc0f437875557068bccc618cc9	[true, true]	class Qux\n          def !\n            99\n          end\n        end\n    
+090184d49e436724223ec248497eaf4d	true	def foo\n              caller\n            end\n            foo.is_a?(
+0908fa5a55bea9aee9bc7bed9a5b9f10	[42, 7, 11, 17]	class A\n          attr_accessor :w, :x, :y, :z\n          def initialize
+0917cb1b1ddcd9e8f09a3f702f602cc3	true	"abc".force_encoding("ISO-8859-9").encoding == Encoding::ISO_8859_9
+0925855f2461e17a8a58156f05bff345	[200000, 200000, true]	require "open3"\n            out, err, st = Open3.capture3("sh", "-c", "yes A | h
+095b320a7ec0b113fdc5f3a7cb232b86	112	class A\n          def calc(x)\n            x * 2\n          end\n        e
+095f6be6b098d85bcd704f1ce0d023d9	[[], "method", [:ran]]	$log = []\n            def se; $log << :ran; 1; end\n            defi
+09627a5f6d11a2530381ed28e1f7c7c3	[true, true, false]	class Foo\n              def bar; 1; end\n              alias_method 
+0964e71f2c41a5e46adc328cd201a170	"MIT License\\n\\nCopyrig"	File.binread("../LICENSE-MIT", 20)
+09729e06a38fd6ed7e727c8b72b7ebab	["StandardError", "inner", true]	o = StandardError.new "outer"\n            i = StandardError.new "in
+0987da7e71ade396456dd11a7581dc57	[:wait_readable, "hi\\n"]	io = IO.popen("sleep 0.05; echo hi")\n            a = io.read_nonblo
+099520774762fb4f96e98ef3c6d2815d	[[1, 2, 10]]	class C\n          def f(a,b,&blk)\n            $res << [a, b, blk.call(a
 09a6b149f6b260242237a6443ffcf622	Infinity..Infinity	(1.0 / 0.0)..(1.0 / 0.0)
+09bdf1acbcd3567e8ee401b618059ae8	[1, [2, 3], 42]	def f\n              yield [1,[2,3],4]\n            end\n            \n
+09c5d14600ee6e1cc49a870b8ecd0fea	["zero", "one", "two", "three-six", "three-six", "three-six", "three-six", "seven", "eight", "nine", "ten-fourteen", "ten-fourteen", "ten-fourteen", "ten-fourteen", "ten-fourteen", "fifteen", "sixteen", "seventeen", "above eighteen", "above eighteen", "zero", "one", "two", "three-six", "three-six", "three-six", "three-six", "seven", "eight", "nine", "ten-fourteen", "ten-fourteen", "ten-fourteen", "ten-fourteen", "ten-fourteen", "fifteen", "sixteen", "seventeen", "above eighteen", "above eighteen", "zero", "one", "two", "three-six", "three-six", "three-six", "three-six", "seven", "eight", "nine"]	res = []\n      50.times do |x|\n        case x % 20\n        when 0\n       
+09da60f0b8af936f2576e6fce8f5b2ce	[["one", nil, 1], "uno", [1, "uno"], [1, 1, nil, [true]], [2, 1, 2, nil], 10, [2, 10, 2]]	def drive(n)\n              r = nil\n              n.times { r = yiel
+09dbda92a05db85d6ad08cef7673aa9d	["extended:C"]	$res = []\n        module M\n          def self.extended(base)\n          
+0a0748b8809f0e8d7f80297870a4da1e	[200000, 0, 999]	a = []\n            200000.times { |i| a << [(i * 7919) % 1000] }\n  
+0a0f30d8ebe55e1e0abe73391dfb071f	[true, true, true, true, 2]	(o=Object.new; def o.to_path; "/tmp/mono_tp_#{Process.pid}"; end; p2=Object.new;
+0a113daaabe1d4a623096c5f5d1b9ad3	"/home/user/monoruby"	File.expand_path("..")
+0aa2fa3cce375400b399c989bb80cc19	[1, 0, 0, 2, 1, 1, 3, 2, 2, 5, 3, 3, 8, 4, 4, 13, 5, 5, 21, 6, 6, 34, 7, 7, 55, 8, 8, 89, 9, 9, 144, 10, 10, 233, 11, 11, 377, 12, 12, 610, 13, 13, 987, 14, 14, 1597, 15, 15]	e = Enumerator.new do |y|\n            a = b = 1\n            loop do\n   
+0abd6eee0fea26b57419ce161524d82a	"Module"	Module.new { using Module.new }.class.to_s
+0abee4f13c81ea36178a7ea1d3967d26	true	Process.getpgid(0) == Process.getpgrp
+0ac4a1a595e5d45cfae6000f22e5b73a	:utterly_undefined_method_name	begin\n              Object.instance_method(:utterly_undefined_metho
+0adbd96399227bda6ca3f78bcce77b16	:ok	old_dep = Warning[:deprecated]\n            old_stderr = $stderr\n   
+0b006d8d0b7c3b6cbbde169c66a256f9	"hello\\n"	require "socket"\n            s = TCPServer.new("127.0.0.1", 0)\n    
+0b0604dcfa5aa2a90ccb9b55c158b24e	101	def get_binding\n              x = 100\n              binding\n       
+0b272bc1eee3862ebd5afe122f6530ac	[0, 50, "custom", true, false, false]	def check(x) = x.is_a?(Integer)\n            def fro(x) = x.frozen?\n
+0b360a7151ca4646f547e0ecffd6cf13	[true, true, true, true, true, ArgumentError, ArgumentError, TypeError, TypeError, Hash, false]	(ENV["MONO_T_ZZ"]="hi"; a=ENV["MONO_T_ZZ"].frozen?; b=ENV.method(:has_key?)==ENV
+0b56e400524c40599f5741f2c015962d	7	class Foo\n              def method_missing(name, *args)\n           
+0b645df6fa816084c17746fbb8754151	-4	class Integer; alias __orig :~; def ~; __orig; end; end; ~(3)
+0b67f0becaeeca974d1e74004df4c680	[[:x], [1, :y]]	class C\n                 def initialize; @log = []; end\n                 def []=
+0b7609ef6d4ba5f8e723f231492ce8ea	1	class Zero\n              def >(other); false; end\n              def
+0b78ccf3ab6dd1487dc5bdd4f2490140	"aa"	eval("/a+?+/").match("aa")[0]
+0b7e162d3ff4a550f0e6444dc364f2ba	2178309	fib = Fiber.new do\n                a = b = 1\n                loop d
+0b7ee82ff88a267033144fce83d01888	[LocalJumpError, 42, :return]	def m\n          proc { return 42 }\n        end\n        begin\n          
+0b867e98052ada5dace0aa91d09d9e98	[true, 0, 1000000, "nil", true, false, true, true, 600, 1000]	class A\n          def flag; true; end\n          def zero; 0; end\n      
+0b897273d98e1e69054efed30d8f0fba	-3	class Integer; alias __orig :-@; def -@; __orig; end; end; -(3)
+0ba27141d5913d3fcc8fa69294a2eb77	:OVERRIDDEN	class Float; def +(o); :OVERRIDDEN; end; end; 3.0 + 4.0
+0bda13f36ccde82b031cc2a78bf9fcbd	["AB", "CD"]	def `(cmd); cmd.upcase; end\n        [`ab`, `cd`]\n        
+0be41d9bd7e1cc54941270e279653ac8	true	class StrPlusSub < String; end; (StrPlusSub.new("a") + "b").instance_of?(String)
+0beb46074e1eb509fdd14935b30258dd	[1, 2, 3]	a = [1, 2, 3]\n            a.shuffle\n            a\n            
+0c1d024a77553ba059ad52023369c614	[false, false]	t = Thread.new { loop {} }\n            sleep 0.05\n            t.kil
+0c31062b279dfc18d7d2c88b1de29087	[:pro1, :pro2]	c = Class.new do\n              def pub; end\n              protected
+0c59e4ca52f8b258d616906a2685e60a	[999, 999]	$flag = false\n        def maybe_redefine\n          if $flag\n           
+0c73d03517bb4f3119910e3eaaaec7c7	"[]\\n"	ENV["SPAWN_T2"] = "parent"\n            r, w = IO.pipe\n            P
+0c83f321648f3f64690fb94178ec7665	"/home/user/monoruby/monoruby"	Dir.pwd
+0cc1878ea30baafb813863f3ce8b91b6	[90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90]	def real(a, *r) = yield(a + r.sum)\n        def g(...) = real(...)\n     
+0cebe4bdba51d916fafb772a61e36f04	42	x = 42\n            binding.local_variable_get(:x)\n            
+0cf52da8cfa0528dc273b8d510378aad	["not_myobj", false]	class MyObj\n          def !\n            "not_myobj"\n          end\n     
+0d15e11cd1a3b81c19b4c71f397879fd	nil	("hello" =~ /z/)
+0d6a2a0f9abdc99f9a6612d7f1a2514a	false	"a\\xC3z".dup.force_encoding("UTF-8").reverse.valid_encoding?
+0d89c6fc6073b1e6bf891b9d457e2158	"'NsX::Cx.boom'"	module NsX\n          class Cx\n            def self.boom; raise "x"; end
+0da04c155a74c747b1e587c007959b4f	"ab20000c"	%Q(ab#{100*200}c#$1)
+0db7d0ff7e80a2bde5e73776a8d53b78	"missing keyword: :x"	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; msg { [1]
+0dc4877a5ca28ef137cb81360730e256	[]	x = *nil; x
+0dd2c5ad94fe7055deaddc495685e3cd	[[0, 7, 0, nil], [0, 2, 3, 4], [0, 7, :k, nil], [0, 2], [-1, 0], [1, 7, 1, nil], [1, 2, 3, 4], [1, 7, :k, nil], [1, 2], [-1, 1], [2, 7, 2, nil], [2, 2, 3, 4], [2, 7, :k, nil], [2, 2], [-1, 2], [3, 7, 3, nil], [3, 2, 3, 4], [3, 7, :k, nil], [3, 2], [-1, 3], [4, 7, 4, nil], [4, 2, 3, 4], [4, 7, :k, nil], [4, 2], [-1, 4], [5, 7, 5, nil], [5, 2, 3, 4], [5, 7, :k, nil], [5, 2], [-1, 5], [6, 7, 6, nil], [6, 2, 3, 4], [6, 7, :k, nil], [6, 2], [-1, 6], [7, 7, 7, nil], [7, 2, 3, 4], [7, 7, :k, nil], [7, 2], [-1, 7], [8, 7, 8, nil], [8, 2, 3, 4], [8, 7, :k, nil], [8, 2], [-1, 8], [9, 7, 9, nil], [9, 2, 3, 4], [9, 7, :k, nil], [9, 2], [-1, 9], [10, 7, 10, nil], [10, 2, 3, 4], [10, 7, :k, nil], [10, 2], [-1, 10], [11, 7, 11, nil], [11, 2, 3, 4], [11, 7, :k, nil], [11, 2], [-1, 11], [12, 7, 12, nil], [12, 2, 3, 4], [12, 7, :k, nil], [12, 2], [-1, 12], [13, 7, 13, nil], [13, 2, 3, 4], [13, 7, :k, nil], [13, 2], [-1, 13], [14, 7, 14, nil], [14, 2, 3, 4], [14, 7, :k, nil], [14, 2], [-1, 14], [15, 7, 15, nil], [15, 2, 3, 4], [15, 7, :k, nil], [15, 2], [-1, 15], [16, 7, 16, nil], [16, 2, 3, 4], [16, 7, :k, nil], [16, 2], [-1, 16], [17, 7, 17, nil], [17, 2, 3, 4], [17, 7, :k, nil], [17, 2], [-1, 17], [18, 7, 18, nil], [18, 2, 3, 4], [18, 7, :k, nil], [18, 2], [-1, 18], [19, 7, 19, nil], [19, 2, 3, 4], [19, 7, :k, nil], [19, 2], [-1, 19], [20, 7, 20, nil], [20, 2, 3, 4], [20, 7, :k, nil], [20, 2], [-1, 20], [21, 7, 21, nil], [21, 2, 3, 4], [21, 7, :k, nil], [21, 2], [-1, 21], [22, 7, 22, nil], [22, 2, 3, 4], [22, 7, :k, nil], [22, 2], [-1, 22], [23, 7, 23, nil], [23, 2, 3, 4], [23, 7, :k, nil], [23, 2], [-1, 23], [24, 7, 24, nil], [24, 2, 3, 4], [24, 7, :k, nil], [24, 2], [-1, 24], [25, 7, 25, nil], [25, 2, 3, 4], [25, 7, :k, nil], [25, 2], [-1, 25], [26, 7, 26, nil], [26, 2, 3, 4], [26, 7, :k, nil], [26, 2], [-1, 26], [27, 7, 27, nil], [27, 2, 3, 4], [27, 7, :k, nil], [27, 2], [-1, 27], [28, 7, 28, nil], [28, 2, 3, 4], [28, 7, :k, nil], [28, 2], [-1, 28], [29, 7, 29, nil], [29, 2, 3, 4], [29, 7, :k, nil], [29, 2], [-1, 29]]	class Mix\n          attr_reader :v\n          def initialize(x, y = 7, k
+0dffb3fd89671761c7403c1e8342fe10	"ıstanbul"	"ISTANBUL".downcase(:turkic)
+0e25ec2f0a510af53301f8cc220f8ed1	3	def false.baz; 3; end\n            false.baz\n            
+0e277bae0cfb8d9381736b25326ac6fe	[[:a], nil]	def m\n              /(?<a>foo)/ =~ "nope"\n              [local_vari
+0e56d42fa329cec66eaa8a31dadafef0	[true, true]	def m; proc{|x| x}; end; p = m; [p.dup.eql?(p), p.dup.hash == p.hash]
+0e58e78424730044c7b8bdc310bb26e6	["Fri Dec 12 ", "Fri Dec 12 ", "Fri", "Dec", "12", 4, ["Fri", "Dec", "12"], ["Fri Dec 12 ", "Dec"], "Fri Dec 12 ", true, 11, "", "1975 14:39", 11, 0, "Fri"]	require "strscan"\n        s = StringScanner.new("Fri Dec 12 1975 14:39"
+0ed19825320ad4f01be8637520de3fe5	[[0, 0, 0], [0, 1, 0], [1, 0, 0], [1, 1, 0], [2, 0, 0], [2, 1, 0]]	res = []\n        3.times do |i|\n          2.times do |j|\n            1.
+0ed9e8d09d16c423c6e622570359536f	[["MONORUBY_ENV_TEST_ASSOC", "yes"], nil]	ENV["MONORUBY_ENV_TEST_ASSOC"] = "yes"\n            r = ENV.assoc("M
+0ee21d2dc9f1c2268555d29eb775b9a4	["ArgumentError", "boom"]	begin\n              begin\n                raise ArgumentError, "boo
+0f235cb6e6c1d96487a2826dadf1a76d	[[1, 2]]	class C\n          def f(a:, b:)\n            $res << [a, b]\n          en
+0f40318ef8ffee7df7431a21e6eeff21	1	class Zero\n              def >(other); false; end\n              def
+0f4d5a85fb5848c40e2b24d4faf4eab2	[{"k0" => 0, "lit" => 1}, [true, true], 0, 0, 0, {"k1" => 1, "lit" => 1}, [true, true], 1, 1, 0, {"k0" => 2, "lit" => 1}, [true, true], 2, 2, 0, {"k1" => 3, "lit" => 1}, [true, true], 3, 3, 0, {"k0" => 4, "lit" => 1}, [true, true], 4, 4, 0, {"k1" => 5, "lit" => 1}, [true, true], 5, 5, 0, {"k0" => 6, "lit" => 1}, [true, true], 6, 6, 0, {"k1" => 7, "lit" => 1}, [true, true], 7, 7, 0, {"k0" => 8, "lit" => 1}, [true, true], 8, 8, 0, {"k1" => 9, "lit" => 1}, [true, true], 9, 9, 0, {"k0" => 10, "lit" => 1}, [true, true], 10, 10, 0, {"k1" => 11, "lit" => 1}, [true, true], 11, 11, 0, {"k0" => 12, "lit" => 1}, [true, true], 12, 12, 0, {"k1" => 13, "lit" => 1}, [true, true], 13, 13, 0, {"k0" => 14, "lit" => 1}, [true, true], 14, 14, 0, {"k1" => 15, "lit" => 1}, [true, true], 15, 15, 0, {"k0" => 16, "lit" => 1}, [true, true], 16, 16, 0, {"k1" => 17, "lit" => 1}, [true, true], 17, 17, 0, {"k0" => 18, "lit" => 1}, [true, true], 18, 18, 0, {"k1" => 19, "lit" => 1}, [true, true], 19, 19, 0]	r = []\n        20.times do |i|\n            s = "k#{i % 2}"\n            
+0f570f4aaf2cd1df8cdf9b539e769104	"[package]\\nname = \\"monoruby\\"\\nversion = \\"0.3.0\\"\\nauthors = [\\"monochrome <sisshiki@mac.com>\\"]\\ndescription = \\"another CRuby implementation with JIT compiler.\\"\\nrepository = \\"https://github.com/sisshiki1969/monoruby\\"\\nedition = \\"2024\\"\\nlicense = \\"MIT OR Apache-2.0\\"\\ndefault-run = \\"monoruby\\"\\nbuild = \\"build.rs\\"\\n\\n[[bin]]\\nname = \\"monoruby\\"\\n\\n[[bin]]\\nname = \\"irm\\"\\n\\n# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html\\n\\n[features]\\ndefault = []\\ndump-bc = []\\ndump-traceir = []\\nemit-asm = [\\"dump-bc\\", \\"dump-traceir\\", \\"jit-log\\"]\\nemit-bc = [\\"dump-bc\\", \\"dump-traceir\\"]\\njit-log = []\\njit-debug = [\\"dump-traceir\\"]\\ndeopt = [\\"jit-log\\", \\"dump-bc\\", \\"dump-traceir\\"]\\ngc-log = []\\ngc-debug = []\\ngc-stress = []\\n# After every minor GC, independently re-mark the whole live graph from\\n# the roots. If the minor collection freed anything still reachable\\n# (a missed write barrier / remembered-set entry), the traversal hits a\\n# freed slot and the is_live assertion in RValue::mark fires. Debug-only;\\n# very slow. See doc/generational_gc_plan.md.\\ngc-verify = []\\n# Force PHYS_XMM_POOL down to 2 so almost every Float-resident slot\\n# becomes a spilled VirtFPReg. Used in CI to stress-test the spill\\n# code paths (LoadSpill / StoreSpill, spill-aware AsmInst lowerings,\\n# 16-byte spill-region alignment).\\nstress-spill-pool = []\\nprofile = [\\"dump-bc\\", \\"dump-traceir\\"]\\nperf = []\\n# §5 Layer-② extraction: stage-1 *placement shadow*. Records, in emission order,\\n# every physical FP placement that ③ commits (one entry per `PhysMap::resolve`),\\n# producing a per-`jit_compile` fingerprint of the FPReg→FPRegLoc lowering. The\\n# P2/P3 separation (① virtual-reg assignment vs ② physical allocation) is gated\\n# on this fingerprint staying byte-identical between the baseline greedy\\n# allocator and the separated ②. Default-off; zero cost in shipping builds.\\nshadow-placement = []\\n# §5 Layer-② extraction, step P2: relocate the physical FP-placement *policy*\\n# (pool-vs-spill) out of ③ (`PhysMap::resolve`) into an explicit ②\\n# (`codegen::phys_alloc`) table-backed function, leaving ③ policy-free (look up\\n# the virtual fpr's physical slot, apply the frame base). Byte-identical to the\\n# formula it replaces (verified via `shadow-placement` digests); the seam where\\n# P4's loop-aware allocator swaps in. Default-off until the M1 A/B gate clears.\\nphys-table = []\\n# §5 §27.3 Stage-2: the loop-aware FP allocation policy. ① (the back-edge\\n# fixpoint) records the loop-carried float set `L`; the phase-1 spill-victim\\n# policy then keeps `L`'s `Sf` caches resident (a fresh value spills instead of\\n# evicting a loop-carried float), cutting in-loop reloads. NON-byte-identical by\\n# design (§26): it changes placement / removes back-edge moves, so the\\n# `shadow-placement` digest becomes a *delta* meter, not an equality check, and\\n# the gate is M1 perf A/B (§27.3-2c). Default-off until that gate clears.\\nphys-loop-aware = []\\nemit-cfg = [\\"dump-bc\\", \\"dump-traceir\\"]\\ndump-require = []\\n\\n[dependencies]\\nclap = { version = \\"4.6.1\\", features = [\\"derive\\"] }\\nrustyline = \\"18.0.0\\"\\npaste = \\"1.0.15\\"\\nmonoasm_macro = { git = \\"https://github.com/sisshiki1969/monoasm.git\\", branch = \\"aarch\\" }\\nmonoasm = { git = \\"https://github.com/sisshiki1969/monoasm.git\\", branch = \\"aarch\\" }\\nonigmo-regex = { git = \\"https://github.com/sisshiki1969/onigmo-regex.git\\" }\\nruby-prism = { git = \\"https://github.com/sisshiki1969/prism.git\\", branch = \\"monoruby-vendored\\" }\\nmonoruby-attr = { path = \\"../monoruby_attr\\" }\\nrubymap = { path = \\"../rubymap\\" }\\nindexmap = \\"2.14.0\\"\\nnum = \\"0.4.3\\"\\nconsole = \\"0.15.11\\"\\nfxhash = \\"0.2.1\\"\\ntempfile = \\"3.27.0\\"\\ndtoa = \\"1.0.11\\"\\nchrono = \\"0.4.44\\"\\nencoding_rs = \\"0.8\\"\\nsmallvec = { git = \\"https://github.com/sisshiki1969/rust-smallvec.git\\", features = [\\n  \\"const_generics\\",\\n] }\\nescape_string = \\"0.1.2\\"\\nhex = \\"0.4.3\\"\\nrand = \\"0.9.1\\"\\nregex = \\"1.12.3\\"\\nlibc = \\"0.2.186\\"\\ngetrandom = \\"0.3.3\\"\\nrand_mt = { version = \\"5.0.0\\", features = [\\"rand-traits\\"] }\\nbitvec = \\"1.0.1\\"\\nansi_term = \\"0.12.1\\"\\ndirs = \\"6.0.0\\"\\nhtml-escape = \\"0.2.13\\"\\nunicode-general-category = \\"1.0.0\\"\\nunicode-normalization = \\"0.1.25\\"\\nunicode-segmentation = \\"1.13.2\\"\\nsignal-hook = \\"0.4.4\\"\\ndivrem = \\"1.0.0\\"\\nlibffi = \\"5.1.0\\"\\n# Digest builtins (`builtins/digest.rs`) — used on every platform, so these\\n# must stay in the cross-platform `[dependencies]`, not a target block.\\nmd-5 = \\"0.10\\"\\nsha1 = \\"0.10\\"\\nsha2 = \\"0.10\\"\\n\\n# macOS aarch64 (Apple Silicon): the bundled libffi-sys 4.1.0 fails to\\n# link `_ffi_prep_cif_machdep` (the arm64 assembly piece doesn't build\\n# into the static archive), so fall back to Homebrew's system libffi via\\n# pkg-config. Linux / x86_64 darwin keep the bundled build, matching the\\n# CI configuration. Install with `brew install libffi pkg-config`.\\n[target.'cfg(all(target_os = \\"macos\\", target_arch = \\"aarch64\\"))'.dependencies]\\nlibffi = { version = \\"5.1.0\\", features = [\\"system\\"] }\\n\\n[build-dependencies]\\ndirs = \\"6.0.0\\"\\n"	f = File.open("Cargo.toml", "r")\n            f.read\n        
+0f63e6832e4ddb8ca1642e64e5c239a2	[true, true]	class Foo\n          def baz; end\n        end\n        um = Foo.instance_
+0f6ac161a1e3d9ede594b15d92879766	3.1	class Foo; def to_int; 1; end; end\n            3.14159.round(Foo.ne
+0f6f971d89e499d4f67b8eb421c0b932	31	class A\n          def foo(x)\n            x + 1\n          end\n        en
+0f7854c323890232e4b92d7171cfc4c8	5310	r = []\n            60.times do |i|\n              x = i\n            
+0f944c152cbd15e6eb219e28bc9f82d1	"#<data M amount=42, unit=\\"km\\">"	M = Data.define(:amount, :unit)\nM.new(42, "km").inspect
+0faacf92f84e04308db3213154815213	true	S = Struct.new(:a, :b)\n            \n\n            s = S.new(10, 20)\n
+0fbdbe22cfcc0c81363949cd54e034ef	[nil, nil, nil]	"foo" =~ /X/\n            [$`, $&, $']\n            
+0fe6569090f53e311e80012169b09689	[1, 2]	def f(a:, b:)\n          [a, b]\n        end\n        \n\n        a = 1\n    
+0ff7ef46c41dd9c5accf0621e8f0e5d2	["X+X*i", "((Y)+(Y)*i)"]	class CplxSub < Numeric\n              def to_s; "X"; end\n          
+0ff92d5aa000cb122d99051cde595719	-1	class MyNum\n              def initialize(n); @n = n; end\n          
+101e019fce19945a9a16a79ca6e6a4bc	[:PUB_CONST]	c = Class.new\n            c.const_set(:PUB_CONST, 1)\n            c.
+102cab6113e26cab16f8e63eee984a60	"missing keyword: :x"	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; class KwO
+10374c999ac01b145c6c3f7ff5211539	["no implicit conversion to float from string", "no implicit conversion to float from false", "no implicit conversion to float from true", "can't set a timeout if non_block is enabled", "can't convert Symbol into Float", "no implicit conversion to float from string", "can't convert TimeoutBad to Float (TimeoutBad#to_f gives String)", 1, 2]	q = Thread::Queue.new\n            r = []\n            begin; q.pop(t
+103cd657f42cfe9d1978ddb2e3c14226	[[1, [0, 0], [0, 0]], [2, [0, 0], [1, 2]], [3, [0, 0], [2, 4]], [4, [0, 0], [3, 6]], [5, [0, 0], [4, 8]], [6, [0, 0], [5, 10]], [7, [0, 0], [6, 12]], [8, [0, 0], [7, 14]], [9, [0, 0], [8, 16]], [10, [0, 0], [9, 18]], [11, [0, 0], [10, 20]], [12, [0, 0], [11, 22]], [13, [0, 0], [12, 24]], [14, [0, 0], [13, 26]], [15, [0, 0], [14, 28]], [16, [0, 0], [15, 30]], [17, [0, 0], [16, 32]], [18, [0, 0], [17, 34]], [19, [0, 0], [18, 36]], [20, [0, 0], [19, 38]], [21, [0, 0], [20, 40]], [22, [0, 0], [21, 42]], [23, [0, 0], [22, 44]], [24, [0, 0], [23, 46]], [25, [0, 0], [24, 48]], [26, [0, 0], [25, 50]], [27, [0, 0], [26, 52]], [28, [0, 0], [27, 54]], [29, [0, 0], [28, 56]], [30, [0, 0], [29, 58]]]	def probe(h)\n              return [h.size, h.to_a.first, h.to_a.las
+10406c07428dfa0886a1bab13dabf6f4	"comparison of String with 7 failed"	begin; "a" < 7; rescue ArgumentError => e; e.message; end
+1044a6ff811467108220b77d16c0df20	nil	GC.start
+10630cb5c02e6154a16815f1db4afaa8	[[:get, []], [2]]	class C\n                 def initialize; @log = []; end\n                 def []=
+10763a10e14efbbc495d2a2b48c4e475	[3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17, 18, 18, 19, 19, 20, 20, 21, 21, 22, 22]	class Foo\n              @@foo = 1\n              def foo\n           
+10825d3f920402467ed0762277926bd9	[1, 2]	def method_with_block\n          Fiber.new {\n            [1,2].each { |x
+10992a62d5e09476c2e0a3c43fd20025	[true, [:a, :b]]	S = Struct.new(:a, :b, keyword_init: true)\n            \n\n          
+10ac4da278feac457c66f69e10a1b0ec	["X1", "A", "X2"]	# super と prepend の組み合わせの例\n            module X\n              def f
+10acb8333f48a4e55ac8abb685753d0c	[false, [1, 2], Array]	class MyArr < Array; def to_a; $flag = true; super; end; end\n        $f
+10bf6df051bcd35070adae7d4ebbbb02	[:initialize, :initialize_copy, :respond_to_missing?]	class DefLifecycle\n              def initialize; end\n              
+10c958573363b28c1ec4edd19f99e265	[2, 2, 3, :not_leaked, [:a], [:a, :b]]	def m\n              binding\n            end\n            bind1 = m\n 
+111968a050c98ee7659b9300078a5a27	"ModuleSpecsP1::Inner"	module ModuleSpecsP1; end\n            module ModuleSpecsP2; end\n   
+11312d061244bf1e2c4a78928f37883c	5	class C\n            end\n            def C.f; 5; end\n        \n\n     
+1141e657fb40cce3237407c1f6ec57f1	42	o = Object.new\n            def o.to_str = "42"\n            def o.to
+1163f0f0f85a4d8121a577678e218640	[3]	module M\n              def a; 1; end\n              def b; 2; end\n  
+1164b6b299a8e58d705998fdc148adbf	1	def f(a = ($x = 1)); 1; end\n        f\n        $x\n        
+118eb5e68bd673de068374bd75347ed3	:OVERRIDDEN	class Float; def %(o); :OVERRIDDEN; end; end; 3.0 % 4.0
+11bda11ec7cbf263e9f52074954288f6	"../"	class MyPath\n          def to_path\n            "../"\n          end\n    
+11cc75ade577235c4ddea752c1daddb7	[[0, 4, 8]]	def cljc_leaf\n          ls = caller(0, 3).map { |s| s[/:(\\d+):/, 1].to_
+11d8f66614d6ef25a5a6c863d202cdb1	14	f = ->{ it * 2 }; f.call(7)
+11e1e88fc746e03236aac26feef4e781	[".", "..", "a", "b"]	base = "/tmp/monoruby_dir_foreach_#{Process.pid}_#{rand(100000)}"\n 
+11ef7cfb28ed3fee72077d2729417664	nil	1.5 <=> 'a'
+12093eb7709b2f29a8934569c6ec1675	3	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \ns.siz
+121e42097ec2d1d15351f0bc5ecc27d5	5.955087954701154e+22	r = 0.0\n        for i in 0..50\n          f = i * 1.1; g = i * 0.9; h = 
+123a397b90ab67e4ccd83ca59fc29237	2	def f(a = ($x = 2)); nil; end\n        f\n        $x\n        
+1244f1881c878c3dc6d1b1caed0b9f68	:jit	def base2; yield :s; end\n        def relay2; base2 { |s| yield(s) }; en
+12ac69d0e3d7829ff39cbbddc61b3277	["elefant", 4]	S = Struct.new(:name, :legs, keyword_init: true)\n            \n\n    
+12b1a598797e50c460f3d7646ca37481	[:y]	class B\n              def x; end\n            end\n            class 
+12cd2297f4d6ac25a476739a253c9292	["RUBZ", "RUBZ", 7, 8, false, true, 7]	class C\n              def succ(s); s.succ; end\n              def po
+12f9391c89c11935d8348e594acea735	[[10, 2, 3]]	class C\n          def f(a, b, c)\n            $res << [a, b, c]\n        
+130d9d1858257d1d752139ea21b67095	3240	def outer(n) = ->{ ->{ n } }\n            (1..80).map { |i| outer(i)
+131328b07507899394604b346dd7ea4c	{"A" => 65, "B" => 66}	hash = { "a" => 97, "b" => 98 }\n        hash.to_h {|key, value| [key.up
+1317901b03e325cdcbdb9c43a59b5785	[[[167, 65, 166, 110], "Big5"], [167, 65, 166, 110]]	require "tmpdir"\n        path = File.join(Dir.tmpdir, "mrb_bytes_magic_
+13323a8d5c81e35bcd4ad9f525e2542e	[true, 2, 9, 0]	h = Signal.list\n            [h.is_a?(Hash), h["INT"], h["KILL"], h[
+138e62ffcfc71d0338a5247a729e81fb	[true, true]	[$:.equal?($LOAD_PATH), $:.equal?($-I)]\n        
+13ad4da7c9b738e48c91a58c2101c684	[false, true, false, false, true]	r, w = IO.pipe\n            res = [$stdout.sync, $stderr.sync, $stdi
+13c09eba52c55ecec3e82b015d3b4f59	[true, true, true]	C = Class.new\n            D = Class.new(C)\n            \n[C.new.clas
+13e499657f84b7c697664ba59ec4b9f4	[true, false, ArgumentError, false, true]	(o=Object.new; a=o.clone(freeze: true).frozen?; b=(x="s".freeze; x.clone(freeze:
+13edcd86f2bff4fcc4b3b29c5635e9f9	"RUBZ"	succ = proc { |s| s.succ }; upcase = proc { |s| s.upcase }; (succ << upcase).cal
+1408dc4e7fb001b397ca65a58a5bb60b	["XXX", "secret"]	class Foo\n          def initialize data\n            @key = data\n       
+142812ded02a16064ed8507c23bc2193	[true, [true, "Addrinfo", "127.0.0.1"]]	require "socket"\n            require "tmpdir"\n            path = Fi
+1438ba7f43337b0f331290b81cfaafb1	true	Random.srand(42)\n        a = Random.random_number\n        b = Random.ra
+144e3b4e925fa2f232d7787b1b6dc480	[:from_block]	r = []; Enumerator.new { |y| r << y.yield(1) }.each { |v| :from_block }; r
+1459ff5827314d509c8b8a521c715151	"numbered parameter '_1' is not a local variable"	-> { _1; (binding.local_variable_defined?(:_1) rescue $!.message) }.call("x")
+145f017d34cec052f0bac339e5f11695	:OVERRIDDEN	class Symbol; def ===(o); :OVERRIDDEN; end; end; :a === :b
+14c3f9744e9557b5dfbd2e2849630a21	[false, true, [:amount, :unit]]	M = Data.define(:amount, :unit)\n\n            sub = Class.new(Data)\n            [
+1539e0e610bc4a455a62e283937c5969	"Dave New York #<struct S name=\\"Dave\\", address=\\"New York\\"> #<struct S name=\\"Dave\\", address=\\"New York\\">"	class S < Struct.new(:name, :address)\n        end\n        \n\n        s =
+157fc470dccd4d7e20ac890dbe941be3	[true, false, true, false]	File.open("Cargo.toml") do |f|\n              before = f.close_on_ex
+15846d0b70eb94af22106344f0341f4f	123	class Foo < BasicObject\n              C = 123\n            end\n     
+158f1530956a75c00dbc0076c4e80d1b	[0, 3]	$lines = []\n            Class.new do\n              def self.method_
+15954591a595c7f736cfc0b2388da468	5	l = lambda { 5 }; lambda(&l).call
+15b0c5d17e501316016f7258c11109a6	["in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out", "in", "in", "out"]	private_matcher = Class.new do\n          def ===(x); x == :hit; end\n   
+15d4899fced88e7c695e2c34db781259	100	class C\n              @@x ||= 100\n              @@x\n            end
+15da316533ccb78f7d7f0508db3a1421	[789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789]	def g(a, b, c) = a * 100 + b * 10 + c\n        def f(...) = g(7, 8, 9, .
+15f147302ae38efd304fc2637a1918d3	["Foo", 1, 2]	class Foo\n              attr_accessor :x, :y\n              def init
+15f8efdf56e50c197d2957085d4fc34f	[true, true, -65536, -2, [1, 2], true, :ts_err, :rtp_err, :frozen_err, true, true, true, true, true, true, true]	nan = 0.0 / 0.0\n            inf = 1.0 / 0.0\n            to_ary_nil 
+16306cca3195a660ca2a70f2fe2de20c	:OVERRIDDEN	class Integer; def <=(o); :OVERRIDDEN; end; end; 3 <= 4
+16367eeef19311ae409181e79f860e76	[3, 12, true, 8, 2, :OVERRIDDEN]	class Float; def +(o); :OVERRIDDEN; end; end\n            # Integer 
+16466a31d783d5117c875050d939771e	["#<data M2 amount=42, unit=#<data M2:...>>", "#<data M2 amount=1, unit=#<data M2 amount=2, unit=\\"m\\">>"]	M2 = Data.define(:amount, :unit)\n            a = M2.allocate\n      
+1650543d70d47b42c2a9fa577c90aea9	[4, 8, 111, 58, 11, 79, 98, 106, 101, 99, 116, 0]	o = Object.new\n            o.singleton_class\n            Marshal.du
+1665e03723dec495d803674632a3c3a7	["<top (required)>", "block in <top (required)>", true, true, true, 1, true]	require 'tmpdir'\n            dir = Dir.mktmpdir\n            r = []\n
+16aa82c76713e1e7863b7987cb43e537	["inherited:B", "inherited:C"]	$res = []\n        class A\n          def self.inherited(subclass)\n      
+16b4d02ee2a3414594794b68432f0897	false	(1 << 100) < Float::NAN
+16b9808739df0dce199ac4196aff3fe7	[4, 8, 125, 0, 105, 0]	Marshal.dump(Hash.new(0)).bytes
+16c009e8564d192627f84f7a8b1ce3d4	"hello....."	class MyInt\n              def to_int\n                10\n           
+16c736a6aa97b55d505de465e21d6925	true	class Foo\n              def initialize\n                @a = 1\n     
+16cfa45d91b4ff2d11a52fd55ed0daa0	[1, 2, 3]	->((a, (b, c))) { [a, b, c] }.call([1, [2, 3]])
+16d57e634ac063bbb0008d44dc0779c9	["123 is not a symbol nor a string", "KeyError", "no implicit conversion of Object into Integer", "no implicit conversion of Integer into String", "string contains null byte", "false"]	q = Thread::Queue.new\n            th = Thread.new { q.pop }\n       
+16ddb08d866605796e37d618c1e0275c	false	File.directory?("readme.md")
+16f5223d8b1faedaff984a44eb22a38e	["hi", MarshalUC]	class MarshalUC < String; end\n            # CRuby-produced bytes fo
+16f615066fcccc6076e47f3c46b905fc	[ArgumentError, TypeError]	h = { a: 1 }\n            [\n              (begin; h.to_h { |k, v| [1
+1734b6bc40227ffa8a335598f1a5f0f2	"[package]\\nname = "	f = File.open("Cargo.toml", "r")\n            f.read(17)\n        
+17360388c4d5caa52af6a98337ba8733	[:thread, :main]	order = []\n            t = Thread.new { order << :thread }\n        
+17505ff21cc36bb3fdb48bc39ea9ddaa	"ff"	class HasToInt; def to_int; 255; end; end\n            sprintf("%x",
+175d3bf3dc8f6885e9ac87e2c9486453	[6765, 1999000, 6765, 1999000]	def fib(n) = n < 2 ? n : fib(n-1) + fib(n-2)\n            def loopy(
+1763e2c9bc0720402e213cbf885dd569	[5, 5, nil, nil, 5, 5, IOError]	(f="/tmp/mono_sz_#{Process.pid}"; File.write(f,"12345"); io=File.open(f); o=Obje
+176a18e075a2502220b53b0982b7de35	[:singleton_method_added, :foo, :bar]	$res = []\n            class C\n              def self.singleton_meth
+176ade062a39fa54620f862c109af764	"US-ASCII"	"abc".dup.force_encoding("US-ASCII").tr("ab", "xy").encoding.to_s
+177267179432c2c7c88151677405f37d	[true, "Process::Status", 0]	pid = fork { exit 0 }\n            ret, status = Process.wait2(pid)\n
+177aa65b5849b4e8af68b7b3b7db3c28	"01AB456789"	path = "/tmp/monoruby_test_binwrite_off_#{Process.pid}_#{rand(10000
+17ae0b2d4d216a1477c7c1095d2b4f96	[true, "EvalDefIM", true, true, :ce, :ie, true]	res = []\n        class EvalDefIM\n          def make\n            eval "d
+17b4dcf867d28ec5b1dd631ad5583e17	{}	/(?<f>x)/.match("x").deconstruct_keys(['s', :f])
+17ead718ac7923b2a550775f94df059c	3	class A < Array\n        end\n        \n\n        a = A.new\n        a << 10
+181190488544c9b5c85380245eaff93b	["B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 9|[]"]	class A\n          def m(a, *r) = "A #{a}|#{r.inspect}"\n        end\n    
+1821c10c6ad04de6330183a77e1e0216	["Binding", 41, 42, 41]	x = 41\n            b = binding\n            b2 = b.dup\n            b
+182caa69fa07777b5c852ab6d6cd523b	[:@b]	class Foo\n              def initialize\n                @a = 1\n     
+185001d9a1904b3f91e65a1932e2bf0b	[11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11]	def g(a) = yield(a * 2)\n        def f(...) = g(...)\n        \n\n        $
+186a15eac97b7392435d31cc9d7e59de	70	class Coercible\n              def to_proc\n                proc { |x
+18a7283ed1dcb3c87a0a51c2be6ebeca	[111, 111]	def add_fold; 5 + 3; end\n        def add_dyn(a, b); a + b; end\n        
+18b3f31c36b0241cca4cd3e50f3ef25a	"hi world"	class Foo\n              def hello(x); "hi #{x}"; end\n            en
+18ccddd91be7d564a96e8bbe8f35689c	true	[Process.ppid, Process.uid, Process.gid, Process.egid].all? { |v| v.is_a?(Intege
+18e53719759492ee280d0bf682120775	"pong\\n"	require "socket"\n            s = TCPServer.new("127.0.0.1", 0)\n    
+18ee9f38f586cbb66857420f64f8aa85	[1, true, Errno::EINVAL, IOError, Errno::EINVAL, Errno::EINVAL, "xxx"]	(f="/tmp/mono_ut_#{Process.pid}"; File.write(f,"x"*10); n=File.utime(nil, nil, f
+18f089886e8d365939940fbda5792632	:OVERRIDDEN	class NilClass; def ==(o); :OVERRIDDEN; end; end; nil == nil
+191fb9b97f7511e2b57d567935998d83	"para\\n\\n"	r, w = IO.pipe\n            t = Thread.new { r.gets("") }\n          
+1923cb14f8333825e8479ee65e7f51ed	[:private, true, "/home/user/monoruby/monoruby/c"]	# `c.rb` defines `Foo::Bar = 20`. Register it as an autoload\n        # 
+194842310fa575c044d0e1a66f34f596	"missing keyword: :amount"	M = Data.define(:amount, :unit)\nbegin; M.new(unit: "km"); rescue ArgumentError =
+195631ef0c05c2341449757ab6263641	[15, 200, 9]	class M\n          def initialize; @h = {}; end\n          def [](*k); @h
+195febb8b072b8a045586f323248b00b	false	class Integer; alias __orig :>=; def >=(o); __orig(o); end; end; 3 >= 4
+196225a058238b3d7995c0419e8bf4b6	"hello"	path = "/tmp/monoruby_test_trunc_#{Process.pid}_#{rand(100000)}"\n  
+19645656088373f712d8fc5a67de8012	["a", {b: "b", c: "c"}, nil]	T = Struct.new(:a, :b, :c)\n            \n\n            s = T.new("a",
+198846091a6d514d5ddbc84033648662	[false, true]	["x".freeze.dup.frozen?, "x".freeze.clone.frozen?]
+1999cd0bdd0e91608867896ca0c71619	[true, true]	n = Process.maxgroups\n            begin\n              Process.maxgr
+19a12989023b1f415b1be2cfc30f3a90	[true, nil]	require "stringio"\n\n            io = StringIO.new("hi")\n            [io.external
+19c3117422e24db6dd0e39d531d1f3f5	[true, true, true, false, false]	class C\n            include Comparable\n            attr_accessor :x\n 
+19f37cc8342f248bcc7ea2bff3525fb8	true	def f; caller_locations(1, 1)[0].lineno.is_a?(Integer); end\n       
+1a0f14b93dbac347cd85f619ff9eb079	1	count = Module.constants.size\n            module ModConstSpec1; end
+1a3da0f2d5820c3da4a22ebe3d606273	[nil, 0]	h = Hash.new(99)\n            h[:a] = 1\n            r = h.except(:a)
+1a561eac221bbb35c7021303bd9f4066	["DEFAULT", true, nil, "SYSTEM_DEFAULT"]	Signal.trap("USR2", "DEFAULT")\n            h = ->{}\n            a =
+1a67742c8115d3d19f33ca885e738ec5	[4, false, :from_block, :lam, 99]	res = []\n        class Y\n          def self.define_deep(&blk)\n         
+1a6b5ca69ba4fe9e17883de574973501	[true, true, false, false, true, true, false, false, true, true, false, true, true, false, false, true, false, false, true, false, true, true]	module A\n          def method1; end\n          private def private_metho
+1a6d975f97f63c92cd34a477308f7ab3	[nil, nil, nil, nil, nil]	"abc" =~ /(b)/\n            $~ = nil\n            [$~, $&, $', $`, $1
+1a7543d5d571e85a19587287f59b0895	"UTF-8"	__ENCODING__.name
+1a7c84e293314c272a878feddea4f651	["hel", "l", "o"]	$/ = "l"; r = "hello".lines; $/ = "\\n"; r
+1ae38b569587dc7e815a7c69503b881c	true	module MOx; end\n            o = Object.new\n            o.extend(MOx
+1ae742d4bea8541ce1070f62d646bf08	[10, 20]	class A\n          X = 10\n        end\n        class B\n          X = 20\n 
+1afceb56e5db6cb2bda8b45085df354a	[4, 5]	r = []\n        10.times { |i| r << i if (i == 4)..(i == 5) }\n        r\n
+1b00cea00812640df424fa48eaa39320	5	def f(k: ($x = 5)); true; end\n        f\n        $x\n        
+1b0c4b3fc3652f480467aee5b851c3c0	"nil"	m = Module.new\n        defined?(m::NOPE).inspect\n        
+1b0f62c23aa971c48a14dc18be913e2c	false	(0x8000_0000_0000_0000 + 39) <= (0x8000_0000_0000_0000 + 39 + 0.0)
+1b3392078081351841956733d919bed4	[true, false, true, true, false]	class S\n              S1 = 100\n            end\n            class C 
+1b3c2125dfb6cec5b1d5b8c703351613	420000	def e\n          10.times do\n            $x += yield\n          end\n     
+1b4f0e33ced070869e7b97b19b0af7ee	"Xhello"	s = "hello"; s.bytesplice(0..-7, "X"); s
+1b5020619890769300a9b8ddb16684a2	[nil, nil]	"abc" =~ /b/; [defined?($+), $+]
+1b63487846c78af5251d8377dfadab0f	610148320.4118465	a = 7.9\n            for i in 0..15\n              a = -(1.1 * a + 2 
+1b67f85d874f2c3b529059abedf36dec	Array	class C < Array; end\nC[3,1,2].rotate.class
+1b6bd41190fe078b389a2449e6273564	[nil, nil, nil, nil]	h = { a: 1 }\n            if h.respond_to?(:__key_at)\n              
+1b7717a9cf4f8f0c5886c8689776237c	Object	Class.new.superclass
+1b7986839febca8cbaa8843e662394d2	"M2"	module M1\n          def who; "M1"; end\n        end\n        module M2\n  
+1ba3ace55b0515468a8a2f6df266c995	2	Rational(0.5).denominator
+1bc0bb99c397269718c4eae33c79382e	[7, 14, "abc\\ndef", "binary\\x00content", "abc", "def"]	base = "/tmp/monoruby_io_write_test_#{Process.pid}_#{rand(100000)}"
+1bc3f035aecf781bdc0de4fe820feab2	"A1B2 C3!"	"a1b2 c3!".upcase
+1bf6840359877e06ef23bf3b29e4fe78	["/home/user/monoruby/monoruby", "../", "/home/user/monoruby", "/home/user/monoruby/monoruby"]	$x = []\n        $x << Dir.getwd\n        Dir.chdir("../") do |path|\n    
+1bf8c5aa3e4b817e3ed1532d61d408f4	1	counter = [0]\n            t = Thread.new { counter[0] += 1 }\n      
+1bfaa45735ddc4e01af09fb8b88768ce	"a-b!OBJ"	r, w = IO.pipe\n            begin\n              $, = "-"\n           
+1c0bdd50f6020b66a3e9c89f534a345e	"bang\\n"	require "tmpdir"\n            Dir.mktmpdir do |d|\n              File
+1c12445c2d79602457293208d6a673ed	127705271.30000001	a = 7.9\n            i = 0.0\n            while i < 15\n              
+1c12dc08811d9019e8d7783f90126800	[Proc, "42"]	def take_block(&blk); blk; end\n              bl = take_block(&:to
+1c1cbd948574428a9c87e8b3ffbf5e17	42	k = Class.new { |c| c.define_method(:foo) { 42 } }\n            k.ne
+1c1fcbdbc611eaff60a3065b29f2ad48	[2, :te]	pth = "/tmp/mono_cov_#{Process.pid}_#{rand(1 << 30)}.rb"\n        File.w
+1c4c2d6d15f9c496df0430ac01991d10	0	255[..-2]
+1c55df1a2ab9f2b7ce881cce3520b3da	["File::Stat", 8, true, false, true, true, true, true, true, "file", false, 8, true, true, true, true, true]	path = "/tmp/monoruby_test_stat_#{Process.pid}_#{rand(100000)}"\n   
+1c6926fa6e1462140ee74bc77342fcc8	[nil, :nme, true]	module PrivC\n              class Sec; end\n              private_con
+1c6d7d2ee7c5c48ff5b7040293a055f2	[42, 42, 2]	module BopPlus\n              refine(Integer) { def +(o); 42; end }\n
+1c979897435ff61b3d8ac16af24e1019	[3, 5, 7, nil, 7, 42, 101, :new, {a: 101, b: :new}]	res = []\n        a = 1; a += 2; res << a\n        b = nil; b ||= 5; res 
+1ca7fb21e8495566f40650238bdfc1f6	[false, true, false, true, false, true, false, true, true, false, false, true, true, true, false, true, false, false]	class C\n            include Comparable\n            attr_accessor :x\n 
+1cb0fc8d0cfb3a0a2c9e0ed0438fb68d	[true, "payload", true, true]	base = "/tmp/monoruby_test_link_#{Process.pid}_#{rand(100000)}"\n   
+1cb2fbd29c1f17641206d01707aa2b1b	["invoked 42", "resume = ", "yield = 1", "resume = 0", "yield = 2", "resume = [0, 1, 2]", "yield = 3", "resume = ", "yield = 4", "resume = 1", "yield = 5", "resume = [1, 2, 3]", "yield = 6", "resume = ", "yield = 7", "resume = 2", "yield = 8", "resume = [2, 3, 4]", "yield = 9", "resume = ", "yield = 10", "resume = 3", "yield = 11", "resume = [3, 4, 5]", "yield = 12", "resume = ", "yield = 13", "resume = 4", "yield = 14", "resume = [4, 5, 6]", "yield = 15", "resume = ", "yield = 16", "resume = 5", "yield = 17", "resume = [5, 6, 7]", "yield = 18", "resume = ", "yield = 19", "resume = 6", "yield = 20", "resume = [6, 7, 8]", "yield = 21", "resume = ", "yield = 22", "resume = 7", "yield = 23", "resume = [7, 8, 9]", "yield = 24", "resume = ", "yield = 25", "resume = 8", "yield = 26", "resume = [8, 9, 10]", "yield = 27", "resume = ", "yield = 28", "resume = 9", "yield = 29", "resume = [9, 10, 11]", "yield = 30", "resume = "]	answer = []\n            f = Fiber.new do\n                outer = 42
+1cb41ddeeb5af573c6219688efd8fee9	[[10, 20, 30, 40, 50, 60, 70, 80], [1, 2, 3, 4, 5, 6, 7, 8]]	class S < Array\n                def initialize\n                    
+1cb5b980d33aba5755973e56b31dfe8b	[[0, "x0", [], [0], nil, :none], [1, "x1", [], [1], nil, :none], [2, "x2", [], [2], nil, :none], [3, "x3", [], [3], nil, :none], [4, "x4", [], [4], nil, :none], [5, "x5", [], [5], nil, :none], [6, "x6", [], [6], nil, :none], [7, "x7", [], [7], nil, :none], [8, "x8", [], [8], nil, :none], [9, "x9", [], [9], nil, :none], [10, "x10", [], [10], nil, :none], [11, "x11", [], [11], nil, :none], [12, "x12", [], [12], nil, :none], [13, "x13", [], [13], nil, :none], [14, "x14", [], [14], nil, :none], [15, "x15", [], [15], nil, :none], [16, "x16", [], [16], nil, :none], [17, "x17", [], [17], nil, :none], [18, "x18", [], [18], nil, :none], [19, "x19", [], [19], nil, :none], [20, "x20", [], [20], nil, :none], [21, "x21", [], [21], nil, :none], [22, "x22", [], [22], nil, :none], [23, "x23", [], [23], nil, :none], [24, "x24", [], [24], nil, :none], [25, "x25", [], [25], nil, :none], [26, "x26", [], [26], nil, :none], [27, "x27", [], [27], nil, :none], [28, "x28", [], [28], nil, :none], [29, "x29", [], [29], nil, :none], [nil, :none, 0, 0], [nil, :none, 1, 0], [nil, :none, 2, 0], [nil, :none, 3, 0], [nil, :none, 4, 0], [nil, :none, 5, 0], [nil, :none, 6, 0], [nil, :none, 7, 0], [nil, :none, 8, 0], [nil, :none, 9, 0], [nil, :none, 10, 0], [nil, :none, 11, 0], [nil, :none, 12, 0], [nil, :none, 13, 0], [nil, :none, 14, 0], [nil, :none, 15, 0], [nil, :none, 16, 0], [nil, :none, 17, 0], [nil, :none, 18, 0], [nil, :none, 19, 0], [nil, :none, 20, 0], [nil, :none, 21, 0], [nil, :none, 22, 0], [nil, :none, 23, 0], [nil, :none, 24, 0], [nil, :none, 25, 0], [nil, :none, 26, 0], [nil, :none, 27, 0], [nil, :none, 28, 0], [nil, :none, 29, 0]]	class Node\n          attr_reader :pos, :name, :dirs, :sels, :file, :src
+1cc6840e99c2ce3689b58081fcc0883b	["missing keyword: :x", [9, 10]]	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; def m(x:,
+1d061f190c766b447c0ce49d2254a833	"miss"	if /(?<w>foo)/ =~ "nope" then "hit" else "miss" end
+1d3b62c9ac33620fface000347a8abc0	"missing keywords: :x, :y"	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; def m(x:,
+1d68e692e3b7f47da7c6ea7772f726dc	[:raised, :wait_readable, :raised, :wait_readable, "hi", "hi", ["yo", "Addrinfo"]]	require "socket"\n            res = []\n            a, b = UNIXSocket
+1db5d35ff78d7fa83b8c03967ca12192	true	def foo; end\n            public :foo\n            private :foo\n     
+1dbac381063982c828c61a6698e1e664	[42, 42, 42]	$a = 1\n            alias $b $a\n            alias $c $b\n            
+1dc4e6b9d13cbb4bda8ad0cf13be134b	[2, "hi"]	(f="/tmp/mono_oa_#{Process.pid}"; n=IO.write(f, "hi", open_args: ["w", nil, {enc
+1dc6884272715101af309365600555df	[:ensured, "boom"]	log = []\n            begin\n              Enumerator.new { |y| begin
+1e08e67e4ca265bf528592b1dae413d1	42	class Foo\n              @@x = 42\n              def self.get_x; clas
+1e1f5f728efe927c10f8e284ecc655b0	[1, 2, [3, 4]]	class C\n              define_method(:m) { |a, b, *c| [a, b, c] }\n  
+1e62e613c49125303aafa003efcbc639	[1, 2, 3]	f = ->{ [_1, _2, _3] }; f.call(1, 2, 3)
+1e7c2ebc503f5dab0f69ac5a8a6e0937	[10, 20, 30]	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \ns.eac
+1e7d43e244f05265e3ab66458644225b	[[File, "hello"], File, File, "", [File, ""]]	path = "/tmp/mono_cov_file_fd_#{Process.pid}"\n            begin\n   
+1e81c8693c8bc896ed9ae743ecf49cc5	[UD, "payload-data"]	class UD\n              def _dump(level); "payload-data"; end\n      
+1e8d0a2f9a9e4b827b4e75d22d4d346c	[true, [:a, :b]]	klass = Struct.new("StructSlotTestNamed", :a, :b)\n            [klas
+1e9c33b77ee7a9871ef5ce1cfd17d5b6	["B[0,1,[],2,3]", "B[1,2,[3, 4, 5, 6],7,8]", "B[1,2,[],3,4]", "B[1,2,[3, 4, 5, 6],7,8]", "B[2,3,[],4,5]", "B[1,2,[3, 4, 5, 6],7,8]", "B[3,4,[],5,6]", "B[1,2,[3, 4, 5, 6],7,8]", "B[4,5,[],6,7]", "B[1,2,[3, 4, 5, 6],7,8]", "B[5,6,[],7,8]", "B[1,2,[3, 4, 5, 6],7,8]", "B[6,7,[],8,9]", "B[1,2,[3, 4, 5, 6],7,8]", "B[7,8,[],9,10]", "B[1,2,[3, 4, 5, 6],7,8]", "B[8,9,[],10,11]", "B[1,2,[3, 4, 5, 6],7,8]", "B[9,10,[],11,12]", "B[1,2,[3, 4, 5, 6],7,8]", "B[10,11,[],12,13]", "B[1,2,[3, 4, 5, 6],7,8]", "B[11,12,[],13,14]", "B[1,2,[3, 4, 5, 6],7,8]", "B[12,13,[],14,15]", "B[1,2,[3, 4, 5, 6],7,8]", "B[13,14,[],15,16]", "B[1,2,[3, 4, 5, 6],7,8]", "B[14,15,[],16,17]", "B[1,2,[3, 4, 5, 6],7,8]", "B[15,16,[],17,18]", "B[1,2,[3, 4, 5, 6],7,8]", "B[16,17,[],18,19]", "B[1,2,[3, 4, 5, 6],7,8]", "B[17,18,[],19,20]", "B[1,2,[3, 4, 5, 6],7,8]", "B[18,19,[],20,21]", "B[1,2,[3, 4, 5, 6],7,8]", "B[19,20,[],21,22]", "B[1,2,[3, 4, 5, 6],7,8]", "B[20,21,[],22,23]", "B[1,2,[3, 4, 5, 6],7,8]", "B[21,22,[],23,24]", "B[1,2,[3, 4, 5, 6],7,8]", "B[22,23,[],24,25]", "B[1,2,[3, 4, 5, 6],7,8]", "B[23,24,[],25,26]", "B[1,2,[3, 4, 5, 6],7,8]", "B[24,25,[],26,27]", "B[1,2,[3, 4, 5, 6],7,8]", "B[25,26,[],27,28]", "B[1,2,[3, 4, 5, 6],7,8]", "B[26,27,[],28,29]", "B[1,2,[3, 4, 5, 6],7,8]", "B[27,28,[],29,30]", "B[1,2,[3, 4, 5, 6],7,8]", "B[28,29,[],30,31]", "B[1,2,[3, 4, 5, 6],7,8]", "B[29,30,[],31,32]", "B[1,2,[3, 4, 5, 6],7,8]"]	class A\n          def m(a, b = 10, *r, y, z) = "#{a},#{b},#{r.inspect},
+1e9d9e8bc3835db359625384d50cc91b	0	(1 << 53) <=> (1 << 53).to_f
+1edd08df432a89a9b178ae378681d2eb	"HELLO world"	s = "hello world"; s.bytesplice(0...-6, "HELLO"); s
+1ee94781f409b3a230df07b7627d13a4	[[1, 1], [], []]	m = Module.new { refine(String) { def z; end } }\n            inner 
+1ef2d05cdf263c4eba0d54cfe8231095	7	class Integer; alias __orig :+; def +(o); __orig(o); end; end; 3 + 4
+1efee822ea5520e550f43603ea2a8469	"a\\nb"	$/ = nil; r = "a\\nb".chomp; $/ = "\\n"; r
+1f0287405ed560b3a72213d8bec092f8	["\\\\u{61}", "/\\\\u{61}/", false]	[/\\u{61}/.source, /\\u{61}/.inspect, (/\\u{61}/ == /a/)]
+1f1c5c7ef4212dc4854a88bfd142db02	:hi	klass = Class.new\n            klass.class_exec do\n              def
+1f223478d7394c50d8d61e0f574f55b5	[[[50, 2, 3], {e: 70, f: 80, g: 90}]]	class C\n          def f(*rest, **kw)\n            $res << [rest, kw]\n   
+1f22844ce32fd2036c65263ce0b9319d	1	x = "Z"; (/#{x}/i =~ "qzq")
+1f3121c4382667758c3988faab82811f	"US-ASCII"	"abcc".dup.force_encoding("US-ASCII").tr_s("c", "X").encoding.to_s
+1fc8a8365c050aced75377b0f9dca4f7	true	$LOAD_PATH.class == Array\n            
+1fd67713bd348911ab844e4987b761b1	[10000, 42]	a = [100 * 100]\n        class Integer\n          def *(other)\n          
+1fe144dc2e4422f0e8bc7cfdb2825361	["\\n", nil, nil, nil, 0]	[$/, $\\, $,, $;, $.]
+1fe906989a77f124f45e44e3abd56610	[true, true]	M = Data.define(:amount, :unit)\n\n            d1 = M.new(42, "km")\n            d2
+1ff5137b6208a39da2e712b5b773b5f5	true	GC::Profiler.total_time.is_a?(Float)
+20109eb03bd3406ceab02f2a214f9f10	[20, 20, 20, 20, 10, 10, 10, 10, 10, 10, 20, 20]	class C\n          attr_accessor :a\n          def initialize\n           
+20246e0e0b12cd595e31cd7c277fa443	{life: 42}	fiber = Fiber.new(storage: {life: 42}) do\n              Thread.new 
+20354b8af635160a503c14b0bc910c4d	["pack length too big", "pack length too big", "pack length too big", "pack length too big", ["b"]]	r = []\n            [["@99999999999999999999999999", :unpack],\n     
+205e65e2298e3b75f7ddf8cf3f3495c6	[false, true, "z", :nme]	res = []\n        30.times { res << ("abc" !~ /b/) << ("abc" !~ /z/) << 
+206652bec5b6b36846721ea87b2a4280	[true, true, true, true]	b = binding\n        sl = b.source_location\n        [sl.is_a?(Array), sl
+207dfdc3a331dc3a9bd12c35a3e92870	["pv\\n", "pv2\\n", "pv3\\n", "/tmp\\n", "/tmp\\n", true, "ISO-8859-1", ["UTF-8", "ISO-8859-1"]]	r = []\n            IO.popen([{"PV" => "pv"}, "sh", "-c", "echo $PV"
+209dfca7e20d5b08fbea7e352067e47e	1	begin\n          abort("test")\n        rescue SystemExit => e\n          
+20a29c3694791809267cf4fb4c026f0b	[true, true, true, true, true]	class C\n              def f(a, b); a + b; end\n            end\n     
+20a5e889d929c3cfef9d0249a0d89866	1	class Foo\n              def initialize\n                @a = 1\n     
+20c118ce0b43441a370030eae9e5f304	[11, "no block"]	def baz(&)\n          if block_given?\n            yield 10\n          els
+20e45524efcf74f976e1ee0d9e08a133	[100, 200, "#<struct S a=100, b=200>"]	S = Struct.new(:a,:b)\n        \n\n        s = S.new(100,200)\n        [s.a
+2145ee25155f67c8b900f252952714be	:ok	old_stderr = $stderr\n            captured = String.new\n            
+215aa4af8c863ad665773263bec5b5b6	[[true, true, true], "345", "closed stream", "closed stream", "01XY456789", "Errno::ENOTTY", "closed stream"]	path = "/tmp/monoruby_test_iodup_#{Process.pid}_#{rand(100000)}"\n  
+21644521b8885b6a2269e71105c1a8fc	[:in_thread, :in_main, :value_raises]	r = []\n            ready = false\n            t = Thread.new {\n     
+21715255d5b7d1640238dce91ff9244f	1	case 9\n        when 0,4,8\n          0\n        when 1,5,9\n          1\n  
+21978a61b3437a37e4576edf77547099	1	def nil.foo; 1; end\n            nil.foo\n            
+21c9333fc83d8b5a0cca96f269070205	["1", "2", "3"]	def forward(&b); [1,2,3].map(&b); end\n              forward(&:to_
+21f8e47a45fd8696940d39593814b503	["hello", "world"]	require "stringio"\n\n            res = []\n            ret = StringIO.open("hello"
+21ff5a76d37a266f84d3f0dce8947ed7	[:bar, [], {a: 1, b: 2}]	class C\n          def method_missing(name, *args, **kwargs)\n           
+220d3fe1c05b2950f05bfe53024be3aa	[false, false]	m = Mutex.new\n            cv = ConditionVariable.new\n            t 
+2240d723f5d81acbdb40781797ea9222	[1, "12", 1]	[ /abc/ =~ "xabc", /\\d+/.match("a12b")[0], ("héllo" =~ /é/) ]
+22421076f8f454c7c15a47288a0294eb	0.25	Rational(3, 4) - 0.5
+22583330547d3269783ffa0a1569db8a	[]	def m; local_variables; end; m
+2262e52c9c6dce5cc613425701fddf85	["D(a)", [1, "D(b)"], :singleton]	def drive(n)\n              r = nil\n              n.times { r = yiel
+22b54a288bd5ab601d9196768156489a	"[yes][]\\n"	# unsetenv_others with an env hash keeps only the given vars\n      
+22c0902963ab6d1ef3fbd095ba2b81fb	[:in_progress, :zero, 0, true]	require "socket"\n            res = []\n            srv = TCPServer.n
+22c7f5e30abd7c5832dafc79b391e2e5	[[4, 2], [:x, :y]]	def m\n              binding\n            end\n            b = m\n     
+22e93d16a9649d57ab7475c4472c954f	["malformed format string", "malformed format string", "malformed format string", "malformed format string", "malformed format string", "malformed format string", "malformed format string", "malformed format string"]	fmts = ["%\\n", " % ", "%.\\n3f", "%.3\\nf", "%\\0", "hello %1$", "%v",
+2304be5a9de8bae9c9cd4757fb54bed5	[true, true]	def foo; end\n        m = method(:foo)\n        loc = m.source_location\n 
+2318655bc806481764b9202140b1af15	[1, 2, 3, 4, [5, 6, 7, {a: 1, b: 2}]]	def f(x,y,a=42,b=55,*z)\n            [x,y,a,b,z]\n        end\n        \n\n 
+234f4921db73a0fcb94d3aabc241314b	"ASCII-8BIT"	"abc".dup.force_encoding("ASCII-8BIT").upcase.encoding.to_s
+236adf9db074533ff6696e1cd5ad7a2e	[[1, 3], [2, 4]]	[[1, 2], [3, 4]].transpose
+23868e074ac73bfea9c45758469abb55	["0.15e3", "0.15e-1", "0.123e3"]	require "rubygems"\n        require "bigdecimal"\n        res = []\n      
+238dac5c14eb1e5ebc188a5c3d5178b0	[true, true, true, true, "instance of IO needed", nil]	require "stringio"\n\n            res = []\n            # (obj, level) — Integer 2n
+239549c97fe9daba196ffabee457a2e2	[Encoding::UndefinedConversionError, [97, 63, 98]]	(a=(begin; "→".encode("IBM437"); rescue Encoding::UndefinedConversionError => e;
+23b5c46bdfbd2a1aa2005c0fb1a745ec	[[0, :a, 2], [0, 1, :a, :b, :c, :d, 6, 7, 8, 9], [0, :a, :b, :c, :d, :e, :f, 7, 8, 9], [0, 1, 2], [0, 1, 2, 3, 4, 5, :a, :b, :c, :d], [0, 1, 2, 3, 4, :a, :b, :c, :d, 9], [:a, :b, 4, 5, 6, 7, 8, 9], [:a, :b, :c, :d, :e, :f, 4, 5, 6, 7, 8, 9], [0, 1, 2, 3, 4, 5, 6, 7, :a, :b, :c, :d], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, :a, :b, :c, :d], [0, 1, 42, 6, 7, 8, 9], [0, 1, :x, :y, :z, :w, 6, 7, 8, 9], [0, 1, nil, 6, 7, 8, 9], [0, 1, 0, 1, 2, 3, 4, 5, 6, 7, 6, 7], [:a, :b, :c, :d], IndexError, FrozenError, [0, :a, :b, :c, 4, 5, 6, 7, 8, 9], [0, :a], [0, :a, :b, 3, 4, 5, 6, 7, 8, 9], [0, :a, :b, 3, 4, 5, 6, 7, 8, 9], [0, 1, :a, :b, 6, 7, 8, 9], ArgumentError, IndexError]	class ToAry; def to_ary = [:x, :y, :z, :w]; end\n        def sl0(a, i, v
+23bc3351ce47d94e083999fe38415774	["old+new", "fresh"]	ENV["MONORUBY_ENV_TEST_BLK"] = "old"\n            ENV.merge!("MONORU
+23e6b8b59d2037e9f3b0bae2a98f7d40	true	FileTest.readable?("/bin/sh")
+23eb3686dbbed3c698cd040745ddc710	["elefant", nil]	S = Struct.new(:name, :legs, keyword_init: true)\n            \n\n    
+23f3838afb92bd57e15d229dd0d1deb0	"method"	defined?(__ENCODING__.name)
+23fb14c94b631d93c9694feb48994552	[RuntimeError, true]	class BlockRaiser\n              def self.raise_in_thread(*args, &bl
+24196e0cebd247d987469fb63b77ec33	:OVERRIDDEN	class Complex; def *(o); :OVERRIDDEN; end; end; Complex(1,2) * Complex(3,4)
+245e848f69575fb36810ea7f6796973c	TypeError	(GC.stat(7) rescue $!.class)
+246af9040a3d2f43e9ddf823ee30471c	true	(0x8000_0000_0000_0000 + 39) > (0x8000_0000_0000_0000 + 39 + 0.0)
+2475f3fc8f38ad071f66332d846bc60b	"symbol"	x = case :symbol\n        when Integer then 'integer'\n        when Float
+249eeebcb774e4d0a04f64968012ff7b	81	class Integer; alias __orig :**; def **(o); __orig(o); end; end; 3 ** 4
+24a18bcaab600fcb97d8a6dfa484fd4b	true	Module.new.is_a?(Module)\n            
+24ac5154b60f3f04786ba9edf76cd37f	"HELLO, WORLD!"	"Hello, World!".upcase
+24b3c2a7f0690e6d1eb054021202ed43	:OVERRIDDEN	class TrueClass; def ===(o); :OVERRIDDEN; end; end; true === true
+24b74847655014f460c36e43e73312e8	7	class C\n          define_method(:add) { |a, b| a + b }\n        end\n    
+24ede66710b2716183990244c9ec7ce2	-3.0	class Float; alias __orig :-@; def -@; __orig; end; end; -(3.0)
+250640ebb28cec0f360f71495d32f526	[227, 65, 66, 227, 129, 132]	s = "\\xe3\\x81\\x82\\xe3\\x81\\x84".force_encoding("ASCII-8BIT")\n       
+251463e9ea3898eef34264e66a5b59f3	["ok Foo", "ok Bar", "ok Foo", "ok Bar"]	module Foo\n          def a\n            'ok Foo'\n          end\n        e
+2544a8f94d2969a859e5ab589a67438b	[2, 2, 5, 2]	q = SizedQueue.new(2)\n            pushed = 0\n            t = Thread
+254596e4a11ae8569f20585ff35424bc	[["\\e[1msecond line\\e[m\\n", "\\e[1mthird line\\e[m\\n"], "a.rb:1: unhandled exception\\n", "a.rb:1: \\e[1;4munhandled exception\\e[m\\n", true]	res = []\n        begin\n          raise "first line\\nsecond line\\nthird 
+255446c3b754da9870de5a3f4fa85c65	[:wait_readable, "k"]	r, w = IO.pipe\n            a = r.read_nonblock(1, exception: false)
+2564e3ad2fe7fb1fdc5d2fa9b88997a2	"US-ASCII"	"\\x01".unpack("h")[0].encoding.to_s
+256686756b653a14cc54ed2fe66c19a5	"hello from Foo"	class Foo\n              def hello\n                "hello from Foo"\n
+259e0bc1539e3e941c430db4dd5e906c	"/home/user/monoruby/monoruby/a.rb"	class C\n          autoload :D, File.expand_path("j")\n          autoload
+25bf8c5753369088e3ee3a5e22313082	["Z", "\\n"]	tr = []\n            trace_var(:$/) { |v| tr << v }\n            $/ =
+25bfb835555c41988ae49ab62e4ae633	["ok", "ok", "ok", "ok", "ok", "abcok"]	class MTosInt; def to_s; 42; end; end\n            class MTosNil; de
+25f0534564d801243342b23debebc6f2	[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19], true, [0, 1, 2, 3, 4, 5, 6], [[0, "s0"], [1, "s1"], [2, "s2"], [3, "s3"], [4, "s4"], [5, "s5"]], [0, 1, 2], FrozenError]	def app(a, v) = a << v\n        def app_blk(a, v, &b) = a.<<(v, &b)\n    
+25f7204942eba1042f12b5429463ecc6	1	Rational(0.5).numerator
+260aadbc1eafcac4daf5a56eb84558cd	true	$/.frozen?
+2635fffd46a3e17a2174ca9ccb6fc7a3	["-", "A"]	module UsingA\n              refine(String) { def tag; "A"; end }\n  
+264b0263d3d2c06bbb4abdb266123919	[:missing_constant, "test message"]	e = NameError.new("test message", :missing_constant)\n            [e
+266e77b9e0f7c96253fed71dffed0fc7	:type_error	class BadAry\n          def to_ary; 42; end\n        end\n        begin\n  
+269718bdf89b8bdcb0901cb7e5ff324c	["nil", "outer"]	res = []\n        catch(:a) do\n          begin\n            raise "boom"\n
+26a76c3e0118f9b66da86729e50796ef	99	IO.popen("exit 99") { |io| io.read }\n            Process.last_statu
+26b78fc3382ae3db23b930049f26460c	true	__ENCODING__.is_a?(Encoding)
+26bbc4560fcf13c127538f0f36e3b0d5	[3, nil]	class C\n          D = nil\n        end\n        load "a.rb", true\n       
+26e599b93dd5074da174749e9779a13c	true	def `(cmd); cmd.frozen?; end\n        x = `ab`\n        x\n        
+26e8da9f4535336eb932db31a0c659df	{x: "hello", y: 99}	x = "hello"\n        y = 99\n        {x:, y:}\n        
+27222675207490b37710ec4eb3e00b5d	[true, true, true]	m = Module.new\n        m.autoload :Lazy, "/no/such/file"\n        loc = 
+2725417552fe9cf3994cb6d9305ea32c	7	class C; def to_int; nil; end; def to_i; 7; end; end; o = C.new\nInteger(o)
+272fe9061909044beaae1c691819f22b	"/dev/null"	File.path("/dev/null")
+273609161e526f0caca0d803b1f5ac8c	3	$x = 0\n            begin\n              $x += 1\n              raise 
+27452ff2af75468b18d93adad2bb0edd	["nil", "nil", "nil", "nil"]	[STDOUT.external_encoding, STDERR.external_encoding,\n         STDOUT.in
+27679c36ace334b798b8ac5753b80532	42	# Test 2: include + prepend where M appears twice in the chain\n#\n# B2 includes 
+2771493de6880db912552ec36e380f75	[true, true, nil, true, true, true, true, IPSocket, TCPSocket, IO, StandardError]	require "socket"\n            sock = Socket.new(:INET, :STREAM)\n    
+2772497c43d33acdc7bca38b5ecb5e24	["Thread#backtrace_locations", "Object#tbl_probe", false, [true, "Thread::Backtrace::Location"], true, "no block given"]	r = []\n            def tbl_probe\n              locs = Thread.curren
+2774b5033b68bbb515f44f151dde4aee	[true, true, true]	def pa; end\n            public\n            def pb; end\n            
+277a36e61a4858f3a5504efad927d367	99	module M; class N; CONST = 99; end; end\n            \nObject.const_g
+27b801313ba7d0170407403d3ed2ed9a	[7, "n=7"]	class Built < StandardError\n              def initialize(n); super(
+27bbd9728c02599e57c39a078921ec2f	["X", "X"]	$/ = "X"; r = [$/, $-0]; $/ = "\\n"; r
+27e09cfb8d3e196da639bfe49a480262	"----hi----"	class Foo; def to_str; "-"; end; end\n            "hi".center(10, Fo
+27fffd6b30a640af5c225b8f9b0b1edb	[false, [:a, :b]]	S = Struct.new(:a, :b, keyword_init: false)\n            \n\n         
+2813eaf79f8e7054ca4fc122c2c44ce9	[[:singleton_method_added, [:method_missing]], [:singleton_method_added, [:foo]]]	$result = []\n        class C\n          class << self\n            undef_
+2817d91ed55d25899a6cafb76ddebc3d	"hi"	class Foo\n              def hi\n                "hi"\n              e
+28212edb8e5f6d2cf627a2eff37d1fb2	["7", "11"]	def crsl_foo\n          begin\n            raise "oops"\n          rescue\n
+282d7606eaab7e52d619102249c17e42	[7, 99, -1]	V = Struct.new(:a, :b, :c) do\n              def initialize(a)\n     
+2834dc2993e41d21a71728e3f38b44bf	["", "", "", "", "0", "0b101", "0xff"]	[sprintf('%#.0b',0), sprintf('%#.0B',0), sprintf('%#.0x',0), sprintf('%#.0X',0),
+284cdc587c8ca622adecc7634d48104f	[true, false, false]	class MyNum\n              include Comparable\n              attr_rea
+285185fceec5d66e9a0b0017921fcdb3	:ok	old_stderr = $stderr\n            captured = String.new\n            
+2856d276c472b3b28a51d514662d76c0	"Cargo.toml"	File.open("Cargo.toml") { |f| f.to_path }
+2857ee8562740e3a303e0b419aa33d73	["EUC-JP", true]	(f="/tmp/mono_tpe_#{Process.pid}"; File.write(f, ""); io=File.new(f.encode(Encod
+286b90c6e98dbe079e4a2b613b749cdb	"nil"	Set[1, 2, 3].freeze.flatten!.inspect
+2890bbfd125193c6fcb4cb125c9bd264	[999, 999]	$flag = false\n        def maybe_redefine\n          if $flag\n           
+28a4af30262d398c6994aca4ced26997	[true, false, true, false, true, false, true, true, true, false]	class C; end\n            class D < C; end\n            o = C.new\n   
+28b294682b3a75ed931f88b8ec443144	[true, false]	k = Class.new { def ==(o); false; end; def equal?(o); false; end }\n
+28bfa4a6493ce52224bf54b55cab2a48	true	base = "/tmp/monoruby_dir_chdir_missing_#{Process.pid}_#{rand(10000
+28c18bf777a8999243ce28f8262e986d	[[false, true], true, true, true, IOError, "ABC", [true, true, true, 0, true, 4]]	(f="/tmp/mono_sy_#{Process.pid}"; io=File.open(f,"w"); a=[io.sync, STDERR.sync];
+28fadb5ec2757db29cec5114c466b782	[4, 6]	[1,2,3].\n          # this is a comment\n          map {|x| x * 2}.\n     
+290233524b8c606fdb5063d01de93f38	"UTF-8"	def g; e = __ENCODING__; e.name; end; g
+290acb743144a02340cf3b45e01749b0	[123, 123, 123, 123, 123, 123, 123, 123, 123, 123, -521]	def g(a, b, c) = a * 100 + b * 10 + c\n        def f(...) = g(...)\n     
+2919233f40561782fac125f189ea5af5	[5, "hello"]	path = "/tmp/monoruby_io_syswrite_#{Process.pid}_#{rand(100000)}"\n 
+29243ebc3ef776238c9f1ef7f0357bea	["matched", "custom not match"]	class Bar\n              def =~(other)\n                "matched"\n   
+293764b891fd3805a23234c9c9b9bc87	2	def true.bar; 2; end\n            true.bar\n            
+2951da256d6850b5b2b5f1f354032d04	false	File.executable?("../LICENSE-MIT")
+295ad12a1384e7957740bbfc0e7fc6d3	"1,2,3"	class C; def to_str; ","; end; end; o = C.new\n[1, 2, 3] * o
+296560b4ebd046b6c59327975bb90459	"[2.5, 1.0]"	1.0.coerce("2.5").inspect
+296cb9b677550e04208e94ca484931e0	false	(1 << 100) == Float::NAN
+2987a50b02c4a3d9e5927d0cf054efc5	[true, true, false, true, false]	[\n              SystemExit.new.success?,\n              SystemExit.n
+29a4782bad89b05e2a89fbdc04ec694a	[[1, :d, [], 1, nil], [1, 2, [3, 4], 1, nil], [1, 2, [], 9, nil], [1, :d, [], 1, :blk], [10, 20, [30], 1, nil], [5, 6, [7], 2, nil]]	def t(a, b = :d, *r, k: 1, &blk); [a, b, r, k, blk ? blk.call : nil
+29be5fcdba7ed7a8c6ca8dadda30fdde	["Xtail-line\\nXpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpad", ["tail", "line", "padpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpad"], "T-line\\npadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpad", "Ytail-line\\nYpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpad", "if @c  tail-line\\n  padpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadend\\n"]	s = "HEADER-LINE\\nmiddle\\ntail-line\\n" + "pad" * 20\n        s =~ /middl
+29c1437316aed84311f490aa6a4532d1	["C", "B", "A", "M3", "M2", "M1"]	module M1; end\n        module M2\n          include M1\n        end\n     
+2a04e0b26f5843b7982d5765e50f29cf	[[:c1, :c2], [:c1, :c2]]	class S\n              def s; end\n            end\n            class 
+2a054f41f0ebb76b11549882f920add6	[]	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \ns.val
+2a2b86ebb2efff59c7eaeba003dc98fc	["abc", "XYZ", "def"]	"abcXYZdef" =~ /XYZ/\n            [$`, $&, $']\n            
+2a2c02a8e1eb184cff179aa37a7afd2c	[[1, 2, 5, 4], A]	class A < Array\n        end\n        \n\n        a = A.new([1,2,3])\n      
+2a331dfdc06006cb6c2d9fb1b276af51	[false, false, true, true, true, true]	[Kernel.private_instance_methods(false).include?(:chop),\n          
+2a3de9772e2bbde8e6d892268ebbd6b6	:m	[1, 2].each.with_object(:m) { |v, m| }
+2a5869ecfcebdbb2da9022b23ccf267d	["constant", true, [:C]]	$res = []\n        parent = Class.new do\n          def self.inherited(su
+2a5cd0c05a4c867471eb9bdcd900f0a1	[[4, 5, 6], 8]	r = []\n        calls = 0\n        10.times { |i| r << i if (calls += 1; 
+2a7ebdf4fd301bbdfa3591753316bc4d	:OVERRIDDEN	class Float; def >=(o); :OVERRIDDEN; end; end; 3.0 >= 4.0
+2a9067ffb78152f7b45306f4f629c67a	[1, 2, 3, 4, [5, 6]]	def f(x,y,a=42,b=55,*z,c,d)\n            [x,y,a,b,z]\n        end\n       
+2aa07b3eea4d7a2718e37df9f1ed496c	5	class C\n              private def f; 5; end\n            end\n\n      
+2abcd2daf8753cc241b16a4109e46098	[true, true, true]	a = Random.new_seed\n        b = Random.new_seed\n        [a.is_a?(Intege
+2ad1b1687928056c2f074002bf5523c8	[[[nil, 0]], [[:v, 0]], [[[1, 2], 0]]]	[Enumerator.new { |y| y.yield },\n                Enumerator.new { |y| y.yield :v
+2ad3ffaba8b53027f23c93b8ea311b97	"M"	module M\n              def f\n                "M"\n              end\n
+2aec6243e92acfe749099144a72533e1	:OVERRIDDEN	class Complex; def !; :OVERRIDDEN; end; end; !(Complex(1,2))
+2b00bd85431dd7a80fc36e28c6bd4ea3	["Enumerator", [], 3, :stopped]	e = loop\n            cnt = 0\n            got = nil\n            e.ea
+2b1ef887a1e8d69589f89bda76a9ed0e	[[164, 162], "EUC-JP", [164, 164]]	File.binwrite("/tmp/mr_gc.txt", [164, 162, 164, 164].pack("C*"))\n  
+2b2a7a697be91f73a6f3e7632ad995c1	["yes", "no"]	class TrueClass; def label713; "yes"; end; end\n        class FalseClass
+2b510e03b79828da0942ba4c9373ce3d	["wrong number of arguments (given 1, expected 2+)", true]	def rq(a, b, *c); end\n            m1 = begin; rq(1); rescue Argumen
+2b5b6ab6b8da93e6db6006879fa273a5	6	x = "wor"; "hello world" =~ /#{x}ld/
+2b64130006b71bbb74c8bb727d06d0ed	[[10, 20, 30], [10, 20, 30]]	class E\n              def initialize(a); @a = a; end\n              
+2b80e35e675c69b12c235aeda04b3512	[true, true, true, false, false, false]	class Object\n              def tp1; 1; end\n              protected 
+2b87eaf9abc9671b3f0ed0a3582bc372	[100, 100, 42]	$res = []\n        class C\n        \tdef f\n        \t\t100\n      
+2b92ff3de3e79725a67adfb4ee7eddd7	1	c = Class.new\n            c.const_set(:FOO, 1)\n            c.send(:
+2bc0eb33664b2981d37291b029907b9c	["A==5", "B==5"]	class A; def ==(o); "A==#{o}"; end; end\n        class B; def ==(o); "B=
+2c2ea327822066e54a80236b6c834904	[1, 5, 255, 1000000, -1, -7, 0, 2, 10, 510, 2000000, -2, -14, 0, 4, 20, 1020, 4000000, -4, -28, 0, 1073741824, 5368709120, 273804165120, 1073741824000000, -1073741824, -7516192768, 0, 2147483648, 10737418240, 547608330240, 2147483648000000, -2147483648, -15032385536, 0, 288230376151711744, 1441151880758558720, 73498745918686494720, 288230376151711744000000, -288230376151711744, -2017612633061982208, 0, 576460752303423488, 2882303761517117440, 146997491837372989440, 576460752303423488000000, -576460752303423488, -4035225266123964416, 0, 1152921504606846976, 5764607523034234880, 293994983674745978880, 1152921504606846976000000, -1152921504606846976, -8070450532247928832, 0, 2305843009213693952, 11529215046068469760, 587989967349491957760, 2305843009213693952000000, -2305843009213693952, -16140901064495857664, 0, 4611686018427387904, 23058430092136939520, 1175979934698983915520, 4611686018427387904000000, -4611686018427387904, -32281802128991715328, 0, 9223372036854775808, 46116860184273879040, 2351959869397967831040, 9223372036854775808000000, -9223372036854775808, -64563604257983430656, 0, 18446744073709551616, 92233720368547758080, 4703919738795935662080, 18446744073709551616000000, -18446744073709551616, -129127208515966861312, 0, 1267650600228229401496703205376, 6338253001141147007483516026880, 323250903058198497381659317370880, 1267650600228229401496703205376000000, -1267650600228229401496703205376, -8873554201597605810476922437632, 0, 0, 2, 127, 500000, -1, -4, 0, 0, 0, 0, 0, -1, -1, 0, 0, 0, 0, 0, -1, -1, 0]	res = []\n        [0, 1, 2, 30, 31, 58, 59, 60, 61, 62, 63, 64, 100, -1,
+2c3d92f1421f92a44e5d4e1e94f9a0f3	[:one, :two, Hash]	klass = Class.new(Hash) do\n              def initialize(*args)\n    
+2c4fa500f8bcf950b28e5b25417f18be	"US-ASCII"	"z".encode("US-ASCII").next.encoding.to_s
+2c60a3b58b3cec1741ef306698cffc54	"missing: hello"	class C\n          def method_missing(name, *args)\n            "missing:
+2cf607598595d4b3f44991e7c7f960a0	[[:typeerr], [:typeerr], [:typeerr], [:ok]]	def t(x)\n              [x].map do |v|\n                begin\n       
+2d0f94c4757acfe87ab61946bc9adbbb	3	st = Process.detach(spawn("sh", "-c", "exit 3")).value; st.exitstatus
+2d2ff1c3ff5d4218de0d6a13eec1eeb7	"a"	"a".reverse
+2d4ecfc6a346da8617ce2f74c132236e	[["1", "9", "0", nil], ["global-variable", nil], nil, nil]	res = []\n        "1234567890" =~ /(1)(2)(3)(4)(5)(6)(7)(8)(9)(0)/\n     
+2d6fd217fba4d2b106219e7de92e4253	["Q", "Q"]	alias $myrs $/; $myrs = "Q"; r = [$/, $myrs]; $/ = "\\n"; r
+2d87641e6927b0cdab85cb7629880462	:OVERRIDDEN	class Float; def /(o); :OVERRIDDEN; end; end; 3.0 / 4.0
+2da8a7a85c40c42e4327d1fdd2068e6c	[2020, 1, 2, 3, 4, 5, true]	t = Time.utc(2020, 1, 2, 3, 4, 5)\n            r = Marshal.load(Mars
+2dab2d60b1e963199abbf4edc69b7b17	["made:k", 3, nil, 3]	h = Hash.new { |hash, key| "made:#{key}" }\n            v = Hash.new
+2dd04b99ea4c74004cb7f6ebf42c571c	"ASCII-8BIT"	Regexp.new('([\\x00-\\xFF])', Regexp::IGNORECASE | Regexp::NOENCODING).encoding.to
+2de87dc95cc7a1a9c4edb24ea1657ff8	:nonpositive	begin; SizedQueue.new(0); rescue ArgumentError; :nonpositive; end\n 
+2e1334cbf1ce1ad1f0ead6825d8ea907	[nil, true, true, true, "", "x"]	require "io/wait"\n            r, w = IO.pipe\n            res = []\n 
+2e419be22648471b9d426d0e2b7fe4a8	[[FrozenError, true], FrozenError]	class Foo\n              def initialize\n                @a = 1\n     
+2e520c993c13bf6afbdcfa9de96cc277	["A", "overridden", "can't create instance of singleton class", "allocator undefined for Integer"]	class A; end\n        class B; def self.allocate; :overridden; end; end\n
+2e9e5cdf982a6b277e6559a8a489f9a7	["Process::Status", 0, true]	`echo hi`; [$?.class.to_s, $?.exitstatus, $?.success?]
+2ea8cf14ab55d43b075b91985f056e0e	42	class C\n          def bar(x); x * 2; end\n        end\n        C.new.publ
+2ef23e171ea7c4b8e44c86a9f992d408	[true, true, true, true, true]	r, w = IO.pipe\n            w.write("x")\n            [\n             
+2eff8aa6beb24cd1e30d17ca832d901e	[ArgumentError, "ASCII incompatible encoding: UTF-16LE"]	(Regexp.union("a".encode("UTF-16LE"), "b".encode("UTF-8")); nil) rescue [$!.clas
+2f052ab414e3e11032af6e0e3daffec3	[true, false, false, true]	class D\n          def m; end\n          private def p_m; end\n        end
+2f0605cfae48d77d3b5b40e6d74bd47b	[[10, 20, 30, 40, 50, 60, 70, 80], [1, 2, 3, 4, 5, 6, 7, 8]]	class S\n                def initialize\n                    @a = 10\n
+2f28cfe17983ddaaf399e013958b9c70	[(3+0i), (8+2i)]	Complex(8,2).coerce(3)
+2f31e2e40ca23f0bd3d0fadfac86b959	[1001.0, 1002.0, 1003.0, 1030.0, 1010.0, 1020.0, 1200.0, 1300.0, 1100.0]	class C\n              def initialize\n                @a = 1\n       
+2f3c934c9f013395202064f7b669614d	["b", "nil"]	r = begin\n              begin\n                raise "a"\n           
+2f922c304c94e10148d4493f457eb26e	:OVERRIDDEN	class Integer; def |(o); :OVERRIDDEN; end; end; 3 | 4
+2f9cea09fc9016f79e2054e732f21dea	42	class C; def to_int; 42; end; end; o = C.new\nInteger(o)
+2ff8cc9459e03d11d492cea61ad183f7	["/home", "user"]	File.split("/home/user/")
+2ffa5525ad2d35c4035401aa68c3c27a	["bb", "bbXX", ["", 0], "bbcc", "ii", "ArgumentError", ["keep", "keep"]]	base = "/tmp/monoruby_test_reopenm_#{Process.pid}_#{rand(100000)}"\n
+30007480deee79e634682a5970c862f6	[true, true, false, "hello"]	m = Module.new do\n              def hi; "hello"; end\n              
+3013ab1939788750547978045c0ea4c8	"\\nx\\n1\\n2\\nS\\n"	r, w = IO.pipe\n            w.puts([])\n            w.puts\n          
+3026addc0fcd2b67ebcfb55aa32756bc	true	m = Module.new\n        m.is_a?(Module)\n        
+3053f18f888b1ea24f609aa1ec916fec	{amount: 1}	M = Data.define(:amount, :unit)\nM.new(1, "m").deconstruct_keys([:amount])
+3063c096c70750fca8ad43016f8a7351	[:considered, :moved, :moved_up, :moved_down]	GC.compact.keys
+308b0e3069363f729a784cb6ad223bb3	[1, 2]	klass = Data.define(:a, :b)\n            inst = klass.new(1, 2)\n    
+3118b9df8fc7baabff879159ce2bf50f	"..hello..."	class MyInt\n              def to_int\n                10\n           
+3119a476e7d9eec457e1b59214ad40f2	[false, false, true, true]	was = GC.config[:rgengc_allow_full_mark]\n            begin\n        
+313f624ae2ea092da9e1d1cbca713465	[true, true, true, true, true, true, nil]	GC::Profiler.clear\n            GC::Profiler.enable\n            begi
+315c5b4ede6802af9112923bb36544ea	3	class C\n                def f\n                    yield\n           
+318bdea838d913fccc46d8c181d3eaba	:ok	mod = Module.new { def foo; :ok; end }\n            obj = Object.new
+31a2f98d7f3401ad6b8d4ee1b71619d4	:OVERRIDDEN	class Float; def *(o); :OVERRIDDEN; end; end; 3.0 * 4.0
+31c544a50d5a96da58f1f2bca81c1529	[true, 42, "boom"]	class MyErr < StandardError\n              attr_accessor :data\n     
+31dbc52d25f8fde84592827fdd169183	42	def f(x)\n          x * 2\n        end\n        f(21)\n        
+3216e8a4e5532edd1d8a9a107a61cb60	"nil"	def t; end; (public).inspect
+323248fe474a5afa887e12205ed145d2	C	a = class C\n          self\n        end\n        a\n        
+3241d752b39412d4f6c02d9dd853ba08	["foo"]	class A; def a(*r); r; end; end\n            class B < A; def a(*r);
+3285c4fda20a8f8870e882093119ec6c	[1, 10, 20, 30]	def f(p, x:, y:, z:)\n          [p, x, y, z]\n        end\n        \n\n     
+329b7b68cb4c629adc01345e10da9fbc	[false, false]	t = Thread.new { :body }\n            t.kill\n            t.join\n    
+329d244d8c9d5d6a9e6c815fbcff58a9	[1, 2, 3, 4, 5]	class C\n          def f(*args)\n            args\n          end\n        e
+32aa3b1383276e92a38f28799809e11b	true	c = Class.new do\n              eval "private"\n              def pub
+32afee60034360e34274b5b54d71e9bb	[Errno::EEXIST, Errno::EEXIST, File, [ArgumentError, "newline decorator with binary mode"], "600"]	(f="/tmp/mono_kw_#{Process.pid}"; File.write(f, ""); a=(begin; File.open(f, "w",
+32b4fc064491e5c8ff37d119788d821d	"nil"	def f(a = ($x = 1)); 1; end\n        f(99)\n        $x.inspect\n        
+32c2b7533445abe2c786addc24166b66	"3/4"	Rational(0.75).to_s
+32dc2c8ce60f570a592f91cf451f6746	99	class C\n          X = 99\n        end\n        \nC.class_eval("X")
+32f8a3ccb6465782cb76e9906981206c	777	class C\n          private\n          def secret; 777; end\n        end\n  
+3311ccd4cb9cd7e5df6df18d7421cb90	nil	Exception.new.backtrace_locations
+33151d5f5ddac3016b0004900224a63a	["warning: the block passed to 'UBWarn#unused' may be ignored\\n", "", "", "", "", "warn-bg", "", "", "silent-strict"]	def cap\n          saved = $stderr\n          buf = +""\n          io = Ob
+3320b224735f4ca919ccdcccb8c4e5bd	-450.5353775047145	def calc(i)\n          f = i * 1.1; g = i * 0.9; h = i * 1.3; j = i * 0.
+33428047f1f658e115c637013b4660d7	[["initial", nil], ["after-match", "zzz"], ["creator-after-resume", "oo"]]	"foo" =~ /(o+)/\n            r = []\n            f = Fiber.new do\n   
+33a37997020cb2a326855e1801974373	"hello\\n"	r, w = IO.pipe\n            t = Thread.new { r.gets }\n            Th
+33b5711e09e6c160215318c1fd17224f	["no error", 5]	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; def m(x:)
+33cbc86f31c1e6a7eb6adf5738c1d3eb	[true, 7, 8]	o = Object.new\n        def o.to_a; $flag = true; [7, 8]; end\n        $f
+33cc5f4be417d616ecd8eb208e890c90	[3, 3, 4]	def f(x, y = x, z = y + 1); [x, y, z]; end; f(3)
+33cd8b36724499dce5c02aaf1ed6ba18	nil	$LOAD_PATH.resolve_feature_path("zzzz")
+33d265b1410d2d73366d85d5914634a0	:bar	class Foo\n              def bar; end\n            end\n            \n\n
+33f240174e1b4ed412a41494df988007	true	rng = Random.new(42)\n        a = rng.rand(0.0)\n        a.is_a?(Float) &
+3412cc41d6de3781c63ffde8aa5321ad	3	class MyNum; def to_int; 2; end; end\nn = MyNum.new\n[1,2,3,4,5].fetch(n)
+34185ec344beed72368ad045d6e8444c	[false, false]	require "tempfile"\n            t = Tempfile.new("mrb_sec")\n        
+342be135e2ef683c60f43547f62d6a1b	42	# Test 1: include + include (via module chain) where M appears twice in the cha
+343056548572c0af99b46d04ac94410d	42	class Foo\n          def !\n            42\n          end\n        end\n    
+346c3ccb2630b081d1268d76b216f8cf	{amount: 4, unit: "km"}	M = Data.define(:amount, :unit)\nm = M.new(42, "km"); m.with(amount: 4).to_h
+3470de4e4871882a3fbb89a9ee3709e3	["MyArr2", [1, 2]]	class MyArr2 < Array; end\n            r = Marshal.load(Marshal.dump
+347cffbb4c975e8f7aba48cffa253e3a	"a-b"	path = "/tmp/monoruby_test_io_open_#{Process.pid}_#{rand(100000)}"\n
+3491bb9ea3ef0d8e8dc6e9d966784850	[true, true, false]	klass = Class.new\n            Class.new do\n              klass.send
+349f590d26b1d8c968d1a0e8cbacad45	"Hash"	(GC.compact if GC.respond_to?(:compact)).class.to_s
+34af1f2f62dae8cd51151425c5414771	"err"	def foo\n              begin\n                raise "err"\n           
+34c5e73b9bc573ebdb2b02dbcf61535c	false	class Integer; alias __orig :>; def >(o); __orig(o); end; end; 3 > 4
+34d92e030feea7a955c11db593e2a994	"3.140000"	class HasToF; def to_f; 3.14; end; end\n            sprintf("%f", Ha
+350fc45901c7ff4041bdf8a1abf3a79c	["via_send", "BSend", "BSend", [], [:a], 1]	class BSend\n              def direct; binding; end\n              de
+351c5e2d7c1113c1b45bd6b66e8aa52a	[2.0, 3.0, -3.0, -2.0, 0.0, 2.0, 0.5]	def fa; 17 % 5.0; end\n            def fb; -17 % 5.0; end\n          
+3535eecf4c57db26badbf664b0539819	["DEFAULT", true, "IGNORE"]	Signal.trap("USR2", "DEFAULT")\n            a = Signal.trap("USR2") 
+355f64ccc41342dde6bb12c04da77410	true	[Process.getpgrp, Process.getpgid(0), Process.getsid].all? { |v| v.is_a?(Integer
+3565c58dca7325f9f598f2c1ae3626b3	true	GC.config.is_a?(Hash)
+356bbf9786b1d2f6d8025e7e3cda3118	[4, [0, 104, 0, 105], [104, 233], "Encoding::UndefinedConversionError"]	path = "/tmp/monoruby_test_iowt_#{Process.pid}_#{rand(100000)}"\n   
+3578263ee9b00b995172d8097fe872a6	["Windows-31J", true, "US-ASCII", "Windows-31J"]	[ /foo/ensuensuens.encoding.to_s,\n                /foo/ensuensuens == /foo/s,\n  
+3586b2a0d44e304e2cc0c8333c54cc78	S	class S\n              def f; end\n            end\n            class 
+35893713489f04b55c3edbf76271232f	true	GC.stat.is_a?(Hash)
+359011e908badac3a43d1cebe1333513	["value of $/ must be String", "value of $, must be String", "value of $; must be String or Regexp", Regexp, "value of $\\\\ must be String", true, "abc", "abc", "xyz", true, true, true]	res = []\n        begin; $/ = 1; rescue TypeError => e; res << e.message
+35aa9419d43039fdce34d20f42d121ee	true	at_exit { }.is_a?(Proc)
+35aed6269230614f514b0cca9f65135f	[496.0, 496.0]	class V\n          attr_reader :x\n          def initialize(x); @x = x; e
+35b552993012bdd3941cb6ad288c6d94	[[true, true], true]	minor = GC.stat(:minor_gc_count)\n            major = GC.stat(:major
+35ba577079fd96d51d364de17df33ad5	:te	begin; 1.instance_eval { alias :foo :to_s }; :no; rescue TypeError; :te; end
+35c34bacae1f61a4e888e6635ce091cd	[1, 11, 21]	a_r, a_w = IO.pipe\n            b_r, b_w = IO.pipe\n            t = T
+35c59e1cf7ef55a085a02265b5be6363	["abc", 1, "aBc"]	x = "b"\n               r = /a#{x}c/imx\n               [r.source, (r =~ "xABCx"),
+362197c8ba0c107c5b63c4c8b7e930e6	false	t = Thread.new { IO.select(nil, nil, nil, 2**62) }\n            Thre
+366101f3454d9c3ba104d799233170e4	14	class Foo\n              def with_block; yield 7; end\n            en
+367c0b57251ec6d8861445efce15a4a2	[3, 4, 5]	class MyNum; def to_int; 2; end; end\nn = MyNum.new\n[1,2,3,4,5].drop(n)
+36e28f3b4bad007127519f2712f4d570	[39, :receiver_class, "constant", "nil", :receiver_class, "class variable access from toplevel"]	$r = []\n        m = Module.new\n        $r << m.class_eval("@@cv1 = 39; 
+36ef6bae649b437bac48a49db4df0dd2	[false, false, false]	a = "\\xff".dup.force_encoding("UTF-8")\n              b = "\\xff".d
+36f30f53930311aedc7940de7a521902	true	FileTest.writable?("/tmp")
+37098ec530fdee99de199ec187ef4aff	["Array", "Array"]	res = nil\n            watcher = Thread.new do\n              res = T
+370a61883bde042b4dd2b533f9826e7d	[1, 15]	module M4; C = 10; end\n        x = 0\n        (x += 1; M4)::C += 5\n     
+3713f9ff76a4ac253e9a68abe86f9490	["NameError: some_undefined_bare_name", "NoMethodError", "NoMethodError", "NameError: _9999", "mm:completely_undefined", "NoMethodError"]	res = []\n        check = proc do |blk|\n          begin\n            blk.
+373dce0647a3563f6f8d43e85dae4894	["B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 1|[2, 3, 4]|5", "B->A 7|[]|8"]	class A\n          def m(a, *r, z) = "A #{a}|#{r.inspect}|#{z}"\n        
+3741f01e297724922a35197b47bec177	42	class A\n          def f\n            42\n          end\n        end\n      
+374be36fbc601473f1499f1bddc9c77a	:OVERRIDDEN	class String; def ==(o); :OVERRIDDEN; end; end; "a" == "b"
+3761b5221f2c41c01988c22c8c014546	["class or module required for rescue clause", "caught", "caught", "unmatched", :fine]	res = []\n        [[42], [RuntimeError], [TypeError, RuntimeError], []].
+376e7a0bc570cc88bf4722d793dbdfbd	"US-ASCII"	"abc".dup.force_encoding("US-ASCII").sub("a", "z").encoding.to_s
+37802d8218ebae3a341d4074b9a69430	[[:ensure], false, false]	r = []\n            t = Thread.new { begin; sleep; rescue Exception 
+37a2ef15c36aa81e8fa9880f709c6173	true	a = "a"\n            a.send(:initialize_clone, "b", freeze: true).eq
+37a3982f27875fdfc73737a1139fb6f7	[[:dm, :dm], :from_send, :normal, nil]	(class MC; define_method(:dm){ [__method__, __callee__] }; def from_send; send "
+37bc41b6eddcd7d75a01000d291a6db3	true	Math.log1p(Float::NAN).nan?
+37c013e01cc33ebbf72b216e9b61f984	2	b = binding\n            b.eval("1 + 1")\n            
+382b0a8d2ba3e8d5eac237fadf834cdd	25275.0	def with_block(&blk)\n          acc = 0.0\n          j = 0\n          whil
+3849de0738411075598f560268990dd7	[100, 200]	module M\n              def initialize\n                $res << self.
+38b6176ce634343e8a5c7383c6c60ed5	["hel", "l", "o"]	$/ = "l"; a = []; "hello".each_line { |x| a << x }; $/ = "\\n"; a
+38c61140d1fbae4f76a1b87985cac70e	["This", nil, " ", "This", nil, " ", "This", " is a", "line2"]	require "strscan"\n        s = StringScanner.new("This is a test")\n     
+38de781e254a5ac2c4c68f48b757c162	["HUP", "EXIT", "ABRT"]	class X\n              def to_int; 6; end\n            end\n          
+38e8535203a45126dec7384677d22eb2	:OVERRIDDEN	class NilClass; def ===(o); :OVERRIDDEN; end; end; nil === nil
+38eccaa13be24490261f4daaad9d3296	[:match, :nomatch, :match, "hell"]	$_ = "hello"\n        res = []\n        res << (/ell/ ? :match : :nomatch
+38f643aa5bcc2f78ba48b486bb393e15	15	(1..5).inject {|result, item| result + item }
+38fadfa8ec11940a56e2acf40f7eb4f0	"pq"	r, w = IO.pipe\n            t = Thread.new { r.readpartial(10) }\n   
+3960bad4527e209ac4eef6f17972f4c6	[true, [1, 2, 3]]	class C; def foo(a, b, cc); [a, b, cc]; end; end\n            cu = C
+3962b2ffd2b48bcb5feb55745b8b6b37	[[40, 50], [40, 50]]	[1, 2].map { [4, 5].map { it * 10 } }
+39740411375592c29d3f5adde2165332	[[10, 20], [0, 10, 20, 9], 1, true, 2, 1, true, 1, true, :type_error]	def m(*a) = a\n        class Obj\n          def initialize(v) = @v = v\n  
+397660fb68b22813a4bbe91972c0b9bf	nil	print 1
+39af2a1340a7198301238c30503a4079	true	Fiber.current.is_a?(Fiber)
+39b040323d16819b1a965df73071e65f	[[true, true, true], [IO::Buffer::AccessError, "Buffer is not writable!"], "HELLO", true, true, "test\\x00\\x00\\x00", "cdef", "abXYefgh", [false, false], [true, false], [6, "\\xC3\\xA9", "\\xC3\\xA9llo"], [ArgumentError, "The given offset is bigger than the buffer size!"], [ArgumentError, "Specified offset+length is bigger than the buffer size!"], "\\x00ab\\x00", 3, "\\x00AAA\\x00"]	r = []\n            s = IO::Buffer.for("abc")\n            r << [s.ex
+39c92c0308629107e62585945ff18f41	7	f = ->{ _1 + _2 }; f.call(3, 4)
+39cebe9290af3ec842595e2aa63877e4	[[233], "ISO-8859-1", [120]]	s = "\\351x".dup.force_encoding(Encoding::ISO_8859_1)\n               m = Regexp.n
+39e6703b6b81cc1675c7d7f7730c417f	[[1, 2, 3, nil, nil, nil, nil], 31, [3, [[:a, 31], [1, 2], [nil, 3]], 31], [4, 4, 31, nil], [nil, nil, 0], [7, 1, 1], ["gen", 1]]	def drive(n)\n              r = nil\n              n.times { r = yiel
+39eb22a6c09538f53ff55e200b562be8	59	f = ->(x){x + 42}\n            \n\n            f.call(17)\n            
+3a01dc8fffbde1143e30f29445a348d4	[42, "z", 99]	out = nil\n        50.times do\n          a = []\n          a << (class C7
+3a319d3cfdb21a4802f64f67da78477f	"US-ASCII"	s = "Hello".encode("US-ASCII")\n              s.swapcase!\n        
+3a3ea224e66a902c9412e5a9bc4f8e3d	[[:A, [7], {}], [:A, [1, 2], {x: 9}], [:A, [], {}], [:A, [3, 4], {}], [:t, [1, 2], {z: 3}], [:t, [], {}]]	class A\n              def m(*a, **k); [:A, a, k]; end\n            e
+3a4a3fd8d76c29f29774b570dd11adcd	[true, :ok, 42, 42, :called]	res = []\n        class DMNest\n          define_method(:dm) { def dm_nes
+3a93a9fe00364f7041508a5bef1a5fa1	[(1.0+0i), (8+2i)]	Complex(8,2).coerce(1.0)
+3aa8cc4b12c2a98850ad0d1867e64eec	:OVERRIDDEN	class Symbol; def !; :OVERRIDDEN; end; end; !(:a)
+3ae4c2b3533e51e91f854e643b29e5b2	"/home/user/monoruby/monoruby/a.rb"	require File.expand_path("a")\n        C::D\n        
+3aff5d6537c677c0f944ab936ad4f4d2	false	GC.auto_compact = false; GC.auto_compact
+3b1644af44f2b478814ac2f40d1b9037	[3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17, 18, 18, 19, 19, 20, 20, 21, 21, 22, 22]	module Foo\n              @@foo = 1\n              def foo\n          
+3b2c8f065c5ebcd815f411c69823e2f8	[true, "hi", "hi", "hi"]	class ReSubA < Regexp; def initialize(*a); super; @a = a; end; attr_reader :a; e
+3b321e6a12da0e61ced761fb33a302e2	"[\\"/\\", 1, 2]"	require "tmpdir"\n            Dir.mktmpdir do |d|\n              out 
+3b322fd7da566474e06ac3cf66a73833	"0"	ENV["MONORUBY_ENV_TEST_FF"] = "0"\n            begin\n              E
+3b39e9db52a30f710cbc3acfcfed2261	["Errno::EINVAL", true]	require 'fcntl'\n            File.open("/tmp") do |f|\n              
+3b523cbc07620a2031af2c15c7078c43	[32, 2]	class Foo; def to_int; 2; end; end\n        \n[8 << Foo.new, 8 >> Foo
+3b591020e07b36bac1b39a55a6a96e88	[true, true]	before = Dir.pwd\n            d = Dir.new("/tmp")\n            fd = d
+3b62a035f769a0af97d60b6305e90297	["B", "M2", "M1", "A"]	module M1; end\n        module M2; end\n        class A; end\n        clas
+3b7bddcc8abc0adf6c34b65a42d6051f	""	require 'stringio'\n            old_stderr = $stderr\n            old
+3b7d88815bcb9d0d3527cba96db56abb	1	proc { |a,| a }.call([1, 2])\n            
+3b8b9967df243db673eead48df27af73	true	r, w = IO.pipe\n            Process.wait Process.spawn("ps -o pgid= 
+3ba3513c4e0478ac885cbf78cee7b5f7	[true, true]	f = File.open("Cargo.toml")\n            begin\n              [f.to_i
+3bc7d9857d044df621b8aa29939fbb5a	[true, {a: 1, b: 2}, {}]	h = { a: 1, b: 2 }\n            [h.to_h.equal?(h), h.to_h, {}.to_h]\n
+3bcb429ddcf2c13f3b1284650ceddfa9	"0+1i"	class C; def to_c; Complex(0, 1); end; end; o = C.new\nComplex(o).to_s
+3bda8299aecb6e6f15c317979b7755ed	[8.0, 1.4142135623730951, 0.125, 0.0, 1.0, -8.0, 16.0]	def fa; 2 ** 3.0; end\n            def fb; 2 ** 0.5; end\n           
+3bfe90f69b324c8b43c4c30b229b9ddc	"my_cls"	c = Class.new\n            c.set_temporary_name("my_cls")\n          
+3c027e2e1ae3889315fbc61098871eaa	3	class MyNum; def to_int; 2; end; end\nn = MyNum.new\n[1,2,3,4,5].delete_at(n)
+3c08d84242fa705f6035b733b22c106c	"no-shebang\\n"	require "tmpdir"\n            Dir.mktmpdir do |d|\n              path
+3c2bfd6217c4e85fafe2bf1e3baa05d5	""	eval("/a+?*/").match("")[0]
+3c3e9df720bcfc9e16e5388ec370e1a6	3.15	class Foo; def to_int; 2; end; end\n            3.14159.ceil(Foo.new
+3c69555cfc9c304438892b113e9bb012	[[:@@inherited, :@@own], [:@@own]]	parent = Class.new\n            parent.class_variable_set(:@@inherit
+3c7f081b962e4c7272b51d99d568feb4	["outer", "outer", "outer", "outer", "nil"]	def brk_while(log)\n          outer = StandardError.new "outer"\n        
+3c8c62dfbc6ab8e4b391463cee4bdbb0	[true, true]	require "io/wait"\n            [IO.instance_method(:wait_readable).i
+3c8d308b1dc06f94ef88b63745ff08be	[false, true, [:a, :b], nil]	t = Thread.new {}.join\n            t.thread_variable_set(:a, 1)\n   
+3ca7dc56ff22d6c2b33235faf84f9b0e	[:gets, :read, :gets_threaded]	require "socket"\n            res = []\n            s = TCPServer.new
+3cf87379e16fe1d3a9d2d96970f0d8bd	true	A = Struct.new(:x)\n            B = Struct.new(:x)\n            \n\n   
+3d28365ff908f010d20822a67b2846df	["ensure in f", "ensure in g", 42]	def g\n          begin\n            yield\n          ensure\n            $r
+3d4f40c1f15e87af5d8f2875562332f0	true	"".dup.force_encoding("UTF-16BE") == "".dup.force_encoding("UTF-8")
+3d5aaee333bdf3c4bc36ded91dcd0aaf	[1, :nme]	class TrueClass; def only_true713; 1; end; end\n        res = []\n       
+3d5adde3fb0edf69c5646dd0efeadc07	["PSubC", :dup, :clone]	class PSubC < Proc\n                 def initialize_dup(o); super; @tag = :dup; e
+3d825ed681f4d3904854e2642bf813b4	A	class A; end\n            Class.new(A).superclass\n            
+3d97f043dbc63d648bc8c08d3cd03cda	Array	class C < Array; end\n(C[1,2] | [3]).class
+3d9c37b87faf349ecb67571fb23a24e7	[[1, 2], 3]	->((*a, b)) { [a, b] }.call([1, 2, 3])
+3dbebf67556767ed46ca1b15b5c6014b	0	("" <=> "".dup.force_encoding("ISO-2022-JP"))\n            
+3dde798cc9545abe28c98d1ee6dfbc9a	[:wrapped, :real, 12]	class Base; def real(x); x * 3; end; end\n            class Sub < Ba
+3dea6009f2f1cee6ca57430c6241a099	"ASCII-8BIT"	s = "abcdef".dup.force_encoding("US-ASCII")\n              arg = "
+3df82d5f32bc7def3d0d985cd7071aa8	:ok	res = :ok; if false; a = [1, 2]; a[] = 9; end; res
+3dfe78bc67c9d66d2fdd2e9ab6b354e7	[1, 9, 10, 7, 107]	class A\n              def initialize(h) @a = h end\n              de
+3e1d53f944590acbe759e3fddf0d6b76	60000	S = Struct.new(:a, :b, :c)\n            \n\n            s = S.new(10, 
+3e2485275f7b329ad73878b64b71abed	false	define_method(:boom2) { :bam2 }\n            Object.private_method_d
+3e3b547575a051c5ad3005c1294bcc60	["heLlo", "heLlo", "heLlo", "heLLo", "heLLo", "heLLo", "heLlo", "heLlo", "heLlo", "heLLo", "heLLo", "heLLo", "heLlo", "heLlo", "heLlo", "heLLo", "heLLo", "heLLo"]	class P\n                  def to_str; "l"; end\n                
+3e71ea53ced04beae6b8eda67e34f8fe	-1	class C; def to_str; "def"; end; end; o = C.new\n"abc" <=> o
+3e888919ce8daf33b5729ceef0ab65a8	[:load_error, "/definitely/not/a/file"]	class AutoRetry\n          autoload :Foo, "/definitely/not/a/file"\n     
+3e888c174905aa623fffe81f01020540	[]	class A3; def a(*r); r; end; end\n            class B3 < A3; def a(*
+3ea714d00ab18c02ddeeeac4648d3d50	"hello\\n"	io = IO.popen("echo hello")\n            s = io.read\n            io.
+3ec757fa265aa412b3b36ba1f96c0f14	["1234", "567", true, "12345", "1234567890", 2, "12XY567890", true]	path = "/tmp/monoruby_io_prw_#{Process.pid}_#{rand(100000)}"\n      
+3edda3e10e05dd7d22ab125a3f3fc747	[true, true, true, true, true, true, true, true, true, true, true, true, true, true]	GC.start\n            s = GC.stat\n            [\n              s[:hea
+3f05b99cbc38adbfbc473b701ac03671	[:solo, :solo, 42]	obj = Object.new\n            def obj.solo; 42; end\n            m = 
+3f11838333fcfd0c716211da92e940b8	[[1, 2], [true, nil], [true, nil], [42, nil], [0, 1, 2], [1, 2], [true, nil], [1, [2]]]	class Ary;  def to_ary; [1, 2]; end; end\n        class Nily; def to_ary
+3f1b46f2be220ff7e899b8081439a046	true	"abc".force_encoding("ISO-8859-16").encoding == Encoding::ISO_8859_16
+3f4dfe13f5216cef0f89b04300d4b2aa	true	GC.enable; GC.disable; GC.enable
+3f6f1c23deee61068ec39f5295c45a16	[[], [:f]]	class S\n              def f; end\n            end\n            class 
+3f839e4337603d2011e09f2f712091a4	[:bar, :foo]	class A\n              def foo; end\n              def bar; end\n     
+3f92dae4c5bb5d0850bb428a743f7317	[4, 5]	r = []\n        10.times { |i| r << i if (i == 4)...(i == 5) }\n        r
+3fcbc9935b035dee352be56a30398754	"world"	IO.popen("echo world") { |io| io.read.chomp }\n            
+3fef9f42692341177896868638c71b46	[["v1", "v2"], [nil, nil, "new"]]	ENV["MONORUBY_ENV_TEST_MN1"] = "v1"\n            ENV["MONORUBY_ENV_T
+3ff02e23d910a4fb58eb4a1180f7d75c	"\\\\u{61}"	Regexp.new(/\\u{61}/).source
+401bf8ea7b3aa33ac1a060658f9ee0cf	[true, true, true, "Class", "Class", "Class", false, true, true, "#<Class:#<Class:MCA>>", true]	class MCA; end\n        class MCH < MCA; end\n        module MCM; end\n   
+402369e00b302b22068e6c528d3bde64	103	$a = 100\n$a.succ.succ.succ
+406d83cba60c86c7a187e07617fbd024	:p	parent = Class.new { def foo; :p; end }\n            child  = Class.
+4086c6059363125acb8e46416f91d20f	"FiberError"	begin\n              Enumerator.new { |y| Fiber.yield; y << 1 }.each
+40871a574065d49f2b0ca7045d6f6391	{life: 42}	f = Fiber.new(storage: {life: 42}) { Fiber.current.storage }\n      
+4098362919565939287f7ffe08a158db	"0.314e1"	require "rubygems"\n        require "bigdecimal"\n        BigDecimal("3.1
+40b3f88b68876a80e1adabd27a506a98	["data", [100, 0], [0, 100], [100, 0, 0, 0], [0, 0, 0, 100], "plain", "xy", [100, 0], [0, 100], [100, 0, 0, 0], [0, 0, 0, 100], "nobom"]	path = "/tmp/monoruby_test_iobom_#{Process.pid}_#{rand(100000)}"\n  
+40cecdcb446e63551e2fcd36919c57d0	true	Data.define.is_a?(Class)
+40dbb62b44df59e21da6740b92d1afe6	[4, 8, 91, 7, 85, 58, 13, 77, 68, 80, 114, 111, 116, 111, 50, 105, 6, 64, 6]	class MDProto2\n              def initialize(x); @x = x; end\n       
+40e716c7328738b3fe988089e88cf750	[false, "d"]	File.open("Cargo.toml") do |f|\n              f.read\n              f
+40ec27ae46c638a3a6280b2acf09bfed	["SocketError", true, 0, ["AF_INET", "127.0.0.1", "127.0.0.1"], true, "127.0.0.1"]	require "socket"\n            res = []\n            # unknown host ->
+4127f9d58f69e19b5bcf5c3c3cefe969	[true, true, false, :fired]	Thread.handle_interrupt(StandardError => :never) do\n              c
+41308fa046142fe3ed9d2bce06bdeb37	[4, 8, 91, 7, 73, 117, 58, 13, 85, 68, 80, 114, 111, 116, 111, 50, 7, 104, 105, 6, 58, 6, 69, 84, 64, 6]	class UDProto2\n              def initialize(s); @s = s; end\n       
+41709673073e0a9bac7681363b4962df	"語本日"	"日本語".reverse
+417394f1be1fb3cb921d2758ca5edc19	nil	defined?($there_is_no_such_global_xxxxx)\n            
+419d77b6e939231fdafd53d3c6c6ea9d	[1, 2, 42, 55, []]	def f(x,y,a=42,b=55,*z)\n            [x,y,a,b,z]\n        end\n        \n\n 
+419ee2f4a5f8c62a9f32d72169a9b695	[true, 100, 91, 97, 112]	[\n              Errno::ENETDOWN.ancestors.include?(SystemCallError)
+4201651c81088820aab64210097ab3f7	[2, "NoMethodError"]	r = Module.new do\n              refine Array do\n                ali
+420fd4ef995831a71e5964759ba88f3b	"ああabc"	"abc".rjust(5, "あ")
+421b2694d3c8d4c86d2dafb625fb56b3	["/no/such/path", nil]	m = Module.new do\n              autoload :Foo, "/no/such/path"\n    
+422706c6f0f10a6e433ccf4efba1b5fd	[[1, 2, 3], [1, 2, 3, 4]]	a = [1, 2, 3]; b = a.dup; b << 4; [a, b]
+422ca904058c1a5d736c6ac08c83267d	42	a=Object.new; a.instance_variable_set("@i", 42)
+4239507f8b8c670abb722bea0b9c254e	"missing keyword: :x"	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; define_me
+423a27c97cfa628fc4d17c0da8f6bb0a	[true, "hi"]	class ReSubB < Regexp; end; r = ReSubB.new("hi"); [r.is_a?(ReSubB), r.source]
+4253be14d49d0c5b2ccb81f0dcb1bbe4	[1, 2, 1, 2, 1, 2]	class C; def to_int; 3; end; end; o = C.new\n[1, 2] * o
+42636ead6d6f845d215efab6f85556c8	[ArgumentError, "mid"]	o = Object.new\n            def o.each; yield 1; raise ArgumentError
+429a7a3919eafaa9c1bebe8facc7d257	[3, :forked, true]	a = Thread.start(1, 2) { |x, y| x + y }.value\n            b = Threa
+429bbb68c8becef2c91b3b88c39ec1b9	0.75	class Float; alias __orig :/; def /(o); __orig(o); end; end; 3.0 / 4.0
+42b5a41ba81c93ef56cb842bd0de353a	[4, 5, 6, 7, 8, 9]	r = []\n        10.times { |i| r << i if (i == 4)...(i == 4) }\n        r
+42eae55c860ab92e208765fba1feebd0	[:g, :f, :g, :f]	class C; def f; 1; end; alias g f; end\n            um  = C.instance
+43287f7f969302f66d6508b01f9391ee	true	path = "/tmp/monoruby_test_link_eexist_#{Process.pid}_#{rand(100000
+432917dce47e57aa2c69d28da5250506	["AAAABB", "BB", nil, nil, "AAAABBBB", [], ["AAA", "AAA"], "", "negative length -1 given"]	require 'tmpdir'\n            f1 = File.join(Dir.tmpdir, "argf_r1_#{
+433c417c950d06949c049cf368ef9844	[0, 1, 1, 1, 2, 2]	a = Enumerator.new do |y|\n                3.times do |i|\n          
+435171489f4203f7936e6fe743d0f104	42	k = Class.new { define_method(:m) { return 42 } }\n            k.new
+436b608d4e0f149fc5e64270419cbc30	["Module#using is not permitted in methods", "main.using is permitted only at toplevel"]	OUT = []\n            MAIN = self\n            m = Module.new do\n    
+437790989f8314db63fc5cb409acc4f7	"US-ASCII"	s = "abc".dup.force_encoding("US-ASCII")\n              s[/(?<x>b)
+43a72f9e36181b89914ddf07298065aa	[1, 2, 99, 4, 5]	class MyNum; def to_int; 2; end; end\nn = MyNum.new\na = [1,2,3,4,5]; a[n] = 99; a
+43ac301501bd4f9ceee646d818f6e415	[:next, :next, :nameerror]	a = Class.new\n            b = Class.new(a)\n            c = Class.ne
+43ccf9c44caf043039162c566a3cf9bd	[4, nil, 7]	a=1\n            x=0\n            b=while a<4 do\n                a=a+
+43cf8f6733d05eaa7ee0c56b3da5cbdf	7074.1	CONST = 5.7\n            sum = 0\n            for i in 0..19 do\n     
+441632d0adc7cf1139fe425ab23da30c	true	class Integer; alias __orig :<=; def <=(o); __orig(o); end; end; 3 <= 4
+44206b9628b17b33c675e72762330bd5	[true]	io = IO.popen("cat", "r+")\n            res = [io.sync]\n            
+442cc99068d79c4d0b979f548fff9db2	[[[1, 2, 3], {}], [[], {a: 1, b: 2}], [[9], {x: 3}], [[1, 2, 3], {}], [[:rest, :*], [:keyrest, :**]]]	def target(*a, **k); [a, k]; end\n        def d_rest(*); target(*); end\n
+442ded55291eaab4990a26fee7bf8cdc	"undef caught: foo [10, 20]"	class C\n          def foo(*args)\n            args\n          end\n       
+4433d71bfa1c5cc6691d2dd71800fbe7	[:range, :range, :type]	h = { a: 1, b: 2 }\n            if h.respond_to?(:__key_at)\n        
+443bfeb84d9c2d708f478b4cd0860091	[true, true, false]	r, w = IO.pipe\n            a = [r.close_on_exec?, w.close_on_exec?]
+44528032436bdb6e6e366e913d073a06	"v1\\n"	r, w = IO.pipe\n            Process.wait Process.spawn({"SPAWN_T1" =
+44559a35406b5a8f1093bcfc268a7dd5	false	File.readable?("nonexistent_file_xyz")
+445fbc5889648d57a0f017eb770cb3aa	[["#<Method:", "#<Method:"], ["#<Method:", "#<Method:"], ["#<Method:", "#<Method:"], ["#<Method:", "#<Method:"], ["#<Method:", "#<Method:"], ["#<Method:", "#<Method:"], ["#<Method:", "#<Method:"], ["#<Method:", "#<Method:"], ["#<Method:", "#<Method:"], ["#<Method:", "#<Method:"], ["#<Method:", "#<Method:"], ["#<UnboundMethod:", "#<UnboundMethod:"], ["#<UnboundMethod:", "#<UnboundMethod:"], ["#<Method:", "#<Method:"]]	module MS\n              module MyMod; def bar; :bar; end; end\n     
+4469cd34806e00d8575f88a69f15e60f	"run"	Thread.current.status
+447a897b741808d693d666ee7af98d00	["NameError", true]	-> { it; (binding.local_variable_get(:it) rescue [$!.class.name, $!.message.star
+44a4e5e4818fc7deff1396b80d456ad8	[[0, {z: 9, w: 0}], [1, {}], [1, {z: 9, w: 1}], [1, {}], [2, {z: 9, w: 2}], [1, {}], [3, {z: 9, w: 3}], [1, {}], [4, {z: 9, w: 4}], [1, {}], [5, {z: 9, w: 5}], [1, {}], [6, {z: 9, w: 6}], [1, {}], [7, {z: 9, w: 7}], [1, {}], [8, {z: 9, w: 8}], [1, {}], [9, {z: 9, w: 9}], [1, {}], [10, {z: 9, w: 10}], [1, {}], [11, {z: 9, w: 11}], [1, {}], [12, {z: 9, w: 12}], [1, {}], [13, {z: 9, w: 13}], [1, {}], [14, {z: 9, w: 14}], [1, {}], [15, {z: 9, w: 15}], [1, {}], [16, {z: 9, w: 16}], [1, {}], [17, {z: 9, w: 17}], [1, {}], [18, {z: 9, w: 18}], [1, {}], [19, {z: 9, w: 19}], [1, {}], [20, {z: 9, w: 20}], [1, {}], [21, {z: 9, w: 21}], [1, {}], [22, {z: 9, w: 22}], [1, {}], [23, {z: 9, w: 23}], [1, {}], [24, {z: 9, w: 24}], [1, {}], [25, {z: 9, w: 25}], [1, {}], [26, {z: 9, w: 26}], [1, {}], [27, {z: 9, w: 27}], [1, {}], [28, {z: 9, w: 28}], [1, {}], [29, {z: 9, w: 29}], [1, {}]]	class KwR\n          attr_reader :h\n          def initialize(a: 1, **h) 
+44a71a0aaf4c652c114d8a3ee53bb9f0	["other", "other", "other", "z0", "z1", "z2", "z3", "z4", "z5", "z6", "z7", "z8", "z9", "other", "other", "other", "other"]	def classify(n)\n          case n\n          when 0 then "z0"\n          w
+44bed6dfa52341a2aab87a99ffd81034	[["UTF-8", "ISO-8859-1"], "wrong number of arguments (given 3, expected 1..2)", [nil, nil], nil, nil, nil]	path = "/tmp/monoruby_test_ioenc_#{Process.pid}_#{rand(100000)}"\n  
+44e35e721c76737a34dd6351e19f068d	[1024, 243, 100000, 1, 16, -32, 1, 0, 4611686018427387904, 1267650600228229401496703205376, (1/8)]	def pow_a; 2 ** 10; end\n            def pow_b; 3 ** 5; end\n        
+44e68a42fc21864d3655bc7637e9b548	[1, 2]	c = Class.new { def foo(*a); a; end; ruby2_keywords "foo" }\n       
+44ef14cc0315a5970badc2886bcac2ee	"mm:bar:[1, 2]"	class Foo\n              private\n              def method_missing(na
+44f1637501a6c7cf0fd3b221e1aa900d	6.466855489220472e+219	def fact(x)\n                if x <= 1.0 then\n                    1.
+44f5057dc05820dc78575222bbfe64a1	[604462909807314587353091, 5]	srand(2 ** 79 + 3)\n            prev = srand(1)\n            o = Obje
+450633a61fa9abd810a2d8f146138580	[-1.0, -0.5, 0.0, 0.5, 1.0]	def test\n          res = []\n          i = 0\n          endv = 1.0\n      
+450edce48c819aa1af5216c7f14d1321	"#<struct x=\\"hello\\">"	Struct.new(:x).new("hello").inspect
+4523045e61b1c499c1a7df8498f60d30	["x", true]	module MarshalExt; end\n            # CRuby-produced bytes for `"x".
+453aa173199f23dcb1925ebf3c19f541	[[:keyrest, :opts]]	def kwrest_named(**opts); end\n            method(:kwrest_named).par
+453b01475bd9f7d1a42fdbfa56e1f6d7	[ModNestOuter::ModNestMiddle::ModNestInner, ModNestOuter::ModNestMiddle, ModNestOuter]	module ModNestOuter\n              module ModNestMiddle\n            
+453d44137039b2306963eb515050023d	:re	a = [1,2,3,4]; begin; a[-5..10] = ""; rescue RangeError; :re; end
+454539e2b45442d94b7989495b4563ef	["UTF-8", [227, 129, 130]]	File.binwrite("/tmp/mr_gc2.txt", [164, 162].pack("C*"))\n           
+454e2e87849398aff023ffd47ce0568a	"hello"	c = Class.new\n            c.class_exec do\n              def hello\n 
+4578bd5fa7148d23a652a1a92eb517df	false	Enumerator.new { |y| y << caller.empty? }.first
+45c219e430e29dc7ecd467638b65c70b	[true, true, true]	pid = spawn("true")\n            t = Process.detach(pid)\n           
+45c9b7ea3cba52cd428385897c67b953	[true, false, false, false, true, false, true, false, true, false]	S = Struct.new(:a, :b)\n        T = Struct.new(:a, :b)\n        \n\n       
+45ca7b6809a873de22eb68bc015aef5c	["abc", "abcd"]	s = +"abc"; t = s.dup; t << "d"; [s, t]
+45e49567be504828e7510a0020c9d651	[true, nil]	class AutoLazy\n          autoload :D, File.expand_path("a")\n        end
+45e7cd851152ce44323bc881e5d31ae3	["FrozenError", {a: 1}, [[:a, 1], [:b, 2]], "RuntimeError", 2, 99, 2]	def drive(n)\n              r = nil\n              n.times { r = yiel
+45ebe9672e6cb7a979a3e5075d15e40b	[1, true, nil]	require "json"\n            data = JSON.parse('{"a":[1,{"b":true}],"
+4635d4b0d1f2878f1956e4eae990f393	[2, 0, false]	File.open("Cargo.toml") do |f|\n              f.gets; f.gets\n       
+464097b0dec5ef95d2a454202f882ff3	[1, true, false]	idh = {}.compare_by_identity\n        foo = 'foo'\n        idh[foo] = tru
+4646d58775453b5799c1369ea16d3305	true	Thread.new { 42 }.is_a?(Thread)
+46590c38d8a9995223435001dd59bc53	[Regexp, "abc", 1]	bytes = "\\x04\\x08\\x49\\x2f\\x08\\x61\\x62\\x63\\x01\\x06\\x3a\\x06\\x45\\x46"\n
+465ff3e1364db1761afb663540910025	C	class C\n          self\n        end\n        
+46653d9439881914bfbd95d3cbc1399c	7	Fiber["skey"] = 7\n            Fiber[:skey]\n            
+4666ffe0c30a05805d070f3ba1540b9e	[true, 8, true]	s = Random.bytes(8)\n        [s.is_a?(String), s.bytesize, s.encoding ==
+46963d49691a45826cdde8d0153bd36e	[4, 8, -2, 0, -1, 0, -1, 8, 0, 1024, -1024, 0, 16, -16, 0, -1, 4611686018427387904, 1267650600228229401496703205376, 13835058055282163712, 18446744073709551616, 23058430092136939520, 32281802128991715328, -23058430092136939520, -1180591620717411303424, 18446744073709551616, 18446744073709551616, 135742175033388171264]	def shr_a; 8 >> 1; end\n            def shr_b; 8 >> 0; end\n         
+46a80dc2cd47df441429de6df71a47a0	["SignalException", true, true, "boom", "Interrupt", "Interrupt: interrupted", "Interrupt", "Interrupt"]	[\n              Interrupt.superclass.name,\n              Interrupt 
+46a989f5bb905a42d54984ad2d7e6916	1	proc { |a,| a }.call(1, 2, 3)\n            
+46c2c2d709c8b4d70ef4956d9bba320c	[11, 11]	class CC\n                 attr_accessor :n\n                 def initialize_copy(
+46e22155017028d95fbdbbc21de4bdfb	[true, true, [:rb, :extrb, :tilde, :lp], ["feat.rb", "feat.ext.rb"], true, false, false, true, false, true, [:rb, :extrb, :tilde, :lp]]	dir = File.join(ENV["TMPDIR"] || "/tmp", "mrb_req_rules_#{Process.p
+46f2f986835a063bd0b0532a252ec8a3	:OVERRIDDEN	class TrueClass; def !; :OVERRIDDEN; end; end; !(true)
+47022d7eeed9794777123c954899a58b	"1010"	class HasToInt; def to_int; 10; end; end\n            sprintf("%b", 
+4711d3c6a104a019b453a9e82b6ed3aa	"[{a: 42, 100 => 100, c: 5}]"	class C\n          def foo(*x)\n            $res << x.inspect\n          e
+47158826963e74a7b4e2bb4bbe467183	"[true, [1, 2], []]"	r, w = IO.pipe\n            pid = fork do\n              r.close\n    
+47191238c441efe6b42cabcfe3e8ac8d	[true, true, true, true, true, true, true, true, true, true, true, true]	File.write("/tmp/mr_enc.txt", "")\n            r = []\n            Fi
+471f3c66f038e2cb40befbb5721648b8	7	def f(a); a; end\n        f(7)\n        
+472c706ca066dc69100827453cbbb6bc	:re	a = [1,2,3,4]; begin; a[-5...-4] = ""; rescue RangeError; :re; end
+473094d74e8eeb2ed376bf1e76f3cfef	"c"	class C; def to_int; 2; end; end; o = C.new\n"abcde"[o]
+473980764eec5281c76961e1ab7b705d	"1-2-3"	class Foo; def to_str; "-"; end; end\n            [1, 2, 3].join(Foo
+476242cd20c0c9f6a22f3e32a70547c0	"boom"	t = Thread.new { begin; sleep; rescue ArgumentError => e; e.message
+47636529d53e0465da757c1394a305d2	["class C\\n", "  D = __FILE__\\n", "end\\n", "if $count.nil? then $count = 1 else $count += 1 end"]	f = File.open("a.rb");\n        res = []\n        f.each_line do |line|\n 
+476a5f416c682927379126dfcc407162	true	h = { a: 1, b: 2 }.compare_by_identity\n            h.select { true 
+4784ac427bd8bf76dea560ab5a1ede1a	"cba"	"abc".reverse
+479ed4b42eeae923683180f667f2d367	[[:alias2, :alias1]]	class SFAR_A\n          def name\n            [:alias1]\n          end\n   
+47a466639c2c1b1719397c1a7d85ddbb	"MIT License\\n\\nCopyright (c) 2022 monochrome\\n\\nPermission is hereby granted, free of charge, to any person obtaining a copy\\nof this software and associated documentation files (the \\"Software\\"), to deal\\nin the Software without restriction, including without limitation the rights\\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\\ncopies of the Software, and to permit persons to whom the Software is\\nfurnished to do so, subject to the following conditions:\\n\\nThe above copyright notice and this permission notice shall be included in all\\ncopies or substantial portions of the Software.\\n\\nTHE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\\nSOFTWARE.\\n"	File.read("../LICENSE-MIT")
+47ae976bfcfac15927d61a026a17110e	false	Module.new.method_defined?(:hash)\n            
+47b4a9d964ab14f6ade2bbe2ebb0af86	true	Enumerator.new { |y| y.yield }.each { |a| a }.nil?
+47d7351976024e90fdb66ae5f2d39fcc	[true, true]	[Process.respond_to?(:_fork), Process.respond_to?(:fork)]\n         
+47e7e98a04a78c655d67c571def18c17	"US-ASCII"	"abc".dup.force_encoding("US-ASCII").gsub(/b/) { |m| "X" }.encoding.to_s
+47ff59203a8ee9640145c8b1f5b27aa1	[1, 2, 3, nil, 4, nil]	def f\n          yield 1,[2,3],4\n        end\n        \n\n        f {|a,(b,
+4804dbad6891c718e5096ff82ef60c7c	["#<Method:", "#<Method:"]	module Mod; def bar; end; end\n            class Foo; include Mod; e
+4806b2df31d1910107eef6e23c081f94	5	def make_counter\n          count = 0\n          inc = Proc.new { count +
+48137d524869d91770282ec59ace6ebb	"US-ASCII"	a = "abc".encode("euc-jp"); /#{a}/.encoding.to_s
+482fe57af7a0767de6479316a00ed916	6	Thread.new(1, 2, 3) { |a, b, c| a + b + c }.value
+4837dfdc276a86f53941ddafe66cb53b	["hello\\n", "world\\n", "foo\\n"]	path = "/tmp/monoruby_test_foreach_#{Process.pid}"\n            File
+483914fde3cb7dac282cf5c352a29b88	"aXXXX"	class C; def to_str; "bc"; end; end; o = C.new\n"abcbc".gsub(o, "XX")
+483a3a15e1c4f82869da871bda9f29e7	["caught m0", "unmatched n0", "type: class or module required for rescue clause", "caught m1", "unmatched n1", "type: class or module required for rescue clause", "caught m2", "unmatched n2", "type: class or module required for rescue clause", "caught m3", "unmatched n3", "type: class or module required for rescue clause", "caught m4", "unmatched n4", "type: class or module required for rescue clause", "caught m5", "unmatched n5", "type: class or module required for rescue clause", "caught m6", "unmatched n6", "type: class or module required for rescue clause", "caught m7", "unmatched n7", "type: class or module required for rescue clause", "caught m8", "unmatched n8", "type: class or module required for rescue clause", "caught m9", "unmatched n9", "type: class or module required for rescue clause", "caught m10", "unmatched n10", "type: class or module required for rescue clause", "caught m11", "unmatched n11", "type: class or module required for rescue clause", "caught m12", "unmatched n12", "type: class or module required for rescue clause", "caught m13", "unmatched n13", "type: class or module required for rescue clause", "caught m14", "unmatched n14", "type: class or module required for rescue clause", "caught m15", "unmatched n15", "type: class or module required for rescue clause", "caught m16", "unmatched n16", "type: class or module required for rescue clause", "caught m17", "unmatched n17", "type: class or module required for rescue clause", "caught m18", "unmatched n18", "type: class or module required for rescue clause", "caught m19", "unmatched n19", "type: class or module required for rescue clause", "caught m20", "unmatched n20", "type: class or module required for rescue clause", "caught m21", "unmatched n21", "type: class or module required for rescue clause", "caught m22", "unmatched n22", "type: class or module required for rescue clause", "caught m23", "unmatched n23", "type: class or module required for rescue clause", "caught m24", "unmatched n24", "type: class or module required for rescue clause", "caught m25", "unmatched n25", "type: class or module required for rescue clause", "caught m26", "unmatched n26", "type: class or module required for rescue clause", "caught m27", "unmatched n27", "type: class or module required for rescue clause", "caught m28", "unmatched n28", "type: class or module required for rescue clause", "caught m29", "unmatched n29", "type: class or module required for rescue clause"]	def rescue_match(exc_msg, clause)\n          begin\n            begin\n   
+48550372bab4ca5a49be495f7a3ccff8	[true, true, false]	root = Fiber.current\n            inner = nil\n            f = Fiber.
+485bfcadd99bf357e22c80c24adff41d	[true, true, true, true, true]	cri = Struct.new(:value) do\n              def to_int; value; end\n  
+486696700c00f3fb37eb234c9c60f677	["only a", false]	a = Object.new\n            b = Object.new\n            a.define_sing
+48839ffd49795e527baeb89db20cb2c2	["2020-12-25T00:56:17+00:00", "2020-12-25T00:56:17.123456789+09:00", 10800, 0, 18000, 500000000, 0, "2020-01-01T00:00:00+00:00", "2020-03-04T00:00:00+00:00"]	[Time.new("2020-12-25 00:56:17").iso8601,\n             Time.new("20
+488d47c4b605cf5749a29b8563730981	"a1b2 c3!"	"A1B2 C3!".downcase
+48ca330894fd5c945a0e50a26d1600c7	["ab!!", "cd"]	r, w = IO.pipe\n            t = Thread.new { r.gets("!!") }\n        
+491e6e98d6a793843248846a95652c6d	[3, 7, :a, [:zsuper, :zs], :fwd]	def base; yield :s; end\n        def relay; base { |s| yield(s) }; end\n 
+492435923a4859ca15afa3b4f458a0a8	nil	if false then 100 end
+4940aab6109c0ac7ad8a593d007f7537	[2, 3, -3, -2, 4, 0]	def rem_a; 17 % 5; end\n            def rem_b; -17 % 5; end\n        
+49474d8fdfcda56581bd37c6364edbf5	12.0	class Float; alias __orig :*; def *(o); __orig(o); end; end; 3.0 * 4.0
+494ec06a0bfc00cd79fe70cbb1732bbc	[true, true, :te, true, true, "proto_edge.rb", [:proto, :proto, :circ]]	dir = File.join(ENV["TMPDIR"] || "/tmp", "mrb_req_proto_#{Process.p
+495eea79c1efddc709cd6b6d494959ce	[10, 20, 30, nil]	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \ns.val
+497bfe2c00ba642cd03d765ebc920d18	[:FOO, :BAR]	$res = []\n            class C\n              def self.const_added(na
+498f27a3323f24163817191bb2ca252f	"ABC"	key = Object.new\n            def key.to_str = "upcase"\n            
+4991081371808b9050b481f9fa77aee6	[true, true, false, false, false, true, true, true, :lo, :eq, true, true, false, false, false, true, true, true, :lo, :eq, true, true, false, false, false, true, true, true, :lo, :eq, true, true, false, false, false, true, true, true, :lo, :eq, true, true, false, false, false, true, true, true, :lo, :eq, true, true, false, false, false, true, true, true, :lo, :eq, true, true, false, false, false, true, true, true, :lo, :eq, true, true, false, false, true, false, true, true, :lo, :eq, true, true, false, false, false, true, true, true, :lo, :eq, true, true, false, false, false, true, true, true, :lo, :eq, true, true, false, false, false, true, true, true, :lo, :eq, true, true, false, false, false, true, true, true, :lo, :eq, true, true, false, false, false, true, true, true, :lo, :eq, true, true, false, false, false, true, true, true, :lo, :eq, true, true, false, false, false, true, true, true, :lo, :eq, true, true, false, false, false, true, true, true, :lo, :eq, true, true, false, false, false, true, true, true, :lo, :eq, true, true, false, false, false, true, true, true, :lo, :eq, true, true, false, false, false, true, true, true, :lo, :eq, true, true, false, false, false, true, true, true, :lo, :eq, false, true, false, true, false, true, true, true, :lo, :eq, false, false, true, true, false, true, true, true, :lo, :eq, false, false, true, true, false, true, true, true, :lo, :eq, false, false, true, true, false, true, true, true, :lo, :eq, false, false, true, true, false, true, true, true, :lo, :eq, false, false, true, true, false, true, true, true, :hi, :eq, false, false, true, true, false, true, true, true, :hi, :eq, false, false, true, true, false, true, true, true, :hi, :eq, false, false, true, true, false, true, true, true, :hi, :eq, false, false, true, true, false, true, true, true, :hi, :eq, false, false, true, true, false, true, true, true, :hi, :eq, false, false, true, true, false, true, true, true, :hi, :eq, false, false, true, true, false, true, true, true, :hi, :eq, false, false, true, true, false, true, true, true, :hi, :eq, false, false, true, true, false, true, true, true, :hi, :eq, false, false, true, true, false, true, true, true, :hi, :eq, false, false, true, true, false, true, true, true, :hi, :eq, false, false, true, true, false, true, true, true, :hi, :eq, false, false, true, true, false, true, true, true, :hi, :eq, false, false, true, true, false, true, true, true, :hi, :eq]	def drive\n              res = []\n              x = 500\n            
+499e401fe668a7ebb37dac8d30c5e5a6	"Encoding::CompatibilityError"	(/\\A[[:space:]]*\\z/ =~ " ".encode("UTF-16LE"); nil) rescue $!.class.name
+49beb012f234aa90122664ef49b7040e	["abc", "abd", "abe"]	other = Object.new\n                def other.to_str; "abe"; end
+49cda40144833b11efa2c118b273671a	[[:lje, "break from proc-closure"], [:lje2, "break from proc-closure"], [:lje3, "break from proc-closure"], :local]	def cap(&b); b; end\n        res = []\n        def use_call\n          b =
+49e75a728c86edcf8a947d85a34a5f24	["foo", "bar", "baz"]	class Foo\n            def foo() "foo" end\n            def bar() "bar" e
+49ed29647c7ff556ed4301a4bae46a92	[[:U8, 1], [:S8, 1], [:u16, 513], [:U16, 258], [:s16, 513], [:S16, 258], [:u32, 67305985], [:U32, 16909060], [:s32, 67305985], [:S32, 16909060], [:u64, 9801809732607083009], [:U64, 72623859790382984], [:s64, -8644934341102468607], [:S64, 72623859790382984], [:f32, 1.539989614439558e-36], [:F32, 2.387939260590663e-38], [:f64, -5.447603722011605e-270], [:F64, 8.207880399132047e-304], [ArgumentError, "Type extends beyond end of buffer! (offset=100 > size=8)"], [ArgumentError, "Invalid type name!"], 2, [1, 2], 4, [2, 1], 5, [255], 8, 1.5, 8, -2.25, [ArgumentError, "Type extends beyond end of buffer! (offset=100 > size=8)"], [[0, 1], [1, 2], [2, 3]], [[2, 1027], [4, 1541]], [[2, 3], [3, 4]], 8, [1, 2, 3, 4], [2282161669], [1, 2, 3], 8]	r = []\n            b = IO::Buffer.for("\\x01\\x02\\x03\\x04\\x05\\x06\\x07
+49ed5a0fe73fd1b796e7a9a4e4845e10	true	$".class == Array\n            
+4a00694fe0703f9bf35b82d0eb475842	5	def f; return 5; end; self.f
+4a27834f1a4d3f1b1dbe388b001f68a5	[true, true, true, true, true]	created = Fiber.new {}\n            res = [created.inspect =~ /\\A#<F
+4a330374eb4fb47c48601113a41fc5c2	[false, true, 1]	h = {}\n        s = 'bar'\n        h[s] = 1\n        [h.keys.first.equal?(
+4a3c010763bbdcf926955a661aa391e2	true	Math.acosh(Float::NAN).nan?
+4a559a2616834976fdd08253452a37af	[1, 2]	def f\n                  yield 1,[2,3],4\n                end\n   
+4a6606db1e1aa4ca08a3681377e4a47e	false	at_exit { }.lambda?
+4a6bb862ea034f302be2cfbedfb744f4	["Integer", 21, 0, 9]	class UnrealNum < Numeric\n                attr_reader :value\n      
+4a81072638ae84178e312daed598c75d	[[0, 4, 8]]	class CLSE_Probe; end\n        def clse_leaf(i)\n          if i == 15\n   
+4a847603089dda435964691badb1916d	["Aello", "Bello"]	path = "/tmp/monoruby_test_flags_#{Process.pid}_#{rand(100000)}"\n  
+4a8ced26fd6e7c6411be14c59f2c32fe	"café"	"CAFÉ".downcase
+4a9b1bb2da57cd0a76d1760578880404	7	f = lambda { |x, y| x + y }\n        f.call(3, 4)\n        
+4a9ca2254538290628be8ee3f39cc3ba	7	def f(a = false, b = ($x = 7)); 1; end\n        f\n        $x\n        
+4aa00ef784df53c58ff8db3c8af730b3	[]	class C\n              def foo; end\n            end\n            C.un
+4ab5f6a6a0bb96ca8dbf476985b27300	true	Process.detach(spawn("true")).value.success?
+4b0562d042e4b29121a3a778a5bbe014	[true, true, [Errno::ENOENT, "No such file or directory @ realpath_rec - /no_dir"]]	(d="/tmp/mono_rdp_#{Process.pid}"; Dir.mkdir(d); a=(File.realdirpath("#{d}/missi
+4b0b098de64405fa2d58af5975f6002d	[nil, nil, nil, "k", nil]	res = []\n        obj = Class.new do\n          def method_missing(*args)
+4b1520a7a94bdbf2346f214e1c7c3c19	"bar"	class Foo\n              def bar; "bar"; end\n              alias :"b
+4b154d366578a9d9516c5ced884aff50	true	$PROGRAM_NAME == $0\n            
+4b21252ebb5ff9b6aa82ae8e6ff502de	[nil, nil, 255, nil, 255]	File.open("Cargo.toml") do |f|\n              [f.ungetbyte(nil), f.u
+4b38f80a2dc496613c01fb765a2095ea	1	("こにちわ" =~ /に/)
+4b4a0439d01a80344c2eaed6545e0e28	"US-ASCII"	"aabbcc".dup.force_encoding("US-ASCII").squeeze.encoding.to_s
+4b507bed2a712e59abaa87a54599f0f4	true	"hello".dup.force_encoding("UTF-8") == "hello".dup.force_encoding("ISO-8859-1")
+4b56bcfd11798fe0667cde0dc5079e4b	[[1, 2], [2, 3], {x: 9}, [5, 3], {h: 1}, {a: 1}, {}]	class Foo\n              def kw(a:, b: 2) = [a, b]\n              def
+4b59335449dc812f8ce85905dcc81af2	[42, "Line one\\nLine two\\nLine three\\nAnd so on...\\n", 8, "Line one", 8, " one\\nLin", 42, [TypeError], 8, 10, 32, 42, false, [IOError], 4, 7, "012Line789", false, 9, "pipe data", false, [Errno::ESPIPE], 42, "Line one\\nLine two\\nLine three\\nAnd so on...\\n", 42, "Line one\\nLine two\\nLine three\\nAnd so on...\\n", 0, 17000, 17000]	require "tempfile"\n            src = Tempfile.new("mrb_cs_src"); to
+4b5b45123447283c4530b768dbe566cd	"US-ASCII"	"hello".encode("US-ASCII").upcase.encoding.to_s
+4b630bdfdd9f1ce5cacddd03b49d4446	[true, false, false, false]	class A; end\n        [A.singleton_class.singleton_class?, A.singleton_c
+4b6fe109f1f968bc1a8d4646ba46c194	"377"	class HasToInt; def to_int; 255; end; end\n            sprintf("%o",
+4b91108237bdda9802ca4299f4114874	[[:singleton_method_added, :singleton_method_added], [:method_added, :foo], [:singleton_method_added, :foo]]	$res = []\n            module M\n              def self.method_added(
+4b97615f1fd9c5dced851f3adf53042b	[:thrown, [:ens]]	$log = []\n            r = catch(:t) do\n              begin\n        
+4ba2572278d477946c8815ee58fef0de	"hello"	class Foo\n              def hello; "hello"; end\n              alias
+4bb8dfa79710364063ae0b96416ec24a	"[C2, C1, M, Object, Kernel, BasicObject]"	module M\n            end\n            class C1\n              include
+4bf63b7ab095dc317e165b1b582247af	[10, 1]	def m(y: 10) = y; [m, m(y: 1)]
+4c1c6f6c3f836877abf737896a925b9d	[true, true, true]	S = Struct.new(:a, :b, :c)\n            \n\n            s = S.new(1, 2
+4c2abed4507b2755e1ec53fe8226c80f	[true, true, :done, :finished]	(a=loop.instance_of?(Enumerator); b=(loop.size == Float::INFINITY); sub=Class.ne
+4c3cdf6fdb768ce2061972f6724dd416	42	class Foo\n              def initialize(x)\n                @x = x\n  
+4c6323de719d0ad254c106b3de0e1ff1	99	b = binding\n            b.local_variable_set("bar", 99)\n           
+4c66c29f7a10c99487fbb86f19ded61a	false	File.file?("readme.md")
+4c6f323c0ce3159e2b7f0992372dd514	false	/a/.match("xay".b).nil?
+4c7471c063042fa95b957878dbb97a5a	[true, false]	class C < Object\n        end\n        class S < C\n        end\n\n        o
+4c7947408d26ed45ead6a30d7a7c8c21	[42, 42, 42, 42, 42, 42, 42, 42, 84, 84, 84]	class A\n          attr_accessor :w\n        end\n        a = A.new\n      
+4c830959762040fd7828ae17cda7609b	false	class Baz\n              def =~(other)\n                true\n        
+4ca5ef22e7c6b22a26e89e772d3bc269	:OVERRIDDEN	class Integer; def +(o); :OVERRIDDEN; end; end; 3 + 4
+4cad44250388355234df828a92361960	200	m = Mutex.new\n            counter = 0\n            ts = 4.times.map 
+4cda4f884a47ad7a4e2e7b5cc240b4e7	[100, 100, 4950]	a=1\n            x=0\n            b=until a>=2500 do\n                
+4cdcd188f20c1d3fc3dc0524a34a00bb	["[1, 2] {a: 3}", "[10, 1, 2] {a: 3}", "[1, 2] {a: 3}", "100", "[10, 1, 2] {a: 3}", "100"]	class S\n          def f(*rest, **kw)\n            $res << "#{rest} #{kw}
+4cf2c2b92a59f794f3435c85df91b8b2	[512, 39104]	src = [[1.0, 1.0, 1.0], [1.0, 0.8, 0.81], [0.78, 0.94, 0.66], [0.79, 0.
+4d3b8cfdb3abf0074873c94df0f08c11	nil	ENV.rehash
+4d3df55da53ba45fdeda6a3f5a171162	[:caught, :caught, :caught, :propagated, :propagated, :propagated, :propagated, :propagated, :propagated]	def caught?(k)\n              begin\n                begin\n          
+4d3e3e2c0afc6cd7e00e85a264e70654	[111, 222, 333, 111, 222, 333]	def add_fold; 5 + 3; end\n        def mul_fold; 100 * 100; end\n        d
+4d59acc812858b13ef3ed51f02730d3b	[]	begin\n          Object.new.no_such_method\n        rescue NoMethodError 
+4d5c5ebc315582c724d99bfe750271af	"M1"	module M1\n              def f; "M1"; end\n            end\n          
+4d68f852fba127b042c84037069425b0	[{1 => "a", 2 => "BB", 3 => "CC", 4 => "DD"}, {1 => "a", 2 => "BB", 3 => "CC", 4 => "DD"}, {1 => "a", 2 => "BB", 3 => "CC", 4 => "DD"}]	foo = {1 => 'a', 2 => 'b', 3 => 'c'}\n            bar = {2 => 'B', 3
+4da42d690f4ae363c784e239d269ee3e	true	class C\n        end\n        C === C.new
+4db6500a830cf8b2a99b743dc6b5a94d	["global-variable", "a"]	"mis-matched" =~ /s(-)m(.)/; [defined?($+), $+]
+4dc4d26946a9b8df8a8ab0edf49e3a8d	["constant", "constant", "constant", nil, nil, "constant"]	module CovM\n              CONST = 1\n              module Inner; DEE
+4dcb81b6869dcf441ba63e6d2c098346	[]	class S\n              def f; end\n            end\n            class 
+4defe7bb5ad979e91a414effdfdd78fb	[true, false, true]	c = Class.new\n            c.class_variable_set(:@@x, 1)\n           
+4e054da7ff8f209d32d166db442d2dc4	"[\\"/\\", 0, true]"	r, w = IO.pipe\n            pid = fork do\n              r.close\n    
+4e28bda19471453041e9cf2cede01564	"missing:WHATEVER"	module MN\n          def self.const_missing(c); "missing:#{c}"; end\n    
+4e3073843c620dd557f8c075aa31dbc8	:OVERRIDDEN	class Integer; def &(o); :OVERRIDDEN; end; end; 3 & 4
+4e3880e1cf98a829d3bc68746cdfb0ef	"́e"	"é".reverse
+4e4513eb2bc8a514535f060b8faddfd8	[10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42]	res = []\n        50.times do |x|\n          res << 100 * 100\n          i
+4e47ffc76fe153dc81662e78c3766e5f	[4, 8, 101, 58, 9, 77, 69, 120, 116, 91, 6, 105, 14]	module MExt; end\n            a = [9]\n            a.extend(MExt)\n   
+4e65c1f861f9096dda31e1a54a334c3c	[Hash, 99, 99]	sub = Class.new(Hash)\n            o = sub.new(99)\n            o[:x]
+4e78c9407fe210294bad93265e6fe237	"Class"	"mutable-str".dup.singleton_class.class.to_s
+4e91589759e06abf5967280f353d07c5	[9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError"]	def g(a, b, c) = yield(a + b + c)\n        def f(...) = g(1, ...)\n      
+4e9bfbcee73c693e57ccc4d38d0dfa34	["x", "y"]	base = "/tmp/monoruby_dir_eachchild_#{Process.pid}_#{rand(100000)}"
+4ebe3f743c44083475b01a20ac7c38bc	false	binding.local_variable_defined?(:_10)
+4edbac695b5ed45b538971de1ca0ed2c	[true, true, true, false]	f = File.open("Cargo.toml")\n            begin\n              [f.binm
+4ef654f58c91b7b93cc8ea7d3a1d2da8	[false, false, false, true, false]	class MEqStrTrue; def to_str; "x"; end; def ==(o); true; end; end\n 
+4f93aca4bf1af1b5c4055cb5ae6b15f5	[nil, false]	t = Thread.new { sleep }\n            r = t.join(0.05)\n            t
+4fa66bde865d8b29ac7a73525c13a9c4	true	path = "/tmp/monoruby_io_dc_#{Process.pid}_#{rand(100000)}"\n       
+4fbfb4f6588f47b184c44eb72d8611a5	[File, true, [Errno::EINVAL, "Invalid argument"], File]	(f="/tmp/mono_nb_#{Process.pid}"; fh=File.new(f, "w") { raise "block called" }; 
+4fda5e163110371f958036531cafe440	[]	def f(*x)\n            x\n        end\n        \n\n            f()\n        
+501deac01fffd75eb557a2e670ad9542	[[:matched, :unmatched], "foo", nil]	def m\n              /(?<matched>foo)(?<unmatched>bar)?/ =~ "foofoo"
+50401c8da659fffc9b6001cdcb30bafb	[1, 7]	h = Hash.new(7)\n            h[:a] = 1\n            r = Marshal.load(
+50508f5aac8320c0afe66c4ad76cad0e	["EQ-RAW", false, "NE-RAW", true, true, false, "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW"]	class CustomEq; def ==(o); "EQ-RAW"; end; end\n        class CustomNe; d
+50630a61a4b6d776c5dc73a592df1d53	[:a, :a, [:a, :b, :c], :a, ["NameError", "implicit parameter '_1' is not defined"], ["NameError", "implicit parameter '_1' is not defined"], ["NameError", "'a' is not an implicit parameter"], ["TypeError", "1 is not a symbol nor a string"]]	def try; yield; rescue => e; [e.class.to_s, e.message.split(" for "
+506afd7190c9d45ecdef2e801c939176	:te	begin; 1.instance_eval { undef to_s }; :no; rescue TypeError; :te; end
+507f32e0a72a071583d973ffea3c15c7	["Hello Dave at New York!", "Hello Gave at Hawaii!"]	Customer = Struct.new(:name, :address) do\n            def greeting\n    
+509d9bea76f0e1d8349ff37b354accf3	2	k = Class.new { define_method(:m) { [1, 2, 3].each { |x| return x i
+50a5f1523f40c371eae52d5bdb271289	[:@b]	class Foo\n              def initialize\n                @a = 1\n     
+50dc75cab4d7c00e25ec748ffac45bee	"[C2, M, C1, M, Object, Kernel, BasicObject]"	module M\n            end\n            class C1\n            end\n     
+5103d830753ac483d2d4c39e44bc03b5	[0, 0, nil]	["‌" =~ /[[:word:]]/, "‍" =~ /[[:word:]]/, "‌" =~ /\\w/]
+5153f5263b097f08fb57811bdbdc5aaa	[true, true, true, false, true, true, true, false, false, false, false]	class A\n          def method1; end\n          protected\n          def pr
+5174f3c6fa3195d1fbd047639e4a904d	[[true, {data: 42}], ["async", "ctx"], [[[true, ["both"]], [false, []]], true, "both", false]]	r = []\n            de = Class.new(StandardError) { attr_reader :dat
+51be01e0d292ac0d9c77567390f1d11f	["Bbar", "B[239, 191, 189]", "Bdbar", "Btbar", Encoding::UndefinedConversionError, [ArgumentError, "too big fallback string"], TypeError, Encoding::UndefinedConversionError]	(r=[]; r << "B�".encode(Encoding::US_ASCII, fallback: { "�" => "bar" }); r << "B
+51bf1bd2c44ca7c76c217e78a6007ece	[true, 3]	a = ARGF.class.new('/dev/zero')\n            [a.read(100) == "\\0" * 
+522c4f8c40e029c9a06a958415c5bba8	["append_features:C"]	$res = []\n        module M\n          def self.append_features(base)\n   
+52737290d47684f2e53ee7646498dbeb	[1, 2, 1, 2, 1, 2, 2, 1, 2, 1, 2]	class S\n              def g\n                f\n              end\n   
+52c715d3341e07f64b568be422ce7c17	true	h = {}\n            h[:self] = h\n            g = Marshal.load(Marsha
+52cc02c8a048877c5eedd646aa6690e1	["US-ASCII", "UTF-8", "EUC-JP", "US-ASCII", "UTF-8", "US-ASCII", "UTF-8", "UTF-8"]	[ /abc/, /abc/u, /abc/e, /\\u{61}/, /\\u{3042}/,\n                Regexp.new("abc")
+52d70b5a956cf65a2161a0c071728cd2	[true, true]	o = Object.new\n            o.freeze\n            begin\n             
+52e034352601862a8ad528f2c0b53e00	"TEST"	/(?<t>\\w+)/ =~ "TEST"; l = -> { Regexp.last_match(:t) }; l.call
+52e3c4053b6635a9049d6b966fd6af93	["bogus", "bogus", false, false, "wxq.rb", "wxq.rb", "vxq.rb", true]	cls = Class.new do\n              def go\n                autoload :Z
+530edafd9da1b1757a0295e4d18879dd	["RSub", "x"]	class RSub < Regexp; end\n            r = Marshal.load(Marshal.dump(
+5326cacf44528935163ede17463c01c9	1	lambda { |a,| a }.arity\n            
+532f5d7ba05f7843743de0b52969bba8	["PSubB", :x, 2, 9]	class PSubB < Proc; def initialize(a, b); @a = a; @b = b; end; attr_reader :a, :
+5344f32f5c73af78489308d9a5575a7d	[["TypeError", "1 is not a symbol nor a string"], ["TypeError", "1 is not a symbol nor a string"], ["TypeError", "1 is not a symbol nor a string"]]	def try; yield; rescue => e; [e.class.to_s, e.message]; end\n       
+536366d9b0b405f788174be1f1a39cb3	[true, true, true, "\\e[1mx (\\e[1;4mRuntimeError\\e[m\\e[1m)\\e[m\\n\\e[1my\\e[m"]	res = []\n        begin\n          begin\n            raise "the cause"\n  
+53a0e18814663d90c976b6d913746bc6	[true, :blocked_ok, :locked, :done]	require 'tmpdir'\n            path = File.join(Dir.tmpdir, "mrb_floc
+53c684da33e546973dbfb03625ab4bc6	"Outer::Inner"	module Outer\n          class Inner\n            def self.name_test\n     
+53d9651dadebd1d49dd5ea2484441652	["hello ", "world", ""]	"hello world" =~ /world/\n            [$`, $&, $']\n            
+53de2e2405d567e57214a9d190333b9b	42	r = nil\n        50.times { r = 1 + (module M730; 41; end) }\n        r\n 
+5421bb91fa4cf1d68d4decc362895d4d	[42, 43]	def g\n            yield 1,2\n        end\n\n        def h\n            yiel
+542bb850481385e5109575d67ea8460c	false	Object.new === Object.new
+5431b0bb58b87b5339855d33232ce8ba	[50, 150, 250, "divided by 0"]	$x = []\n            begin\n                begin\n                   
+545e4c0f948bea1d881dd72283b09578	[[:b, :m, :a, "Object"], [:b]]	m = Module.new { def chain; super << :m; end }\n            a = Modu
+54769890b128ed28f27f4a72e21598de	"S:#<Symbol:0xADDR>"	class Symbol; def to_s; "S:" + super; end; end\n                :foo.to_s.sub(/0x
+5495a4ecfc8034c3e6e7fc205e4e41f4	[UMS, "hello-data"]	class UMS\n              def marshal_dump; "hello-data"; end\n       
+54cec27c16a23055cb1af1f7bd0ee7f2	[nil, nil, nil, nil, 1, true, false, false, 1, :blocking]	res = []\n            res << Fiber.scheduler\n            res << Fibe
+54d92cf0264334597de6d135e289a10d	[[:block, 1], [:proc, 2], [:block, 2], true, [:block, 3], 1, :fired, :argerr]	res = []\n            trace_var(:$tv_spec) { |v| res << [:block, v] 
+550657b209502598ac09bdd6794b2088	[Encoding::CompatibilityError, "5!", ArgumentError]	[ (begin; format("hello %s".encode("utf-8"), "world".encode("UTF-16LE")); rescue
+55124e846ccfc03a163c2cfdf4d72203	:raised	class E\n              def initialize() @a = {k: 1} end\n            
+553588ca0ab5030b1fb038e8bcdbc8f5	"Bar"	class Bar; end\n        Bar.to_s\n        
+5560cb313539dc27e921167b0c6a08ea	[1, 2]	[1, 2].each.with_index { |v, i| }
+55977b99b181a0f40d3ac1f217cc0211	[false, 1, 2]	arr = [1, 2]\n        def arr.to_a; $flag = true; super; end\n        $fl
+55a58dcc1901800753da4c940eef31fe	[-3, -3]	def f(a,b)\n          a-b\n        end\n        \n\n        a = []\n        a
+55d3766f222609a4076548bde20c92c4	5	m = Module.new; m.const_set("ἍBB", 5); m.const_get("ἍBB")
+55d4331ac5b0d6b85a29b08cd75d814c	["echo hi", false]	def `(cmd); [cmd, cmd.frozen?]; end\n        x = "hi"\n        `echo #{x}
+55e0c5f6cdca1e7736c6f5a8ef3c31a9	[[[:a, 1], [:b, 2], [:a, 1], [:b, 2]], [[:a, 1], [:b, 2]], [[:a, 1], [:b, 2]]]	S = Struct.new(:a, :b)\n               s = S.new(1, 2)\n               r = []\n    
+55f0fc54d8a7b9fc5936d77ffe989680	true	File.absolute_path?("/tmp")
+5625d0e94e4d1bc9b84e2742fce64c08	true	class Foo\n              def initialize\n                @a = 1\n     
+565141a1ed8e896232b365303c5ac4d4	:OVERRIDDEN	class Integer; def ===(o); :OVERRIDDEN; end; end; 3 === 4
+56568fdc7f4e0b46c94d29cb9def4ec2	["renudged-to-main", 0]	r, w = IO.pipe\n            pid = fork do\n              r.close\n    
+5674c6743eb1f8cb3c5480370147f096	[10, 20]	class A\n          def initialize(x)\n            @x = x\n          end\n  
+5682fe3035100385f60effc866827604	[false, false]	def foo; end\n            def bar; end\n            public [:foo, :ba
+569d1753aae6166485a592748257a963	[[[:a, 1], [:b, 2], [:c, 3]]]	class C\n          def f(**kw)\n            $res << kw.sort\n          end
+56b85c950efd2cb0bd3500751c39686e	[2.4676811938123496e+176, -1.8507608953592623e+176]	def f(n)\n          x = 0.0\n          y = 1.0\n          i = 0\n          
+56bcba9795510ae298d1929763e4b300	100	foo = false\n        bar = true\n        quu = false\n        \n        cas
+56be47cd692556e12f7876ff5251e406	[[10, 100, 10, 100, 20, 200, 30, 300], [1, -1, 2, -2]]	r = []\n        c = {}\n        [1, 2, 3].each do |i|\n          begin\n   
+56c66dbccb073aee6589ec1565f0bc4a	[true, true, :from_m]	m = Module.new { def hello; :from_m; end }\n            c = Class.ne
+56d2acea00f86435c09eba201d394a6a	"US-ASCII"	"abc".encode("US-ASCII").ljust(5).encoding.to_s
+56e7e0addb979c7b45676dd416029bbd	false	c = Class.new do\n              def foo; 'x'; end\n              unde
+570b040bdaffa1b8418ad19df9963b51	["/home/user", "file.txt"]	File.split("/home/user/file.txt")
+572b1d6bee4d9881bea673d3703255a2	"Kernel"	Object.instance_method(:respond_to_missing?).owner.to_s
+572b883c230b4f69d4b415b30b19b9c2	1	pid = fork { sleep 5 }\n            count = Process.kill(0, pid)\n   
+573a889f327b5f24c438d7517aacf15a	nil	"hello".byteindex("ll", 3)
+573fe669ac971343defbd1cde20dc915	["MONORUBY_ENV_TEST_KEY", nil]	ENV["MONORUBY_ENV_TEST_KEY"] = "uniq_value_5678"\n            r = EN
+576157356419a5741dbdbde29df95789	true	GC.stat.values.all? { |v| v.is_a?(Integer) }
+57bd29081de5740463b29a1c3ee0ef00	"US-ASCII"	s = "hello".dup.force_encoding("US-ASCII")\n              s[/(ll)/
+57f002dbbc2a38d20a751f8e1d4218fe	[255, 15, 240, -1, 15, -16, 42, 0, 42, 42, -43, 244837815148286, 304366200, 244837510782086]	def or_a; 0xFF | 0x0F; end\n            def and_a; 0xFF & 0x0F; end\n
+5802c597582fbeab79b6c6ee6bfe6fed	[true, false]	a = ["a","b","c"]\n        \n\n            [a.include?("b"), a.include
+581a9eeda65b4118ca39d22e6e34f801	[:caught, "boom"]	class C\n              def initialize; @h = {}; end\n              de
+582de92dfc668c66f3fca99c56ea0221	9	M = Data.define(:amount, :unit)\nM.new("amount" => 1, amount: 9, unit: "m").amoun
+58330bef80223af992dc7623e3ec3084	[312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3]]	def g(x, y, z)\n          x, y, z = z, x, y\n          x * 100 + y * 10 +
+58661de46a8dc941342a4319c35b9c90	1	obj = Object.new\n            def obj.infinite?; nil; end\n          
+586ab40f2dfcbd13d521be385c9a6b38	[2, 2]	[[1, 2].each.with_index.size, [1, 2].each.with_object(:m).size]
+586c6036c606500ee67ef673b7e6ef50	:foo	obj = Object.new\n            obj.define_singleton_method(:foo) { 42
+5872cbdbe2d3cb1265b437c0e39ffbe1	501	def f\n          1\n        end\n        a = 0\n        i = 0\n        while
+587c499fd37a68c05b7c06341a709b7a	["Windows-31J", "UTF-8"]	x = "o"; [ /fo#{x}/ensuens.encoding.to_s, /fo#{x}/su.encoding.to_s ]
+58a1a089d1ee9115b20cba5211e09986	Errno::ENOENT	(d1="/tmp/mono_cr1_#{Process.pid}"; d2="/tmp/mono_cr2_#{Process.pid}"; Dir.mkdir
+58ae474979a8f24c46f6287c4ea2d27e	42	begin\n          exit(42)\n        rescue SystemExit => e\n          e.sta
+58e3d47261cf211685533a77ad92ecdd	[:lje, :m, :good]	res = []\n        # a return whose home chain crosses a class body is in
+58eabdb793930657cccdfdf8db5c2d99	[[1, 2], 3]	lambda { |((*a, b))| [a, b] }.call([[1, 2, 3]])
+59104be79a3c34af64f1252be7287e04	42	x = 1\n            binding.eval("x = 42")\n            x\n            
+591cc1df80c9acab4811bc6f380f4314	"<STDIN>"	$stdin.path
+5935b2a14b1389efa07807ca17f49618	true	f = File.open("Cargo.toml")\n            begin\n              f.flush
+5977ceb1393805e0581d80719dcdd920	["US-ASCII", "UTF-8", "US-ASCII"]	s = "ab,cd".dup.force_encoding("US-ASCII")\n              s.partit
+599a1aeb51d29b478a71e17f2ffd3eeb	"hi"	r, w = IO.pipe\n            stop = false\n            busy = Thread.n
+59a5cb7a0c17abeadcdd4fb2b0ab7b76	1	case 9\n        when 0,4,8\n          0\n        when 1,5,9\n          1\n  
 59a6ce8e2915130ae9576712b5a0f444	[1.0, Infinity]	[1.0, 1.0 / 0.0]
+59b430ac9ae86f562aec95304e3961db	[:FOO]	$res = []\n            class C\n              def self.const_added(na
+5a20645aebc0d88e162feb3d416ba777	3	class Integer; alias __orig :/; def /(o); __orig(o); end; end; 12 / 4
+5a5d7ffbe02389d8d6a83efb9a7937c6	[0, 2, 3, 3, true, 4]	File.open("Cargo.toml") do |f|\n              a = f.lineno\n         
+5a735dfa86fec86676f6e6204efc5ceb	"UTF-8"	"abc".reverse.encoding.to_s
+5a8e5757dd64b417433416b14e098c89	-2	class C; define_method(:m) { |a, *| a }; end\n            C.new.meth
+5ab18a8afa5b4ef499cdca6770a28a63	["MyStr", "hi"]	class MyStr < String; end\n            r = Marshal.load(Marshal.dump
+5ab18cd50f5e88dfaffed040fa6b1cd0	42	class C; def to_int; "1"; end; def to_i; 42; end; end; o = C.new\nInteger(o)
+5acf233119e091dcf9d1cca93f311388	[true, true, true, true, false]	ENV["MONORUBY_ENV_TEST_HK"] = "1"\n            r = [\n              E
+5af94d85b8d9f3a2909b4a56a92ba7c3	[true, true, true]	# IOStub: capture writes through `$stderr.write(s)`.\n        class IOSt
+5b16730d5a0f8467ee8b197b9ac4f883	["EUC-JP", "EUC-JP", "bar", "EUC-JP", ["EUC-JP", "EUC-JP"], "EUC-JP", "EUC-JP", "EUC-JP", "Windows-1251", "EUC-JP"]	(p="/foo/bar.baz".encode(Encoding::EUC_JP); [File.basename(p).encoding.name, Fil
+5b210308d292742e419cb6858b5f486f	"あ"	s = "hello"; s.bytesplice(0, 5, "あいう", 0, 3); s
+5b25596f97b36691f45783308ef66569	42	def f(handled:)\n          handled\n        end\n        \n\n        handled
+5b3483f96d997976f0f4974e1d96b628	["y", nil, "MONORUBY_ENV_TEST_DEL2!missing"]	ENV["MONORUBY_ENV_TEST_DEL2"] = "y"\n            a = ENV.delete("MON
+5b44a248a61dc40383d51a96cc748f88	14	[2, 3, 4, 5].inject {|result, item| result + item }
+5b723a2cb7483967f04b7359c4f52ccd	[11, 11, 5, 3, 8, nil, nil, nil]	class C; attr_accessor :m; end\n\n        res = []\n        o = C.new\n        o.m =
+5b79cfb335c3c10194e188b3310b2096	["RuntimeError", "msg", false]	root = Fiber.current\n            fiber = Fiber.new { root.transfer;
+5b81f105b406bdc1f8f48edc118fcd74	[{a: 1, b: 2, c: 3}]	def f(*x)\n            x\n        end\n        \n\n            f(a:1, **{b:2
+5b8ecdb9df6b1aeb7486f686fafdbe3d	["0,10,[],1", "0,1,[2, 3],4", "50|[1, 2, 3, 4, 5]|6|7", "1,10,[],2", "1,2,[3, 4],5", "50|[1, 2, 3, 4, 5]|6|7", "2,10,[],3", "2,3,[4, 5],6", "50|[1, 2, 3, 4, 5]|6|7", "3,10,[],4", "3,4,[5, 6],7", "50|[1, 2, 3, 4, 5]|6|7", "4,10,[],5", "4,5,[6, 7],8", "50|[1, 2, 3, 4, 5]|6|7", "5,10,[],6", "5,6,[7, 8],9", "50|[1, 2, 3, 4, 5]|6|7", "6,10,[],7", "6,7,[8, 9],10", "50|[1, 2, 3, 4, 5]|6|7", "7,10,[],8", "7,8,[9, 10],11", "50|[1, 2, 3, 4, 5]|6|7", "8,10,[],9", "8,9,[10, 11],12", "50|[1, 2, 3, 4, 5]|6|7", "9,10,[],10", "9,10,[11, 12],13", "50|[1, 2, 3, 4, 5]|6|7", "10,10,[],11", "10,11,[12, 13],14", "50|[1, 2, 3, 4, 5]|6|7", "11,10,[],12", "11,12,[13, 14],15", "50|[1, 2, 3, 4, 5]|6|7", "12,10,[],13", "12,13,[14, 15],16", "50|[1, 2, 3, 4, 5]|6|7", "13,10,[],14", "13,14,[15, 16],17", "50|[1, 2, 3, 4, 5]|6|7", "14,10,[],15", "14,15,[16, 17],18", "50|[1, 2, 3, 4, 5]|6|7", "15,10,[],16", "15,16,[17, 18],19", "50|[1, 2, 3, 4, 5]|6|7", "16,10,[],17", "16,17,[18, 19],20", "50|[1, 2, 3, 4, 5]|6|7", "17,10,[],18", "17,18,[19, 20],21", "50|[1, 2, 3, 4, 5]|6|7", "18,10,[],19", "18,19,[20, 21],22", "50|[1, 2, 3, 4, 5]|6|7", "19,10,[],20", "19,20,[21, 22],23", "50|[1, 2, 3, 4, 5]|6|7", "20,10,[],21", "20,21,[22, 23],24", "50|[1, 2, 3, 4, 5]|6|7", "21,10,[],22", "21,22,[23, 24],25", "50|[1, 2, 3, 4, 5]|6|7", "22,10,[],23", "22,23,[24, 25],26", "50|[1, 2, 3, 4, 5]|6|7", "23,10,[],24", "23,24,[25, 26],27", "50|[1, 2, 3, 4, 5]|6|7", "24,10,[],25", "24,25,[26, 27],28", "50|[1, 2, 3, 4, 5]|6|7", "25,10,[],26", "25,26,[27, 28],29", "50|[1, 2, 3, 4, 5]|6|7", "26,10,[],27", "26,27,[28, 29],30", "50|[1, 2, 3, 4, 5]|6|7", "27,10,[],28", "27,28,[29, 30],31", "50|[1, 2, 3, 4, 5]|6|7", "28,10,[],29", "28,29,[30, 31],32", "50|[1, 2, 3, 4, 5]|6|7", "29,10,[],30", "29,30,[31, 32],33", "50|[1, 2, 3, 4, 5]|6|7"]	def opt(x, y = 10, *rest, z) = "#{x},#{y},#{rest.inspect},#{z}"\n       
+5ba2284b4a9919cb69fea58f727dadd6	"0146"	r, w = IO.pipe\n            Process.wait Process.spawn("sh -c umask"
+5ba8c95cd0e4d8e9673a6ec6aa3742b5	true	Random.srand(42)\n        a = Random.rand(100)\n        a.is_a?(Integer) 
+5bb79adb70db2492a63d985196173e00	["the consequence", "the cause"]	begin\n              begin\n                raise "the cause"\n       
+5bf6ebae296f44c8abb3c8fafc8a29d1	11	def f; a=5; b=6; return a+b; end; f
+5c16d0b3014ac8f0fad144e5e1eec769	"[1, 2]3{b: 5}"	class C\n          def foo(*x, a:100, **y)\n            x.inspect + a.ins
+5c34dd38baaa6a3e378ec2dea3176199	"あabcあ"	"abc".center(5, "あ")
+5c3913c478e6af41c6e88e68cf79f146	[1, "/home/user/monoruby/monoruby/a.rb"]	load "b.rb"\n        load "b.rb"\n        load "b.rb"\n        [$count, C:
+5c4eaaf68949431e9b9816a72e33d7c9	"ab20000cGquux"	class C; @@a = :Gquux; $res = %Q(ab#{100*200}c#@@a); end; $res
+5c54276df75bb39ec1d87961406e8d9a	"M:Base"	module M\n          def greet\n            "M:" + super\n          end\n   
+5c591e9ff73fb3eaf82f8472fbe461ed	:nme	class Float; def *(o); super(o); end; end\n                begin; 2.0 * 3; rescue
+5c78c8c1a1899c06122f988ae4e55650	true	module MNs; module Ext; end; end\n            o = Object.new\n       
+5c9a399e6be0e655dcde007dc7ece9b8	true	r, w = IO.pipe\n            t = Thread.new { sleep 0.2 }\n           
+5c9bd2b9dbdb63097f4a4accca2a9df4	nil	def f(&p)\n            p.call\n        end\n        \n\n        f{}\n        
+5d03329e8ce3ae472df7fb2691c658f9	[3, :redefined]	a, b = 3, 9\n            r = []\n            50.times { r << [a, b].m
+5d04703a221875b0b4d2a0813111741a	nil	class CSrcLocMissing; end\n            CSrcLocMissing.const_source_l
+5d0c9438a810db95f43044dee3f665ba	[true, true]	class CSrcLocScopeOuter\n              class Inner\n                I
+5d2068c7082fde255a8c47d3b3b3e849	nil	$stdout.write("a")\n            print "b"\n            $stdout.write(
+5d33630c505ca95acb062afbe222be3f	"Float"	before = Time.now\n            (Time.now - before).class.to_s
+5d37270fae8d3495ac4405dcd8502866	["fiber called across threads", "fiber called across threads", "fiber called across threads", "fiber called across threads", :r]	res = []\n            f1 = Fiber.new { :r }\n            f2 = Fiber.n
+5d3e8beda2cfe6c5baa2a2cd21c8d001	:ok	S = Struct.new(:x)\n            \n\n            s = S.new(1).freeze\n  
+5d3ec2f2c61ae49660281bbdcd726dc3	true	class C\n        end\n        C.new.is_a? C
+5d53a8af94b50b97064e8d51ff1aee9b	["ASCII-8BIT", true, true, "UTF-8"]	t = Thread.new { "x" }\n            t.join\n            s = t.to_s\n  
+5d6c8b649c34e181f15d691733d4d981	[3, 5, 9, 4, 1, TypeError, [NotImplementedError, "Unsupported advice: :bogus"]]	(f="/tmp/mono_ss_#{Process.pid}"; File.write(f,"0123456789"); io=File.open(f); a
+5d7f92fded187ab734dbc79a4aec62ad	[[nil, NilClass, false], [7, NilClass, false], [nil, Proc, false], [nil, NilClass, true], [:d, NilClass, false]]	def probe(h)\n              [h.default, h.default_proc.class, h.comp
+5d99f984ecc5beafe25ac272f6e841d1	[IO, "hello\\n"]	path = "/tmp/mono_cov_io_new_#{Process.pid}"\n            begin\n    
+5da42f6c8778648a29ceb2994861a7cb	[1, 3, 5, 7]	[1, 2, 3, 4, 5, 6, 7].filter { |x| x.odd? }
+5dbf9a8047fd94fd04731be638681e64	[true, Time, Time, "hello", 0, 0]	(f="/tmp/mono_cov_#{Process.pid}.txt"; File.write(f,"hello world"); io=File.open
+5dd6439377bb9ba0cd5bad7fbf28a410	[false, false, true, false, true, true]	f = -> x { x * x }\n        g = proc { |x| x + x }\n        l = -> x { x 
+5dd8cc466f78b091e4a3dd39040187a0	true	k = Class.new\n            k.new.is_a?(k)\n            
+5dec0ce6276f9df416cee244f966b93e	0.0	Math.acosh(1)
+5e0011b1cd9d12d7ec364c9c48ede6a8	["'sing_meth'", "'BTM.mod_meth'", "'BTC.cls_meth'"]	res = []\n        o = Object.new\n        def o.sing_meth = raise("x")\n  
+5e06af9ee5ff391ddbb209a101bde232	[42, 2, 2]	module BopScoped\n              refine(Integer) { def +(o); 42; end 
+5e3cf3856946da1c03607a2ceedbdda1	["EUC-JP", [143, 171, 177], "EUC-JP", [143, 171, 177], [212, 134], [216, 180], [RangeError, "1286 out of char range"]]	euc = "%c".dup.force_encoding("euc-jp")\n            r1 = sprintf(eu
+5e3d5c833a9f1e0f4c8ccd312b4d43c1	true	class Foo\n              def initialize\n                @a = 1\n     
+5e3e2c62315ae652d5e2d1f51a03f0ae	170850	class C\n          a = 42\n          define_method :foo do |x|\n          
+5e6c79ceefd1d93ee41e1edb47425d9b	true	# Linux-only: the macOS CI runner's CRuby dies on this\n            
+5e810d05537bd3deab6aa664f97b9554	["1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "1|[2, 3, 4]", "9|[]"]	def g(a, *r) = "#{a}|#{r.inspect}"\n        def f(...) = g(...)\n        
+5e90b0f7b0ac6601255109439bd5f631	[[1, 5], [2, 6]]	r = []; [1, 2].each.with_index(5) { |v, i| r << [v, i] }; r
+5ebedc689b393f6ba2135c7bd7ab5949	[:foo, :foo, nil]	$res = []\n        def foo\n            __method__\n        end\n        al
+5ed6efbc5d69e7f5d1858a2ae2807c9a	[nil, "error"]	h = { one: nil }\n        [h.fetch(:one), h.fetch(:two, "error")]\n      
+5eeb620d0147e289ac5adddbb4f41e79	20100	f = ->{ _1 + _2 }; s = 0; i = 0; while i < 200; s += f.call(i, 1); i += 1; end; 
+5eecdf3af171258d2183384a2c3370c7	["abc", "a", "b", "c"]	"abc" =~ /(.)(.)(.)/\n            alias $md $~\n            $md.to_a\n
+5f0569ade8d86da38a36eb38659c1886	[100, 200, [100, 200]]	S = Struct.new(:x, :y)\n            \n\n            s = S.new(1, 2)\n  
+5f13837bff8d207bda00a02916bd6e02	[nil, false]	t = Thread.new { raise "boom" }\n            Thread.pass until t.sta
+5f3db22eac0a8e7c15126c82100c9ef4	["<7>", ["<1>", "<2>"], ["coerced"]]	module ProtoR\n              refine Integer do\n                def t
+5f4db5ebb75f3bf2b8fad5e3973d2488	false	Signal.list.key?("STKFLT")
+5f502389a3a181f8cfec5b92a9db85e4	true	class C; def to_hash; {a: 1, b: 2}; end; end; o = C.new\n{a: 1} < o
+5f637862fb315cc465da084fe56c166d	["hello", "text"]	sup = Class.new do\n          def self.message; "text"; end\n          de
+5f9274ee61ad6f85ef19d9e87caf59fa	"/home"	File.realpath("./../../../")
+5f968c34cfb703342017f7f54f8c80f2	[[[:p, 1], [:q, 2]], [[:p, 1], [:q, 2]], [[[:p, 1]], [[:q, 2]]]]	cls = Class.new(Hash)\n            h = cls.new\n            h[:p] = 1
+5fb588dcb4947000799dc1e9785f944e	["[1, 2] {a: 100}", "[3] {e: 70, f: 80, g: 90}", "[2, 50, 3] {e: 70, f: 80, g: 90}"]	class C\n          def g(*rest, **kw)\n            $res << "#{rest} #{kw}
+5fcac55c31908b7b4a4a1adfec76e1e7	[:x, :y]	D = Data.define(:x, :y)\nClass.new(D).members
+5fee1723e9372140a6d0310d9d05a6cd	70	def calc(x); x * 10; end\n            um = Object.instance_method(:c
+6005e3937830e1c15b335e4245114545	[true, IOError, true, IOError, true]	(f="/tmp/mono_ch_#{Process.pid}"; File.write(f,"x"); r=File.open(f); r.close_rea
+6014beaaf4bdf666913e7a4cc1cb20d2	[8, 16]	f = proc { |x| x * x }; g = proc { |x| x + x }; [(f >> g).call(2), (g >> f).call
+6021d94b0296f218e79c204338031a47	[:a, :b]	S = Struct.new(:a, :b)\nClass.new(S).new(1, 2).members
+606a176cebc2382e58517d09e8888639	[[:@x], 99]	S = Struct.new(:a)\n            \n\n            s = S.new(1)\n         
+6087d3a1d3261cbfee36d9e80b29633e	"10"	class HasBoth; def to_int; 10; end; def to_i; 20; end; end\n        
+609d57a66871d577b1aa1937c49dcfcb	0	ObjectSpace.define_finalizer(Object.new, ->(id){ id })[0]
+60a159b987446cca066168f9a2f6a547	["line one\\n", "line two\\n", "rest"]	require "socket"\n            s = TCPServer.new("127.0.0.1", 0)\n    
+60db8107f4253dc3563316257cdb5c49	"#<Object:0xADDR>"	Object.new.to_s.sub(/0x[0-9a-f]+/, "0xADDR")
+60e12b0996506a089ca690904fc7428d	["1-2-3", "1-2-3", "1+2+3", "", "1-2-3"]	$, = "-"; r = [[1,2,3].join, [1,2,3].join(nil), [1,2,3].join("+"), [].join,\n    
+60e7801250bb0dce26c76cbfe1c94612	[1, 2, 3, 4, false, false, true, false, true, false]	o = Object.new\n            def o.foo = 1\n            m = Module.new
+60fa84926456bf38e08b292f42e6048b	[true, false, true]	parent = Class.new do\n              protected; def parent_pro; end\n
+61004613ce868620a7ea63f5833c5be8	[100, 200]	def f(&p)\n            g(&p)\n        end\n                \n        def g(
+610beb27fdef4abad74c027625346d0e	"I:#<Integer:0xADDR>"	class Integer; def to_s; "I:" + super; end; end\n                5.to_s.sub(/0x[0
+610cff7c16d66dbb480b5af49ae1652c	"hello"	m = Module.new\n        m.module_eval do\n          def hello; "hello"; e
+61163d4d16d5c6f9c2f86809889cf976	[[:v]]	r = []; Enumerator.new { |y| y.yield :v }.each { |*a| r << a }; r
+61466a87e0fedb23a45f3b7c64429c6c	["////some/path", "//some/path", "/some/path", "/a/c/d", "/root/x", "/~root/a", "/a", "/bin", [ArgumentError, "user no_such_user_zzq doesn't exist"]]	[File.expand_path("////some/path"), File.expand_path("//some/path"), File.expand
+61660a919ed4f692e9e171857accf5f5	{amount: 9, unit: "m"}	M = Data.define(:amount, :unit)\nM.new(1, "m").with("amount" => 9).to_h
+616efb681caa4d7c28b46d9f16f821ab	[:args, :blk, :kw]	def m(*args, **kw, &blk); local_variables.sort; end; m(1)
+6181677ef04f4ef6305c1971b5503690	true	class MyStr\n              def to_str\n                "hel"\n        
+618dbff5bb318c45c0cbcadad310f756	"pow 3"	class Foo\n              def **(other)\n                "pow #{other}
+61999c6ea193c221146e7ca8536ca661	[1, 0, 7, 8, false, true, false, "File", true, true, "A", "B"]	require 'tmpdir'\n            f1 = File.join(Dir.tmpdir, "argf_t1_#{
+61d6a9b0085afd6c0cbfefe4fc3fe618	[true, true, true, Hash]	klass = Class.new(Hash)\n            [\n              klass[].instanc
+61fdd1242a66df09095c5df145f21012	12	def m(n); eval("BEGIN {return n*3}"); end; m(4)
+6201f6ca2228419027d2e3763e300a6c	:OVERRIDDEN	class Float; def !=(o); :OVERRIDDEN; end; end; 3.0 != 4.0
+62299cb34bf9144c91ccc814afcbeb05	"ab"	$/ = "c"; r = "abc".chomp; $/ = "\\n"; r
+623b167ed005d1a8a28f3d3a8053c3ed	[:v, :v, :w]	class B\n              def initialize() @h = {} end\n              de
+623c780251b09b2380a85de8d8651972	[true, true, true]	File.write("/tmp/mr_enc2.txt", "")\n            Encoding.default_int
+625ae98b945176f640a4b3585c1acc5f	[:from_rescue, [:ens]]	$log = []\n            def m\n              raise "x"\n            res
+62825865a591b21dbb6b9d05adb0c05a	["echo hello", true]	def `(cmd); [cmd, cmd.frozen?]; end\n        `echo hello`\n        
+62abd44369ee4b6cc7e6dbf66a868f1d	[[nil, nil, nil], [1, nil, nil], [1, 2, nil], [1, 2, 3]]	S = Struct.new(:a, :b, :c)\n            \n\n            [S.new.to_a, S
+62caa309e31dac2a3bb4c9e5ed060cf8	[false, "elefant", 4]	S = Struct.new(:name, :legs, keyword_init: false)\n            \n\n   
+62d15ca21ed1dd74ca65f3735e8b6c5a	false	File.writable?("nonexistent_file_xyz")
+63422c9740b43bc9e10c2b9e48ec2652	42	x = 1\n            binding.local_variable_set(:x, 42)\n            x\n
+6342f8bdbf7fb127f0fe51c760a63f08	[true, "z"]	r, w = IO.pipe\n            t = Thread.new { sleep 0.02; w.write "z"
+634c7a5e93593cc0d60ce377ffcc8f54	3	class Integer; alias __orig :>>; def >>(o); __orig(o); end; end; 48 >> 4
+636623b3d0f703dc7b71fcb417b67800	[true, false]	class ClassExecLexA; end\n            ClassExecLexA.class_exec {\n   
+63a9bd642fd895ef294a01db60ca5c2d	{amount: 42, unit: "km"}	M = Data.define(:amount, :unit)\nM.new(amount: 42, unit: "km").to_h
+63ae129d0273fad94c91f73160dc689d	422100	class Foo\n              def initialize(a, b, c); @a = a; @b = b; @c
+63b1daa2620d1e343314d1df22f4a78c	true	m = Module.new\n            m.define_method(:foo) { 42 }\n           
+63b60c0c69def15847506f7bed0e6707	"ModuleSpecs2::Anonymous2::WasAnnon2"	module ModuleSpecs2; module Anonymous2; end; end\n            m = Mo
+63b722f43834fba8b8578809e4d8f64d	false	File.open("Cargo.toml") do |f|\n              g = File.new(f.fileno,
+63e644345315a92587e6531509cddace	true	require "json"\n            data = JSON.parse("{\\"name\\": \\"Nokogiri
+6400ae64c9910a3864a764454ee1737f	["SystemExit", true, 0]	begin\n              Process.exit(0)\n            rescue SystemExit =
+64304d338b2e1d9153798436746ba67c	[:plus, :lt, :bang, :aref, 3, true, false, 9]	class BopUser\n              def +(o); :plus; end\n              def 
+646b6df81e3b78ea650391aa2912e6d4	["0.33333e1", "0.3333333333e1", "0.25e2"]	require "rubygems"\n        require "bigdecimal"\n        res = []\n      
+64745fd3594011f602b1ae98a52ab4ae	["Array", true, ["prompt>"], ["prompt>"]]	require "expect"\n            res = []\n            r, w = IO.pipe\n  
+64813a4dde67dc42192c53915b8c2dc5	true	M = Data.define(:amount, :unit)\nM.new(42, "km").frozen?
+64843c02e7455fb4484247761ff462ec	[10, 20, 30]	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \n[s[:a
+6494dbd0fb783a11fa0b05b82041e84f	[3, [[0, 0], ["j", 0], [0, 1], ["j", 1], ["i", 0], [1, 0], ["j", 0], ["i", 1], "foo"]]	def foo\n              2.times do |i|\n                2.times  do |j
+649ee50b7bd01cce342d0321c5914a3c	"missing keyword: :x"	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; def m(x:,
+64a27da2565ad42bdc32599ebb8d578f	[:TypeError, [], :ArgumentError, [:imported]]	src = Module.new { def imported; :imported; end }\n            out =
+64b62f0e230da23a1badb458e05be83c	[["abcdef", "ISO-8859-1"], ["UTF-16LE", [97, 0, 98, 0, 99, 0, 100, 0, 101, 0, 102, 0]], ["UTF-16LE", [97, 0, 98, 0, 99, 0, 100, 0, 101, 0, 102, 0]], "EUC-JP", ""]	File.write("/tmp/mr_cr4.txt", "abcdef")\n            r = []\n        
+64e26798705605fcef88d5e76308ea72	[["RuntimeError", "", nil], ["RuntimeError", "", "RuntimeError"], "TypeError", ["StandardError", "[\\"foo\\"]", nil], ["TypeError", "exception object expected"], ["RuntimeError", "m", "TypeError"], ["ArgumentError", "only cause is given with no arguments"], ["bt.rb:9"]]	def t; yield; rescue Exception => e; [e.class.to_s, e.message[0, 50
+64e8a4eb83aec12b37467823fc490c11	:fiber2	fiber1 = Fiber.new { :fiber1 }\n            fiber2 = Fiber.new { fib
+64ecc9fc243a974c35cf6e474c240d91	[true, true, true]	def m; proc{|x| x}; end; p = m; [p == p, p == p.dup, p == p.clone]
+64fcf43e2db76908eb6c8d48ce499ec1	[4, 8, 111, 58, 14, 69, 120, 99, 101, 112, 116, 105, 111, 110, 7, 58, 9, 109, 101, 115, 103, 48, 58, 7, 98, 116, 48]	Marshal.dump(Exception.new).bytes
+6510451a0438417f52a7734863b53d41	[42, 7]	Thread.current[:k] = 42\n            Thread.current.thread_variable_
+6515a9a295a9e459766f100befc056c4	[4, 5]	class C; def to_int; 2; end; end; o = C.new\n[1,2,3,4,5].last(o)
+654971fbef6e7c3957b7be0b83106d49	"from ensure"	def m\n              raise "orig"\n            rescue\n              r
+65669ec73369ef6bc4ab9748ee3726fa	[{"a" => 10, "b" => 20}, {1 => :a, 2 => :b}, {}, {a: 1, b: 2}]	h = { a: 1, b: 2 }\n            [\n              h.to_h { |k, v| [k.t
+65694a727aa519d1f24a0ad7779439d7	["a", "b"]	sup = Class.new do\n          def a; "a"; end\n          def b; "b"; end\n
+658a3d798e2393a25a6923d06ab095be	[:tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok, :tok]	def tmo(klass)\n              perform = Proc.new do\n                
+659055cc978aefe6697faff4fd6e1315	[[1, 2, 3], 10, 20]	def f(*pos, a:, b:)\n          [pos, a, b]\n        end\n        \n\n       
+65d10140470d60de44657d841741db77	[0, 1, 2, 3, 4]	a = []\n            p = Proc.new {|x|\n                a << x\n       
+65f089c7f8670902b073a707f21a776d	["/p", nil]	m = Module.new { autoload :X, "/p" }\n            [m.autoload?("X"),
+6622d68b20aa2154a49d5b127ef16dc7	:assigned	module MM\n          def self.const_missing(c); c; end\n        end\n     
+6640768cb0201ad9cc8cdbbc1ff67cd8	42	c = Class.new\n            c.class_exec do\n              define_meth
+664f853aae1b23342a7f3f6347677439	[nil, [:r]]	$clog = []\n            def craise; $clog << :r; raise "x"; end\n    
+666756434f77a17dca0c4a9844a9e4e2	[true, true]	def foo; end\n            def bar; end\n            public :foo, :bar
+6689fdb915718c542fa7f92d001dacc0	["inherited:B"]	$res = []\n        class A\n          def self.inherited(subclass)\n      
+66b655e81e48c32825c0aeea0b53995d	[0, 10]	f = File.open("Cargo.toml")\n            begin\n              before 
+66b92d6cfcc69793ed5cdd6b3fb7ad21	3.14	class Foo; def to_int; 2; end; end\n            3.14159.truncate(Foo
+66bad7d3dcfda30f39c99e813ab6eccd	"constant"	class A\n          B = 42\n          def f; defined?(B); end\n        end\n
+66c387030d22cc81f205aa813593c248	[[1, 2], [2, 3]]	r = []; [1, 2].each.with_index(2.9) { |v, i| r << [v, i] }; r
+66cedbdd1ae3d91dacc69ce72dd69c63	nil	GC::Profiler.disable; GC::Profiler.raw_data
+66d3a720ccfcd8a4c65aa4a7264f96c3	nil	um = Integer.instance_method(:to_s)\n        um.source_location\n        
+66de5b13ad3146aa31137d2a2a57cbda	[1, 2, 3, 4, 9]	t = Process::Tms.new(1, 2, 3, 4)\n            u = Process::Tms.new\n 
+66ffaa1b0f890b32d4446740cc7383f4	["Struct::MStructA", 1, "two"]	Struct.new("MStructA", :a, :b)\n            \n\n            s = Struct
+676948299cc86ad51d988c8190977471	:OVERRIDDEN	class Float; def -(o); :OVERRIDDEN; end; end; 3.0 - 4.0
+676a91e7312a022bcb4dc087ee24de72	["super", nil]	class S\n              def f\n                defined?(super)\n       
+67825914c378828613082b33f1dd81d4	[45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45]	j = 42\n        a = []\n        f = ->(x){x + j}\n        for i in 0..30\n 
+678ce53a4e9ee942f7f9f7d7e314e0e7	"[package]\\n"	f = File.open("Cargo.toml", "r")\n            f.readline\n        
+67c065af410a1d8e77c5401fa3d78481	:foo	def foo; end
+67c20bd660fa8b773e20eeb7e199398e	{}	S = Struct.new(:x, :y, :z)\n        s = S.new(1, 2, 3)\n        \ns.decons
+67c7848b4f4e7a9032f08a513e276ec2	3	idh = {}.compare_by_identity\n        idh['x'.dup] = 1\n        idh['x'.d
+67cbad67410af8c2d8f47f45771f54f4	[4, 8, 111, 58, 14, 69, 120, 99, 101, 112, 116, 105, 111, 110, 7, 58, 9, 109, 101, 115, 103, 73, 34, 8, 102, 111, 111, 6, 58, 6, 69, 84, 58, 7, 98, 116, 48]	Marshal.dump(Exception.new("foo")).bytes
+67d9779ae7baebb23fd2e1f34232d6e2	0	$c = 0\n            def bump; $c += 1; self; end\n            defined
+67d9f8b69f6a016eade0a68a270498d3	" world"	s = "hello world"; s.bytesplice(0..4, "ABCDE", 0..-100); s
+681e3c0d02b02a91a999281604e81c60	"Ruby"	"ruby".send(:sub, /./, "R")\n        
+681fd3ccba5816796a6f87e5163660da	["US-ASCII", "US-ASCII", "US-ASCII"]	s = "abc".dup.force_encoding("US-ASCII")\n              s.rpartiti
+6867d900d8bc23f027af9e908bfd1fbc	[File, "hello"]	path = "/tmp/mono_cov_file_new_#{Process.pid}"\n            begin\n  
+688b520eaa53b818c032ed84ebb90ba3	1234	Random.srand(1234)\n        Random.srand(4567)\n        
+68aaf8840f49575ccb7aee97d2c25227	true	__ENCODING__.equal?(Encoding::UTF_8)
+68acd2045cc595907a8dd13ac1cc06ac	[[:a, 10], [:b, 20], [:c, 30]]	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \ns.eac
+68c63ec13376de46973a48e77ab880cf	[]	Module.nesting
+68e49708b8d687279395040708948ca4	true	o = Object.new; ObjectSpace.undefine_finalizer(o).equal?(o)
+68f09b0570cde3da15203e0ee81f4d7f	true	s = "blablabla"; s.index(/bla/, s.length + 1); $~.nil?
+68f4361ccb18fadb55264f42091b2bc7	42	x = 42\n            x\n        
+690f7a9479d83c4f5efc9942963213df	["bc", "bc"]	class C; def to_str; "bc"; end; end; o = C.new\n"abcabc".scan(o)
+6918db71780c28b00e597c253bde368e	"default"	GC.config[:implementation]
+691b2c56eea7b2b314d5eb00cd44238a	nil	def f; end; f
+693bb18ddab0f71baad7547f17a5170e	true	File.executable?("/bin/sh")
+693f5aa61446e94a059879fc0e8410e4	C	class C\n        end\n        \n\n        a = 1\n        C.class_eval do |m|
+69454519988d1917d0cf2b32b8ad0e08	["a", "a"]	$/ = "b"; s = "ab"; r = [s.chomp!, s]; $/ = "\\n"; r
+6948d55dbe7957e5100beced57da2704	[[]]	def m; [1].map { it; local_variables }; end; m
+695a85fd2ea772e6ce3142edd7a921e4	[false, true]	S = Struct.new(:a, :b)\n            T = Struct.new(:a, :b)\n         
+695e21e95a722ab6137b89c61da5089c	42	def f\n          42\n        end\n        \n\n        f\n        
+6969aaf807e98c28a5dfa52dd28504f9	[255]	s = "".b\n            s.append_as_bytes(-1)\n            s.bytes\n    
+698060c4130b662b0ebfb2120f8893ce	[true, true, true]	l = ->(x){ x }; [l == l, l == l.dup, l == l.clone]
+69ad25699413b1fe63f62bc829f927dc	[{}, {x: 10}]	f = Fiber.new(storage: {life: 42}) { Fiber[:life] = nil; Fiber.curr
+69b168e7d0ad487fc9118309039d2192	"HELLOworld"	s = "hello world"; s.bytesplice(0..-6, "HELLO"); s
+69c5968b4eb20ac66bb1a05cf40e9cd8	[:dup, :clone]	class CH\n                 attr_accessor :tag\n                 def initialize_dup
+69d8601366cb9c364194ec7f9a90b959	25200	o = Object.new; def o.to_int; 7*3600; end\n               Time.new(2000,1,1,0,0,0
+69f49ce287605942316b64a3f0b0f5f9	12	class S\n          def f(x,y,z)\n            x + y + z\n          end\n    
+6a0c184b3e4f1cbf73f4c3924d6f92e6	1	x = 1 until x\n            x\n        
+6a0e2ea7d7a981bac74e9d7198383c7a	[1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995]	def drive\n              res = []\n              x = 1000\n           
+6a19d218cec0dbda0ee9b1ce74bd9d9f	[true, Module, false]	m = Module.new\n        res = []\n        res << m.is_a?(Module)\n        
+6a23abfb8fa8bf98cc7d6a1d94fd7571	[true, false, [:body_pre, :body_post, :t2_done]]	dir = ENV["TMPDIR"] || "/tmp"\n            path = File.join(dir, "mr
+6a47f34ac66869b22808720b24d7a573	55	module Foo\n          def self.bar; yield; end\n        end\n        Foo::
+6a5bf9538c6984ef1c607bee25d61d6e	true	io = IO.popen("true")\n            pid = io.pid\n            io.close
+6a60051631028617e63ef5a493474e41	NoMethodError	begin\n              nil.foo\n            rescue => e\n              e
 6a746985c7bc6408f83085340479fbf6	[1.0, NaN]	[1.0, 0.0 / 0.0]
+6a8c9e9a6d23a92d8a98ff382b620742	[["", 0], ["", 1], ["", 2], ["", 2], ["", 2], ["", 1], ["", 0], nil, nil, "b", true, false, true, false]	r = []\n        [0, 1, 2, 3, 9, -1, -2, -3].each do |i|\n            m = 
+6aafe015c3410b6ae65d66f8f67d1dd5	["boom", nil, [:done, "TypeError"], "b199"]	class T; attr_accessor :e; end\n\n        res = []\n        t = T.new\n        begin
+6adba7a52d188043ac47d2a6ceae5508	42	class C\n              def bar\n                42\n              end\n
+6aff68386825a6831642fe95c7e580e7	:raised	r = nil\n            100.times do\n              begin\n              
+6b0b243416e0d106d617e4ad489ecdf7	42	class C\n          attr_writer :x\n          def get_x; @x; end\n        e
+6b3c869c4119e716ff2561b706f41427	"UTF-16LE"	Regexp.new("a".encode("UTF-16LE")).encoding.to_s
+6b4af7ca5b9a5430ebaa6f57763959e3	true	(1 << 53) == (1 << 53).to_f
+6b5c527a35a6e84b5f466edc5a765e96	:OVERRIDDEN	class Integer; def -(o); :OVERRIDDEN; end; end; 3 - 4
+6b5df255bb3d61a71b92a9142b777854	[[164, 162], "EUC-JP"]	m = /./e.match("\\244\\242".dup.force_encoding(Encoding::EUC_JP))\n               [
+6b6dfbea494d895f88178ed4fd8780ed	[[nil], [[1, 2]]]	[Enumerator.new { |y| y.yield },\n                Enumerator.new { |y| y.yield 1,
+6b7c29f7108cc984781c81784cefb56d	"aa"	eval("/a+?*/").match("aa")[0]
+6b82ebaaa0df8e456b952c1649290d36	["INT-NE", "RAW-B", false, true, true, true, true]	class Integer; def !=(o); "INT-NE"; end; end\n        class CustomEqB; d
+6bab7203c03f2793f901298b3357f169	true	"abc".force_encoding("ISO-8859-5").encoding == Encoding::ISO_8859_5
+6bc256a131cd947b4c256d4afa639789	["y", Encoding::ConverterNotFoundError, Encoding::ConverterNotFoundError, [254, 255, 0, 97, 0, 10, 0, 98], "UTF-16", [[254, 255, 0, 97, 0, 10, 0, 98]], true, Encoding::ConverterNotFoundError]	(a="\\x79".dup.force_encoding(Encoding::BINARY).encode(Encoding::Emacs_Mule); b=(
+6c331f471496111694ecb08afb04cab9	[1, 2, 3]	v = []\n            t = Thread.new { v << 1; sleep; v << 3 }\n       
+6c858418f8d579a73265ea125ceceeeb	1.5	class C; def to_f; 1.5; end; end; o = C.new\nFloat(o)
+6c891eca2cb89ba2ef5d9d75c6d8f60f	[20, 20]	def m\n              binding\n            end\n            b1 = m\n    
+6c8f517d749d2dbedcad192eb4098b30	42	module Foo\n                def self.bar; 42; end\n                pr
+6d02db687943a63ad711b5395a933b96	"str"	class C; def to_s; "s"; end; def to_str; "str"; end; end\n[C.new].join
+6d4221cf12759db4700deb70a10b88df	["can't modify frozen Class: #<Class:#<Class:0xX>>", "can't modify frozen Object: #<Object:0xX>"]	res = []\n        c = Class.new\n        sc = c.singleton_class\n        s
+6d4635412b101da73e8aca3b2253868a	nil	m = Module.new\n            m.set_temporary_name("temp")\n           
+6d8c9772db1244467ff1535ac1b91921	[["w", "a", "w", "a"], ["w", "a", "w", "a"], ["abc"], "a"]	a = "wawa".to_enum(:scan, /./).map { $& }\n            b = []\n      
+6d8d3f9c41b7635a18fc38f965811324	[:outer_ensure, :swallowed, nil, [:inner_begin, :inner_ensure, :outer_ensure, :before_return]]	$pad = []\n        def f\n          begin\n            begin\n             
+6dad723dff6c0a9e98e242d72b120002	["hello world\\nsecond\\n", "ASCII-8BIT", "ASCII-8BIT", "ISO-8859-1", "ISO-8859-1", ["ISO-8859-1", "ISO-8859-1"]]	File.write("/tmp/mr_rd.txt", "hello world\\nsecond\\n")\n            r
+6dcb51b99c788c3ce1f7ead68e2e10be	true	S = Struct.new(:a, :b)\n            \n\n            s = S.new("v", 2)\n
+6dcfb7ed29eb370f8b60cf546d5ae302	[1, 2, 3, 4]	[*(1..10)].take_while { |i| i < 5 }
+6dd41ec1ded5717c0e4843842d875e1e	[100, 200, 30]	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \n\n    
+6e3f4d68346f263bda44d7cf25bdde4c	"ok"	path = "/tmp/monoruby_test_intmode_#{Process.pid}_#{rand(100000)}"\n
+6e55e9c4e17738f1d844db95211ebfcc	"numbered parameter '_1' is not a local variable"	-> { _1; (binding.local_variable_set(:_1, 1) rescue $!.message) }.call("x")
+6e572d93b20a8692a4e7ddd298baa9ee	true	class Foo\n              def bind; binding; end\n            end\n    
+6e7aebe2556be39faee23d7b63bd31d6	[false, false, false, false, false]	S = Struct.new(:a, :b, :c)\n            \n\n            s = S.new(1, 2
+6eadac74beac0aa21a211ec67fcdc95d	["0.514e1", "0.114e1", "0.628e1", "0.45e1", "0.7e1", "0.3e0"]	require "rubygems"\n        require "bigdecimal"\n        a = BigDecimal(
+6ec1acc4c17516bb23420e702e9103d2	[:done, true, 64]	def make_enum\n              Enumerator.new { |y| sleep 0.05; y << :
+6ee8709f21799482d6bff0182f48702d	"/\\n"	r, w = IO.pipe\n            Process.wait Process.spawn("pwd", chdir:
+6ef053c1cbcdce8316676a2978cf3fe7	A::B::C	class A\n            class B\n                class C\n                end
+6ef397ad6cceaf2ba157bceaa2004a48	true	r, _w = IO.pipe\n            r.wait(:r, 0).nil?\n            
+6f19d43aaec4984e4746f24685612f73	"num: 42"	class MyFmt\n              def to_str; "num: %d"; end\n            en
+6f24de5d11a542e7e8ae8c08bd85f5b7	[true, TypeError, IOError, Errno::ENOENT, Time]	(f="/tmp/mono_ep_#{Process.pid}"; File.write(f,"abc"); base=Object.new; def base
+6f2c032bb56f206798d710670edd906e	"Ruby on Railsd"	a = "Ruby"\n            a << " on Rails"\n            a << 100\n      
+6f3586689788165519257e6a0519ec54	"false"	require "tmpdir"\n            Dir.mktmpdir do |d|\n              out 
+6f48a4a001fdd1b6d3fd9bc7a12ae5fe	[true, "directory"]	[File.stat("/tmp").directory?, File.stat("/tmp").ftype]
+6f6180f86272a5e7760efeac4c2a956e	"abcああ"	"abc".ljust(5, "あ")
+6f89c5db7683986a9e61229515e918a3	"[] {a: 42, 100 => 100, c: 5}"	class C\n          def foo(*x, **y)\n            $res << x.inspect + " " 
+6f9e3eb9473b85b89a35086c448b5d42	true	obj = Object.new\n            begin; obj.nope_method; rescue NoMetho
+6fb70e1ac677ec5293ce90caf3afcdf5	true	Time.utc(2000,1,1,0,0,0,500000).subsec > 0
+6fd7a2503b2b0d8020435a1135d8760a	["extended:Bar"]	$res = []\n        module Foo\n          def self.extended(base)\n        
+6ff6c6d86d977c8d2388dd6f11a63d5c	[4, 5, 7, 8]	r = []\n        10.times { |i| r << i if (i == 4)..(i == 5) or (i == 7).
+701d361bd27c998921b0175898afa6dd	[]	r = []\n        10.times { |i| r << i if 4..5 }\n        r\n        
+7024bc7639e60c88c6af2fbcb7e0c1db	[true, true, true, true, :OVERRIDDEN]	class String; def ==(o); :OVERRIDDEN; end; end\n            [1 == 1,
+703349e3423321fee656c77d38481e9a	["wrong argument type Object (expected MatchData)", "wrong argument type Integer (expected MatchData)", "b", "f", "foo", true, nil, nil]	res = []\n        begin; $~ = Object.new; rescue TypeError => e; res << 
+7035cc6c279448d53dca22fc48d55f97	["a,", "b,", "c"]	class C; def to_str; ","; end; end; o = C.new\nr = []; "a,b,c".each_line(o) { |l|
+70388c515facfbc492c4d262332bd5dc	true	S = Struct.new(:a, :b)\n            \n\n            x = S.new(nil, "ta
+70460ddb5639edd8a51bb189333c7d35	[2, 3, 1, 2]	def f(x,y,b:200,c:300)\n              [b,c,x,y]\n            end\n    
+704e725b4b5d761ef261e9bd0491038b	0.75	Rational(3, 4).to_f
+705519c630a831804749a02887790307	[true, true, true]	module M; class N; CONST = 1; end; end\n            \n\n            [\n
+7068324754662230dd6cba5af8947f71	"hel"	class Foo; def to_str; "lo"; end; end\n            "hello".chomp(Foo
+7073b2cf059ea135845fa20451762fce	[1, 2, 3]	class E\n              def initialize(a); @a = a; end\n              
+707b7fd02add3d39fff2a8fb60b17cde	["hello", "text"]	klass = Class.new do\n          def hello; "hello"; end\n          def se
+70a1593046773caec35e978f0c08553c	["", "shown\\n"]	require 'stringio'\n        def cap; $stderr = StringIO.new; yield; s = 
+70ae62584feac2ecded5e03fc39ac020	[["AF_INET", "127.0.0.1", "127.0.0.1"], true, ["AF_INET", "127.0.0.1", "127.0.0.1"], true, "AF_INET", "127.0.0.1"]	require "socket"\n            s = TCPServer.new("127.0.0.1", 0)\n    
+70bdfd5e68a7d505347fcfb446cf1af5	[1, 1, true, false]	o = Object.new\n        o.instance_variable_set(:@a, 1)\n        s = Obje
+70d61ef5f4ed6c1e8f4e23f26222ad7d	"mm:hello:[]"	class Foo\n              private\n              def method_missing(na
+70e58b5b7dbd4dc37d12b0b873604fa6	[:my_is_a?, :is_a?, true]	class C\n              define_method(:my_is_a?, Kernel.instance_meth
+710af167780333af253a35d1dc8b0346	[20008, "head", "tail", 20000]	path = "/tmp/mr_buf_big.txt"\n            f = File.open(path, "w")\n 
+711aa5cc92164813c06e40b326f626bd	["Bonjour", "Bonjour", "Bonjour", "Guten Tag"]	class F\n          def hello\n            "Bonjour"\n          end\n       
+712dca9ea514253684ee241cb0842ccb	7	def f(a)\n          a\n        end\n        f(7)\n        
+7147936003db8a32b07eb1bb5089096f	[[:it, :j]]	def m; [1].map { |it| j = it; local_variables.sort }; end; m
+719d10e6b19ee956599a34926b2812c4	[[0, "SystemExit"], [0, "SystemExit"], [7, "SystemExit"], [0, "msg"], [0, "SystemExit"], [1, "SystemExit"], [0, "SystemExit"], [3, "x"], [0, "y"], [2, "SystemExit"]]	[\n              [SystemExit.new.status, SystemExit.new.message],\n  
+71a91bb93ad21f17fda2dab2d2720ef2	"foo12"	class Foo\n              def foo(x, y)\n                "foo" + x.to_
+71b94208b971bf119d6f24e1a29ca23a	[1, 2, 3]	class Foo\n              def to_proc\n                Proc.new {|v| $
+71c24f8639e7747006e674bc0fbf4547	256	def f(x)\n          x * 2\n        end\n        def g(x)\n          x + 2\n 
+71d85b9646b325d57ec9e46b0c5bd105	"hello"	class Foo; def to_str; "hello"; end; end\n            String.new(Foo
+7235ebfc85831c502397c3cbb35ce813	Foo	class Foo\n              def bar; end\n            end\n            \n\n
+723ea63495140106ebdfae5448e3e464	80	class C\n          def f(a, b)\n            a + b\n          end\n        e
+7252f1c8ab400b2d14e205f52ce07f84	["warned", "silent", "warned", "silent", "warned", "warned"]	require "stringio"\n        res = []\n        capture = proc do |verbose,
+725d2fdc2eaf1d2bff1408d39bfaa2f4	["BA"]	module SVSE_A\n          private\n          def derp(message)\n           
+72646a541277ded41b2f584e45b344f9	[true, true, false, false]	res = []\n            f = Fiber.new { Fiber.yield }\n            res 
+7279cfebff4f2431e12a11ac0cd8b2fc	:ok	Enumerator.new { |y| y.yield(1) }.first; :ok
+728b693008cde91b8e668b5188312960	"stream closed in another thread"	require "socket"\n            s = TCPServer.new("127.0.0.1", 0)\n    
+72974cf937f6e974bf3d810fa2d06cb0	15	SystemExit.new(15, "woo").status\n        
+729af1cd6bd675bb594030ffacbd8561	[true, "fifo"]	path = "/tmp/monoruby_test_mkfifo_#{Process.pid}_#{rand(100000)}"\n 
+72c671a8d35d91c187dcae14e7d6acfa	true	"abc".force_encoding("ISO-8859-15").encoding == Encoding::ISO_8859_15
+72e5566a1bbca4743ca6172eaaed27c4	["hello", nil]	ENV["MONORUBY_ENV_TEST_BASIC"] = "hello"\n            v = ENV["MONOR
+72f2a3b4b542af05e8ddd39460142cfe	"through"	r, w = IO.pipe\n            w.write("through")\n            res = r.r
+72f356a4a88e38d005c4c8636142c8ff	42	class C\n          self\n        end\n        42\n        
+730e1dd1e124574580b6f001181345ff	0.375	Rational(3, 4) * 0.5
+731ce78fae292cc788986e931cc0244b	true	old = srand(42)\n              old.is_a?(Integer) && srand(old).is
+7329c521c362fe46b1869d7c65854155	"[-1, true, true]"	r, w = IO.pipe\n            pid = fork do\n              r.close\n    
+732e3b62d4517a16377b7e4316feaf87	:OVERRIDDEN	class Float; def -@; :OVERRIDDEN; end; end; -(3.0)
+73476741def13e8cdeb243cff0772ebd	{"a" => 2}	pairish = Class.new do\n              def initialize(a, b); @a = a; 
+734dfdfc3af46f6004a0860570e0da99	[[]]	def m; [1].map { it; binding.local_variables }; end; m
+7386de8954a7dcef530043ef4769c016	[Hash, true, 2]	sub = Class.new(Hash)\n            o = sub.new\n            o.compare
+738f2f4bac99511afc9b7dcf74088974	[2, ["Array", "String"], [:a, :b]]	m = Module.new do\n              refine(String) { def a; end }\n     
+73a81654219a984861a6f71fa1797a2e	[[true, "123456"], "123", [true, "1234567890", "UTF-8"], ["", ""], [nil, ""], :frozen, [true, "1234"], "ISO-8859-1"]	require "tempfile"\n            t = Tempfile.new("mrb_readbuf")\n    
+73b5b9f7068d2f4d7eb3c69976ab650d	1	class C\n              @@x = 1\n            end\n        
+73c9dec5b896221d19b6233b9db54621	[:rescued, "caught"]	f = Fiber.new do\n              begin\n                Fiber.yield :a
+73cf450d13041a7f92cc5202727762b7	"/"	File.realpath("..", "/tmp")
+7416b95f5e87edec12c271dfa849a210	[200, [:body, :ensure_start, :ensure]]	def baz\n              $x = []\n              $x << :body\n           
+74265315f293e83823e6e37edea00c74	[true, true, true, true, true, 1.0, 42, nil, nil]	srand(42)\n            a = rand\n            srand(42)\n            [\n
+742cf7259eae88dd4512794b3c9d16ad	[:i, :j]	def m; [1].each { |i| j = i * 2; return local_variables.sort }; end; m
+7441660ef7a2d951150dad613bc4907b	[:x, :x=, :y, :y=]	$added = []\n        class Module\n          alias_method :orig_method_ad
+7483001417ab19fd0c97c04334cd3e4a	[-1.0, -0.5, 0.0, 0.5, 1.0]	def test\n          res = []\n          i = 0\n          lo  = -2.0\n      
+7487c3bf6df41321ad221f8888a96604	:OVERRIDDEN	class Integer; def ~; :OVERRIDDEN; end; end; ~(3)
+748e241d7044c339274b01953e5a3301	[[:a, :a=, :b, :b=, :c, :c=], [:d=, :e=], [:f, :g]]	class C\n              def self.method_added(name)\n                G
+74afcdf5e655c49c966530c2b4d35e9d	["MStructB", :sym, [1, 2, 3]]	MStructB = Struct.new(:x, :y)\n            \n\n            s = MStruct
+74bb6f6237a0e70304325c88a24a0534	true	GC::Profiler.result.is_a?(String)
+74be49a029541ccb41607ba5dd9a427a	42	class C\n          def baz; yield + 1; end\n        end\n        C.new.pub
+74cf022318a40b13e77e2acc43ae4547	:hit	o = Object.new\n            def o.to_str; "alias_target"; end\n      
+74d160ca2f28d23fa20aea5de491f015	ArgumentError	(GC.config(implementation: "x") rescue $!.class)
+74d59ca8be05bd356579126c02ff2443	[1, 2, 3, 4, [], 5, 6, 10, 20, {z: 99}, 42]	def f(req1, req2, opt1=0, opt2=0, *rest, post1, post2, a:, b:, **kw, &b
+74e5acc644f523fada53601b2ed453ae	"raised"	obj = BasicObject.new\n                def obj.to_str; "abc"; en
+74e7cdc6ad90c96ea5cdefff7f990333	nil	r, w = IO.pipe\n            begin\n              IO.select([r], nil, 
+74fde25cc190396a4f3751c20850e35f	["SyntaxError", "SyntaxError", "SyntaxError", "SyntaxError", "SyntaxError", "nil"]	res = []\n        obj = Object.new\n        ["class << obj; yield; end",\n
+7535124d760c4c0a785e8ea480beec65	[nil, nil]	r, w = IO.pipe; v = [r.path, w.path]; r.close; w.close; v
+757079451a7218940c5e1548dbf8b7b7	[[:source_buffer_empty, nil, nil, nil, nil], nil, :invalid_byte_sequence, [:invalid_byte_sequence, "UTF-8", "ISO-8859-1", "\\xF1", "a"], Encoding::InvalidByteSequenceError, ["\\xF1", "a", false], :finished, [:finished, nil, nil, nil, nil], nil, :invalid_byte_sequence, ["ef", "abcef"], "d", "", :finished, ["", "abcef"], :invalid_byte_sequence, [:invalid_byte_sequence, [85, 84, 70, 45, 49, 54, 76, 69], [85, 84, 70, 45, 56], [0, 216], [97, 0]], [97, 0], :incomplete_input, [:incomplete_input, "EUC-JP", "UTF-8", "\\xA4", ""], Encoding::InvalidByteSequenceError, true]	(r=[]; ec=Encoding::Converter.new("utf-8","iso-8859-1"); r << ec.primitive_errin
+7594ef08c00240ce6aa9cc4c8da38186	[UncaughtThrowError, :abc, "uncaught throw :abc"]	begin\n          throw :abc\n        rescue UncaughtThrowError => e\n     
+75aa5279b9de5e0524d3833ce166ea1c	:assigned	class Object\n          def self.const_missing(c); c; end\n        end\n  
+75b113d3b79894812ec54346427be988	[[255], [233], [128], [65], [128], [RangeError, "256 out of char range"], [RangeError, "256 out of char range"], [RangeError, "1286 out of char range"], [65], [177], [130, 160], [ArgumentError, "invalid character"], [ArgumentError, "invalid character"], [ArgumentError, "invalid character"], [65], [142, 177], [164, 162], [143, 161, 161], [ArgumentError, "invalid character"], [ArgumentError, "invalid character"], [ArgumentError, "invalid character"], [ArgumentError, "invalid character"], [ArgumentError, "invalid character"], [130, 160], [164, 162], "A", ""]	def c(enc, v)\n              begin\n                ("%c".dup.force_e
+75c57885787c3754c814298944519355	:value	klass = Class.new do\n              def m\n                yield\n    
+763b67d3ef3e1c8ffe7d61ecae99e06f	"/home/user/monoruby/monoruby/a.rb"	require File.expand_path("./b")\n        C::D\n        
+7679a579d835ee8b69befeae2cee0a2b	"Z"	class MyInt\n                  def to_int; 90; end\n             
+76816dc27924ee3f477d020204e7cbd2	:ok	old_stderr = $stderr\n            captured = String.new\n            
+768d732177da90b2c02a306f1f672d62	[[1, 2, nil], [true, nil], [true, nil], [42, nil], "Ary", ["Ary", 1], [[1, 2, nil]]]	class Ary;  def to_ary; [1, 2]; end; end\n        class Nily; def to_ary
+76980b7d628abc009ae2670280836614	[["ArgumentError", "only cause is given with no arguments"], ["StandardError", "hi"], ["TypeError", "exception object expected"], ["TypeError", "exception class/object expected"]]	results = []\n            # cause: only ⇒ ArgumentError "only cause 
+76a4361de08288d7f1e53eb3855bdaef	[:refused, "nil", "nil"]	require "socket"\n            # Grab a free port, close the listener
+76d3c5429fdfa8af5370245762d7d60e	7	inc = proc { |n| n + 1 }; mul = proc { |n, m| n * m }; (inc << mul).call(2, 3)
+76d509e8caeda190c6d7f40c93ccd441	["can't convert nil into Rational", "can't convert nil into Rational", nil, "3/4", "3/2", "can't convert 1+2i into Rational", "7/1"]	[\n              (begin; Rational(nil); rescue TypeError => e; e.mes
+76f23d253bc9500bc54883b3fca2396f	[Array, :rb, true, true]	res = $LOAD_PATH.resolve_feature_path("pp")\n              [res.cl
+76f39b244a1c5e6d61a888dd4e103f5b	:OVERRIDDEN	class Float; def ===(o); :OVERRIDDEN; end; end; 3.0 === 4.0
+770025e2293750c0989f11bccedf3d21	"US-ASCII"	"abc".dup.force_encoding("US-ASCII").sub(/a/) { "Z" }.encoding.to_s
+770f72aa65c64daaf0d4ca21c395a0a8	"/home/user/monoruby/monoruby"	File.realpath(".")
+77337821311624241f8ad9125742e17e	[Data, true, Object]	M = Data.define(:amount, :unit)\n[M.superclass, M.new(1, "m").is_a?(Data), Data.s
+775a31c94e1007711b082e64008297bc	[3, [3]]	$log = []\n            def m\n              n = 0\n              begin
+775d8635fb7fe113ade374c0179881a4	"world"	m = Module.new do |mod|\n              mod.define_method(:hello) { "
+776068fb5a75af967139c99ca72fd131	3.14	class C; def to_f; 3.14; end; end; o = C.new\nFloat(o)
+7766681c09761e7b66d6fdb86feb1bae	[3.2, 1.6, 238.18399999999997, -267770.88, 924.0, -1124.0]	def f(d1, d2, x, y, s, c, p)\n          px = x - 100.0\n          py = y 
+7783137d4cd2c70faf7f01584872ab95	"\\x04\\bo:\\bBar\\b:\\n@nameI\\"\\nhello\\x06:\\x06ET:\\v@valuei/:\\v@items[\\bi\\x06i\\ai\\b"	class Bar\n              def initialize\n                @name = "hel
+778b89eb473f320143b57466fe6c623b	2	[1, 2, 3].each.with_object(:m) { |v, m| break v if v == 2 }
+77a7dafab8914bfd337708beb97921b8	[9223372036854774900, 900, 9223372036854774901, 899, 9223372036854774902, 898, 9223372036854774903, 897, 9223372036854774904, 896, 9223372036854774905, 895, 9223372036854774906, 894, 9223372036854774907, 893, 9223372036854774908, 892, 9223372036854774909, 891, 9223372036854774910, 890, 9223372036854774911, 889, 9223372036854774912, 888, 9223372036854774913, 887, 9223372036854774914, 886, 9223372036854774915, 885, 9223372036854774916, 884, 9223372036854774917, 883, 9223372036854774918, 882, 9223372036854774919, 881, 9223372036854774920, 880, 9223372036854774921, 879, 9223372036854774922, 878, 9223372036854774923, 877, 9223372036854774924, 876, 9223372036854774925, 875, 9223372036854774926, 874, 9223372036854774927, 873, 9223372036854774928, 872, 9223372036854774929, 871]	def drive\n              res = []\n              a = 3\n              
+77b00e5257cfe366d9ad6a60194785e2	[true, false, true, false]	x = 1\n            b = binding\n            [\n              b.local_v
+77be5f23f43f53c251e9965e79fe7154	true	class MyStr\n              def to_str\n                "llo"\n        
+77c54f817439de91d7af1ba0fc2f7703	2.0	[1.0, 1e100, 1.0, -1e100].sum
+77d8bf3df315e6839b43925962f505ad	[5, ["\\n", "\\n", "\\n", "plain\\n"], true]	path = "/tmp/mono_cov_puts_#{Process.pid}"\n            begin\n      
+77e87f734b11d0483e6b3360a59c3d1a	["-", "+", "~", "-", "+", "~"]	class C\n          def -@\n            "-"\n          end\n            \n   
+77ef6df0c04f7f116f5f35aaaea42fca	[7, 7, true]	b = binding\n            b.local_variable_set(:foo, 7)\n            [
+77f33491c631e48bf3b64ecae0803bc2	{0 => 1, 1 => 2}	S = Struct.new(:x, :y, :z)\n        s = S.new(1, 2, 3)\n        \ns.decons
+780000579ca44d3089a6235cecf1a5d8	"hit"	if /(?<w>foo)/ =~ "foofoo" then "hit" else "miss" end
+78082c42730aab237d42ab24975965e6	[nil, 99, 97, 116, 112]	File.open("Cargo.toml") do |f|\n              f.getbyte\n            
+7862b5af18cc17717c5063cd4c3df41d	[10, 3, "nil", 9]	x = 10\n        [1, 2, 3].each { |i; x| x = i * 100 }\n        a = nil\n  
+788c3b7f7d26d8ce64421732d85d9f4f	[9, 8, [7, 6], [5, 4], 3, 2, 2, 1, {}, nil]	f = ->(a, b = 1, *c, (*d, (e)), f: 2, g:, h:, **k, &l) do\n          [a,
+78a9147b5bb75312ad6a700a83ce8209	["can't create instance of singleton class", "can't create instance of singleton class", "ok", true]	o = Object.new\n        msgs = []\n        begin; o.singleton_class.new; 
+78d7ea39e2bafbf7649c9fc6b54bb309	[90300, 50, 50, [6, 6], [8, 8]]	class Base\n          def helper(x); x.succ; end\n          def m(v); [he
+7933b76f3fbc5da321278e1298f09b68	"1/2"	0.5.to_r.to_s
+79444ab999b1bb6218ce359077c8b24d	true	$LOADED_FEATURES.class == Array\n            
+79670f7488f2c3d15c92d158fb9043d3	"ab20000c"	%Q(ab#{100*200}c#$a)
+797f4bcc2f336f9d89d45a2f223ea819	["Bar", "Foo"]	$a = []\n            class Foo\n                CONST = 'Foo'\n       
+7991c7541e8d526d568dee250322b317	[nil, false]	f = nil\n            f = Fiber.new { Fiber.current.kill; :unreachabl
+79acc783b0537b1be76231c39ec86d9f	[true, true, true, false]	File.write("/tmp/mr_enc3.txt", "")\n            Encoding.default_ext
+79c41e4825bbd02f88869adf709237b7	[7, [1, 2], [10, 20], [:d, :e, nil], [3, 4], [5, 6, 7], [8, 9]]	res = []\n        m = Module.new\n        (m)::X = 7\n        res << m::X\n
+79c7f3f543fdcbf05090c26eb53f552a	[:it]	def m; it = 5; local_variables; end; m
+79df004215796258833bafeb383ba684	5	def f; return 5; end; f()
+79f521b7a2931ecaf21b4ae269dca011	"AB"	[65, 66].pack("C # first byte\\nC")
+7a214163208727ff855a9c86b078e3e2	[:foo, :bar]	$res = []\n            class C\n              def self.method_added(n
+7a22fbab65c686870df2b5b99250f03d	["bc", "Windows-31J"]	m = /b./s.match("abc".dup.force_encoding(Encoding::Windows_31J))\n               
+7a415869e06f95e7cb959c0401f52ced	"/home/user/monoruby/monoruby"	File.realpath("../monoruby")
+7a4714b990c4d0b20606ba3b944a11b0	[Module, 42]	$res = []\n        m = Module.new do |mod|\n          $res << mod.class\n 
+7a71024a6baabcef6c46340fdbabf5f4	[[], true, "global-variable", "ARGF", true, "$* is a read-only variable", "$< is a read-only variable", "stubbed", "stubbed"]	r = []\n            r << $*\n            r << $*.equal?(ARGV)\n       
+7a7670b0fefdd322f6a8b0743e2b769f	[5, 5]	->(x, y = x) { [x, y] }.call(5)
+7a8a882460efca56e1418c13c7848cba	45	j = 42\n        f = ->(x){x + j}\n        f.call(3)\n        
+7aa104817c34af089a380bbb177b03d3	42	mod = Module.new do\n              def hash\n                42\n     
+7ac6b8aa02383ba3314c395498fc236a	[[ArgumentError, "comparison of Array with Array failed"], [ArgumentError, "comparison of String with 0 failed"]]	h = { "b" => 2, "a" => 1, "c" => 3 }\n            [\n              (b
+7adfa44dbf68ad36a743e9faf5801875	"EUC-JP"	s = "文字化け".encode("euc-jp"); /#{s}/.encoding.to_s
+7afc130c6dddd70cd06a7fb2706c4350	["#<Module:0xADDR>::N", "m::N", nil, "y::N"]	m = Module.new\n            m::N = Module.new\n            a = m::N.n
+7b03c2c83fce81f7abe1c6fd481f47df	[210000, 210000, true]	r, w = IO.pipe\n            data = "xyz" * 70_000\n            t = Th
+7b0b7768060c36268fa1847da64eb14c	[nil, nil, nil]	f = File.open("Cargo.toml")\n            begin\n              [\n     
+7b0d6b404ec3d154debce9f17bc58e52	"Encoding::CompatibilityError"	(/\\A[[:space:]]*\\z/.match?(" ".encode("UTF-16LE")); nil) rescue $!.class.name
+7b213ebedfc5726a4fbeb0c8bb752579	[1, 2, 3, 5, 8, 13, 21, nil]	fib = Enumerator.new do |y|\n                a = b = 1\n             
+7b345e9a01115d5c1108b31830ad691d	[:a, :b, :c]	Struct.new(:a, :b, :c).members\n        
+7b47124790dadc26ab7e6c5335c167c5	[1, true]	o = Object.new\n            def o.method_missing(name, *) = raise(No
+7b478df870305bb2c4abbcc13749a6ad	false	called = false\n        klass = Class.new do\n          define_method(:in
+7b555b52656a57bad5a5fdc143ced21c	["yield", "yield", "yield", "yield", "yield", nil, nil, nil, nil, nil, "yield", "yield", "yield", "yield", "yield"]	def f\n                5.times { $x << (defined? yield) }\n          
+7b5681c9ae3d68fbc0040ffb94ea2759	[1, 0, 1, 1, 2, true]	def lvl3\n              [\n                caller(1, 1).size,    # im
+7b5f68952152e7580c6ab25f3f926de2	[false, false, false, nil, false, false, false, nil, false, false, false, nil, false, false, false, nil, false, false, false, nil]	def f(x)\n          x&.nil?\n        end\n\n        a = [1,2,3,nil] * 5\n   
+7b7476abdf009af6db3f49d35ef4d89d	[]	def g(*a); a; end; g(*nil)
+7b7f468fd7e708b03afd14b1c5882f15	"hELLO, wORLD!"	"Hello, World!".swapcase
+7bac2eab198ba99ba15061f668fa67ce	[0, "nil", "nil"]	o = Object.new\n        [o <=> o, (o <=> Object.new).inspect, (o <=> 3.1
+7bd487fc3bae8a806a0ddc5f0394215f	[true, false]	m = Mutex.new\n            slept = false\n            t = Thread.new 
+7bfe1905c8cfcd84d8d0ad738c459253	[1, 2, 3, 4, 1, 2]	def f(x,y,a:100,b:200,c:300,d:400)\n              [a,b,c,d,x,y]\n    
+7c1f60d60806a84dcf3a11a88bdef692	TypeError	("a" =~ "b" rescue $!.class)
+7c28dee19aa27309293f956968134d84	"HELLOd"	s = "hello world"; s.bytesplice(0...-1, "HELLO"); s
+7c3a942bb1335abaf415dc95e59e5dfd	[0, 1, 2, 3, 4, 5, "break:5", "done: main"]	def bar(&b)\n      10.times &b\n      $i << "done: bar"\n    end\n\n    def foo(
+7c486608085102bd6bffa726334867ac	[true, true, true, "warned", [1, 2]]	res = []\n        f = -> *a { a.last }\n        res << f.ruby2_keywords.e
+7c5038a4d5ba70145bd20b012d3bb5eb	"Encoding::CompatibilityError"	(/\\A[[:space:]]*\\z/.match(" ".encode("UTF-16LE")); nil) rescue $!.class.name
+7c86c0be211e4b0f63c5ef92a193151b	[true, false, true]	S = Struct.new(:a, :b)\n            \n\n            [\n              St
+7c968641ade256752ac11b31f04be656	[true, false, true, false]	res = []\n        o = Object.new\n        o.freeze\n        res << o.singl
+7cb9811ddfc93318db7e1d0abe07127d	["0.123e3", "0.456e0", "0.0", "0.456e0", "0.1e3", "0.0"]	require "rubygems"\n        require "bigdecimal"\n        res = []\n      
+7ccce38a43a199c2eea56a72eda7f6dc	[[], [:foo], [], [:foo]]	res = []\n        class S\n          def foo\n            "foo"\n          
+7cd1d5bab06d282edfbce720b2d1606b	[1, 2, [], 3, 12]	def f\n          yield [1,2,3]\n        end\n        \n\n        f { |a,b,x=
+7d0c6bafe5a5ef234657281422caca93	["[", "p", "a"]	f = File.open("Cargo.toml")\n            begin\n              [f.getc
+7d1501ee72153df4a1af95a0a484f13b	[true, false]	GC::Profiler.enable; r = GC::Profiler.enabled?; GC::Profiler.disable; [r, GC::Pr
+7d4fb0ea252c3834303824e7d9f4f7c8	false	arr = [1, 2]; x = *arr; x.equal?(arr)
+7d566060f439422030b6a00d4ff60ee1	true	Integer.instance_method(:inspect) == Integer.instance_method(:to_s)
+7d6854cd651142049c443c4e92d72f00	50	x = 10\n        eval("x * 5")\n        
+7d8b0536aa2c8c96c141de63562053a8	[16, 8]	f = proc { |x| x * x }; g = proc { |x| x + x }; [(f << g).call(2), (g << f).call
+7dbf766e4faeae2f9ef65b162d2a7f4b	["no 0", "match 1", "no 2", "NoMethodError"]	klass = Class.new do\n          def ===(o); o == 1; end\n          privat
+7dcb621c6c844f83fc03a82810bbf155	"US-ASCII"	"abc".dup.force_encoding("US-ASCII").gsub("b", "x").encoding.to_s
+7df2430b101d25b712234fd3adbbd74d	[:v, 0]	q = Queue.new\n            t = Thread.new { q.pop }\n            Thre
+7df952393eebbe3287d4e8c89d1c4fc0	true	cause = RuntimeError.new("cause")\n            begin\n              r
+7e04e97d709154a8293c77ad4d9d2d1e	{0 => 1, x: 1}	S = Struct.new(:x, :y, :z)\n        s = S.new(1, 2, 3)\n        \ns.decons
+7e07db27a2fcc657a814b6cd413ead2f	[1, 2, 42]	def f\n          yield 1,2,3,4\n        end\n        \n\n        f {|a,b|\n  
+7e1690daa5a419c7c3840bcdd22ff153	["string_path"]	def boom; raise "no"; end\n            def test; [1].map { begin; bo
+7e1ed6afd9824cec85287b40fc6d7254	[600, 1, 256, 257, 600]	n = 1; a = [n + 0, n + 1, n + 2, n + 3, n + 4, n + 5, n + 6, n + 7, n + 8, n + 9
+7e375b6e36df88ed1b40fe29c199fe50	[1, true]	r, w = IO.pipe\n            w.write("hi")\n            a = r.wait(IO:
+7e414128a427ed5dd5b917799233dfae	[true, true, true, true, [], "ARGF", "ARGF", true, true, true]	require 'tmpdir'\n            f1 = File.join(Dir.tmpdir, "argf_t1_#{
+7e4559b70c502c86877961c7b64752d8	nil	a = "abc".dup.force_encoding("UTF-8")\n              b = "abc".dup
+7e45850c6cdb83e1fc5ed24237cfec5d	5	def m(a:); a; end; m(a: 5)
+7e695e7d7420eee5331fcf41cfe54dfc	true	Process.getrlimit(:NOFILE).is_a?(Array) && Process.getrlimit(:NOFILE).size == 2
+7e74e9a2ca31d86582e638cf1d8cc09d	true	m = Module.new; r = nil; mod = Module.new { r = using m }; r.equal?(mod)
+7e7c0b1b6e6693f9e664b1a54dbde111	0	m = Object.new\n        def m.==(x); true; end\n        m <=> Object.new\n
+7e7e4d6aef6bf7266adf4b085dc59d23	[:one, :two]	rec = []\n        one = proc { |&arg| arg.call(:one) if arg }\n        tw
+7e96f5f901b2f6fae7a6ccede1e6bf9c	[true, "a b c"]	s1 = "a b c"\n            s2 = s1.dup\n            ok = false\n       
+7f230ec5e7c81dcb14df9d04bf7eb5df	"raised"	class BadInt\n                  def to_int; "not an integer"; en
+7f39046674eb2565ca621a342f701cae	[true, true, true]	M = Data.define(:amount, :unit)\n\n            a = M.allocate\n            a.send(:
+7f48ec6081718c6875731cb8393d7b9c	["echo hello", true]	def `(cmd); [cmd, cmd.frozen?]; end\n        %x{echo hello}\n        
+7f684c2506ac66a75606077c90b5924f	"US-ASCII"	s = "hello".encode("US-ASCII")\n              s.upcase!\n          
+7f68c0c2608b0a93888ba660052937e5	7	mul = proc { |n, m| n * m }; inc = proc { |n| n + 1 }; (mul >> inc).call(2, 3)
+7f747f780d48143c0ab242713c240386	["Foo", "Bar", "Foo"]	$a = []\n            class Foo\n                CONST = 'Foo'\n       
+7f859e89e1379a7cf00760b56af97285	"あ"	class HiroChar\n                  def to_int; 0x3042; end\n      
+7f983c97ff2d7632ca2566839b2d0aa5	true	rng = Random.new(42)\n        a = rng.rand(1.5)\n        a.is_a?(Float) &
+7f9f876eb22b2bc16a64bd780036a90b	:ok	using Math; :ok
+7fbef115b72649d4c93632808a3c7664	200	superclass = Class.new\n            200.times.map { Class.new(superc
+7fd970408fef4686f9a03d7219e2c592	[false, :arg_error, :arg_error, :arg_error, :arg_error]	class N\n            include Comparable\n            attr_accessor :x\n 
+7fde780ffabe4bf9d5cdf993a4ba165d	["main", "main", true, true, "main", true, false]	c = self.clone\n            [\n              to_s, inspect,\n         
+7fe6acbcc38e6d331c6b562b26a7766b	true	"abc".force_encoding("ISO-8859-2").encoding == Encoding::ISO_8859_2
+7ff29e4f8d290ec73b7f9a83c58fdd4d	[ArgumentError, "ASCII incompatible encoding: UTF-16LE"]	(Regexp.union(Regexp.new("a".encode("UTF-16LE")), Regexp.new("b".encode("UTF-8")
+8043ee50b7e295aec19dfea005b5d206	"US-ASCII"	"abc".encode("US-ASCII").reverse.encoding.to_s
+804b1557848b61bcf447552cac485286	:ok	c = Class.new\n            c.freeze\n            begin\n              
+804bf123f4d6e236bd9c3800e5582083	1	Inner = Struct.new(:b)\n        Outer = Struct.new(:a)\n        o = Outer
+805e377322d362957ff65c2466591c45	"ENV"	ENV.to_s
+8069191a22d0b6b29811cbab5a50dd8e	[:@@a, :@@b]	c = Class.new\n            c.class_variable_set(:@@a, 1)\n           
+809281e76b95d635f181be9aa9c1cf05	[1, [], true]	S = Struct.new(:x) do\n              FLAGS = { foo: 1 }\n            
+8098133adc30ffe32c8d9dbe5ae12a78	[1, 2, [3, 4, 5, 6], 7]	def f(x,y,*z,a)\n            [x,y,z,a]\n        end\n        \n\n        f(1
+80baa197387e4aa5b6889e7c3b340c5a	[:initialize_dup, :initialize_copy]	$called = []\n            class Foo\n              def initialize_dup
+8102d033b6a3823b4f48b0cf3c51ecae	[7, 8]	o = Object.new\n            def o.respond_to?(name, *) = true\n      
+812c40542c17a0b548a32baae3a41bd3	[0, 0, true, true, "root", "root", true, 0, true, true]	require "etc"\n            pw = Etc.getpwnam("root")\n            gr 
+81371fe30cb669fe8f93af5e539a0a50	["ZeroDivisionError", "user"]	begin\n              raise "user"\n            rescue\n              b
+813c1561f0a475d62542217c3b16d990	["boom", true]	t = Thread.new { Thread.current.abort_on_exception = true; sleep 0.
+81521b66a2141f9037bbfa1330b6895b	"abcdefghijabcdefghijabcdefghijabcdefghijabcdefghij"	"abcdefghij" * 5
+815fb5dfd31836a4be23fedfa5db3a46	"ok"	r, w = IO.pipe\n            t = Thread.new { r.read(2) }\n           
+81674508001763ecbda6a61bcd269308	[1, :assigned]	module M1; end\n        x = 0\n        (x += 1; M1)::C ||= :assigned\n    
+8193766d4ea2f53b2e9b0d421c63493f	["no keywords accepted", :ok, :ok, :ok, "no keywords accepted", 3, "no keywords accepted", :mok, "no keywords accepted", "no keywords accepted", :mok]	def rescue_msg\n              yield; :no_error\n            rescue Ar
+819786c3c521ff97cda2204ae5eaf866	[true]	def check(o); o.is_a?(Integer); end\n            r = []\n            
+81a4893d8dc3fd03a6cb2cc3f973f7b0	[4, 8, 111, 58, 14, 69, 120, 99, 101, 112, 116, 105, 111, 110, 8, 58, 9, 109, 101, 115, 103, 73, 34, 6, 120, 6, 58, 6, 69, 84, 58, 7, 98, 116, 48, 58, 10, 64, 105, 118, 97, 114, 105, 12]	e = Exception.new("x")\n            e.instance_variable_set(:@ivar, 
+81e0c55d71a2b7b73cce48922e4bf66e	:OVERRIDDEN	class Integer; def /(o); :OVERRIDDEN; end; end; 3 / 4
+81eacd02531187a80cb90a83f0c4824c	[[130, 160], "Shift_JIS"]	Encoding.default_internal = Encoding::Shift_JIS\n              t =
+81fd4c71c1be9be22bcbec82f890766a	[:method_missing, :method_missing]	class CM\n              def method_missing(name, *) = [__method__, _
+8200b7ed09f157ac5e736b20f1274721	[:custom, false, true, true, false]	class Baz\n          def !\n            :custom\n          end\n        end
+823812ee0e73bed95cbd8ff75188a377	[[65], [195, 168], nil]	File.write("/tmp/mr_gc3.txt", "A" + [0xC3, 0xA8].pack("C*").force_e
+82381ff0592af11a45910f0a463d629f	[[1, 2, 4, 8, 32, 64, 128], true, true, [:AllocationError, RuntimeError], [:AccessError, RuntimeError], [:LockedError, RuntimeError], [:InvalidatedError, RuntimeError], [:MaskError, ArgumentError], "#<IO::Buffer 0xA+8 INTERNAL>", "#<IO::Buffer 0xA+8 INTERNAL>\\n0x00000000  00 00 00 00 00 00 00 00                         ........", "#<IO::Buffer 0xA+4096 MAPPED>", "#<IO::Buffer 0x0000000000000000+0 NULL>", [true, true, true, 0], "#<IO::Buffer 0x0000000000000000+0 NULL>", [true, true, 0], [true, false, false], [true, false], true, [ArgumentError, "Size can't be negative!"], [IO::Buffer::AllocationError, "Could not allocate buffer!"], [TypeError, "not an Integer"], [TypeError, "no implicit conversion of Integer into String"]]	b = IO::Buffer\n            r = []\n            r << [b::EXTERNAL, b:
+823a698188f9806bd147be948d889ba7	[nil, :empty, :closed, 1, nil]	q = Queue.new\n            r = [q.pop(timeout: 0.02)]\n            be
+823f7b6229174b0da18f59b5a5c7cca0	[1, 2, "constant"]	module QTopA; X = 1; module Inner; Y = 2; end; end\n            [QTo
+82447060301c9a64b3ac42318f460e62	[1, 2, 3]	class C\n          def foo(*x)\n            x\n          end\n        end\n 
+8256e9068f6e136c99b87f2f7f97fdb8	[[ArgumentError, "negative signal name: -HUP"], "negative signal name: -INT"]	[(begin; Signal.trap("-HUP") {}; rescue => e; [e.class, e.message]; end), (begin
+82abda467be3a95b2f6d81fbf7dfb3da	"a:a b:{x: 100, y: 200}"	def f(a, b)\n          "a:#{a} b:#{b}"\n        end\n        \n\n        f("
+82afafb55f0b808c4e046dd1d983831d	["ASCII-8BIT", "US-ASCII", "US-ASCII"]	[/\\xc2\\xa1/n.encoding.to_s, /abc/n.encoding.to_s, /\\x7f/n.encoding.to_s]
+82c9966b62ff6ac43f8a7ad749c3fa16	1	p = proc {\n          a = 10\n        }\n        a = 1\n        p.call\n    
+82e2b73c1395323ecb44d17bc3a32421	Complex	8.0.quo(Complex(2, 1)).class
+82ea00d4003b7161aa2102e05ff69c66	3	"わたし".byteindex("た")
+82ff14b74e3eca76717b9af689a3898e	[:foo, [1, 2, 3, 4]]	class C\n          def method_missing(name, *args)\n            [name, ar
+8305358285ffef3eabb5f06f63fe896b	[[[1, 2], [:a, :b]], [[1, nil], [nil, nil]], [[1, 2]], [[1, 2]]]	def drive(a)\n              acc = []\n              a.each_with_yield
+8370c5ed8e43de9e99d7f41038618f1b	[true, true, true, [1, 2]]	Nc = 1\n        module RM1; end\n        RM2 = Class.new\n        msgs = [
+83806d03f4525939aff12798777778b6	[ArgumentError, "incompatible encodings: UTF-16LE and UTF-16BE"]	(Regexp.union(Regexp.new("a".encode("UTF-16LE")), Regexp.new("b".encode("UTF-16B
+839e2c6e4a8712955a1f09c759e45e93	[]	Module.new.included_modules
+83a20113cd2d9bf88c262b3b65329020	[[[:s, :t]], [:s], [[:s, :t]]]	hs = {a: 1, b: 2}\n            def hs.each; yield :s, :t; end\n      
+83b0222e9f4a161caa6a486f916acfe6	[1, 2, 3]	class MyNum; def to_int; 3; end; end\nn = MyNum.new\n[1,2,3,4,5].first(n)
+83b1d2a51155f5bd85651c8843b3a5ba	:OVERRIDDEN	class Float; def !; :OVERRIDDEN; end; end; !(3.0)
+83b784235d0769c7b814205d33a9ce5b	["HSub", 1]	class HSub < Hash; end\n            h = HSub.new\n            h[:a] =
+83ceae37b80f34a2aa9d0002533a67d6	42	a=Object.new; a.instance_variable_set("@i", 42); a.instance_variable_get(:@i)
+84084af32e200c43d9a0f21c314d8935	""	"".reverse
+842592b1bb99be694e92c22a5315ee23	[false, false, false, nil, false, false, false, nil, false, false, false, nil, false, false, false, nil, false, false, false, nil]	a = [1,2,3,nil] * 5\n        x = []\n        for e in a\n          x << e&
+8426848ab8fdf086ee8cf3191a12c5f8	"MShip2::Blob"	module MShip2\n              class Blob\n                def _dump(l)
+846556768cd567bd24d3916bd92ff7db	[false, false, true, [true, true, false], true, false, false, ["NameError", "'a' is not an implicit parameter"], ["TypeError", "1 is not a symbol nor a string"]]	def try; yield; rescue => e; [e.class.to_s, e.message]; end\n       
+846653c25256021e7ac217987b6ab247	[nil, true]	r, w = IO.pipe\n            pid = fork { r.close; Signal.trap("TERM"
+8479b8263b2031ca390cec82e34d1347	"yes-shname\\n"	env = Object.new\n            def env.to_hash = {"VIA_TO_HASH" => "y
+84d91589fff917e43c1d88cde1f37516	[false, false, false, [:include, :TypeError], [:extend, :TypeError], [:r_include, :TypeError], [:r_prepend, :TypeError]]	r = Module.new { refine(String) { } }.refinements[0]\n            ou
+84f4b6da4f67b5e0629d3c8cdef84518	"A"	class A\n              def who; self.class.name; end\n            end
+85019cb4cb8a7b9dda94fc30fc53ddb9	""	class EmptyStr\n                  def to_str; ""; end\n          
+8512fe4bb7149eeb9d286f11a5e56253	["EUC-JP", "EUC-JP", "EUC-JP", "EUC-JP", "ISO-8859-1", "ISO-8859-1", "EUC-JP", "EUC-JP", "EUC-JP", "EUC-JP"]	res = []\n        "abc".dup.force_encoding(Encoding::EUC_JP) =~ /b/\n    
+851e94b29a9d81a9e1896d24980ff816	[true, true, true, true, true]	class F\n            include Comparable\n            attr_accessor :x\n 
+85205f289f421cdfa21b230f172235db	"ISO-8859-1"	path = "/tmp/monoruby_test_iodi_#{Process.pid}_#{rand(100000)}"\n   
+8575d528e7322eae6ebb7d94d1ddbeb9	[10]	def f(r, a = ($x = 10)); 0; end\n        f(9)\n        [$x]\n        
+85931ef34cf7bdff8906a812f59a2891	[101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101]	def bar\n          eval("x += 1", $b)\n        end\n            \n\n        
+85a10f866a98eda982860b346626d872	1.25	Rational(3, 4) + 0.5
+85d3118446d032c5dad2d62a7bcc2938	[true, "interrupt immediate", false]	Thread.handle_interrupt(RuntimeError => :never) do\n              cu
+85db7cb07fda771baf0fc0e15052b278	"method"	defined?(!__ENCODING__)
+85e7593e9dd66c1c5a37afa22f1b7d68	"nil"	r, w = IO.pipe\n            t = Thread.new { sleep 0.2 }\n           
+85e7620ff95003251b4405ba74cbfb03	[0, 0]	path = "/tmp/mr_fsync_test.txt"\n            r = File.open(path, "w"
+85fe2b8468951fc30f0d8cabe844b706	Module	m = Module.new\n        m.class\n        
+860c557ff310749db06b9beabc01cc56	["Process::Status", 0]	IO.popen(["true"]) { |io| io.read }\n            [$?.class.to_s, $?.
+861e99795f6f1ed683e95e52e573c574	["US-ASCII"]	"abc".dup.force_encoding("US-ASCII").split("").map(&:encoding).map(&:to_s).uniq
+8634204d0d711f3c760e95c063499f29	["superclass must be an instance of Class (given an instance of Integer)", "superclass must be an instance of Class (given an instance of Integer)", "superclass must be an instance of Class (given an instance of String)", "superclass must be an instance of Class (given an instance of String)", "superclass must be an instance of Class (given an instance of Symbol)", "superclass must be an instance of Class (given an instance of Symbol)", "superclass must be an instance of Class (given an instance of Module)", "superclass must be an instance of Class (given an instance of Module)", "can't make subclass of singleton class", "can't make subclass of singleton class"]	res = []\n        [42, "s", :sym, Module.new, Object.new.singleton_class
+86a4d6ced3f4342dfd6b853b74858c93	[[1, 2, {}, 1], [18, 2, {c: 4, z: 6}, 2], [1, 2, {z: 7, 5 => 2}, 3]]	def f(a:1,b:2,**c,&block)\n          [a, b, c, block.call]\n        end\n 
+86addf8e26db6827d46f956b835833d8	[true, true, true, true, true, true, true, true, true, true, true, true, true, {a: 2}, {a: 2, b: 3, c: 3}]	require 'stringio'\n            def cap; $stderr = StringIO.new; yie
+86cc33f4ca22bf932070781d16fd754e	0	Time.utc(2000,1,1,0,0,0).subsec
+86d934731c116eb5dc06a1f26530d093	1267650600228229401496703205376	Integer(2.0 ** 100)
+86fe1bb2c2a5fd5c1014bbd1bf5febd8	"foo12"	class Foo\n              def foo(x, y)\n                "foo" + x.to_
+870cdf933c326e30a4dd064a7cb24da4	7	class UDProto\n              attr_reader :s\n              def initia
+870e7cf6a151b8e9687d331fa725f97b	["HI!", "HI!", "GLOBAL"]	module JitR3\n              refine(String) { def shout; upcase + "!"
+8716c7722401456bc142c663e9841982	["0.85397e1", "0.585e1", "0.43e0"]	require "rubygems"\n        require "bigdecimal"\n        res = []\n      
+87305cab4ce459da4f12b255d2e568a4	true	class Coercible\n              def ==(other); true; end\n            
+873209a668c450584c681b28f3af09f3	7.0	class Float; alias __orig :+; def +(o); __orig(o); end; end; 3.0 + 4.0
+8741050c3a5bc835bcab3cb04b928f9d	"UTF-8"	x = __ENCODING__; x.name
+875df8f0024d1eac090bc7a8e80f17a3	[6, 9, 0, 9, true, false, 9223372036854774000, 8, 16, 0, 12, true, false, 9223372036854774002, 10, 25, 0, 15, true, false, 9223372036854774004, 12, 36, 0, 18, true, false, 9223372036854774006, 14, 49, 0, 21, true, false, 9223372036854774008, 16, 64, 0, 24, true, false, 9223372036854774010, 18, 81, 0, 27, true, false, 9223372036854774012, 20, 100, 0, 30, true, false, 9223372036854774014, 22, 121, 0, 33, true, false, 9223372036854774016, 24, 144, 0, 36, true, false, 9223372036854774018, 26, 169, 0, 39, true, false, 9223372036854774020, 28, 196, 0, 42, true, false, 9223372036854774022, 30, 225, 0, 45, true, false, 9223372036854774024, 32, 256, 0, 48, true, false, 9223372036854774026, 34, 289, 0, 51, true, false, 9223372036854774028, 36, 324, 0, 54, true, false, 9223372036854774030, 38, 361, 0, 57, true, false, 9223372036854774032, 40, 400, 0, 60, true, false, 9223372036854774034, 42, 441, 0, 63, true, false, 9223372036854774036, 44, 484, 0, 66, true, false, 9223372036854774038, 46, 529, 0, 69, true, false, 9223372036854774040, 48, 576, 0, 72, true, false, 9223372036854774042, 50, 625, 0, 75, true, false, 9223372036854774044, 52, 676, 0, 78, true, false, 9223372036854774046, 54, 729, 0, 81, true, false, 9223372036854774048, 56, 784, 0, 84, true, false, 9223372036854774050, 58, 841, 0, 87, true, false, 9223372036854774052, 60, 900, 0, 90, true, false, 9223372036854774054, 62, 961, 0, 93, true, false, 9223372036854774056, 64, 1024, 0, 96, true, false, 9223372036854774058]	def drive\n              res = []\n              j = 0\n              
+876de098296efcddcfbefb47ad345e9d	[1, 0]	module M5; C = nil; end\n        x = 0; y = 0\n        begin\n          (x
+8794978b94a718366bd0ea968a26e48c	"u"	ENV.update("MONORUBY_ENV_TEST_UP" => "u")\n            v = ENV["MONO
+879bfe5babe8b785bb97793dbddc720d	[Hash, "gen:missing", false]	sub = Class.new(Hash)\n            o = sub.new { |h, k| "gen:#{k}" }
+87ae9b46ca3c04ae2ff6b67ee9129262	[[0, 0, 0, 0, 0, 0, 0, 0, 0], 0, 0, 0, [1, 0, 0, 0, 0, 0, 0, 0, 0], 0, 0, 0, [1, 1, 1, 1, 1, 1, 1, 0, 0], 1, 7, 1, [1, 1, 1, 0, 0, 0, 0, 0, 0], 1, 7, 1, [0, 0, 0, 1, 1, 1, 1, 0, 0], 0, 0, 0, [1, 1, 1, 0, 0, 0, 0, 0, 0], 1, 7, 1, [0, 0, 0, 1, 1, 1, 1, 0, 0], 0, 0, 0, [0, 0, 0, 0, 0, 0, 1, 0, 0], 0, 0, 0, [0, 0, 0, 0, 0, 0, 1, 0, 0], 0, 0, 0, [0, 1, 1, 1, 0, 0]]	def bits(n) = [n[0], n[1], n[5], n[62], n[63], n[64], n[100], n[-1], n[
+87b2611ad47f2c5311c480d58f1afdc4	"hello"	class A\n              def greet; "hello"; end\n            end\n     
+87b703ef2494b2ac663477f4127d842a	0	obj = Object.new\n            def obj.infinite?; 1; end\n            
+87b8d29ec9e5e3a888103c75087c2a9a	:OVERRIDDEN	class Float; def >(o); :OVERRIDDEN; end; end; 3.0 > 4.0
+87c45ead14ca906b6a7e5c0e5c10bbd4	:ok	old_dep = Warning[:deprecated]\n            old_stderr = $stderr\n   
+87e3c706132a5ebc1a248cc7d38c661a	[1, "m"]	M = Data.define(:amount, :unit)\nM.new(1, "m").deconstruct
+87f49526ab8a8379c1cb4b2bf34acccd	["US-ASCII", "UTF-8", "UTF-8"]	(a=format('%s'.encode(Encoding::US_ASCII), 'foobar').encoding.name; b=format('%s
+88136a75e44955e0b880a37966cf907a	[7, 11, [:v, :w]]	c = class A\n          def f(x,y)\n            @v = x\n            @w = y\n
+881cb167c3929471c6ff191ff16d5b8b	nil	body = "module SelfRegister; end\\nSelfRegister.autoload(:Foo, __FIL
+882e656de94f305b67af452dff533068	["ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError"]	def g(a, b, c) = a + b + c\n        def f(...) = g(...)\n        \n\n      
+88320802bc565288d8c18da56893b106	1	0.5.to_r.numerator
+8839abbb098998a11f5c468bba1cf779	"N:#<NilClass:0xADDR>"	class NilClass; def to_s; "N:" + super; end; end\n                nil.to_s.sub(/0
+88429942b0f99a3ca980582a1ff1f50e	[StopIteration, "StopIteration"]	o = Object.new\n            def o.each; yield 1; raise StopIteration
+88461a469aef4d8d3db4456b16e10a19	[25, 750.0]	def check(x) = x.nil?\n            def step_like(limit, by)\n        
+8853b8884228122ac56519cd2ee8b71c	[:fiber_1, :fiber_2]	f1 = Fiber.new { :fiber_1 }\n            f2 = Fiber.new { f1.transfe
+885b49a51181fdd9a665649f5d6afb97	[1, 2, 3, 4]	class C; def to_ary; [3, 4]; end; end; o = C.new\n[1, 2] + o
+889ef2d076f0c4bf33ee8cb138f1383a	[:a, "b"]	module M\n              def a; 1; end\n              def b; 2; end\n  
+88b402e7fdaa8b2f9583d10a43b30b83	[true, false, true, false, true]	class C\n          def pub_method; end\n          private\n          def p
+88b74eaedd70ab6521c45c598a99a423	:OVERRIDDEN	class Float; def <=(o); :OVERRIDDEN; end; end; 3.0 <= 4.0
+88babe728a4927abe5d2e25cd6b25a80	:OVERRIDDEN	class TrueClass; def ==(o); :OVERRIDDEN; end; end; true == true
+88c361bca62c3fbea0462a14aedadf27	[15, 11, 3, [77, 2], [:key, :key, :side, :side]]	class C\n          def initialize; @h = {}; @w = nil; end\n          def 
+88d4180cc8261b799934c513e7ea401c	13	def f(a,b)\n          a + b\n        end\n        f(5,7)\n        f(4,9)\n  
+88f8e9f112097e82f8a521e470848673	["<1>", "'x'"]	module AncInner\n              refine(Integer) { def wrap; "<#{to_s}
+88fba5d2266fa4ee0bba24a92af6c067	[[], 1]	->((*a, b)) { [a, b] }.call([1])
+89a90f1ae033d44d7cd236ed88be4129	:bar	class Foo\n              def bar; end\n            end\n            \n\n
+89c218222121411715e9cbdc51498eb5	[21, 28, 35, 42, 49, 56, 63, 70, 77, 84, 91, 98, 105, 112, 119, 126, 133, 140, 147, 154, 161, 168, 175, 182, 189, 196, 203, 210, 217, 224]	def g(a, b, c, d, e, f, g) = [a, b, c, d, e, f, g].sum\n        def f(..
+89cc804a9b06b07941ab2d5dd4a30fc8	true	def `(cmd); $g = cmd.frozen?; end\n        `ab`\n        $g\n        
+89cd6dacc925b6c1f2d159336fe1b843	[:deferred]	def run_masked(timing, blocking = true)\n              klass = Class
+89f7fffd38b177b008b30d0eee379904	[:a, :b]	def m; a = 1; b = 2; binding.local_variables.sort; end; m
+8a1a61b156937416ceb0e77d4253c4bd	[true, false, false, :typeerr]	class C; end\n            o = C.new\n            klasses = [C, String
+8a3f407160682fc555874ca61a253421	:OVERRIDDEN	class Complex; def %(o); :OVERRIDDEN; end; end; Complex(1,2) % Complex(3,4)
+8a4246e8aab236dda86d054528427552	[[10, 2, 60]]	class C\n          def f(a, b, &blk)\n            $res << [a, b, blk.call
+8a44343beec7f35a4c79738be44889de	[",", ","]	$; = ","; r = [$;, $-F]; $; = nil; r
+8a45cc21144735e8505e2a9b3b2065d5	[:considered, :moved, :moved_up, :moved_down]	GC.latest_compact_info.keys
+8a608d11c3f657ca379bad311ef65e13	294	class C\n          def f\n            x = 0\n            7.times { x += yi
+8a6b94b64e2a0b0af3908b52f147185f	true	class S\n        end\n        class C < S\n        end\n        S === C.new
+8a806116e8db9855524e6f7e79e47938	[nil, 2, 9999999999999999999999999999999]	[[].max, [1,2,-42].max, [-42.4242, 100, 999999999999999999999999999
+8ab7255cc645f88bcc12b9b985e76688	[[:protected_foo, :public_foo], [:protected_foo, :public_foo], [:private_foo], [:private_foo]]	class Foo\n          private;   def private_foo()   end\n          protec
+8ac98985ac612f0703d37bf0737bc3e8	["ABいう", true]	s = "あいう"\n            s.bytesplice(0, 3, "AB".force_encoding("ASCII
+8ad0bb005e97f639e1a5c706a270ed11	[true, false, true, true, true, true]	class W\n            include Comparable\n            attr_accessor :x\n 
+8aff130d4cf4e00d7d7b4435b5691762	[true, "hi"]	require 'tmpdir'\n            path = File.join(Dir.tmpdir, "mrb_fifo
+8b1c707195f0233d91b133db6b2549a0	3	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \ns.len
+8b55158395e31dd88ba473b1a6f3e551	true	GC.auto_compact = true; GC.auto_compact
+8b98d44ec4272b482412f750678a9964	1	obj = Object.new\n            def obj.infinite?; -1; end\n           
+8bc4cf0cc800784b3cf613c74c5a0702	[[:init, :body], true, :uninitialized, "must be called with a block", :already, true, 2, 1]	r = []\n            arr = []\n            sub = Class.new(Thread) do\n
+8bc5ef741a233aec240c5b062658f9b1	[4, 2, 4, 2, []]	splat = BasicObject.new\n        def splat.to_a; [2, 3, 4]; end\n        
+8bc9d3da4bf1a6f87b5745a463b34756	0	base = "/tmp/monoruby_dir_openblk_#{Process.pid}_#{rand(100000)}"\n 
+8be3c3f98ba598dac745b5259d3d2b29	[[1, :m], [2, :m]]	[1, 2].each.with_object(:m).to_a
+8c030a2b323ad9f1ba7df7f60a9bf461	[:interrupted]	def run_masked(timing, blocking = true)\n              klass = Class
+8c04e9b6af13aa499a29667f5c6c462c	true	m = Module.new\n            m.define_method(:foo) { 42 }\n           
+8c219db74709871ec327288e7ea87574	[]	Object.const_source_location(:String)
+8c40f6716dfa0774268666a9a7189bac	[true, true, true, true]	GC.measure_total_time = false\n            frozen = GC.total_time\n  
+8c46a079787a46583d7ff5f5a286bda0	[3, 3, 9, 9, 3, nil, nil, -2.5, 1.5, 1.5, 3, "abc", "abd", 3, 9, "Float", "Integer"]	a, b, c = 3, 9, 5\n            f, g = 1.5, -2.5\n            s1, s2 =
+8c642f07da5999c0439d1ea9db1dfdbb	"a,b,c"	class C; def to_str; ","; end; end; o = C.new\n"a,b,c".split(o) {|_| }
+8c70e2dbc965b5a240d04429bfa944de	["UTF-8", "UTF-8", "abc", "nil", "plain"]	path = "/tmp/monoruby_io_bom_#{Process.pid}_#{rand(100000)}"\n      
+8c83bb3ecc9ac2c1e06a16d061103347	Array	class C < Array; end\n(C[1,2,2] & [2,3]).class
+8c8d2f17496ea5fcffabf17deeb83042	["a", "b"]	base = "/tmp/monoruby_dir_eachinst_#{Process.pid}_#{rand(100000)}"\n
+8cccb4747cfdbfa71bed00dbdaf949ab	[["RuntimeError", "TypeError"], ["RuntimeError", nil], "TypeError", ["RuntimeError", nil], "ArgumentError"]	def t; yield; rescue Exception => e; [e.class.to_s, (e.cause && e.c
+8cf61f75f99a0e9c53f3bf071168dad0	[:foo]	class P\n              def foo; end\n              def bar; end\n     
+8d2889917a7f7f98ff652806d0833021	[195]	"\\xC3".dup.force_encoding("UTF-8").reverse.bytes
+8d3d0ca2dbeed6c68ea827b8891e29e3	[[[130, 160], "Shift_JIS"], [65], [65, 0], [65, 0, 0, 0], [[233], "ISO-8859-1"]]	File.binwrite("/tmp/mr_gc4.txt", [0x82, 0xA0, 0x41].pack("C*"))\n   
+8d3ded30d75b25bfe7b9b6473fe28499	"X"	File.open("Cargo.toml") { |f| IO.new(f.fileno, path: "X", autoclose: false).path
+8d56cf68fe7c6a0dbc65f86b0fdd0789	[true, true, false]	m1 = Module.new\n            m2 = Module.new\n            c = Class.n
+8d79a95a9c94d782628a4f1a36105103	[1, [2], 3]	class MyNum; def to_int; 1; end; end\nn = MyNum.new\n[[1,[2]],3].flatten(n)
+8d830e1b0b9fd01963265a605718108d	[false, false, TypeError, TypeError, "a/b/c", [ArgumentError, "string contains null byte"], "/", ".", "."]	(a=File.directory?(STDIN); o=Object.new; def o.to_io; STDIN; end; b=File.directo
+8d9530b39ee52f718426ea8687708e0f	"data"	path = "/tmp/monoruby_test_filewrite_kw_#{Process.pid}_#{rand(10000
+8d974b46554a5e083a4cc64738f912b3	[true, true, true]	r, w = IO.pipe\n            v = [r.external_encoding.equal?(Encoding
+8daa6433e635cb816f0ee8a52cea83ef	[:initialize_clone, :initialize_copy]	$called = []\n            class Foo\n              def initialize_clo
+8daf37824b1f3c973b8f0c2a54183cdd	"[{1:2},{3:4}]"	module Json\n              refine(Integer) { def fmt; to_s; end }\n  
+8db37e22413acdf65493704315f3fd6b	100	def create_fiber\n              a = 100\n              Fiber.new do\n 
+8db4f45e6d902a0a8ed237a9b0957a9d	"nil"	require "socket"\n            a, b = UNIXSocket.pair\n            a.c
+8db6f981e526d175bb2f3e8b581ef3f4	[true, true]	first = nil\n            begin; raise "a"; rescue => first; end\n    
+8dc6c93e97fe91c24838e4750f37be37	true	Rational(3, 4) == 0.75
+8dd55defdf95efbdd977e6c2174cf434	[3, false]	s = "abc"\n            s.instance_eval { alias my_len length }\n     
+8df6d4abdff110c4dbaffcd3404ca581	{amount: 42, unit: "km"}	M = Data.define(:amount, :unit)\nM[42, "km"].to_h
+8e1574a4b3216e60ac128b6d348f4518	"bar is true"	foo = false\n        bar = true\n        quu = false\n        \n        x =
+8e4e8019a5cb826e7c04db9f7be00c08	[[10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4]]	def g(a, b, c, d) = [a, b, c, d]\n        def f(...) = g(10, ...)\n      
+8e5bf6a49a3af8219a95bf2205693b54	"from ensure"	def m\n              raise "orig"\n            rescue\n              r
+8e826807820a874b952371a0550c1442	true	m = Module.new\n            m.const_set(:X, 1)\n            m.depreca
+8e83fac50815e329dc3e40f5adcaa07a	2	("hello" =~ /l/)
+8eaf00627afa12f991d7822691a992f6	nil	def m\n            i = 0\n            while i<30\n              i += 1\n   
+8ecdce534f197d24c11242d670ad79f9	[10, 20]	k = Class.new { define_method(:m) { |a, b| return a, b } }\n        
+8ee806cab177edc397e24367bdc4e394	"numbered parameter '_9' is not a local variable"	(binding.local_variable_defined?(:_9) rescue $!.message)
+8eeaf0abee322b0a5454ad414ae8d6a6	100	class S\n              S1 = 100\n            end\n            class C 
+8f178015170b96dfca9921a76a8c6015	["[1, 2] {a: 3}", "[10, 1, 2] {a: 3}", "[1, 2] {a: 3}", "100", "[10, 1, 2] {a: 3}", "100"]	class C\n          def g(*rest, **kw)\n            $res << "#{rest} #{kw}
+8f1b2ad792a44dcb449fd1bc511ce10a	[[9], true]	module MExt2; end\n            a = [9]\n            a.extend(MExt2)\n 
+8f26ceb8d756a624063601b5d5d2a3d7	12	class Integer\n              define_method "baz" do |other|\n        
+8f546b4ff31fe6b0376265631574fe4b	[false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, false]	res = []\n        class FooNeq\n          def ==(o); true; end\n        en
+8f5f09443a0cd060c38ce202e62038cb	Math::DomainError	Math::DomainError
+8f67c78ba31f0a6357a4112ae8560fd4	:obj	class HKey\n              attr_reader :h\n              def initializ
+8f7df97d18d332f611f1a9692084573c	"numbered parameter '_1' is not a local variable"	-> { _1; (binding.local_variable_get(:_1) rescue $!.message) }.call("x")
+8f9378f104f526908f49ee6e58f6dbcd	[1, nil, nil]	S = Struct.new(:a, :b, :c)\n            \n\n            s = S.new(1)\n 
+8f9dc86214e621963cf92bcaea0137e9	[:f, "f", nil, ["f"], [:f, :g, :h]]	class C\n              def f; end\n              def g; end\n         
+8fbfe9a481b19089dfb4a54479baae30	[[:req, :a], [:req, :b]]	class Foo\n              def baz(a, b); end\n            end\n        
+8fca2ce7c52899e2c07bdcd2c3d2c70a	nil	def foo(&blk)\n            Fiber.new { blk.call }\n            .resume\n  
+8fcfadb4abb8627dcaf4fc849fb25e7c	[:@a, :@b, :@c, :@d, :@e, :@f, :@g, :@h, :@i, :@j, :@k, :@l]	a=Object.new;\n            a.instance_variable_set("@b", 1);\n       
+90275e3f8c29d550454ae4bb1ee91949	[[1, 120000], [3, 120001], [5, 120002], [7, 120003], [9, 120004], [11, 120005], [13, 120006], [15, 120007], [17, 120008], [19, 120009], [21, 120010], [23, 120011], [25, 120012], [27, 120013], [29, 120014], [31, 120015], [33, 120016], [35, 120017], [37, 120018], [39, 120019], [41, 120020], [43, 120021], [45, 120022], [47, 120023], [49, 120024], [51, 120025], [53, 120026], [55, 120027], [57, 120028], [59, 120029]]	def g(*r) = r.sum\n        def k(a, b, *r) = a * 1000 + b * 100 + r.sum\n
+9032a4e8e61373965d123f3119082f9f	"ok"	path = "/tmp/monoruby_test_modekw_#{Process.pid}_#{rand(100000)}"\n 
+9035f52710e5eeab346817dcbe49d72e	[:foo, :bar]	$res = []\n            obj = Object.new\n            def obj.singleto
+90462680540563a848d4f44db273be17	42	m = Module.new do\n          def foo; 42; end\n        end\n        Class.
+9060fe594581e811b5c93429c0c3b848	false	File.directory?("bin")
+907dd932fc53f68468f45e8c5e5d4230	[String, "def", "blk:NO_SUCH_VAR_ZZ", TypeError, KeyError]	(a=ENV.fetch("PATH").class; b=ENV.fetch("NO_SUCH_VAR_ZZ","def"); c=ENV.fetch("NO
+907fc927440486b8d024ee91cf5754ad	42	define_method(:foo) { 42 }\n            foo\n        
+909428abf1fc17f7fd0de50ef615f4ea	[nil, 20, nil]	T = Struct.new(:a, :b, :c)\n            \n\n            s = T.new(b: 2
+90a1c0092c608b8199143c079d1b053f	:OVERRIDDEN	class Float; def +@; :OVERRIDDEN; end; end; +(3.0)
+90d0b935f23f20e9b8e82361062e98ac	[nil, nil, nil]	class CovP; def pm; end; private :pm; end\n            class CovU; d
+90dbab7731d0c6bb6ffa218659b675cd	["child", "main"]	$_ = "main"\n            t = Thread.new { $_ = "child"; $_ }\n       
+90e98d9804a827ad88c11c1513efb60b	["a", "b", "c"]	$; = ","; r = "a,b,c".split; $; = nil; r
+90edc31ad26249dccd0721e307bdd03e	["RuntimeError", "boom"]	e = RuntimeError.new("boom")\n            r = Marshal.load(Marshal.d
+911a1a8918ffd39a3e822b2d8719aaa1	true	line = __LINE__; b = binding\n        b.source_location[1] == line\n     
+912fd346a1b61ad17f13eb538df0400a	["R1", "R2", "none"]	module JitR1\n              refine(String) { def kind; "R1"; end }\n 
+9135d4a47d2bbd8170a57ff97b280129	"world"	class Foo; def to_str; "world"; end; end\n            s = "hello"\n  
+913bfe3766f3554bf30db1b62a47c038	"hello"	def greet; "hello"; end\n            m = method(:greet)\n            
+91421c25fe4e4558d853bb154248d72b	[true, true]	File.write("/tmp/mr_enc4.txt", "")\n            Encoding.default_ext
+916d6060500f3effbd0ea33470148e8c	[13504500, [10, 105, 20000000000000000000000000000000000000000, 10000000000000000000000000000000000000100, 20000000000000000000000000000000000000002, 10000000000000000000000000000000000000101, 14, 107, 200000000000000000000000000000000000000000000000000000000000000000000000000000000, 100000000000000000000000000000000000000000000000000000000000000000000000000000100, 18, 109, -16, 92, -20000000000000000000000000000000000000000, -9999999999999999999999999999999999999900]]	class Integer\n          def dbl; self * 2; end\n          def add5(x); s
+918db2281354f39c63d6e971a2025831	[[3, 8], [0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 3, 4, 5, 6, 7, 8, 9, 10, 11]]	def f\n                7.times {\n                    9.times { |x|\n 
+9190ae6f089eda791c3f2130a7c18ac9	["inherited:D", "block"]	$res = []\n        class D\n          def self.inherited(sub)\n           
+91aadbc8d776fd2eff8e537cbfa17476	[[1, 3], [2, 4]]	class C; def to_ary; [3, 4]; end; end\n[[1, 2], C.new].transpose
+91d8838f16b2f3190b56fe75404f0d9e	[true, 9]	pid = fork { sleep 5 }\n            Process.kill(9, pid)\n           
+91f987385c6a19307759fd818d31dd9a	[ArgumentError, "invalid byte sequence in UTF-8"]	x = [150].pack("C").force_encoding("utf-8");\n               (/(.).(.)/.match("ab
+9206c6e77af29d97539dba996c39dbd8	"wrong number of arguments (given 0, expected 1; required keyword: x)"	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; def m(a, 
+923d6bdf52a1863fc4c42ff21acd6f46	["x", "y"]	base = "/tmp/monoruby_dir_children_#{Process.pid}_#{rand(100000)}"\n
+926cd74052e6697baac660a6c8df2d4f	"hello, world!"	"Hello, World!".downcase
+926dc795e3f8884de7460f5297a88103	[1, 0, 2, 1, 3, 2, 5, 3, 8, 4, 13, 5, 21, 6, 34, 7, 55, 8, 89, 9, nil]	fib = Enumerator.new do |y|\n                a = b = 1\n             
+9270be8e025f7cd9ba1ea30eee9c9d76	[[:f, :f], [:f, :g], [:f, :h], [[:blk, :blk], [:blk, :blk]], [[:blk, :blk2], [:blk, :blk2]], [:dm, :dm], [:dm, :dm2], [:helper, :helper], [:f, :f], [nil, nil]]	class CA\n              def f; [__method__, __callee__]; end\n       
+929ec88122ad3533893000031753c174	[999, 999]	def m_dyn(a, b)\n          yield\n          a + b\n        end\n        def
+92ae34eef31e84efce3356329a17c934	"US-ASCII"	"\\x01".unpack("b")[0].encoding.to_s
+92c320086797b71e965185f0332f276e	[true, "nil"]	begin\n              raise "x"\n            rescue => e\n             
+92c81d1822b4b41aa65c4eff4e01c590	[[100, 200, 300], [[:a, 250], [:c, 400]], [100, 200, 300], [[:a, 250], [:c, 400]]]	class S\n            def f(*x, **y)\n                $res << x\n         
+92d03f760ad8afc09f2a68a94487b012	["Fri Dec", "Fri Dec", " Dec", " Dec", " Dec", " Dec", nil, 2, [" Dec"], "Fri Dec", 7, "", " 12 1975 14:39", "IndexError", " 12", "Fri Dec ", " 1975 14:39", "12", 7, " 12", "Fri Dec ", " 1975 14:39", 10, " ", " ", " ", 1, 5, "19", "75", ["19", "75"], "1975 ", 3, 0, 3, 3, "tes", nil, ["t", "e", nil, "s"], ["tes", "s", "s", nil], 0]	require "strscan"\n        r = []\n        s = StringScanner.new("Fri Dec
+92d55f7191fed22f0d1af9face39145d	[:a, :b, :block, :x, :z]	a = 1\n        b = 2\n        def f(x, &block)\n          z = nil\n        
+92e0d6751ffe55fbb725230f9af7de44	"UTF-8"	"abcあ".reverse.encoding.to_s
+930d79ab56d8f793cc4caede2beafe11	0	ObjectSpace.define_finalizer(Object.new){ |id| id }[0]
+93116a0d3b8d41fed6f23d459fd4adc8	false	(0x8000_0000_0000_0000 + 39 + 0.0) >= (0x8000_0000_0000_0000 + 39)
+933b1066338fc62cc4297ee4bc493e32	[[[:x, 9]], [[[:x, 9]]], "ArgumentError", [[]]]	cls = Class.new(Hash) { def each; yield [:x, 9]; end }\n            
+9343abce32f04d953cc04ff67ed4bf31	["Socket", "Addrinfo", "127.0.0.1", true]	require "socket"\n            srv = Socket.new(:INET, :STREAM)\n     
+935122a7066cc663cf26533147c2cda5	[true, true, true, nil, false, false, true, "main", false, true, true, true, :meth, :clean]	$probe = []\n            path = "/tmp/mrb_load_wrap_t1_#{Process.pid
+9367674835b7363d7b25734fa0d598d3	[["a", "b"], ["a|b"]]	$; = "|"; r = ["a|b".split, "a|b".split(",")]; $; = nil; r
+93c5aa7882439219082961392f4d9537	["can't convert Object to Array (Object#to_ary gives Integer)", "N\\na\\n[...]\\n"]	r, w = IO.pipe\n            bad = Object.new\n            def bad.to_
+93e0fd9789bb5c32798b9de710a89935	67	putc(65); putc("Hi"); o=Object.new; def o.to_int; 66; end; putc(o); putc(67)
+93e6ef7313e6853be460ee30b0736410	[true, 5]	pid = fork { exit 5 }\n            w = Process.detach(pid)\n         
+940e03901c8843bf06aca61f6ac64658	true	pid = Process.fork { exit 0 }\n            pid.is_a?(Integer)\n      
+94317fffff39c9093268791671c631b0	[true, false, 1, -1, nil, true, false, true, false, false, true, false, false, true]	require "rubygems"\n        require "bigdecimal"\n        res = []\n      
+9455609d2dcf2780b3bf58180504fb90	["a", nil, "b"]	ENV["MONORUBY_ENV_TEST_VA1"] = "a"\n            ENV["MONORUBY_ENV_TE
+948c8ebc5838aacb75bb4ad2c54cd528	[true, true, true]	[Process.respond_to?(:exit),\n             Process.respond_to?(:abor
+9491706684975503cce7f8dd96dffe40	:OVERRIDDEN	class NilClass; def !; :OVERRIDDEN; end; end; !(nil)
+94a248be46cc9a5b4c954fe6542cb28d	true	class C\n              def f; self; end\n            end\n            
+94d16a880c403ea2e19da802c0030a76	true	rng = Random.new(42)\n        a = rng.rand\n        a.is_a?(Float) && a >
+94d69a47bd08e4c9374ae38d1d60aff3	["hello", true]	require "open3"; out, _, st = Open3.capture3("printf", "hello"); [out, st.succes
+94de90d6e7f1c554254f3e9e9e71014f	[false, :name_error, true, :sm, 42, "Object", true]	res = []\n        obj = Object.new\n        class << obj\n          DUP_CO
+94f0bb96e02d0b85c1f18a366b6a31ed	[10, 20, 30]	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \n[s[0]
+952fc260871595a1d028215408c82939	[[1, 2], [1, 3]]	ar = Object.new\n            def ar.method_missing(name, *a); name =
+954dc9dfa7000421a9864eaee0a9f5b6	["O\\n", "E\\n", 2]	require "open3"; out, err, st = Open3.capture3("sh", "-c", "echo O; echo E 1>&2;
+9552245cf0a47cc05a49a09a2a019426	false	File.directory?("README.md")
+955708d09435794eef9b4fbe5edf0451	[100, 200, 300, 250, 400, 100, 200, 300, 250, 400]	class S\n            def f(x, y, z, a:0, c:0)\n                $res << x
+955a8a7c59c1d4329779dff0936455e9	"ういあ"	"あいう".reverse
+95658a05fe2886c4efc933aeee5d5bf5	[nil, 200, "c"]	h1 = { "a" => 100, 75 => 200, :c => "c" }\n            h1.compare_by
+958801182970b5dfab163fab5d8365b6	[:x, :y, :z]	def m(x, y); z = 3; local_variables.sort; end; m(1, 2)
+95a3dead7a2937d2986a83dfca6ae8fd	:OVERRIDDEN	class Integer; def ==(o); :OVERRIDDEN; end; end; 3 == 4
+95b4760e2f5808caa8e9af258ad11a5a	[[".", "..", "a"], true, true, true]	base = "/tmp/monoruby_dir_inst_#{Process.pid}_#{rand(100000)}"\n    
+95c0582a47926be0a7c2f8735c3c9357	[true, false, nil]	File.write('/tmp/monoruby_autoload_no_const.rb', "# defines nothing
+95d1cb5e14f0af779723a7ba97575839	"1-2"	class C; def to_ary; [1, 2]; end; end\n[C.new].join("-")
+95f59528714ae0d3fce9ccaa1b5e66a4	true	Process.getpriority(Process::PRIO_PROCESS, 0).is_a?(Integer)
+961150456f2c31bf4a1c9fbd4becd341	true	class Foo\n              def bar; end\n            end\n            \n\n
+9619ef829595e3f837004456ebae2ce5	6	it = 5; it + 1
+963fb0997ae48404fd9a6ffd9a9a5a2e	[[1, 2], [1], [nil], [], [3, 4]]	def r; *a = yield; a; end\n            [r{[1,2]}, r{1}, r{nil}, r{[]
+9650b208e0fd60371177900b125c9dc7	[621, 628, 635, 642, 649, 656, 663, 670, 677, 684, 691, 698, 705, 712, 719, 726, 733, 740, 747, 754, 761, 768, 775, 782, 789, 796, 803, 810, 817, 824]	def g(a, b, c, d, e, f, g, h, i, j) = [a, b, c, d, e, f, g, h, i, j].su
+9654828de246bee535681a18dadb92ac	["before", false]	ENV["MONORUBY_ENV_TEST_REPL2"] = "before"\n            ENV.delete("M
+967087a7b4b8b591af552ea304e4f008	["ensure", 42]	def foo\n              begin\n                eval("return 42")\n     
+9688571ca68b697dbfbba96221a9f286	Foo	class Foo\n              def bar; end\n            end\n            \n\n
+96e3694435312b4930df7a7be3c47ef2	[[nil, nil, 5, nil, nil, nil, nil, nil, nil, nil, 4], A]	class A < Array\n        end\n        \n\n        a = A.new(10)\n        a <
+96fd9678f0dfe97f7c36c920dd7add18	[123456789, 123456789, 123456000, 123456000, 123000000, 500000]	[Time.at(0, 123456789, :nanosecond).nsec, Time.at(0, 123456789, :nsec).nsec, Tim
+970a7c81313ab20891884b7ce441755a	false	c = Class.new do\n              def m; 1; end\n              undef :"
+972f0dda9403b085a3a271026cdf1d04	[true, 7]	S = Struct.new(:x, keyword_init: 1)\n            \n\n            s = S
+974291e66576b4792c6134bc16187092	{amount: 42, unit: "km"}	M = Data.define(:amount, :unit)\nM.new(42, "km").to_h
+975f29740a52c016b0753267cdbbe847	["r", "", "r", "r", "r", "", nil, nil]	str0 = "bar"\n[str0[2,1], str0[2,0], str0[2,100], str0[-1,1], str0[-1,2], str0[3,
+975fffd01b63122a02d7d00979c459c3	[4, 2]	module CslOuter\n              class CslInner\n              end\n    
+976da7daee8c2f0938d825147f77be58	["Encoding::CompatibilityError", "Encoding::CompatibilityError", "Encoding::CompatibilityError", "Encoding::CompatibilityError", "Encoding::CompatibilityError"]	["UTF-16BE", "UTF-16LE", "UTF-32BE", "ISO-2022-JP", "UTF-7"].map do
+9773dbdaacb92270250c514bf12ac49f	[-1, [:anything, [1, 2]]]	class D\n              def respond_to_missing?(name, priv = false); 
+977723f01dd4af9bcf43bc2fb00646d8	nil	o = Object.new; o.extend(GC); o.garbage_collect
+97830589936141f7fa5227ba7e0b4ef7	0	m = Module.new { CONST_DEDUP = 1 }\n            c = Class.new { incl
+97a184496ac3f5bea30e677881037eb1	[10, 20, 30]	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \ns.val
+97f734cedb3b58d3a049801e7056dd1d	149850000	a = Array.new(300000) { |i| [i % 1000] }\n            200000.times {
+97f9bfadb4df4cf27eece30a84f5d9fe	["ArgumentError", "invalid byte sequence in UTF-8"]	("\\x80".dup.force_encoding("UTF-8") =~ /./; nil) rescue [$!.class.name, $!.messa
+980d4eece4669d875a5fd387891afb49	[0, 0, 0, 0, 0, 0, 0, 1099511627776, 1152921504606846976, 2305843009213693952, 4611686018427387904, 9223372036854775808, 18446744073709551616, 1267650600228229401496703205376, 2199023255552, 2305843009213693952, 4611686018427387904, 9223372036854775808, 18446744073709551616, 36893488147419103232, 2535301200456458802993406410752, 3298534883328, 3458764513820540928, 6917529027641081856, 13835058055282163712, 27670116110564327424, 55340232221128654848, 3802951800684688204490109616128, 4398046511104, 4611686018427387904, 9223372036854775808, 18446744073709551616, 36893488147419103232, 73786976294838206464, 5070602400912917605986812821504, 5497558138880, 5764607523034234880, 11529215046068469760, 23058430092136939520, 46116860184273879040, 92233720368547758080, 6338253001141147007483516026880, 7696581394432, 8070450532247928832, 16140901064495857664, 32281802128991715328, 64563604257983430656, 129127208515966861312, 8873554201597605810476922437632, 17592186044416, 18446744073709551616, 36893488147419103232, 73786976294838206464, 147573952589676412928, 295147905179352825856, 20282409603651670423947251286016, 109951162777600, 115292150460684697600, 230584300921369395200, 461168601842738790400, 922337203685477580800, 1844674407370955161600, 126765060022822940149670320537600, 135742175033388171264, 142335986927810035071320064, 284671973855620070142640128, 569343947711240140285280256, 1138687895422480280570560512, 2277375790844960561141121024, 156500072678099869064174771821728497664, -1099511627776, -1152921504606846976, -2305843009213693952, -4611686018427387904, -9223372036854775808, -18446744073709551616, -1267650600228229401496703205376, -4398046511104, -4611686018427387904, -9223372036854775808, -18446744073709551616, -36893488147419103232, -73786976294838206464, -5070602400912917605986812821504, -5497558138880, -5764607523034234880, -11529215046068469760, -23058430092136939520, -46116860184273879040, -92233720368547758080, -6338253001141147007483516026880, -281474976710656, -295147905179352825856, -590295810358705651712, -1180591620717411303424, -2361183241434822606848, -4722366482869645213696, -324518553658426726783156020576256, 5070602400912917604887301193728, 5316911983139663490462306736514531328, 10633823966279326980924613473029062656, 21267647932558653961849226946058125312, 42535295865117307923698453892116250624, 85070591730234615847396907784232501248, 5846006549323611671547088730636902677127026966528, -5070602400912917605986812821504, -5316911983139663491615228241121378304, -10633823966279326983230456482242756608, -21267647932558653966460912964485513216, -42535295865117307932921825928971026432, -85070591730234615865843651857942052864, -5846006549323611672814739330865132078623730171904]	r = []\n            [0, 1, 2, 3, 4, 5, 7, 16, 100, 123456789,\n      
+9839ce942dc6ceffe4fdfca27b091194	{amount: 42, unit: "km"}	M = Data.define(:amount, :unit)\nM.new(42, "km", **{}).to_h
+9839f0f17947005555bee6338f175943	318.75	obj = Object.new\n        acc = 0.0\n        i = 0\n        while i < 30\n 
+98411750aed4bab667c24946e33e5cb0	[100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10]	$a = []\n            C = 100\n            \n            for i in 0..19
+988c0b8f8c44428ac627b741f329756c	100	# Ret\n            begin\n              100\n            end\n        
+98996233bfa191027494af2f2287502c	[:inner, :early, :late]	def m1\n          obj = Object.new\n          class << obj\n            re
+98bdea24e737b24b5b5e21db74beb80e	[true, 0]	pid = fork { exit 0 }\n            ret = Process.wait(pid)\n         
+98c5c25856a804e6b5a96f570e24c999	true	class Foo\n              def ==(other)\n                other == 42\n 
+98cd6cba82daea6511d16b70c1d31e7c	:OVERRIDDEN	class Float; def <(o); :OVERRIDDEN; end; end; 3.0 < 4.0
+98f77e852104ed256e796f4418a162bb	false	-> { a = it; binding.local_variable_defined?(:it) }.call("x")
+9907ee4ddc82e7f27c73f5e428d68e32	["012345678901234", "56789", true, "012345", ""]	path = "/tmp/monoruby_io_sysread_#{Process.pid}_#{rand(100000)}"\n  
+99357d2c6506b01239df9e673f3bc0aa	true	File.readable?("/bin/sh")
+9947be8405301395ae46b28e447a36f5	:OVERRIDDEN	class Integer; def +@; :OVERRIDDEN; end; end; +(3)
+99500332ebd34fd5a4f467cf5dc6c881	153	a = 100\n            p = nil\n            q = nil\n            3.times
+9969ffd50c24ec6d1a98300d62417879	[4]	r = []\n        10.times { |i| r << i if (i == 4)..(i == 4) }\n        r\n
+996aaccf5c8a4c3d296d04988aa5eb7a	A	class A < Array; end\nA[1, 2, 3].class
+998065fab2e254e368acd5c9264b5767	[[:req, :a], [:opt, :b], [:keyreq, :c], [:key, :d], [:keyrest, :rest], [:block, :blk]]	def m(a, b = 1, c:, d: 2, **rest, &blk); end\n            method(:m)
+99bb34801d29ed3f9e2aa19ad41e3e16	true	proc{ 1 + 1 }.hash.is_a?(Integer)
+99c86d200493ccc2ea42e7d9e6990a3e	true	r, w = IO.pipe\n            begin\n              writers = IO.select(
+99c9a2df91f9cf9273cac10f6bf9fdd4	[[2, 4, 6], 6, 6, 42]	module BopLeak\n              refine(Integer) { def +(o); 42; end }\n
+99cfc04650144986127f45b7743e69aa	[900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900]	class A\n          def m(a, *r) = yield(a + r.sum)\n        end\n        c
+99d9f00bc752fd756d973756cc553768	:OVERRIDDEN	class Hash; def [](k); :OVERRIDDEN; end; end; ({1=>2})[1]
+99ecbfe1c60911aafcec1d108ca89493	[false, true, true]	path = "/tmp/monoruby_io_eof_#{Process.pid}_#{rand(100000)}"\n      
+9a0db96111752b4a7ebf036bac1d4c9d	[nil, nil]	[\n              NameError.new.name,\n              NameError.new("ju
+9a1505ab976bab44314875f75f0aad94	true	o = Object.new\n            def o.to_str = "CORE"\n            Proces
+9a22f6dc0c7579d2bfa1447443b56f1f	[42, "nil"]	def bar\n              begin\n                raise "err"\n           
+9a380b66d043485e0a0a37c95be6a53e	["LoadError", "nonexistent_file_that_does_not_exist_12345"]	begin\n              require "nonexistent_file_that_does_not_exist_1
+9a6e41140cc5bce63cf4551de96c121c	[{a: 1, b: "x"}, 1, nil]	Fiber[:a] = 1\n            Fiber[:b] = "x"\n            [Fiber.curren
+9a932583042db11061d16bd05d100137	[1, 2, 3, 10, 11, 12, 13, 14]	a = [1, 2, 3]\n            seen = []\n            i = 0\n            a
+9a97b6b5000a38e4f4599c6abc8d1d0f	2	c = Class.new\n            c.class_variable_set(:@@x, 1)\n           
+9a9ee2b7febbe6ac3308d40b167ee24f	[:bar, [1, 2], 42]	class Foo\n              def method_missing(name, *args, &blk)\n     
+9a9f18aebf89682aececa7232ea169a0	[true, true, "y"]	h = { count: "x", __other__: "y" }; r = GC.stat(h); [r.equal?(h), h[:count].is_a
+9afc6c54e7bfc3e9e81388fb8fff321d	:OVERRIDDEN	class Integer; def ^(o); :OVERRIDDEN; end; end; 3 ^ 4
+9b1676026ef1fc1fd87a66af89a92bd5	[A, Array]	class A < Array\n        end\n        [A, A.superclass]\n        
+9b1c7db19e056adb0f3971b0c50b245c	[21]	class C\n          def g(&)\n            $res << yield(7)\n          end\n\n
+9b1dae5be5d8cbce138449b60606501e	"RUBZ"	succ = proc { |s| s.succ }; upcase = proc { |s| s.upcase }; (succ >> upcase).cal
+9b2b571524ea1228fd5b6b7d00cef540	:OVERRIDDEN	class Complex; def +(o); :OVERRIDDEN; end; end; Complex(1,2) + Complex(3,4)
+9b54107b18369e699d5c69bc43d74fac	[]	def boom; raise "no"; end\n            def test; [1].select { begin;
+9b5c13115b5bff8bc6f4a7e3fca92e18	["B", "M2", "A", "M1"]	module M1; end\n        module M2; end\n        class A\n          include
+9b61bcda595469dd25e2e58381c1be05	["first", true, true]	begin\n          raise "x"\n        rescue => e\n          e.backtrace.uns
+9b647520e61fd7b3680dcbb7c919469b	[true, true, "Windows-1250", [228, 224], "Windows-1251", "abc"]	(a=(Encoding::CP1251 == Encoding::Windows_1251); b=(Encoding::CP437 == Encoding:
+9b8994e2e94d4a2a2b7af7119922b89c	[[195], "Windows-31J", [], [169]]	m = /./s.match("\\303\\251".dup.force_encoding(Encoding::Windows_31J))\n           
+9bcad6e1f55d1f4c7fc6bfeb8c9bbe56	[2, 18000, 3]	m = Object.new; def m.to_str; "feb"; end\n            s = Object.new
+9bd107237f282e1e13d6e5732b44b57d	"#<struct M::N a=1, b=2>"	module M\n              N = Struct.new(:a, :b)\n            end\n     
+9bd770147e93a1552f5dd2b6ee5aafab	:OVERRIDDEN	class Symbol; def ==(o); :OVERRIDDEN; end; end; :a == :b
+9bec896de850b7dff3e1df7a67717b59	true	module MarshalSingletonExt2; def hi; end; end\n            o = Objec
+9bfef2a27b99b9c708f79d4a785e9c82	[[1, 2, 10, [], 1, 2, 3], [1, 2, 3, [], 20, 2, 10], [1, 2, 3, [4, 5, 6, 7, 8], 1, 2, 3], [1, 2, 3, [4, 5, 6, 7, 8], 1, 50, 3]]	def f(x,y,z=10,*r,a:1,b:2,c:3)\n          [x, y, z, r, a, b, c]\n        
+9c0e42fc1d7c082eb407e3dd55466653	[[1, 2, 10, [], 1, 2, 3, 42], [1, 2, 3, [], 20, 2, 10, 42], [1, 2, 3, [4, 5, 6, 7, 8], 1, 2, 3, 42], [1, 2, 3, [4, 5, 6, 7, 8], 1, 50, 3, 42]]	def f(x,y,z=10,*r,a:1,b:2,c:3,&p)\n          [x, y, z, r, a, b, c, g(&p)
+9c378cc8b7903c3d2a6f4b5fa41e0546	6	def f(a,b,c=12,d=23)\n          a+b+c+d\n        end\n        \n\n        f(
+9c42c89245729b05ebbfbcbfe0ac6866	[[[], {a: 38}], [[{b: 38}], {}], [[], {a: 39}], [[{b: 39}], {}]]	def target(*args, **kw); [args, kw]; end\n        class << self\n        
+9c4ebeae14bfd545fcd9f97591a4f7ea	[42, true]	called = nil\n            Process.singleton_class.send(:alias_method
+9c8dba1032bde3183b8033406c275203	"FiberError"	t = Thread.new { Fiber.yield rescue $!.class.to_s }\n            t.v
+9caa03a6554f9f51a6930123fab2a973	0	Process.setpriority(Process::PRIO_PROCESS, 0, Process.getpriority(Process::PRIO_
+9cb8e00505ce4bf6a3d19ab5bc5bfa5f	["HELLO", "HELLO", nil]	s = "hello".dup\n              [s.upcase!, s, s.upcase!]\n         
+9cd05a1a888db596ffb7734ce811da90	["$: is a read-only variable", "$\\" is a read-only variable", "$-I is a read-only variable", "$? is a read-only variable", "$FILENAME is a read-only variable", "$< is a read-only variable", "$-a is a read-only variable", "$-l is a read-only variable", "$-p is a read-only variable"]	res = []\n        [proc { $: = [] }, proc { $" = [] }, proc { $-I = [] }
+9cde6b4c9ea3125d8d47145a80290cdd	[10, 1, 2, 3]	def f(x, a:, b:, c:)\n          [x, a, b, c]\n        end\n        \n\n     
+9ce400382b1e9ef3649d2b40a548257d	:re	a = [1,2,3,4]; begin; a[-5..-5] = ""; rescue RangeError; :re; end
+9d02c77d162d28eea621b8b9bfb99df5	0	begin\n          exit\n        rescue SystemExit => e\n          e.status\n
+9d2eca396f0625dffe0e9284609ca429	[true, 2, true]	class CSrcLocBasic\n              MY_CONST = 1\n            end\n     
+9d342dce67e67be32b5b4e4410deaf44	ArgumentError	(GC.stat(:bogus_key) rescue $!.class)
+9d345c691cfd0eb9929bd91286d2cad6	["/nope", true, "/nope"]	m = Module.new\n        m.autoload :Lazy, "/nope"\n        a = m.autoload
+9d37ece3c95f6ed41dcee850e24bab6b	[25, 15, 100, 4, 2, 32, 15, 6, 12, 16, 32]	class C\n          attr_accessor :v\n        end\n        \n\n        c = C.
+9d3a8273d76bab638959e38cd8c0a68c	[[:woke], true]	r = []\n            t = Thread.new { sleep 0.05; r << :woke }\n      
+9d4ee118279609a4658649ce219050c0	"a:1 b:{x: 100, y: 200} c:"	def f\n          yield 1,x:100,y:200\n        end\n        \n\n        f do 
+9d6d362d02ec388b6d9235b807fc78d2	5	class C\n              private def f; 5; end\n              def g; f;
+9d90ba7627480755e747fc4a1045f51e	[2, 1]	[1, 2, 3].each.with_index { |v, i| break [v, i] if i == 1 }
+9dad3fcfbb4f15771bbac751e3869047	42	module A\n          module B\n            module C\n              VAL = 42
+9dbc194b1b0f6de59813ff04a2e9663a	[20, 20, 100, 2, 2]	Bar = 100\n            class Foo\n              autoload :Bar, "./c"\n
+9dbef04511724f84642f3b1be7361af9	[:get_raised, :set_raised]	class D\n              def initialize() @a = {k: 1} end\n            
+9dc570781d3034551d04772d71561543	:OVERRIDDEN	class Float; def ==(o); :OVERRIDDEN; end; end; 3.0 == 4.0
+9e349938558e7f648ad2c96a5fab61e1	:NOPE	class CGetMissingNameErr; end\n            begin\n              CGetM
+9e41b878cb2cd158c0051841526faf43	:OVERRIDDEN	class Integer; def !; :OVERRIDDEN; end; end; !(3)
+9e717e788200f4da9792d264e6819b02	[[], [1], [1, 2], [nil], [[1, 2]], nil, 1, [1, 2], nil, [1, 2]]	p = []\n        o = Object.new\n        def o.each\n          yield\n      
+9e7acbe5ace0bfd7fa04b1637e3d8894	-1.0	class Float; alias __orig :-; def -(o); __orig(o); end; end; 3.0 - 4.0
+9e7f15a13c2d416dcb29990ed32c87a2	["[1, 2, 3, {a: 1, b: 2}]"]	class C\n          def initialize(*a)\n            $res << a.inspect\n    
+9e8641f7edcf9595f649c4f9ac976649	"Complex"	3.14ri.class.to_s
+9e9adfb2fab4bb39897074fa058521e3	"Module#using is not permitted in methods"	mod = Module.new do\n              def self.foo\n                usin
+9ea00fe4a9f13b4cabf05e28e6571f87	[1, 0, "nil", "nil", -1]	class MCmpNeg; def <=>(other); -1; end; end\n            class MCmpZ
+9eb98c1b5f6e2d631b2b51c04acc62e5	"m::N"	m = Module.new\n            m::N = Module.new\n            m::N.name 
+9ec21f255b64bf6cee16e04bbbaa7ae3	[[:C1, :C2, :S1], [:C1, :C2]]	class S\n              S1 = 100\n            end\n            class C 
+9eeb8d867dcde677d9837c5ba30e2c40	[:yes, "NoMethodError", false]	module EscA\n              refine(String) { def only_here; :yes; end
+9f0c968145034ea2d742ba8456a2e243	["Scheduler must implement #block", "Scheduler must implement #unblock", "Scheduler must implement #kernel_sleep", "Scheduler must implement #io_wait", true, nil]	required = [:block, :unblock, :kernel_sleep, :io_wait]\n            
 9f1a90eeaa16fa36daa6ad13a43b2591	{a: Infinity, b: -Infinity}	{ a: 1.0 / 0.0, b: -1.0 / 0.0 }
+9f2e97978468dcf092100b2198ed8c1d	"nil"	BasicObject.superclass.inspect
+9f3f4db8aedc09ee1c6c04fdd3f70da9	[0, 1, 1, 1, 2, 2, 3, -1, -1, -1, -2, -3]	def a; end\n            def b(x); end\n            def c(x:); end\n   
+9f5f309834433f1fe01c04dcbc116a24	[[["a", 1], ["b", 2], ["c", 3]], [["c", 3], ["b", 2], ["a", 1]], [["b", 2], ["a", 1], ["c", 3]]]	h = { "b" => 2, "a" => 1, "c" => 3 }\n            [\n              h.
+9f902ab91833e894590a7b4ce20857b3	"UTF-16LE"	Regexp.union("a".encode("UTF-16LE")).encoding.to_s
+9f9544ba61d7f96d5ef6fd821c8d171a	"Encoding::CompatibilityError"	(/x/ === "y".encode("UTF-16LE"); nil) rescue $!.class.name
+9fa4b722eedc5d1a090e293d5e8fdd27	0	"hello".byteindex("h")
+9fbc0e313a58ac0a436184f469d5653a	99	def bar\n              1\n            rescue\n              2\n        
+9fe32a360db73178af9915a14b3eb234	"MIT License\\n\\nCopyright (c) 2022 monochrome\\n\\nPermission is hereby granted, free of charge, to any person obtaining a copy\\nof this software and associated documentation files (the \\"Software\\"), to deal\\nin the Software without restriction, including without limitation the rights\\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\\ncopies of the Software, and to permit persons to whom the Software is\\nfurnished to do so, subject to the following conditions:\\n\\nThe above copyright notice and this permission notice shall be included in all\\ncopies or substantial portions of the Software.\\n\\nTHE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\\nSOFTWARE.\\n"	File.binread("../LICENSE-MIT")
+9ff357f1f7deff5df58394308a09e60d	[nil]	r = []\n            Enumerator.new { |y| r << y.yield(1) }.to_a\n    
+a020918817615145edd613c059e9d86c	"baz"	obj = Object.new\n            obj.define_singleton_method("bar") { "
+a0259347c2c9aaca8d0fb2ab3172334f	[(3+4i), (1+2i)]	Complex(1,2).coerce(Complex(3,4))
+a025ebc9c10902ee0c976c9724d84b2e	"US-ASCII"	"abcabc".dup.force_encoding("US-ASCII").delete("b").encoding.to_s
+a031cb64f47d2225424e4e78e8fefb45	"M2:M1:Base"	module M1\n          def foo\n            "M1:" + super\n          end\n   
+a03c80bceb90c824ed45c7a75729b0db	5	def f; return 5; end; self.f()
+a056cccf7d9d7860c407b35025f65bad	[false, true]	path = "/tmp/monoruby_io_closed_#{Process.pid}_#{rand(100000)}"\n   
+a07170e4ef584cda7c72916079abb052	true	soft, hard = Process.getrlimit(:NOFILE)\n            Process.setrlim
+a0c737e8c20c63632912e6e053757479	"1!"	ENV["MONORUBY_ENV_TEST_TOH"] = "1"\n            h = ENV.to_h { |k, v
+a0c8c214c743f932e1377fb1194651a2	["US", true, "bar"]	class US < String; end\n            s = US.new("x")\n            s.in
+a0ca30adffd4c4596c95a3912134c5cd	2	0.5.to_r.denominator
+a0d8a60091bf358a78984cd54491c359	[true, 12, true, false, false]	t = Thread.new { 3 * 4 }\n            [t.is_a?(Thread), t.value, t.j
+a0ed7fceb0bb6c6c16a0106636e9eb4a	"あ"	s = "hello"; s.bytesplice(0..4, "あいう", 0..2); s
+a119cef46ae9c1190d2bbd29791572a2	true	def `(cmd); cmd.frozen?; end\n        def m; `ab`; end\n        m\n       
+a11ed1527c89aa21a332303e09009bd7	true	M = Data.define(:amount, :unit)\nM.new(1, "m").with(amount: 9).frozen?
+a143f6cff1e98f1d5b4da11574acdd7a	true	r = nil; 3.times { r = __ENCODING__ }; r.equal?(Encoding::UTF_8)
+a145f94943dc0794a58051ca1c98752f	[false, [1, 2]]	arr = [1, 2]\n        def arr.to_a; $flag = true; super; end\n        $fl
+a14e904cc31582d611449d8caacf0884	true	"abc".force_encoding("ISO-8859-1").encoding == Encoding::ISO_8859_1
+a158e5fc1d4c5a682510d00791a34f7b	[true, false]	m = Module.new do\n              module_function\n              def t
+a161e71f31bf14603b9f94a476644366	[:a, :a]	-> { a = it; binding.local_variable_set(:it, :b); [a, it] }.call(:a)
+a164c646ebdbe3551b16c27fa5e2aab0	5	def f; return 5; end; f
+a189356012c67f14ffd149bedd2d23b2	nil	$/ = "xyz"; r = "abcde".chomp!; $/ = "\\n"; r
+a1a984bb2edd75a78229a94547d15825	[true, true, :outer, "nil", ["NoMethodError", "RuntimeError"], "RuntimeError"]	def restore_check(log)\n          outer = StandardError.new "outer"\n    
+a1c461fb313f0da82569acd28c4ca299	[1, 3, 5, 7]	(1..7).filter(&:odd?)
+a204f15cf81d104e4412940bba47afbb	[[5, 5], [9, nil, 9], [nil, nil], nil, [7, 1, 7], 42, "FrozenError"]	def drive(n)\n              r = nil\n              n.times { r = yiel
+a207205e2108ee451fae4d6f0df8308a	nil	File.open("Cargo.toml") { |f| f.ungetc(100) }
+a21ceda5ef436f9167f0988b18686885	[true, true, "backtrace must be an Array of String or an Array of Thread::Backtrace::Location", true]	def probe = caller_locations\n        locs = probe\n        e = RuntimeEr
+a2258a3c861ffb257f7a53cf3eb62746	[10, 20, 30]	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \ns.to_
+a228de78f3361a64902cd2242ba752da	[true, true, false]	class Foo\n              def bar; 1; end\n              alias_method 
+a2359d988b1e9852b116a4aa588e8ad7	99	module M; class N; CONST = 99; end; end\n            \nM.const_get(":
+a249ec32f6d93a75cfac3be0d217bf1d	[49, 50, 51]	s = +""\n            s.append_as_bytes(0x131, 0x232, 0x333)\n        
+a283f7c1c01ed5e8343b5c0c337ff2cc	[[1, 5, 6, nil, nil], [1, 5, 6, 2, nil], [1, 5, 6, 2, 3], [1, 2, 6, 3, 4], [1, 2, 3, 4, 5], [1, 2, 3, 4, 5], [1, 2, 3, 4, 5], [1, 2, 3, [4], 5, 6], [1, 5, 6, [], 2, 3]]	def t(a) yield a end\n        \n\n        [\n          t([1])             {
+a295425f2386f7b487cea440a10accb4	99	class C\n              def initialize(&blk)\n                @v = blk
+a2a0991ecb4019b7303f2bad37c2c02f	[true, true, 7]	c = Class.new { attr :foo, true }\n            i = c.new\n           
+a2d359f2c679ed0c41cd0e8c0e78b3b5	"Xhello"	s = "hello"; s.bytesplice(0...-7, "X"); s
+a2d5fdfdd6933f6f7b5579a98d897e1d	["abc", "de", 1, :sys_neg_arg, :rnb_neg_arg, :sys_eof, :rnb_eof, nil]	require "stringio"\n\n            res = []\n            io = StringIO.new("abcdef")
+a2e679bc25d5bbcdcffa24d1390f7717	[true, 0, true, true, true, 0]	pid = fork { exit 0 }\n            Process.wait(pid)\n            s =
+a2fe58a4b8970857e7e6bc4daf663e90	[["UTF-8", "EUC-JP", 1, false], ["UTF-8", "EUC-JP", 1, false], ["UTF-8", "EUC-JP"], [true, "ASCII-8BIT", true], 1, [42, []]]	path = "/tmp/monoruby_test_iostate_#{Process.pid}_#{rand(100000)}"\n
+a31930a9e915d99cf23e80f66584373b	["m0", 420, 21, "m0", 0, 4, 109, 30, 777, 5, 880, 24, "argerr", "NoMethodError", "m0", 70, 0]	class C\n          def m0; "m0"; end\n          def m1(a); a * 10; end\n  
+a32adc46f1bb4ed6ce92840c775bbf19	""	"".upcase
+a32db795d17419028fabd7b655b6becb	"bar"	class Foo\n              def bar; "bar"; end\n              alias :'b
+a32e5a59e048d15bbb352b6fdb7e1699	[0, 0.0, 6, 8.5, 15.25, "abc"]	[[].sum, [].sum(0.0), [1, 2, 3].sum, [3, 5.5].sum, [2.5, 3.0].sum(0.0) {|e| e * 
+a32ecda935b7e94450e788b8832e13a4	[3, 1, 5, 3]	class C\n            include Comparable\n            attr_accessor :x\n 
+a331276eee9103e6d3857063f69777b4	[:foo, :bar]	$res = []\n            class C\n              def self.singleton_meth
+a34c4e369e6d5139f06cb9ce6026b999	42	class C\n          def self.class_method\n            42\n          end\n  
+a3618f8ad00f6c37b513a42900293bee	[[233], "Windows-1250", [234, 247, 241], "Ω≈±", [240, 210, 201, 215, 197, 212], "Привет", [146, 165, 225, 226], "абв"]	(a="é".encode("Windows-1250").bytes; b="é".encode("Windows-1250").encoding.name;
+a3921c92237d852a5bc1ad370ba61b79	["Enumerator::Yielder", true]	y = nil\n            Enumerator.new { |yy| y = yy; yy.yield 1 }.firs
+a3baab6cd54895307ab33a2e43c7a755	true	rng = Random.new(42)\n        a = rng.rand(100)\n        a.is_a?(Integer)
+a3c1f3715d0c4e66afd79ece55a249ad	[1, "c", Errno::EEXIST, [ArgumentError, "invalid access mode rx"], "invalid access mode ax", "invalid access mode fake", [ArgumentError, "wrong number of arguments (given 4, expected 1..3)"]]	(f="/tmp/mono_x_#{Process.pid}"; a=File.open(f, "wx") { |x| x.write("c") }; b=Fi
+a3ee8370b62260dbe97cbc7ed605dd03	"missing keyword: :x"	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; def m(x:,
+a3fbe69a6d5dbf4f950d529b546578ff	[true, true]	def bar(x); x * 2; end\n        m = method(:bar)\n        loc = m.source_
+a40cda8b2c175e21feb1879eeb9ab44f	[]	def m\n              "foofoo" =~ /(?<matched>foo)/\n              loc
+a4149a238fc4b1eb2b5d83d5a3a1df6e	[1, [2, 3, 4], 5]	->((a, *b, c)) { [a, b, c] }.call([1, 2, 3, 4, 5])
+a41897885873df2832ff2e4ca224faf4	true	class Foo\n              def initialize\n                @a = 1\n     
+a438a5b6095e3a044e9fc3a4b29764a8	[false, true, true, false, false, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true]	class StrMock\n          def to_str; "abc"; end\n          def ==(o); o =
+a46413028c2e82be019705a623976977	[1, 2, [], 4, 5, 3, 12]	def f\n          yield [1,2,3,4,5]\n        end\n        \n\n        f { |a,
+a4739bf8ad36ba60eb568b2316e72ec9	[99, false]	c = Class.new\n            c.class_variable_set(:@@x, 99)\n          
+a4748dc92361b8ec397bdcc7a0edea32	[4000, [0, 0, nil, nil, nil, 3999, nil]]	h = { 0 => [0, 0, nil, nil, nil, 0, nil], 1 => [0, 0, nil, nil, nil, 1, nil], 2 
+a476fbd8b3d5aa7065ffc4804ce4f8f2	[0, 3, true]	f = File.open("Cargo.toml")\n            begin\n              [f.syss
+a47e9f7e5d8840ea66dbc911b04a963d	"hello\\n"	class MyIO; def initialize; @s = ""; end; def write(s); @s += s.to_
+a4db6dd3efcae77a460c948122d1c92b	[[1, 2, 3], [5, 4, 3], [1, 2], [5, 4, 3], [], [], true, true, "comparison of Integer with String failed", "comparison of Integer with String failed", 5, 5, true, 3, 3, [[1, 2], [3]]]	r = []\n            r << 1.upto(3).to_a\n            r << 5.downto(3)
+a4e43ebb21a5f309981a2e9669bc7542	true	class Coercible\n              def ==(other); true; end\n            
+a4f12222abe673f85cdc48a9c1a4c7b8	476.47972474548203	def calc(i)\n          f = i * 1.1; g = i * 0.9; h = i * 1.3; j = i * 0.
+a5002eba90890e1dc0d2d8335a143b89	[true, true, true, true, true, 10]	class C; define_method(:dm) { |x| x + 1 }; end\n            sl = C.i
+a516a144253bfb2db2abb6311d188c0b	"ModuleSpecs3::Mod3::N"	module ModuleSpecs3; end\n            m = Module.new\n            mod
+a53b92743804f7c6164c3d95e576c03e	"\\x04\\bo:\\bFoo\\a:\\a@xi\\x06:\\a@yi\\a"	class Foo\n              def initialize(x, y)\n                @x = x
+a5402a7dbd2394336f436588929fbb2c	false	File.executable?("nonexistent_file_xyz")
+a54f6b24c80364648f5efeda11e21170	[:ensured, "boom"]	log = []\n            begin\n              Enumerator.new { |y| begin
+a55b98e9b8eb1d3f7e509f6d3ac592c0	"missing keyword: :x"	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; msg { pro
+a5b4244b815843859e162c8ca4f4db2a	[4, 8, 67, 58, 10, 77, 121, 65, 114, 114, 91, 7, 105, 6, 105, 7]	class MyArr < Array; end\n            Marshal.dump(MyArr.new([1, 2])
+a5d8327abff55336ba0aca5e5b3d3676	[[:r0, []], [:r0, [1, 2, 3]], [:r1, 1, []], [:r1, 1, [2, 3]], [:ro, 1, :dy, []], [:ro, 1, 2, []], [:ro, 1, 2, [3, 4]], [:rk, [], {}], [:rk, [1, 2], {}], [:ro, :L, :dy, []], [:ro, :L, 1, [2, 3]], "wrong number of arguments (given 0, expected 1+)", [1, 2, 3], [1, 2]]	def r0(*a) = [:r0, a]\n            def r1(x, *a) = [:r1, x, a]\n     
+a5d96ad6d6abcfbe7ebc92d3c098653f	:no_raise	begin\n          eval("x=1; y=2; x..y if x")\n          :no_raise\n       
+a5ea42a5d2799be99e3f391567c82039	nil	class C; end\nArray.try_convert(C.new)
+a5ed14348511ba792e4c20ead35820a6	[:undefined_local_or_method, true]	begin\n          undefined_local_or_method\n        rescue NameError => e
+a60cbbe3be0b3849b6ebda11580495a2	"a:a b:42 c:[1000, {x: 100, y: 200}]"	def f(a, b, *c)\n          "a:#{a} b:#{b} c:#{c}"\n        end\n        \n\n
+a615e9df5e2ed23cbed823bac88c1889	"    a199\\n    b\\n"	def fmt(ruby)\n              lines = ruby.each_line.to_a\n           
+a631c90664947d5eab59dc2b3dcd60a6	true	"a".casecmp?("A")
+a6543c8de298e00b7a80c6733b286111	[["MONORUBY_ENV_TEST_RASSOC", "uniq_value_1234"], nil, nil]	ENV["MONORUBY_ENV_TEST_RASSOC"] = "uniq_value_1234"\n            r =
+a6544dcf937b0f3548e6509ea65a3df5	[true, false, false, true]	res = []\n            begin\n              [1].fetch(5)\n            r
+a65f043ef2457f2fffdc0c3ec7c6e584	["#<Object:0xX @host=\\"h\\", @user=\\"u\\", @password=\\"p\\">", "#<Object:0xX @host=\\"h\\", @user=\\"u\\">", "#<Object:0xX>", "#<Object:0xX @x=1, @y=2>"]	o = Object.new\n            o.instance_eval { @host="h"; @user="u"; 
+a673d29f8eccc1337bd03a34d5c90188	"a message\\n"	class MyIO; def initialize; @s=+""; end; def write(*a); a.each{|x| @s<<
+a67981aa119a7af5876972896067ed8c	[[97, 255, 98], "UTF-8"]	s = "a\\xffb".force_encoding("UTF-8")\n            e = Regexp.escape(
+a68743ceca70ef6224e2fdb19aa54955	["foo\\n", "foo\\n", "bar\\n", "bar\\n", nil, nil, "a\\n", "x\\n"]	require 'stringio'\n        res = []\n        sio = StringIO.new("foo\\nba
+a68c0cccee2a55ed8f794145ed571e40	[true, false]	class Foo\n              def respond_to_missing?(name, ia)\n         
+a69006568c860bcfc4b9e02a486ab1df	[1, 2]	m = Module.new\n            m.const_set(:X, 1)\n            m.const_s
+a6babd44133ab8ff72391643e33f3032	[true, true, false, true]	md = /foo/.match 'foo'\n        res = [md.is_a?(MatchData), $~.equal?(md
+a6bf8339d0472705c28fe00c90b76501	1	raise(StandardError) rescue 1
+a6cd1aa39f1855a925c68ee19f8abd1f	["global-variable", nil, "$! not set", true, ["custom"], ["single"], "TypeError", "TypeError2", "TypeError3", nil]	res = [defined?($@), $@]\n        begin\n          $@ = ["x"]\n        res
+a6d1396f813ed5a286b235897f532cc9	420	class Foo\n          def **(other)\n            other * 10\n          end\n
+a6e76941b428102c2ba4a628d8639080	1000	S = Struct.new(:counter)\n            \n\n            s = S.new(0)\n   
+a6f799b2f3bd4b9cbb9608e44dd52dbc	true	Process.warmup
+a71e54a7d566380aaed8baaea63868be	99	def make_proc\n          Proc.new { yield }\n        end\n        def get_
+a7bbd186c86ac3ce9091503517f8a4c7	[true, true, false]	class Foo\n              def bar; 1; end\n              alias_method 
+a7d85b5b4b74fdccaa32b812610588e7	true	d = +"foo"\n            h = Hash.new(d)\n            h[:any].equal?(d
+a7dfe3e551ac8402163609fb863ca4e0	["US-ASCII"]	s = "abcabc".dup.force_encoding("US-ASCII")\n              s.scan(
+a7e6aaf932959ee4c972ae4048325b70	[1, 2, 3]	class Foo\n            def foo(arg)\n                arg\n            end\n
+a7e6e135e95d618e3ae7fc235b8624b8	17158183388.626425	def calc(i)\n              f = i * 1.1\n              g = i * 0.9\n   
+a7ea202d40851dfadabc161faaaaffb7	true	GC.config({}) == GC.config
+a800cb1d66d4f7c50d700a30535cce0f	["UTF-16LE", [97, 0, 98, 0, 99, 0]]	File.write("/tmp/mr_rd2.txt", "abc")\n            r = []\n           
+a8018262ffba8fba491e3b1e7bcd20b9	42	module M\n              @x = 42\n              remove_instance_variab
+a86010e766462d5eea966a5e9133b6f0	[nil, true, nil, true]	a = Signal.trap(:EXIT, proc { })\n            b = Signal.trap(:EXIT,
+a87019ce1fb4a58da98eb0fcd22f397c	[1.0, "caught", 2.0, "caught", 3.0, "done"]	x = 0.0\n            $res = []\n            begin\n              x += 
+a88bdad4ba8d9e033a1c6a53c309f4ea	["42", 100]	class C\n          def [](idx)\n            idx.to_s\n          end\n      
+a893feccfcbaee91bc5522b1657fcd1f	[true, true, false, nil]	ENV["MONORUBY_ENV_TEST_HV"] = "uniq_v_9999"\n            r = [\n     
+a8a0ba72dab0adb84480e368a4e097dd	[301, 1, 9999]	s = { 9999 => 1 }; h = { 0 => 0, 1 => 1, 2 => 2, 3 => 3, 4 => 4, 5 => 5, 6 => 6,
+a8a204fa65005f1986e0577c71740024	[100, 200]	def f(&blk)\n          $res << blk.call\n        end\n        \n\n        $r
+a8ba12681e022f58d203e578e86db197	[true, true, false, false]	class Foo; def ==(other); other == 42; end; end\n            \n[42 ==
+a8c21cc1d90e2fb1a53cf94a2f4d4a2a	[21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError", 21, "ArgumentError"]	def g(a) = a * 3\n        def f(...) = g(...)\n        \n\n        $r = []\n
+a8d3b539aad843935d7deedb87352417	23100	def mk(n) = ->{ n += 1 }\n            fs = (1..150).map { |i| mk(i) 
+a8d6091e10bbc45917c1a585bc789d77	[]	$added = []\n        S = Struct.new(:x, :y) do\n          def self.method
+a8ec17eee20a20a10e9a36dde25e12c1	:ok	m = Module.new\n            m.freeze\n            begin\n             
+a90058e9df5ff2516b212820f11e49d2	[[1, 100, 200], [1, 2, 200], [1, 2, 3]]	class C\n          def f(a, b=10, c=20)\n            $res << [a, b, c]\n  
+a91e35aabe535987657d57b7716d7a69	:OVERRIDDEN	class String; def !; :OVERRIDDEN; end; end; !("a")
+a92420dfa104c119e6e5e272d114ec4f	"US-ASCII"	"abc".encode("US-ASCII").ljust(2).encoding.to_s
+a92a96b88eead854be7aa30c83453789	1	Process.detach(spawn("false")).value.exitstatus
+a93aff5f67ff2713cf29404f5b2f4a64	42	class C\n          def call_priv\n            priv_method\n          end\n 
+a93f36f86e60d2939747b3460e0e9680	[["A", "B"], ["-", "-"], ["A", "-"], ["A", "B"]]	module SnapA\n              refine(String) { def tag;  "A"; end }\n  
+a94375bbeca8fabd095d830c8dca16dd	["Y", "Y"]	$-0 = "Y"; r = [$/, $-0]; $/ = "\\n"; r
+a966ff673f0471a0f7996609730def4c	"missing keyword: :x"	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; def m(x:)
+a98bef4ea7d42ca9b3589602d2392195	[[5, 6], [0, 0], [5, 6], [1, 1], [5, 6], [2, 2], [5, 6], [3, 3], [5, 6], [4, 4], [5, 6], [5, 5], [5, 6], [6, 6], [5, 6], [7, 7], [5, 6], [8, 8], [5, 6], [9, 9], [5, 6], [10, 10], [5, 6], [11, 11], [5, 6], [12, 12], [5, 6], [13, 13], [5, 6], [14, 14], [5, 6], [15, 15], [5, 6], [16, 16], [5, 6], [17, 17], [5, 6], [18, 18], [5, 6], [19, 19], [5, 6], [20, 20], [5, 6], [21, 21], [5, 6], [22, 22], [5, 6], [23, 23], [5, 6], [24, 24], [5, 6], [25, 25], [5, 6], [26, 26], [5, 6], [27, 27], [5, 6], [28, 28], [5, 6], [29, 29]]	class N\n          attr_reader :v\n          def initialize(a: 0, b: 1) =
+a9a64f0fa64e4bb1ec264c4f7c86df8b	:OVERRIDDEN	class Integer; def *(o); :OVERRIDDEN; end; end; 3 * 4
+a9b082961457f87dd5dd3df08a2bc22e	"CAFÉ"	"Café".upcase
+a9cceae0d32dce8d89f28a34f27a49e1	[RuntimeError, "boom"]	o = Object.new\n            def o.each; raise "boom"; end\n          
+a9d059f319ef4e98b5696e426ac2c89b	TypeError	(Regexp.new("x").send(:initialize, "y"); nil) rescue $!.class
+a9dd588673ce02d7bc2ce7e1651c939c	[[100], [1, 2, 3, 4, 5]]	def f(*x); x; end\n        \n\n            a = [1,2,3,4,5]\n           
+a9f8309dd982b3d74ed3911045dbdd26	101	class MyInt\n              def to_int\n                1\n            
+a9ff6dc8c0a696afe692246be87ec6a0	:ok	old_stderr = $stderr\n            captured = String.new\n            
+aa0179c6a7db9bb0b86a4d9b4c86ce88	"val\\n"	k = Object.new\n            def k.to_str = "COERCED"\n            v =
+aa05186b88affb226a363d28386e0fc0	"hello"	obj = Object.new\n            obj.define_singleton_method(:greet) { 
+aa23b238b8244c565a6b33e66edb6dcb	Array	class C < Array; end\nC[1,2,3].to_a.class
+aa28322a935799ae96e4d6670e2a2139	["MStructInherited", "a", "b"]	MStructBase ||= Struct.new(:p, :q)\n            class MStructInherit
+aa3e20c82eb68ebd7b70f787874a0acb	[A, A, A]	class A\n        end\n        class B < A\n        end\n        class C < B
+aa3f3d27b7e1869ad3ebc4224526e592	[1, 2]	def f(a = ($x = 1), b = ($y = 2)); 7; end\n        f\n        [$x, $y]\n  
+aa58807d2dc7e8b5bf01ecc1377defd1	[true, true, true]	[\n              Process.argv0.is_a?(String),\n              Process.
+aa75159d845bfceeb430dbf3a8147e5a	[1, 2, 3, 5, 6, nil, 42]	def f(a,(b,c),d,(e,f))\n          g = 42\n          [a,b,c,d,e,f,g]\n     
+aa9826a02db68be1092571574e433dbe	"bar is true"	foo = false\n        bar = true\n        quu = false\n        \n        cas
+aa9dc49c4157aab8cd435e0906d16a35	true	m = Module.new do\n              module_function\n              defin
+aa9e9d2d059255551ef82b97e189dbf9	0	Time.utc(2000).utc_offset
+aab458ff0c2a03718b6c9b73c90f2db1	:ok	old_stderr = $stderr\n            captured = String.new\n            
+aab9942daadbde6b7f6d2ea8f2774472	[:Receiver, :singleton]	module IEv\n              module ReceiverScope\n                class
+aac724226cfcaf6fac1a6d9fa08ab5f2	0	h = Object.new\n            def h.finalize(id); end\n            Obje
+aad2bfda760893a138c4884a558ad072	[[:dynamic, [1, 2]], [:dynamic, [3]], [:dynamic, [4]], -1, [[:rest]], :dynamic, true, Foo, nil, 70]	class Foo\n              def respond_to_missing?(name, include_all)\n
+aadd8748b0f862759047055ef8ee291d	"piped"	require "open3"; Open3.capture3("cat", stdin_data: "piped").first
+aae6b9aa0d96352bf9b4ef52696aca7e	[42]	class E\n                 def []=(*a); @v = a; end\n                 def go; self[
+aae6ed0fbc6ac3776bb745bc101bcc2e	[300000, true, true]	require "open3"\n            data = "x" * 300000\n            out, _, st = Open3.c
+aaedf0251eca99b1554de529a1ef7cf5	46900	class H\n          attr_reader :a, :b\n          def initialize(a: nil, b
+ab312ebadfbc96b42cab59f735954c12	3	symbol_proc = :+.to_proc\n            klass = Class.new { define_met
+ab3d5efaceb0aaf63327a5c1530b448e	[:bar, [1, 2, 3, 4]]	class Foo\n              def method_missing(name, *args)\n           
+ab3f4cfac97655ea0e7bb969aff8111e	"ok"	m = Module.new\n            module m::N; end\n            m::N.set_te
+ab535c2e7cd8b5a3fe1563c1f8eceada	["refined", "refined", true, "refined", "refined", "refined", "refined", "NoMethodError", false]	module RefR\n              refine String do\n                def foo;
+ab5e7b6bbbd5afe245e3a8a582cb7990	[3, 3]	def find_first(arr)\n          arr.each { |x| break x if x > 2 }\n       
+ab63839dbe29e9f17d36f1cc7849d7da	[[3, 4, 5, 6, 7, 0, 1, 2], [0, 1, 2, 3], [2, 3, 0, 1], [5, 6, 7, 0, 1, 2, 3, 4], [2, 3, 0, 1], [0, 1, 2, 3], [0, 1, 2, 3], [], [2, 3, 4, 1], [], [2, 3, 0, 1], [2, 3, 0, 1], true, FrozenError]	class Cnt; def to_int = 2; end\n        def rot0(a) = a.rotate!\n        
+ab6ac3209d2195ae9950646eb1022c17	:OVERRIDDEN	class Integer; def <<(o); :OVERRIDDEN; end; end; 3 << 4
+ab8885657a2a64a7b6e8875e78bb2e7b	Array	class C < Array; end\nC[1,2,3].sort.class
+ab957de646f7c725670ace2cad00bc40	1700	class C\n              def bar\n                "bar"\n              e
+ab9797f0718836e71434ef89cce1af7b	[:a]	def m(a, **nil); local_variables; end\n            m(1)\n            
+abac46e7f888623f5b3b5c9004331c85	nil	GC::Profiler.clear
+abc67d37977fba3b4336957c67169a2c	"5の倍数"	c = 5\n        case\n        when c == 3, c == 6, c == 9\n          '10より小
+abe0c3902c3cd046fd37e3943ef50099	[true, "c"]	bytes = Marshal.dump(String)\n            t = Marshal.load(bytes)\n  
+abf60dabe0438d35647d189c45c8647a	["sleep", false]	t = Thread.new { IO.select(nil, nil, nil, nil) }\n            Thread
+abfb1548c35bf7bc7b09797fe26223cb	[1, 2]	class Array; def []=(i, v); nil; end; end\n            a = [1, 2]\n  
+abff45e2e4ccefb2ed9daaa747abd7e9	[false, true, "ASCII-8BIT", "US-ASCII", "US-ASCII", true, true, nil, "UTF-16", nil, ".bak", nil, "no implicit conversion of Integer into String"]	require 'tmpdir'\n            f1 = File.join(Dir.tmpdir, "argf_t1_#{
+ac05813546d64cee5c65087151515f0e	2	class C\n              class_variable_set(:@@a, 1)\n              cla
+ac297a4af1959cc67e21eec34a53aea8	"nil"	def t; end; (private).inspect
+ac3fd0f0d8305e489381e6ee6e5c07bd	[100, 100, 4950]	a=1\n            x=0\n            b=while a<2500 do\n            if a=
+ac462de061f87c41bfe50ec870af58fd	[false, true]	io = IO.popen("cat", "r+")\n            begin\n              io.close
+ac47b35a8659a773ec56fdd4d59752c6	"m1+m2"	m1 = Module.new do\n          def foo; "m1"; end\n        end\n        m2 
+ac6d8683c7b77f0f7ebb11f4109c3bb2	[]	def m\n              /(?<matched>foo)/.=~("foofoo")\n              lo
+aca93977702ff68a47ea803d661ec922	[[1, 2, 3], [1, 2, nil], [1, nil, nil], [nil, nil, nil], [1, 2, 3]]	def drive3(a)\n              acc = []\n              a.each_with_yiel
+acaecec60e1d4df64f4888d1585ffb87	[[1, 5], [2, 6]]	[1, 2].each.with_index(5).to_a
+ace3583fa43b814b77f102993799e3b9	["Array", true, true, "nil", true]	res = []\n            t = Thread.new { sleep }\n            Thread.pa
+aced21e1e31e2ddc5465a70187f24f60	["para1a\\npara1b\\n\\npara2\\n", "para", "ASCII-8BIT", "ra1a", "para1b\\n\\npara2\\n", "para1a\\npara1b\\n\\npara2\\n", nil, "US-ASCII", ["para1a\\n", "para1b\\n", "\\n", "para2\\n"], ["para1a\\n", "para1b\\n\\npara2\\n"], ["para1a\\npara1b\\n\\npara2\\n"], ["para1a", "para1b", "", "para2"], ["para1a\\npara1b\\n\\n", "para2\\n"], ["pa", "ra", "1", "a\\n", "pa", "ra", "1", "b\\n", "\\np", "ar", "a2", "\\n"]]	require 'tmpdir'\n            f = File.join(Dir.tmpdir, "file_read_a
+ad1ae32a9a55d70e4730df3370a823db	[1, 2]	class C; def to_ary; [1, 2]; end; end\nArray.try_convert(C.new)
+ad3d114daa3fe697d3d65acf89424a99	[1, 2, 3]	c = Class.new\n            captured = nil\n            c.class_exec(1
+ad40135a1d283484c7b5cb46e05719d4	99	class C\n              X = 99\n            end\n            C.class_ev
+ad52e0b309ea2912c81a5103e18a6a3b	true	$LOAD_PATH.equal?($:)\n            
+adb5347f268fc22c27faf56c962755bd	[[true, 0], [[5]]]	log = []\n            sched = Object.new\n            [:block, :unblo
+ae16c0ef49b811c8c9cb52504e1b3d70	"out\\nrescued\\n"	r, w = IO.pipe\n            pid = Process.spawn("echo out; echo x >&
+ae1df911ace1255e65960a00b34e7ba7	{"a" => 1, b: 2}	def m(**k); k; end; m("a"=>1, :b=>2)
+ae211f0d43594ed597c756bcdcf34bac	[3, 3, 3]	class C\n              def initialize(x)\n                @x=x\n      
+ae37ce4067e4d5e36fd8d0ebd70c0629	[:blk, [[1, 2], {x: "y"}]]	obj = Object.new\n            def obj.to_open(*a, **kw) = [a, kw]\n  
+ae3df5be2726180def3104ed09ede6c3	[["KOI8-R", [225], true], ["KOI8-U", [225], true], ["Windows-1250", [225], true], ["Windows-1251", [225], true], ["Windows-1252", [225], true], ["Windows-1253", [225], true], ["Windows-1254", [225], true], ["Windows-1257", [225], true]]	%w[KOI8-R KOI8-U Windows-1250 Windows-1251 Windows-1252\n                 Windows
+ae483aee73535f0d92de8806d97adf62	[{f: "foo", b: "bar", c: "baz"}, {f: "foo"}, {}, {f: "foo"}, {f: "foo", b: "bar"}]	m = /(?<f>foo)(?<b>bar)(?<c>baz)/.match("foobarbaz")\n            [m
+ae49dfee117fbba28b8a954a82eb86dd	[[:a, :b, nil], [:one, nil], :before, :after, [true, false, true, false]]	a = Object.new; b = Object.new\n            h = { a => :a, b => :b }
+ae49e1b457314db4f6f7066ab9960d90	[5, "hello"]	path = "/tmp/monoruby_test_binwrite_#{Process.pid}_#{rand(100000)}"
+ae592d84c95871e8234f4dc3442a3db0	[:ok]	class VTest\n          def initialize; @host = "example.com"; @port = "8
+ae63fe71c4d5bee9c9ad35bf73642038	[true, true]	before = GC.count\n            GC.start\n            after = GC.count
+ae67028ed6bd7eea9010e301188d5c70	[-1, 1]	class Foo\n              def coerce(other)\n                [other.to
+ae6f79ff36cec9eed117b8ade45a005a	["L3", "L2", "L2", "L1", "nil"]	log = []\n            begin\n              raise "L1"\n            res
+ae8479eaafd0bffd069c9a8a39e2b8f4	[:a, :b]	def m; a = 1; b = 2; local_variables.sort; end; m
+ae8bb532a5849f5cb7160f3f7ce192d7	[[1, 2], [10, 2], [10, 20], "wrong number of arguments (given 3, expected 1..2)", [1, 9], 3]	$effects = []\n            def g(a = ($effects << :a; 1), b = ($effe
+ae9c21fb0bcca31090458cf615bcd66d	[true, true, true, true]	File.write("/tmp/mr_enc5.txt", "")\n            r = []\n            f
+aea7097b4756187bea544ff7270e0b0b	[MonoRubyExceptionTestErr, "new message", :boom]	class MonoRubyExceptionTestErr < StandardError\n              attr_r
+aeb1f2ef69ff2c6d602bc90ff2553233	""	"".downcase
+aed061dc6e19d21ef29d6c8d825a05cb	"ASCII-8BIT"	Regexp.union(/abc/, /[\\x00-\\x7f]/n, /[\\x80-\\xBF]/n).encoding.to_s
+aed53099ff3853e38b0609e15583d008	[true, true]	S = Struct.new(:a, :b)\n            \n\n            x = S.new(nil, "ta
+aeef9bd39cae0a88c4fb5f9174a5dbbf	["NoArg", "wrong number of arguments (given 1, expected 0)", "ArgumentError", "BasicObject"]	class NoArg; end\n            res = []\n            res << NoArg.new.
+af01a63acba6bf69555376a4548815fe	["sleep", "aborting", false]	r = []\n            q = []\n            t = Thread.new { begin; q << 
+af2115fbacf6ff881e536a9721478bf1	true	old_dep = Warning[:deprecated]\n            old_stderr = $stderr\n   
+af24445d9bfdc33c636c496d63505764	[["anon", "anon", "non-anon"]]	unless defined?(SCDMB_Twice)\n          class SCDMB_Base\n            def
+af365d29a316e30f9da873398ef58d55	:OVERRIDDEN	class Float; def **(o); :OVERRIDDEN; end; end; 3.0 ** 4.0
+af382db001b064f5b7f44cd44981ca11	42	k = Class.new\n            k.define_method(:foo) { 42 }\n            
+af3b3d6c1de8cefcdb70c10300234ad5	true	class MyStr\n              def to_str\n                "world"\n      
+af48e5c222ea17b50461e99b09a9628e	[["A1\\n", "A2\\n", "B1\\n", "B2\\n"], ["A", "A2\\n", "B", "B2\\n"], ["A1\\n", "A2\\n", "B1\\n", "B2\\n"], true, "Enumerator", ["A1\\n", "A2\\n"], ["A1\\n", "A2\\n"], ["A1\\n", "A2\\n"]]	require 'tmpdir'\n            f1 = File.join(Dir.tmpdir, "argf_t1_#{
+af72bf1cbfaf29e4742210fc2dccd3a1	["hELLO", "hELLO"]	s = "Hello".dup\n              [s.swapcase!, s]\n            
+af9c50b606859e165d88610397042afd	[true, ArgumentError]	(class KC; def initialize_clone(orig, **kw); $rec=kw; super(orig); end; end; obj
+afbcad07e617b095dc96d973a2845197	[:bar, [1, 2, 3]]	class Foo\n              def method_missing(name, *args)\n           
+afc664b3664dbfb2235fee8c114e24dc	["a\\n", "b\\n", "c"]	path = "/tmp/monoruby_io_classreadlines_#{Process.pid}_#{rand(10000
+afe017e12ee32ba781bc419214f2db54	"e\\n\\nCopyright (c) 202"	File.binread("../LICENSE-MIT", 20, 10)
+afecc303354ce360b53ad03479bdb2f0	2	t = Time.utc(1970, 1, 1, 0, 0, 0); def t.succ; self + 1; end\n      
+b017ead69b837578afee4295eb840ed7	"#<Class:Time>"	Time.singleton_class.to_s
+b041b0aaea8a7d40b26a35b251c0f897	[[:req, :a], [:nokey]]	def m(a, **nil); end\n            method(:m).parameters\n            
+b07897e1515470c5f367e6c838cd3ca3	true	h = {a: 1}.compare_by_identity\n            Marshal.load(Marshal.dum
+b13eb772180c210a5c10579da6ea6cfb	true	a = []\n            a << a\n            b = Marshal.load(Marshal.dump
+b15052c5abbd93a1a9004be3b57beb9c	[:foo, :bar]	$res = []\n            obj = Object.new\n            def obj.singleto
+b18169111f27cd344540accc05f616fe	nil	File.open("Cargo.toml") { |f| IO.new(f.fileno, autoclose: false).path }
+b18a80835134d8dffe61ec8e951213f0	["あcba", "あcba", true]	s = "abcあ".dup\n              t = s.reverse!\n              [s, t, 
+b196364f0e469cc01f39c67211d6218a	["abcdef", "abcdef", "abc", ["abcdef", "UTF-8"], "abcdef"]	File.write("/tmp/mr_cr5.txt", "abcdef")\n            r = []\n        
+b1e42cb82ca28ab492397ec61bd6e2b5	[159600, 79800, 159600, 79800]	def osr_mul(n); s = 0; i = 0; while i < n; s = s + (i * 2); i = i + 1; 
+b1e841a013941b44c006b4154587a777	[{a: 1, b: 2}, nil]	T = Struct.new(:a, :b)\n            \n\n            s = T.new({a: 1, b
+b1e95110d8ea3a01a8392d5fcde03380	[true, "nil"]	begin\n              raise RuntimeError, "x"\n            rescue Runt
+b1f575a8d57c1ae9a8351ad21a875204	true	[true, false].include?(GC.auto_compact)
+b1fe8d72aed6bdfd75350fcc54ac6891	10	obj = Object.new\n            pr = Proc.new { |x| x * 2 }\n          
+b20a481ce0203a766d78c51b6ec17f1a	[[[ArgumentError, "comparison of Array with Array failed"], [ArgumentError, "comparison of String with 0 failed"]], [[ArgumentError, "comparison of Array with Array failed"], [ArgumentError, "comparison of String with 0 failed"]], [[ArgumentError, "comparison of Array with Array failed"], [ArgumentError, "comparison of String with 0 failed"]], [[ArgumentError, "comparison of Array with Array failed"], [ArgumentError, "comparison of String with 0 failed"]]]	a = [[1], [2]]\n            f = ->(m) { begin; a.send(m) { |x, y| ni
+b22bc514c07a095c143e3f7049f6dcd2	[true, false, false]	ensured = false\n            rescued = false\n            f = Fiber.n
+b2581c86d8fd4f38392d54c50df9db10	[5, 2, "hABlo", 2, "hABzz", "not opened for writing", 2, [0, 0, 104, 105], "not opened for writing", 1, 3, "x123"]	path = "/tmp/monoruby_test_iowrite_#{Process.pid}_#{rand(100000)}"\n
+b2795d944c1781663b943914a7470a30	:OVERRIDDEN	class Integer; def -@; :OVERRIDDEN; end; end; -(3)
+b289172cd420abd93cd3d2aa0cec0079	["handler-ran", 0]	r, w = IO.pipe\n            pid = fork do\n              r.close\n    
+b29dca01dfe62ecc7a28c6ee542bc4af	[true, false, true, true, true, false, true, 42]	h = Hash.ruby2_keywords_hash(a: 1)\n        res = [Hash.ruby2_keywords_h
+b2d38391b3ffe286d499d5b0f8b8425c	[12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345]	def g = 12345\n        def f(...) = g(...)\n        \n\n        $r = []\n   
+b2d8d3b6539361a8364045da7cfbfa9e	false	a=Object.new; a.instance_variable_set("@i", 42); a.instance_variable_defined?(:@
+b2ec3518315b390f605929160559793b	6	eval("1 + 2 + 3")\n        
+b3426882a7540443a327be9a9da66f26	[10, 20, 30]	res = []\n        [10, 20, 30].each do\n            res << it\n        end
+b37a18c27e0a579600146a5c3a6aea5e	[:wait_readable, "hello"]	r, w = IO.pipe\n            a = r.read_nonblock(1, exception: false)
+b37c44d8c2e41bb2c540d40ee9f7ad20	[11, 220, 11, 220, 11, 220, 220, 11, 220, 11, 220]	class S\n              def g\n                x = 0\n                f
+b38e37a07c9700ce3f2acd61ef3076fa	[1, true]	base = "/tmp/monoruby_test_lutime_#{Process.pid}_#{rand(100000)}"\n 
+b3956f9c76b60deb656bfc1e08c12d32	"x x"	sprintf("%1$s %1$s", "x")
+b39ccce5edc71c1ba64c4d13b947c3ff	["Hello", "Hello", nil]	s = "hello".dup\n              [s.capitalize!, s, s.capitalize!]\n 
+b3adf092d96c22e3501d6bfe532e7b20	[200, 0]	class C; attr_accessor :x; end\n\n        o = C.new\n        o.x = 0\n        n = ni
+b3b5193f5b68f7690f8b6ec8be90574c	["US-ASCII", "US-ASCII", "UTF-8", "incompatible character encodings: UTF-8 and BINARY (ASCII-8BIT)", "UTF-8"]	res = []\n        res << eval('"a#{"b"}c"'.dup.force_encoding("us-ascii"
+b3c393a3c5b749ded888ddfe68fc78a6	0	/(?<z>foo)(?<opt>bar)?/ =~ "foofoo"
+b3c960b4731c64112549a1ccd0286905	0	def my_div_loop(num, base)\n              base = base.to_i\n         
+b3d9a677b11ea326bcf884e335f92d27	[".", "file.txt"]	File.split("file.txt")
+b40eae923404ecf2105fe030f12724f0	[1, true]	o = Object.new\n            def o.to_ary = nil\n            [[o].flat
+b41bffeda38054f0bb00b19ec600c703	[99, true]	module A\n          module B\n            C = 99\n          end\n        en
+b42bad7e45c631cf9775c857dd2d449c	false	"\\xff".dup.force_encoding("UTF-8") == "\\xff".dup.force_encoding("ISO-8859-1")
+b43ddc3e9a6f575f283274020874d5a5	[false, false, {a: 1}, false, false, true, true, [[1], {a: 1}]]	h = Hash.ruby2_keywords_hash(a: 1)\n        res = []\n        # splat int
+b469f80ba7eec6cc7a60db78417e67c6	100	#Ret\n            begin\n              100\n            rescue\n       
+b4789d9d7a7df43156b528780a6dd708	[-4, 1, 2, 5, 7, 10, 12]	[1, 2, 5, 10, 7, -4, 12].sort { |n, m| n - m }
+b48421b0d63a4f1dfbd01b42afbcbd69	[[true, "Other 2\\n", "File", true], [true, false, "Other 1\\n"], ["one", "two"], "closed stream", "closed stream", ["File", "Other 1\\n"], "can't convert Object to IO (Object#to_io gives String)", true]	base = "/tmp/monoruby_test_reopen_#{Process.pid}_#{rand(100000)}"\n 
+b4b8f74ab1ab36ffeaae5c220a83557e	[true, true]	m = Module.new do\n              eval <<-CODE\n                module
+b4da8c820c2dab4428659d300baa5cc4	[:foo]	$res = []\n            class C\n              def self.method_removed
+b4de022176f4c5de67942bada3f160da	[[Fold], [FoldRest], [FoldOpt], [Impure], 99, ArgumentError, ArgumentError, ArgumentError, Fold, 100]	$effects = []\n            class Fold\n              def initialize(x
+b4ebd9e4bda33219cab1ca52fb00c022	[[[1, 2, 3], [[:x, 10], [:y, 20]]]]	class C\n          def f(*args, **kw)\n            $res << [args, kw.sort
+b50aa88cac9a4ea0fd9adfd0ecc7d571	20	Random.urandom(0).size\n        Random.urandom(1).size\n        Random.ur
+b5186a1f8fc3fcc5d73748e08564545a	[1, 1]	->(a = 1, b = a) { [a, b] }.call
+b51eae0c2c71a30215e7785e93ca25f3	[true, false, true, false, true, true, true, false]	res = []\n        class CrefCtx\n          T = Object.new\n          def T
+b52b7ae0ebcd04b048eece7e69745703	nil	Struct.new(:a, :b).keyword_init?
+b5364021df82a5d981ffb0442dee337f	["global-variable", "global-variable", "global-variable", "global-variable"]	"abc" =~ /(b)/\n            [defined?($&), defined?($'), defined?($`
+b5723530913b7d276ae3a021dcd95908	["a", "b", "c"]	class C; def to_str; ","; end; end; o = C.new\na = []; "a,b,c".split(o) {|p| a <<
+b57826ceb9ae42340cd8925b6d77b11c	["THX1138", true, true]	md = /(.)(\\d+)/.match("THX1138"); [md.string, md.string.frozen?, md.string.equal
+b5be46d949f1eea1ccbb975b82d2b2eb	[nil, nil]	r, _w = IO.pipe\n            [r.wait(IO::READABLE, 0), r.wait_readab
+b5bfc59cf1f27ffbdc15d96514f4adfa	"unknown keyword: :system"	M = Data.define(:amount, :unit)\nbegin; M.new(amount: 1, unit: "m", system: "x");
+b5e1a6c63376ab03776669f38829f3e6	[false, false, false, false, false]	a = proc{ :foo }; b = proc{ :foo }\n               [a == b, (->(){:x}) == (->(){:
+b5f124da7406c2b2ad712bf89fb93e70	[true, true]	done = false\n            i = 0\n            t = Thread.new { done = 
+b60ff879bee18769859dc1d15209e4fd	[100, 2, 3, 400, 1, 2]	def f(x,y,a:100,b:200,c:300,d:400)\n              [a,b,c,d,x,y]\n    
+b61334cf4a0a91be12a6bb93925dda94	6	1.instance_exec(2, 3) { |a, b| self + a + b }\n        
+b6222454a310e9ff5bb303f4ff3250ba	[true, nil, false]	saved = $VERBOSE\n        $VERBOSE = 1\n        res = [$VERBOSE]\n        
+b641fbd5ebdf00e1aed645d54b50f668	[[100, 400]]	class C\n          def f(a, b)\n            $res << [a, b]\n          end\n
+b665e7999873f7c9a5bf25c8c8c1ffeb	42	klass = Struct.new(nil, :a)\n            klass.new(42).a\n           
+b6799d38502adf59ced438f5fcef43f4	["pp", ["Socket", "Socket"], "qq", true, "Socket", "zz"]	require "socket"\n            res = []\n            x, y = Socket.pai
+b680671714a43502907fe153774b1c85	true	GC.config(nil) == GC.config
+b69f2239bbc4e9cae5e303c2918e8843	33	class D\n              attr_accessor :val\n            end\n          
+b6aca556c6399f547ba3bb3ac5005179	10	def foo(&b)\n          b\n        end\n        \n\n        foo { |x| x * 2 }
+b6ba588f2d7306ef117e4e3c470a4b66	true	res = nil\n            k = Class.new { |c| res = c }\n            res
+b6bd962cfccd912a07dc6a5d26084a70	["sleep", "sleep", "sleep", "sleep", "sleep"]	require "socket"\n            require "tmpdir"\n            res = []\n
+b6c8e6ca6f1c4a33c2343829c6261f01	[200, 200, 200]	$res = []\n\n        class S\n            def f(x)\n                $res <<
+b6d1b4d4e1ae4574a89c62456ad9ddce	43990	parents = []\n            300.times { |i| parents << ("hello world "
+b6d47e1aff62ee9cd1aa1825069153f4	["aaa\\n", "bbb\\n"]	path = "/tmp/monoruby_test_file_foreach_#{Process.pid}"\n           
+b6e1b26f26c510fe896a5e3a645bc4c5	"42"	class HasToInt; def to_int; 42; end; end\n            sprintf("%d", 
+b7009118e9f964641491220f6e4f7ab4	["unix!\\n", "/s.sock"]	require "socket"\n            require "tmpdir"\n            path = Fi
+b7091d188869013ccaa15480c8f7b154	["Block isn't given.", "Block is given."]	def check\n            if block_given?\n                "Block is given."
+b72e139f9584a1a1c990a63100a2e98c	[["NoMemoryError", nil, true], ["ScriptError", nil, true], ["SecurityError", nil, true], ["SignalException", nil, true], ["SystemStackError", nil, true], ["LoadError", nil, true], ["SyntaxError", nil, true], ["NotImplementedError", nil, true]]	[\n              NoMemoryError, ScriptError, SecurityError, SignalEx
+b76b635413644a9ee6cb10accbfe88d1	false	class Float; alias __orig :>=; def >=(o); __orig(o); end; end; 3.0 >= 4.0
+b76d6e4320dd94711348a48796e6ef33	[42, 100]	$res = []\n        class S\n          class C\n            def f\n         
+b7b791ae9b8a5b32ebb0e713566b57b5	[:foo, [1], {x: 10, y: 20}]	class C\n          def method_missing(name, *args, **kwargs)\n           
+b7cb35744fdfaa984b6e9aa7ca2b4447	[4000, 3999]	n = 0; a = [n, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
+b7d68f9088d3f3aed2ab62dc9d949be5	[true, true]	class Foo\n              def bar; 42; end\n            end\n          
+b82f7004e67d1dce1e4af8e9795a0307	:OVERRIDDEN	class FalseClass; def !; :OVERRIDDEN; end; end; !(false)
+b831c7c725c3ecbf2dd649e236c9fbcd	"Hello world"	"hello world".capitalize
+b838044a3ab73c7623063d1b22818274	[1, 2, [5, 6], 3, 4]	def f\n          yield [1,2,3,4,5,6]\n        end\n        \n\n        f { |
+b843b98c578472cd813d8c5ddb8158b4	"f"	def f\n          "f"\n        end\n        alias g f\n        g\n        
+b85aa27afabd41f49479b590bb38e22f	[4, 8, 73, 99, 25, 77, 66, 83, 112, 101, 99, 58, 58, 87, 105, 100, 101, 227, 129, 130, 67, 108, 97, 115, 115, 6, 58, 6, 69, 84]	module MBSpec; end\n            name = "WideあClass"\n            MBSp
+b8659d9eac8d9dda73d245a1976bcfbd	256	253.succ.succ.succ
+b8a21a20381c12eb8fd88a75578fcc20	["mm: probe [7]", "super: no superclass method 'probe'"]	res = []\n        klass = Class.new do\n          def method_missing(name
+b8a48c3aa1c3407546058fae28da4256	[false, false]	def foo; end\n            def bar; end\n            public :foo, :bar
+b8add92dc4f86330682dc9fa57fea596	"[nil, true]"	r, w = IO.pipe\n            pid = fork do\n              r.close\n    
+b8d3738377245420bc2378da58f5f7d9	100	p = Proc.new { 100 }\n            define_method(:foo, p)\n           
+b8d68ef10028da6842a236893e45d2cb	:local_jump	begin\n              Thread.new { return }.value\n              :no_e
+b8fdb4f51c8e75670a1418eb17bac041	:ok	pat = "ア".encode(Encoding::EUC_JP)\n            begin\n              
+b93a89bc24fb2ce9a85934322dd7c06b	[[[:rest, :*]], [[:keyrest, :**]], [[:nokey]], [[:rest, :*], [:keyrest, :**], [:block, :&]], [[:rest, :*], [:keyrest, :**], [:block, :&]], [[:req, :_], [:req, :_], [:opt, :_], [:rest, :_], [:keyreq, :_], [:key, :_], [:keyrest, :_], [:block, :_]], [[:req, :a], [:rest, :rest], [:keyreq, :k], [:keyrest, :kw], [:block, :blk]], [[:block, :&]], [[:rest]], [[:req]]]	class C\n              def un_splat(*); end\n              def un_kwr
+b95a04e2a38f61bbd5a709fe2765858d	["US-ASCII"]	"a1b2c".dup.force_encoding("US-ASCII").split(/\\d/).map(&:encoding).map(&:to_s).u
+b96940f575b56c9465d2b5278d0b69ee	[true, true]	S = Struct.new(:a, :b)\n            \n\n            a = S.new(1, 2)\n  
+b99d82bae511b91e5a04196a59b9ec54	[true, -1, :dyn, [[:rest]], nil, true, false]	class Foo\n              def respond_to_missing?(name, ia); true; en
+b9a3cf79facba89ba9427e8a3927bcc8	[[["a", 1], ["b", 2], ["c", 3]], [["a", 1], ["b", 2], ["c", 3]], [["a", 1], ["b", 2], ["c", 3]]]	h = { "b" => 2, "a" => 1, "c" => 3 }\n            [\n              h.
+b9a7a07ccfa8e547bb15218d8ea8a606	:ok	c = Class.new do\n              def foo; :foo; end\n            end\n 
+b9a8e93ca294ef22a9d91b72fa37855f	"gen"	(Enumerator.new { |y| raise "gen" }.each { }) rescue $!.message
+b9e4a202e801d221011f287254121bb3	"Errno::EPIPE"	r, w = IO.pipe\n            r.close\n            begin\n              
+b9ee309e3978ec232bdf774078592539	["5", 2]	def apply(x, &b); b.call(x); end\n              [apply(5, &:to_s),
 b9f8172cb8555b07f17ee7e3934a585e	[Infinity, -Infinity]	[Float::INFINITY, -Float::INFINITY]
+ba003b37b9cb4190b13068e285fa5a72	[[0, "fresh"], [0, "other"]]	require "stringio"\n\n            res = []\n            a = StringIO.new("orig")\n  
+ba14940825be38e026fae59620419fd4	42	class A\n          private\n          def secret\n            42\n         
+ba2759338f46738112684574d1873d91	["C", true, :overridden, "BetweenBAndC", "B", nil, "BetweenBAndC"]	module B; def overridden; "B"; end; end\n            module BetweenB
+ba33ae227745c6540c696d6d1939ee32	Complex	8.0.fdiv(Complex(2, 1)).class
+ba39d4e07d48704cbbd5237bda1f2e52	3	class C\n          def f(a = ($x = 3)); self; end\n        end\n        C.
+ba4b2a427a6ae2a8c8e93903224a4e27	[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, true, :lexical, :lexical, :lexical, :lexical, :lexical, :lexical, :lexical, :lexical, :lexical, :lexical]	$r = []\n        # Constants stored directly in the singleton class.\n   
+ba4f1d7bb4ae928b997cbb3df7f887d9	nil	m = Module.new\n            m.name\n            
+ba4ff971390140cc452d6a37019cd25e	["hello", "hellohellohellohellohellohellohellohellohellohello"]	class Foo\n          def initialize(data)\n            @key = data\n      
+ba657172c9c846fc29d3c12c19422d81	3	m = Mutex.new\n            cv = ConditionVariable.new\n            wo
+ba6f639d6a80fdb3a0102d2205ebee91	[["one x\\n", "two x\\n", "\\n", "\\n", "\\n", "three\\n", "four\\n"], ["one x\\ntwo x\\n\\n", "three\\nfour\\n"], ["one ", "x\\n", "two ", "x\\n", "\\n", "\\n", "\\n", "thre", "e\\n", "four", "\\n"], ["one ", "\\ntwo ", "\\n\\n\\n\\nthree\\nfour\\n"], "invalid limit: 0 for each_line", ["one x", "two x", "", "", "", "three", "four"], [], ["one x\\ntw", "o x\\n\\n"], 7, ["one x", "two x", ""], ["one", " x", "\\ntw", "o x", "\\n\\n\\n", "\\nth", "ree", "\\nfo", "ur\\n"], 1, :t1, :t2, [["one x\\n", 1], ["two x\\n", 2], ["\\n", 3], ["\\n", 4], ["\\n", 5], ["three\\n", 6], ["four\\n", 7]], "nil", ["one x\\n", "two x\\n", "\\n", "\\n", "\\n", "three\\n", "four\\n"], ["one x\\ntwo x", "three\\nfour\\n"], "nil", 7, 7, :notread, ""]	require "tempfile"\n            t = Tempfile.new("mrb_lines")\n      
+ba7058a9f888bace3485573d10433a9e	true	M = Data.define(:amount, :unit)\nm = M.new(42, "km"); m.with.equal?(m)
+ba73e17b465fecb689735f04e9f7047e	[1, 2, "l1\\nl2\\n"]	path = "/tmp/mr_gvar_lines.txt"\n            File.write(path, "l1\\nl
+ba8132b4a761c3cc445f79982ea307f1	[:frozen, :frozen, 1]	klass = Class.new; klass.freeze\n            r1 = begin; klass.class
+ba8abe11f8c7c450d64cf7c0c8aaeef7	:finished	ec = Encoding::Converter.new("UTF-8", "ISO-8859-1")\n             
+baac0bfbcda44d7ed24d7aedf15dba23	["0.1e1", "0.2e1", "0.1024e4", "0.98596e1"]	require "rubygems"\n        require "bigdecimal"\n        res = []\n      
+bab29f9aef949a72c454db04f4b8ae98	["10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30]]	def real(a, *r)\n          r << 999\n          "#{a}:#{r.inspect}"\n      
+baf2588a6b03f124f0c0206d4f3549b8	[:foo, true, [:one, :two]]	receiver = Object.new\n        begin\n          receiver.foo(:one, :two)\n
+bafce2a62bf4dbfd6186bef21db44b6c	15	p = lambda { |x| x * 3 }\n            define_method(:baz, p)\n       
+bb0bb1e20659a29aa7c8c5cdd425b146	"wrong number of arguments (given 0, expected 1; required keywords: x, y)"	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; msg { lam
+bb19f6171b9db4e6cae6dfe8c8c41cc8	true	c = Complex(1, 2); Complex(c).equal?(c)
+bb1ce69cddb8eef987fcca8c5854bd7f	[1, nil]	p = Proc.new { |a, b| [a, b] }\n            Class.new do\n           
+bb25f681814e00a730286dbf4fff8b3b	[:m, 1, C]	class C\n        end\n        \n\n        a = 1\n        C.class_eval %Q{\n  
+bb3259c8518859b67fd8d6ebce8a469b	[122, 195, 97]	"a\\xC3z".dup.force_encoding("UTF-8").reverse.bytes
+bb4676ea48e5e84be75e86137b7ccbf0	[[104, 101, 108, 108, 111, 226, 130, 12, 43, 172], "ASCII-8BIT"]	s = "hello".b\n            s.append_as_bytes("\\xE2\\x82", 12, 43, "\\x
+bb5498e7dcf365fa231082e385a52382	[42, 7, :nme]	class NestOuter\n              def build; def built; 42; end; end\n  
+bb7dc7125b3d11eacda38a33f25683d7	["global-variable", "global-variable", "global-variable", "global-variable", "global-variable"]	[defined?($/), defined?($\\), defined?($,), defined?($;), defined?($.)]
+bb7e42a0efd2830d60846fb262b25aba	:OVERRIDDEN	class FalseClass; def ===(o); :OVERRIDDEN; end; end; false === false
+bb9bac558eea3d2782caab01dd00745b	12.1	def f(a,b)\n          a + b\n        end\n        f(5.1, 7)\n        
+bba413775b9fdc4e5a5520013caecba6	true	Process.getpriority(Process::PRIO_USER, 0).is_a?(Integer)
+bbb536d6446e4acae479f2a76bbc22b8	[false, true, "payload"]	base = "/tmp/monoruby_test_rename_#{Process.pid}_#{rand(100000)}"\n 
+bbf39b957f63dc57cf6be6b238e3322a	"HELLO world"	s = "hello world"; s.bytesplice(0..4, "HELLO WORLD", 0..-7); s
+bc0ccc0a16c986d29598ed69b9038ff8	[false, true, true]	h = {}\n        before = h.compare_by_identity?\n        ret = h.compare_
+bc2025afe3d4e746f87d06a3bac3e3db	[[]]	r = []; Enumerator.new { |y| y.yield }.each { |*a| r << a }; r
+bc2e5f3b4a16256b7dc6b55712d5a785	nil	Encoding.default_internal
+bc3dddbacac3d7f8c64e3bc43ea8697d	[true, true]	class S\n        end\n        class C < S\n        end\n        c = C.new\n 
+bc5ee3d6a54ec78cbbccd9f386e31604	[true, true, "test"]	class MyMod < Module\n              def initialize(name)\n           
+bc7468de3c49bfa7febfbc6e20e4709c	[4, 1170]	a = 0\n        for i in [0,1,2,3,4]\n            1.times do\n             
+bca890206e651d8b1e7121a1d6d0052d	[1, 2, 3, 4, [5, 6, 7]]	def f(x,y,a=42,b=55,*z)\n            [x,y,a,b,z]\n        end\n        \n\n 
+bcd4d79874131b33a41f66ab63d74f9a	[["historical binary regexp match"], ["historical binary regexp match"], true, true, true]	def cap\n              saved = $stderr\n              buf = +""\n     
+bd014186227c44d7add99e1236397a73	[[[:a, 1], ["b", 2], [3, :c]], ["k99", 99], [], [["k", 1], ["k", 2]]]	def entries(h)\n              if h.respond_to?(:__key_at)\n          
+bd22533535800c77fe48058df3d9f037	"1"	def foo\n          eval("a = 1", $b)\n        end\n        \n\n        eval(
+bd24763614b3434c4b3cad2ef0cf23cd	"1234"	from_out, from_in = IO.pipe\n            to_out, to_in = IO.pipe\n   
+bd36bb84fd6bb7a503446ba088e410d5	100	X = raise("err") rescue 100\n            X\n        
+bd3f9345b51422969e152af15f9cd73c	[10, 30]	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \ns.val
+bd5bcb876056c6cb8592a7ad4872c350	Array	class C < Array; end\nC[1,2,2].uniq.class
+bd72323eccae40b197ebea1283639273	[nil, 42]	a = []\n        a << $std\n        $std = 42\n        a << $std\n        $s
+bd7a26e1f462e26d42e9543689bc3430	3862152.611328125	def calc(n, vals)\n          a = 0.0; b = 1.0; c = 2.0; d = 3.0\n        
+bd9970837b8009b39aca5efafe329d8e	["true", "5", "", "foo"]	[true.to_s, 5.to_s, nil.to_s, :foo.to_s]
+bd9f54fa26238d51503216b560dcfe9d	"M:C"	module M\n          def foo\n            "M:" + super\n          end\n     
+bde4f5647e4c5f426e0b6b9de2ad09ab	[[], [:it], [:_1, :_2, :_3], [:it], [], [], []]	[\n              binding.implicit_parameters,\n              proc { i
+bde9a54a7762ba3fd118c904ccaac5c2	[:rescued]	def boom; raise "no"; end\n            def test; [1].map { begin; bo
+bdea9d1c4693119e7bb516fdfdf9210c	:done	r = false\n            t = Thread.new do\n              f = Fiber.new
+be095b38571f7deb19f1b1d863acabf4	true	GC.stat(:count).is_a?(Integer)
+be1808a6727b8d3bac7af6a899237547	1	class C; define_method(:m) { |a,| a }; end\n            C.new.method
+be32db402f76154708fa32e248c791d9	[[:a, :c, nil, true, false], [1, 3, 4, 5, 6, nil], [:int, :float], [:x, :dflt], [:hit, "miss2"], [:one, nil, :int], [30, 110, [1, 2, 3]], [30, nil, 5], [:nan, nil]]	r = []\n            h = { 1 => :a, 5 => :b, 9 => :c }\n            r 
+be4f9b746714ae0e4ffd2af6d6fbee22	[0, 1, 2, 3, 4, 5, 6, 7, 8]	def f(*x)\n          x\n        end\n        \n\n        f(0,1,2,3,4,5,6,7,8
+be742cca1782a87afe5f5416052525fb	["CHUNKED BODY", "chunked body"]	require "socket"\n            s = TCPServer.new("127.0.0.1", 0)\n    
+be89db2e4e8d046b8a6387300e1417a7	[["Other 1\\n", true], [false, "Line 1\\n"], "Other 1\\n", true, true, "Errno::ENOENT", true, true, ["original data", "new data"]]	require 'fcntl'\n            base = "/tmp/monoruby_test_reopenp_#{Pr
+be99d9b9ef932ccac7c6d76c7e115282	[3, 9, 9, 1]	a, b = 3, 9\n            x = [b, a]\n            r = nil\n            
+bea8826dff62c61422cfd5dbadf7f523	[ArgumentError, "invalid byte sequence in UTF-8"]	x = [150].pack("C").force_encoding("utf-8");\n               (/(.).(.)/.match("ab
+befb7bb929d62293c096da8d0fa1c2f4	false	class Float; alias __orig :==; def ==(o); __orig(o); end; end; 3.0 == 4.0
+beff793a575fd1da376ddff78afa2cac	"ok"	class Plain; end\n            \nbegin; "%c" % Plain.new; rescue T
+bf13f3e9538e69a75bfc907d0f9b3c76	{x: 1, y: 2}	S = Struct.new(:x, :y, :z)\n        s = S.new(1, 2, 3)\n        \ns.decons
+bf354da14296c2321b4a8ddf0cc0624a	[5, 5, nil, 7]	class C; attr_accessor :x; end\n\n        res = []\n        o = C.new\n        res <
+bf380bae0b013e5ef49ff6921b2e19b5	[true, true, 7, true, :meth, true, true, true]	$probe = []\n            path = "/tmp/mrb_load_wrap_t2_#{Process.pid
+bf39db004497b29f8581ac02aee86b02	[[:inner, 9], :outer]	Enumerator.new { |y|\n                 Enumerator.new { |z| z << [:inner, 9] }.ea
+bf3d11668fc5dd6e5e3148589ab67d6a	[]	[] & []
+bf40163bde7aa119153a9bdee95d6f93	"<custom>"	class M\n                  def inspect; "<custom>"; end\n        
 bf421e316fb7533cb8d9a80876438745	[[Infinity], {x: -Infinity}]	[[Float::INFINITY], { x: -Float::INFINITY }]
+bf43e4b5ea5dc43387ed9bdbb1d33e91	["A", 49, "\\n", 65, nil, nil, "end of file reached", [65, 49, 10, 65, 50, 10, 66, 49, 10, 66, 50, 10], ["A", "1", "\\n", "A", "2", "\\n"], [65, 49, 10, 65, 50, 10], [65, 49, 10], "Enumerator"]	require 'tmpdir'\n            f1 = File.join(Dir.tmpdir, "argf_t1_#{
+bf642b858ac68f1754855ea56af9f010	["inherited"]	$res = []\n        class A\n          def self.inherited(subclass)\n      
+bf69a12e40aa6429315d6d5c29ddfe91	[0, 5, 5, 0]	f = File.open("Cargo.toml")\n            begin\n              a = f.p
+bf79cea739fcb7a0ec6546a5b4e6528a	[Encoding::CompatibilityError, Encoding::CompatibilityError, Encoding::CompatibilityError, Encoding::CompatibilityError, "incompatible character encodings: UTF-16BE and US-ASCII"]	(f = ->(x) { begin; x.call; rescue => e; e.class; end }; [f.(-> { File.basename(
+bf9d53c3fd6b4e9d4cb7eef1119ed43f	[false, nil, true, 15, nil, false]	pid = fork { sleep 5 }\n            Process.kill("TERM", pid)\n      
+bfb3c432ce87e3afc690e1a4090e98dd	1	e = [1,2,3,4,5].to_enum\n        e.next\n        
+bfb74f48cb5d72df6c677a6148c66445	[12, 12, 12, 12]	p = Proc.new {|x,y| x * y} \n        \n\n        [p.call(3,4), p.yield(3,4
+bfbe34cf61fcca55c3ea92c6839bb454	1	IO.popen(["false"]) { |io| io.read }\n            $?.exitstatus\n    
+bfdcfc70fda8f2b3db9a8020171aae4b	"AB"	[65, 66].pack("C C")
+bfe630e757e308e4abdf4d36bdcd4969	0	/(?<z>foo)/ =~ "foofoo"
+bffb45c1c4c4bfb1f18ef0093606fbaa	"/tmp"	File.realpath("tmp", "/")
+c02bfb68f21771671d9a8ba7a101c48d	99	class C; def to_int; 99; end; end; o = C.new\nInteger(o)
+c02dd9efb46f0fbc32fc6404c32838a8	[4, 8, 101, 58, 24, 77, 97, 114, 115, 104, 97, 108, 83, 105, 110, 103, 108, 101, 116, 111, 110, 69, 120, 116, 111, 58, 11, 79, 98, 106, 101, 99, 116, 0]	module MarshalSingletonExt; def hi; end; end\n            o = Object
+c05498d2dce695c0c085a97705cf15db	[[[50, 2, 3], [[:e, 70], [:f, 80], [:g, 90]]], [[3], [[:e, 70], [:f, 80], [:g, 90]]], [[2, 3], [[:e, 70], [:f, 80], [:g, 90]]]]	class C\n          def f(*rest, **kw)\n            $res << [rest, kw.sort
+c05bcb586784da1890206d1923334339	"bar"	class Foo\n              def bar; "bar"; end\n              x = "baz"
+c0655828bd6ac1a942d0f73214dcdb55	"xababababa"	"x".ljust(10, "ab")
+c06cb75dcbfbe5108ed3b14e28739fcc	[nil, 0, "[", false]	File.open("Cargo.toml") do |f|\n              c = f.getc\n           
+c0710f66aa32b93c2c5060b354fcb21d	true	r, _w = IO.pipe\n            r.wait_priority(0).nil?\n            
+c07fcc3865dc57f54ec3bdc13bc0b007	42	define_method(:bar) { |x| x * 2 }\n            bar(21)\n        
+c0881cd94be539716025acb5c9e22156	true	Time.utc(2000,1,1).getlocal.is_a?(Time)
+c08acbdd18f61a8d59ca99c4b368848f	"US-ASCII"	"abc".encode("US-ASCII").rjust(5).encoding.to_s
+c095a2c797a127b8e7be93cfb4834bac	300000	def osr_sum(x)\n          total = 0\n          i = 0\n          while i < 
+c09c839979cea217eea20b122b702919	"T:#<TrueClass:0xADDR>"	class TrueClass; def to_s; "T:" + super; end; end\n                true.to_s.sub(
+c09d6cb41615f95536118d7f2c2d3ac5	"UTF-8"	-> { e = __ENCODING__; e.name }.call
+c0bd20c1f72134f81f9605cb0369bad4	["hello", "helloworld", "helloworld"]	path = "/tmp/mr_buf_rw.txt"\n            res = []\n            f = Fi
+c0ccecf51a28d34a9407d29cd759ff8a	[:f, :f]	class C; def f; 1; end; end\n            \n\n            m = C.new.met
+c0d486ae823c1add3b9717cbf806e267	54	[2, 3, 4, 5].inject(0) {|result, item| result + item ** 2 }
+c0ddaa891fb7a63e6690683fe1ec0f3d	[["a"], ["abc"], ["1"]]	[/\\p{Word}/.match("a").to_a, /\\p{Alpha}+/.match("abc").to_a, /\\p{^L}/.match("1")
+c0f4d9f562f9dd0bd39e836e62a9886e	[:rescued]	def boom; raise "no"; end\n            def test; [1].map { begin; bo
+c1115c20142acf811917f45366cfe9fe	[:intercepted, true]	module PcMiss\n              X = 1\n              private_constant :X
+c156933e6602c868faaa2ed9b64aa3db	"4.0nil"	def f\n          if $a\n            a = 1.0\n            b = 1.0\n         
+c163debad94d714f7738a102065dddc5	[{a: 1}]	def f(*x)\n            x\n        end\n        \n\n            f(**{a:1})\n  
+c16bdd04cdf3f5410193045353857953	[:m1, :m2]	class D\n              def m1; end\n            end\n            class
+c17c57dd87c027d558263625f41dd3cf	[true]	[IO::RDONLY, IO::WRONLY, IO::RDWR,\n             IO::APPEND, IO::CRE
+c18661906ca2e772fdad430ac1e5b9bb	[true, true]	a = -49.52\n            id = a.object_id\n            \n\n            [
+c197a049cd35567cfceeaf1bd6c3713f	["path name contains null byte", :no_raise, "path name contains null byte", "path name contains null byte"]	%w[entries foreach children].map { |m|\n              begin\n        
+c19bc4eec6fab3848d5a490d13f7ba1c	["5:in 'Object#inner'", "10:in 'Object#outer'", "11:in '<main>'"]	def inner\n          begin\n            raise "x"\n          rescue => e\n 
+c1acb2e84caf5248f3e686e286fabd3b	[1, true]	base = "/tmp/monoruby_dir_brace_#{Process.pid}_#{rand(100000)}"\n   
+c1b37b0c67caf29fc851a4986dea8d03	0	class MyAry; def to_ary; [1,2,3]; end; end\nobj = MyAry.new\n([1,2,3] <=> obj)
+c1b8f9f9b21272f2e4d55644d9a62241	20	f = lambda { _1 * 10 }; f.call(2)
+c1bb063ef8447e04a64c4c5e22ad4b5c	100	class C\n              D ||= 100\n              D\n            end\n   
+c1c036ee2be7d5996cbeadf631f512d9	1	base = "/tmp/monoruby_test_lchown_#{Process.pid}_#{rand(100000)}"\n 
+c1d87157ff5a01d47e7d4063803b73dd	["sleep", false, true, false]	t = Thread.new { sleep }\n            Thread.pass while t.status != 
+c2014a49d1e30b9f6c135aaec1772a50	[1, 99, 2, 3]	class MyNum; def to_int; 1; end; end\nn = MyNum.new\na = [1,2,3]; a.insert(n, 99);
+c2165d7ba0399023a5673c5d758b88c0	"a:1 b:2 c:[3, {x: 100, y: 200}]"	def f\n          yield 1,2,3,x:100,y:200\n        end\n        \n\n        f
+c2223c03773eac42c8717805d9010dc8	[true, 15]	s = Random.new.bytes(15)\n        [s.is_a?(String), s.bytesize]\n        
+c23c0da3e526eae19f62c4292b4742ae	[1, 2, 3, 4]	(1..10).take_while { |i| i < 5 }
+c246464bb5079a22d329f9492e66ad21	2	"hello".byteindex("ll")
+c24e889e6534a23037c752be10f59b59	[false, "This", nil, " ", nil, "is", 1, "an", 3, " example", 10, " example str", 22, "str", "This is an example ", "ing", 2, 1, "g", 24, "g", true, ""]	require "strscan"\n        s = StringScanner.new("This is an example str
+c257bb9e864287f47978774c855dc69c	"UTF-8"	def f(e); e.name; end; f(__ENCODING__)
+c261d781b9877973a753350ce81c1a13	[9, true, 9]	it = 5; binding.local_variable_set(:it, 9); [binding.local_variable_get(:it), bi
+c28bae0a3135ba3b9c4c6679a486ac05	[4, 8, 67, 58, 9, 72, 97, 115, 104, 123, 6, 58, 6, 97, 105, 6]	Marshal.dump({a: 1}.compare_by_identity).bytes
+c2910de0e0734222b500d1aa225eb6eb	true	class C\n          def f(a = 42); self; end\n        end\n        c = C.ne
+c29bcc58eb00a417bb4c4a4d346075ff	[1, :a]	module M3; C = 1; end\n        x = 0\n        (x += 1; M3)::C &&= :a\n    
+c2a32c061a6df0b6f062900fb9a8b1de	["Not matched", "Matched 1", "Matched 1", "Matched 2", "Not matched", "Matched 1", "Not matched", "Not matched", "Not matched", "Matched 2"]	a = []\n\n        10.times do |x|\n          case x\n          when *[1,2],
+c2d8a47ea38993301137ebb001049fb2	[1, 2]	c = Class.new { def foo(*a); a; end; ruby2_keywords :foo }\n        
+c2d97a349b86a09c5fd224aef7dda8c9	["unknown keywords: :b, :c", "unknown keyword: :z", "missing keyword: :a", "missing keyword: :y", "missing keywords: :x, :y", "missing keyword: :a"]	def one(a:); end\n        def two(x:, y:); end\n        msgs = []\n       
+c2ddc4b987960c63ecfe548001121a15	501	def f; 1; end\n            a = 0; i = 0\n            while i < 20000\n
+c2f1188cf58009e1f4929f6667b6493e	["C", "M"]	module M\n            end\n            class S\n            end\n      
+c3423608f46c2ab24a0a71094cd5ae93	[1, 2, 1, 2]	class MyNum; def to_int; 2; end; end\nn = MyNum.new\nres = []; [1,2].cycle(n) { |x
+c371620ea2df438989e85db786cb3351	[true, true]	GC.config(rgengc_allow_full_mark: false)\n            begin\n        
+c374efe593f3736150bcf4d3b491c4f6	:te2	ar = Object.new; def ar.to_ary; 5; end; begin; [1].product(ar); rescue TypeError
+c395a855a07a1b6fc115ed058695bea2	"İSTANBUL"	"istanbul".upcase(:turkic)
+c3a07328ee0431ca943190fff38d871d	[1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034, 1034]	class A\n          def m(a, b) = a * 10 + b\n        end\n        class B 
+c3bd239c90e457c144a5f47e376ddfee	[true, false, 42]	c = Class.new { attr :foo }\n            i = c.new\n            i.ins
+c3ca1c783780c3d76d7669a9f4d0d745	[true, 5]	class PSubA < Proc; end; p = PSubA.new { 5 }; [p.is_a?(PSubA), p.call]
+c3ffcd6dd0e59f62af3d001787996ea9	[123, 123, "abc", "abc", "123"]	module Foo; end\n            res = []\n            res << Foo.const_s
+c4059aae50d3642d63e42cce975fb78f	[:a, :b]	def m; for a, *b in [[1, 2, 3]]; end; local_variables.sort; end; m
+c418df741a7f92e381a2a8580ecc7074	0	a=42; b=35.0; c=7; def f(x) a=4; end; if a-b==c then 0 else 1 end
+c41e6b2246bc0ba8d8b5f2c8d8a791ea	{x: 1, y: 2, z: 3}	S = Struct.new(:x, :y, :z)\n        s = S.new(1, 2, 3)\n        \ns.decons
+c431f27a212f229c0d702b83f694670a	[true, true]	def f(k: false, j: 1.5); true; end\n        [f, f(k: :x, j: nil)]\n      
+c48885b3fbd7a1a20faf1adae918a3e1	[true, true, true, true, true, false, false, nil, true, true, true, true, false, false, nil]	module Foo; end\n        class Bar; include Foo; end\n        class Baz <
+c4aad381945577c7d224be25741b79c1	["Hello ", "there, ", "Dave", "!\\n"]	class Interpreter\n              def do_a() $res << "there, "; end\n 
+c4b18be49d96a9fcf781e931b81a7adb	true	h = {a: 1, b: 2}; h.rehash.equal?(h)
+c4bd1413a0e0e43d5ccb56e00501ef61	[[[:a, 1], [:b, 2]], [[:a, 1], [:b, 2]], [[:a, 1], [:b, 2]], [[:a, 1], [:b, 2]], [[:a, 1], [:b, 2]], [[:a, 1], [:b, 2]], [[:a, 1, 3], [:b, 2, 3]], [[:a, 1], [:b, 2]], [[:a, 1], [:b, 2]], [[:a, 1], [:b, 2]], [["Proc", true], ["Proc", true]]]	h = {a: 1, b: 2}\n            def two(k, v) = [k, v]\n            def
+c520fc850e949eb2bf64f11afc5f2940	"Foo"	module Foo; end\n        Foo.to_s\n        
+c5374e944984f6dd8304adbe5f87f4d5	[10, 20]	fiber1 = Fiber.new { true }\n            fiber2 = Fiber.new { fiber1
+c53a4d5b6fe802b427b290829cb4dc35	[5, [:a, :b, :c, :d, :e], 0, 3, false, 5, [:a, :b, :c, :d, :e], 1, 3, false, 5, [:a, :b, :c, :d, :e], 2, 3, false, 5, [:a, :b, :c, :d, :e], 3, 3, false, 5, [:a, :b, :c, :d, :e], 4, 3, false, 5, [:a, :b, :c, :d, :e], 5, 3, false, 5, [:a, :b, :c, :d, :e], 6, 3, false, 5, [:a, :b, :c, :d, :e], 7, 3, false, 5, [:a, :b, :c, :d, :e], 8, 3, false, 5, [:a, :b, :c, :d, :e], 9, 3, false, 5, [:a, :b, :c, :d, :e], 10, 3, false, 5, [:a, :b, :c, :d, :e], 11, 3, false, 5, [:a, :b, :c, :d, :e], 12, 3, false, 5, [:a, :b, :c, :d, :e], 13, 3, false, 5, [:a, :b, :c, :d, :e], 14, 3, false, 5, [:a, :b, :c, :d, :e], 15, 3, false, 5, [:a, :b, :c, :d, :e], 16, 3, false, 5, [:a, :b, :c, :d, :e], 17, 3, false, 5, [:a, :b, :c, :d, :e], 18, 3, false, 5, [:a, :b, :c, :d, :e], 19, 3, false]	def m(i) = {a: i, b: 2, c: 3}\n        r = []\n        20.times do |i|\n  
+c55e6248eb41c6e540c40b61f2e992ed	420	class C\n          def f\n            x = 0\n            10.times { x += y
+c56c19f790a407710bd65fa095a58592	[3, 3]	from = 1\n        to = 2\n        [(from..to ? 3 : 4), (from...to ? 3 : 4
+c57f3073a34696e272a4c621e59717cf	false	"a".index(/a/); $~.nil?
+c5f5ea4d7ccb33511960c242704f06f0	[[195], [169], 3, [195, 169], [195]]	s = "\\303\\251\\303".dup.force_encoding(Encoding::Windows_31J)\n               m = 
+c60883d6df2480fbe9ec2ae4e169130c	[200, 300, 250, 60, 200, 300, 250, 60]	class S\n            def f(x, y, a:10, b:20)\n                $res << x\n
+c617cc39117c830a63eb6334242e1a40	[2, "aa", 2, "cc", 2, "bb"]	require "socket"\n            srv = UDPSocket.new\n            srv.bi
+c622030023f401e5576556f338a06cf1	:typeerr	class Bad\n              def to_int; "not an int"; end\n            e
+c62977ddda7102f63ccbfd212390f727	277.5	acc = 0.0\n        i = 0\n        while i < 30\n          acc += i.to_f * 
+c62bb457e32daf91f80df5e888b47539	[true, false, "fresh"]	ENV["MONORUBY_ENV_TEST_REPL_OLD"] = "old"\n            saved = ENV.t
+c637ccc2b9f394757d125bf066549adf	[0, 1, true]	S = Struct.new(:a, :b)\n            \n\n            [\n              S.
+c645f7f040f5628747baf4113d682cec	Array	class C < Array; end\n\n            a = C.new([1, 2, 3])\n            a.shuffle.cla
+c65203960bc3757c2aa2a247a3461786	[true, true]	S = Struct.new(:name, :legs, keyword_init: true)\n            \n\n    
+c65a11bb4b1b448c82e07f864e8135a5	["UTF-8", true]	(base="/tmp/mono_pwd_#{Process.pid}"; Dir.mkdir(base); name="#{base}/あ".dup.forc
+c65dfa6cf6e1e70dbf838b908202198d	nil	->(a = a) { a }.call
+c6683cf0ef52f6cb79ff46704cbc5877	["MyFiber", :done]	class MyFiber < Fiber\n            end\n        \n\n            f = MyF
+c67abacc118f750b4c4602e5803bf054	[true, false]	klass = Class.new do\n              define_method(:initialize) { }\n 
+c68a937ebbf20dbda216eebda6b83971	["x", "x"]	class C; def to_int; 2; end; end; o = C.new\nArray.new(o, "x")
+c69571585acd0ae97070c46877ef1630	"uninitialized constant MdName::NOPE"	m = Module.new { def self.name; "MdName"; end }\n            begin; 
+c6aa47f3d7123c5ac7cf49f88732c23f	[true, [:waiting, :woken]]	m = Mutex.new\n            cv = ConditionVariable.new\n            lo
+c6c590c4f5e99e29b5e950ed25d95e8a	"abcabcabc"	class MyInt\n              def to_int\n                3\n            
+c6cf506f9e1bf56b2c88982b59d4a0fe	[(13/25), (1000/1), (3/200), (3/1), (10000/1), (1/2), (-191/30), "invalid value for convert(): \\"1/-2\\"", :zde, :ae, :ae2, (13/25), (1/1), (1/1), (-191/30), (0/1), (1/100), (19/2), (3/1), (7/2), (0/1), nil, nil, :tie, nil, ["Complex", (1/5), (-2/5)], (1/2)]	bad_to_int = Object.new\n            def bad_to_int.to_int; raise No
+c6d3dade907fe66184348357856a018e	[2, -2, 1, -1, 0, 3, -3, 1, 3, -2, 3, 6, 16, 0]	require "rubygems"\n        require "bigdecimal"\n        res = []\n      
+c6eb9b15a65b550251f8bc847a36dd0d	5.955087954701154e+22	r = 0.0\n            for i in 0..50\n              f = i * 1.1\n      
+c6ec882095c32db233297f4e203f6a3b	[1, 2, [5, 6], 7, 8, 3, 4]	def f\n          yield [1,2,3,4,5,6,7,8]\n        end\n        \n\n        f
+c6f097206e76981036cfc465a5190636	true	Process.maxgroups.is_a?(Integer)
+c6fe44f6e625e7833496d0a607b52675	"Xhello"	s = "hello"; s.bytesplice(0..-100, "X"); s
+c7101771745858d945b8e3d5c923d7a5	[{a: 1}, 42]	h = Hash.new(42)\n            h[:a] = 1\n            h[:b] = nil\n    
+c73d8fd4413dceb9e1c357241d5c7060	[1, 1]	def f(a = false); 1; end\n        [f, f(:x)]\n        
+c74d9a3bb35036e7f36f56e1f583d839	"x"	r, w = IO.pipe\n            t = Thread.new { sleep 0.02; w.write "x"
+c751f92f56c89f58a14286cc0c36da94	"only cause is given with no arguments"	begin; raise(cause: nil); rescue ArgumentError => e; e.message; end
+c768883f4acd41bed94467f44abc3f51	:bar	class Foo\n              def bar; end\n            end\n            \n\n
+c777d09052b733d4effcb9c5d1e3f8c8	[{"a" => 100, "b" => 200}, {"a" => 100, "b" => 246, "c" => 300}, {"a" => 100, "b" => 357, "c" => 300, "d" => 400}]	h1 = { "a" => 100, "b" => 200 }\n            h2 = { "b" => 246, "c" 
+c7802f79b36ab7778aaa91a3179263c5	[4, 8, 12, 16, 20]	[*(1..10)].filter_map { |i| i * 2 if i.even? }
+c7ae74cbc1bdfe4a7722e21761d38540	["0.1235e1", "-0.1235e1", "2", "3"]	require "rubygems"\n        require "bigdecimal"\n        res = []\n      
+c7b8ba87d70241438c36b15d97425b51	"abc"	/(\\w+)/ =~ "abc"; [1].each { }; $1
+c7ceb2821acebf823f33d0bb6ed10208	{amount: 1, unit: "m"}	M = Data.define(:amount, :unit)\nM.new(1, "m").deconstruct_keys(nil)
+c7e692092275e682810d559b51276ff0	52	module Foo\n          BAR = 42\n        end\n        def baz(x)\n          
+c7eb3c942c1a7e00adfa5acdd395b7c7	"bar"	class Foo\n              def bar; "bar"; end\n              alias :ba
+c7fb69f1af1e10ae1e5ae2528ed35951	42	class Foo\n          BAR = 42\n        end\n        \n\n        some = Foo.n
+c7fcb26d3c719c7adab1775ac5cda0b5	[true, true, true]	[\n              Errno::EWOULDBLOCK.equal?(Errno::EAGAIN),\n         
+c801c5a63980ff11f7bd7eff3602884d	[1, 2]	class C; define_method(:m) { |a,| a }; end\n            C.new.m([1, 
+c816041bde5459f3245045930373570e	[[nil, nil], ["a.rb:1:in 'x'"], nil]	err = RuntimeError.new\n        before = [err.backtrace, err.backtrace_l
+c816fde3644e3aa0561e323a872662ca	[true, true, true, false]	[/abc/u, /abc/e, /abc/s, /abc/].map { |r| (r.options & Regexp::FIXEDENCODING) !=
+c82a457d317d4f5cad984d9f01f914c0	["boom (RuntimeError)", "unhandled exception", "ArgumentError", "\\e[1mx (\\e[1;4mRuntimeError\\e[m\\e[1m)\\e[m", "\\e[1mbad (\\e[1;4mArgumentError\\e[m\\e[1m)\\e[m", "a (RuntimeError)\\nb", "m", "\\e[1;4munhandled exception\\e[m", "z (ArgumentError)"]	[RuntimeError.new("boom").detailed_message,\n             RuntimeErr
+c8799d1336ebc55a682946bdf05acb08	"world"	"hello world" =~ /world/\n            alias $MATCH $&\n            $M
+c88b8c3752c39d8970e218b314f54141	:OVERRIDDEN	class Integer; def **(o); :OVERRIDDEN; end; end; 3 ** 4
+c88d879be35ce530404a7d7d86ef3e35	"<STDERR>"	$stderr.path
+c8bf8011aa78146fd38ed4085528fb94	"EUC-JP"	Marshal.load(Marshal.dump("a".encode("EUC-JP"))).encoding.to_s
+c8c5061b79a576ee1e2ea779548f7e63	[[], [nil, nil, nil], [:x, :x, :x], [0, 2, 4], "negative array size", "wrong number of arguments (given 3, expected 0..2)", ["MyA", [:z, :z], false]]	class MyA < Array\n              def self.allocate; $called = true; 
+c8e2a671d745fa2d9c8ee6d19996e1d2	0	123456789123456789123456789123456789123456789[..-3]
+c8e6f7682f6e2ba6c65474d90a14e533	"bang"	t = Thread.new { sleep }\n            t.report_on_exception = false\n
+c8ff2e0bd488186fea065275bd8a264c	[true, true]	a = [1,2,3]\n            id = a.object_id\n            \n\n            
+c8ffe864d471dc51f814e35c9a7e01c6	[30, 10]	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \n[s[-1
+c912b6b05ac5bdaaf8efd791f9455329	[2, nil, "negative level (-1)", "negative size (-1)", true, true]	def lvl2\n              [\n                caller(1, nil).size,\n     
+c91801e4ce439788cd99f4e3ce3955b9	["HCbi", true]	class HCbi < Hash; end\n            h = HCbi.new\n            h[:a] =
+c920c837a40fe8db1cc70a621e714dba	false	binding.local_variable_defined?(:_0)
+c921f6a9c5e6eeda528ca1e442fc5581	[[1, 2, {}], [7, nil, {x: 5}], "wrong number of arguments (given 1, expected 2)", [1, 2]]	class Foo\n              attr_reader :a, :b, :k\n              def in
+c92be7c8455335ce95725c16875fb8ea	[[1, 2], [1, nil], 5, "struct size differs"]	S = Struct.new(:a, :b)\n            K = Struct.new(:x, keyword_init:
+c951489b07a2c303c3b2a936741436aa	{1 => :amount, "m" => :unit}	M = Data.define(:amount, :unit)\nM.new(1, "m").to_h { |k, v| [v, k] }
+c95e82b12f56d193f726165a2ea36520	[nil, -42, -42.4242]	[[].min, [1,2,-42].min, [-42.4242, 100, 999999999999999999999999999
+c9680cb53fc0f3d06760b4803a4f62c9	50.0	[2.7800000000000002, 5.0, 2.5, 4.44, 3.89, 3.89, 4.44, 7.78, 5.0, 2.780000000000
+c97c02f0ab73d588d9ec5c3a5febdc77	[true, true, true, true]	require 'stringio'\n            orig = $stderr\n            $stderr =
+c9a3be96b3cae2aa0ba5aaa77abb03fb	[1, true]	path = "/tmp/monoruby_test_chown_#{Process.pid}_#{rand(100000)}"\n  
+c9a4154fe84fc8b393888e82c5380102	[true, true, true, true, true, true, true, true]	[\n              Process::UID.rid == Process.uid,\n              Proc
+c9ca6f42fac96c8b1cd2b2cb32d2204e	["Refinement", "String", [:shout], 1, false]	m = Module.new do\n              refine String do\n                de
+c9db17651301d6059855d9863a843bfc	[1, 2, 3, [4, 5], 6, [7], 8, 9, 10, 11]	f = ->(a, (b, (c, *d, (e, (*f)), g), (h, (i, j)))) { [a, b, c, d, e, f,
+c9e7ef05749cfbb7600f414d8ffb61cb	true	r, w = IO.pipe\n            w.write "x"\n            box = Object.new
+ca0adf3b136bf932b6e0b7511c794550	1.5	Rational(3, 4) / 0.5
+ca1e0eb8fd577e22648c19c118153570	"refused"	require "socket"\n            # Grab a port that is momentarily free
+ca23ef27e73796162ee1e53425e88043	[2, 1]	class C\n                CONST = 1\n            end\n            CONST
+ca52734c6644d5ea8d449f149120fcc2	[3, -1, :nme]	res = []\n            res << (1 + 2)\n            class Integer\n     
+ca6aea137215ef3580ab386ef7dcb37d	[[1, 2], [1, 2]]	def f(a,b,*)\n              [a,b]\n            end\n        \n\n        
+ca79e057f33cc52f3f630ba69bc2c841	42	x = 42\n            binding.local_variable_get("x")\n            
+ca8e2478f764162473914c7004640057	[10, 20, 30, 40, 50, 60, 70, 80, 1, 2, 3, 4, 5, 6, 7, 8]	class S\n                def initialize\n                    @a = 10\n
+caa5a428511c21ba4721bdcbbcf8f21e	true	Random.srand(42)\n        a = Random.rand\n        a.is_a?(Float) && a >=
+cacaf13ae02371850924314a3901d3fb	[[9]]	class C\n                 def initialize; @log = []; end\n                 def []=
+cae47d49ae46af5b3807106c9e781864	"BYE"	s = "hello world"; s.bytesplice(0..-1, "BYE"); s
+cafecfd681e4d94a313ba7da78fe1925	:OVERRIDDEN	class Integer; def !=(o); :OVERRIDDEN; end; end; 3 != 4
+cb0bc7f4aa93e3a26ac6a8f1dec40146	:reraised	begin\n              raise(Exception) rescue 1\n              :not_re
+cb1c0eadbc0f5e7109f425dcc77dee3d	["SystemExit", true]	begin\n              Process.exit\n            rescue SystemExit => e
+cb4478e73aab25c758637cb13389a676	true	Process.respond_to?(:exit!)
+cb6813c622f9c03c3a741e5ea65819a7	-1	class Integer; alias __orig :-; def -(o); __orig(o); end; end; 3 - 4
+cb7c9ec2433344c197fcd2854cff3c52	"abc"	"abc".center(3)
+cb9f3248f2f6bc5c98916096bf18af2d	[false, nil, nil]	class NilClass; def to_a; $flag = true; super; end; end\n        $flag =
+cba85401e6793856ca7879fbbe19af13	0	Process.euid
+cbc5428b9ea75e034300c93910733635	[10, 20, 30]	class C\n              attr_accessor :x,:y,:z\n            end\n      
+cbe2fdfe5524a2252322956fc39595d8	{}	M = Data.define(:amount, :unit)\nM.new(1, "m").deconstruct_keys([:amount, :x, :un
+cbe3f9d7f0f78ad36ec65a1451b615ad	["hello", "hello", nil]	s = "HELLO".dup\n              [s.downcase!, s, s.downcase!]\n     
+cbe64ded3fd38dffc69ffc58091c15c7	[1, 2, 3, 4, 100]	def f\n                yield [1,[2,3],4]\n            end\n           
+cbef1c6c957859d39ab391994e2eec19	42	class Parent\n          INHERITED = 42\n        end\n        class Child <
+cbef5e866450bcc812bdfa2227f87d4f	[:bar, []]	class Foo\n              def method_missing(name, *args)\n           
+cbf47e030925d52d7a3859c2f64e34d6	[ArgumentError, "incompatible encodings: UTF-16LE and ISO-8859-1"]	(Regexp.union("a".encode("UTF-16LE"), "©".encode("ISO-8859-1")); nil) rescue [$!
+cc22d30b23aca65e57663f87e7e7b55c	["f", "f", "f", "g"]	class S\n          def f\n            "f"\n          end\n          def g\n 
+cc502105da56462b6875a604543b3a6c	99	module M; class N; CONST = 99; end; end\n            \nM.const_get("N
+cc663087814e38d92d69a54be85556da	"e"	class MyIdx; def to_int; 1; end; end\n            s = "hello"\n      
+cc8aebeeff87148f768f16c8f957f04b	[File, Errno::EEXIST, "hello\\nmore\\n", nil, ""]	(f="/tmp/mono_om_#{Process.pid}"; a=File.open(f, File::CREAT) { |x| x.class }; b
+cca80bdce242e79abc49108091469b12	3	module MShip\n              class Widget\n                attr_reader
+ccd878c1f1810dfef13a53d1e1a05fb8	:te	begin; :sym.instance_eval { alias :foo :to_s }; :no; rescue TypeError; :te; end
+ccee79e211a63a6f8408eaaa13a6aee9	[{a: 1}, [1, {a: 1}], {}, "no implicit conversion of Object into Hash", "can't convert Object to Hash (Object#to_hash gives Integer)"]	def f(**o) = o\n            def g(a, **o) = [a, o]\n            m = O
+cd29ece16f52c170d36a353d72be8fb8	[1, 2, [3, 4, 5, 6, 7]]	def f(x,y,*z)\n            [x,y,z]\n        end\n        \n\n        f(1,2,3
+cd2df73dc4bb642c9c1db8166dee2691	true	t = File.birthtime("Cargo.toml") rescue :unsupported\n            t 
+cd4f0795009d40364b489188418b4b29	42	$a = 42\n            alias $b $a\n            $b\n            
+cd5a0ee7ae230ee1ef7198bbdb317c7f	[[20, 60]]	class C\n          def f(a:, b:)\n            $res << [a, b]\n          en
+cd6ec7b17b336346c11d027de22134a3	"ModuleSpecs4::Mod4::N"	module ModuleSpecs4; end\n            m = Module.new\n            mod
+cdd817bbe04dcccd5789be10d0c9e391	true	module MBSpec2; end\n            name = "Wideあmod"\n            MBSpe
+cde7486a8ec494a41cd937151aeb8979	["global", false]	Thread.abort_on_exception = true\n            t = Thread.new { sleep
+cde8be92d24d46ac492d28d94cf6baa4	false	Float::NAN > (1 << 100)
+cdfb00531284d4111c26a83cd032ad5a	["iberico", true, true, "gouda", "stilton"]	module MM\n          class C\n            class << self\n              cla
+ce3cb44e401aaa8cd3345ff6d95183b6	12	class Integer; alias __orig :*; def *(o); __orig(o); end; end; 3 * 4
+ce4131c8f9a4a5e155b38f61bca917e4	[[100, 2, 3, 100, 200, 70], [100, 2, 3, 100, 200, 70]]	class C\n              def f(a,(b,c),d,e:30,f:40)\n                $r
+ce62ddea72f477fdc9d5919218bb9a1c	"missing keyword: :x"	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; def m(x:)
+ce89e95320a8ea01740c37250a1966c9	["A1", "\\nA2\\nB1\\nB2\\n", "A1\\nA2\\nB", "1\\nB2\\n", nil, "", ["A1\\n", "A1\\n"], "negative length -1 given", "A1\\nA2\\n", "", "B1\\nB2\\n", "end of file reached", "A1", ["\\nA2\\n", "\\nA2\\n"], "end of file reached"]	require 'tmpdir'\n            f1 = File.join(Dir.tmpdir, "argf_t1_#{
+ce8eab351b5f58169c33634c2db2f744	[[1, 2], [1, 3], [2, 3]]	class MyNum; def to_int; 2; end; end\nn = MyNum.new\nres = []; [1,2,3].combination
+ce93a6b828d04eedc97c81bbb33e90c3	true	m = Module.new\n            m.set_temporary_name("foo").equal?(m)\n  
+ce97f7e30225b4766661a1ca5eea640e	["US-ASCII"]	"a,b,c".dup.force_encoding("US-ASCII").split(",").map(&:encoding).map(&:to_s).un
+ceb00f8b8ea6a7e9a44636698f8e1014	[0, 123, 321, "TypeError"]	res = [$.]\n        $. = 123.5\n        res << $.\n        obj = Object.ne
+cec2e4a4735508727ba059b9404b5c1e	[true, true]	klass = Class.new do\n          def self.allocate\n            raise "all
+ced5712f3f56898e6479ddda935644e9	5	class C\n            end\n            c = C.new\n            def c.f; 
+cf154d83dbefe1d87cac17d0b188f7dd	[5, 8, 6, 9, 7, 10, 8, 11, 9, 12, 10, 13, 11, 14, 12, 15, 13, 16, 14, 17, 15, 18]	def f(x,y)\n            yield x,y\n          end\n          \n          r
+cf1d7ef2fb786f57a3cf9e0f019f1486	true	Regexp.private_instance_methods.include?(:initialize)
+cf347485acd73ea7a73489e5f1fbd249	"ASCII-8BIT"	("hello %s" % 195.chr).encoding.to_s
+cf356b4efb46036b428c784f29f8dc15	["3.140000", "1-2", "raised"]	class MAry1; def to_ary; [3.14]; end; end\n            class MAry2; 
+cf3b55682f6ea08ebc4b9fe0dcc62971	[[0, 3, 5, 9, 12, 4], A]	class A < Array\n        end\n        \n\n        mul = 3\n        a = A.new
+cf6872bba5781ae3921f031445dcb5b8	[1, 2]	class C\n              define_method(:m) { |a| a }\n            end\n 
+cf6bd38f8f98b72059f152760441d427	[true, 5, false, nil, false, nil, false, false, true, 1280, true, false, false, true, true, true, true]	pid = fork { exit 5 }\n            Process.wait(pid)\n            s =
+cf85f9548841ec0b0c470064817b4d36	""	f = File.open("/dev/null", "r")\n            f.read(0)\n        
+cf9672bc0f3346ba3de51fd90ea702e4	[:foo]	$res = []\n            class C\n              def self.singleton_meth
+cfa30b29bf3ccea5e600ee36663af61d	["US-ASCII", "US-ASCII", "US-ASCII"]	s = "abc".dup.force_encoding("US-ASCII")\n              s.partitio
+cfaf7efe92a4e7e016bf9da03af47c5a	[true, "m"]	bytes = Marshal.dump(Enumerable)\n            t = Marshal.load(bytes
+cfd1776d77256768f5ae301400965afe	["No such file or directory - no-such-cmd-xyzzy", 127]	begin\n              Process.spawn("no-such-cmd-xyzzy")\n            
+cffe2bea88b632377cf81196a0f5adbc	:OVERRIDDEN	class Integer; def %(o); :OVERRIDDEN; end; end; 3 % 4
+d005def98ec838cc7d6f37a7bdf0aaa0	[1, 2, 42, 12]	def f(x,y,z=42,w=12)\n            [x,y,z,w]\n        end\n        \n\n      
+d00a59254916621fa57745491676e04c	[true, false]	m = Module.new\n            m.freeze\n            ok = false\n        
+d01f7af924363a6dde43e88de3de59d1	nil	"hello".byteindex("x")
+d044b1d1eedcdda6f15b67ec84350344	4	"hello".byteindex("o")
+d05976bbfb14033f00937939ab90a32c	36000000	class Lib; def twice(n); n + n; end; end\n        $lib = Lib.new\n       
+d07ee4e87e21212dcf67ec14eaa4fbbc	Object	include Math\n        
+d08434c822205293acd0c331ff42f857	"Object"	Time.superclass.to_s
+d08702c38e94487e4a318ebe2df55f9b	["A1\\n", "A2\\n", "B1\\nB2\\n", nil, "A1\\n", "A", "2", "ASCII-8BIT", "A1\\n", "end of file reached"]	require 'tmpdir'\n            f1 = File.join(Dir.tmpdir, "argf_t1_#{
+d0bb585537946665509f62335ccbc169	[{c: 3}, nil]	f = Fiber.current\n            f.storage = {c: 3}\n            r = f.
+d0c220ecab6e9d45055a59739b820795	[false, true, true, true, false, false, :not_locked, :recursive]	m = Mutex.new\n            r = [m.locked?, m.try_lock, m.locked?, m.
+d0c6abf7f73c6d4b08fdf4d5b4cc620a	"  あい   "	"あい".center(7)
+d10b829ef1e04926b1eae930571f658d	55	class C\n              def initialize\n                @x = raise("er
+d12a3b0760c9f5495da3bdd386716f31	1764	class Foo\n          def foo(arg)\n            yield arg\n          end\n  
+d133788290afc523b36cbba30cef7365	[".", "..", "Cargo.lock", "Cargo.toml", "a.rb", "b.rb", "build.rs", "builtins", "c.rb", "gem", "src", "stdlib", "tests", "vendor"]	Dir.entries(".").sort\n            
+d14d27a0ccbf206a99bcc45de94738e6	[:start, :end]	states = []\n            fiber = Fiber.new { states << :start; fiber
+d157b5aa41a0464df41645c0e9994fd0	42	class MDProto\n              attr_reader :x\n              def initia
+d15e7cd2159b999732c814af04194abe	["b", "a", "z", 1]	cls = Class.new do\n          def bar; ['a']; end\n        end\n        ob
+d18e5eb60974a2044761b9d441234d80	[true, true, true, true, true]	c = Class.new do\n              def public_one; :one; end\n          
+d192f501e35fa1bc0e0242a09104fe74	[["warning: non-nil '$/' is deprecated", "warning: non-nil '$/' is deprecated"], ["warning: non-nil '$,' is deprecated"], ["warning: non-nil '$;' is deprecated"], ["no longer effective"], ["no longer effective; ignored"], true, ["warning: global variable '$completely_uninit_gvar_zz' not initialized"], true]	def cap\n          saved = $stderr\n          buf = +""\n          io = Ob
+d19be72e25b9de2024bf0d36a3f8d563	{"a" => 1, "b" => [2, 3]}	require "json"\n            JSON.parse("  {  \\"a\\" : 1 ,  \\"b\\" :  [
+d1a295f75a785d2141f8551da1a6f041	Array	class C < Array; end\nC[1,2,3].map { |x| x }.class
+d1a2f6b3b40a551652027bc197b91882	[:deferred]	def run_masked(timing, blocking = true)\n              klass = Class
+d1b8a6b7678b598205d8118224d254db	"99"	class HasToI; def to_i; 99; end; end\n            sprintf("%d", HasT
+d1fb6e221ee581e85d0263cbc4321970	[false, false, false]	[$VERBOSE, $-v, $-w]
+d22622fcd363dab097a0d4aa0bfe2e93	30	def f(a:, b:)\n          a + b\n        end\n        \n\n        f(a: 10, b:
+d241f6cfa000d985ad83831917fcd9ab	15	def f(x)\n          yield *x\n        end\n        \n\n        f([1,2,3,4,5]
+d248c4c75d6d6152979eacdd22264ac7	[true, "3.2", "OS"]	T = Struct.new(:version, :platform)\n            \n\n            pos =
+d251e356957ab6fc062c3f28a863a7d8	[[TypeError, "wrong element type Integer (expected array)"], [ArgumentError, "element has wrong array length (expected 2, was 3)"], [ArgumentError, "element has wrong array length (expected 2, was 1)"]]	h = { a: 1 }\n            [\n              (begin; h.to_h { |k, v| 5 
+d28ba746b6e9c87f48b3e3e7b6c1a0f5	[["x", "y"], false, false]	base = "/tmp/monoruby_dir_instchildren_#{Process.pid}_#{rand(100000
+d2a85e324b33b9f9990c7beff0a3d580	[:found, :found, ["EvA::EvB", "EvA::EvB", "EvA"], :found, :found]	module EvA\n              Lookup = :found\n              module EvB\n 
+d2b6db2c9aa9c30420a314b4f596b01f	:OVERRIDDEN	class Integer; def <(o); :OVERRIDDEN; end; end; 3 < 4
+d2d1880f3dd38515f65d753514537dd7	["one\\ntwo"]	$/ = nil; r = "one\\ntwo".lines; $/ = "\\n"; r
+d2d68c2a74f6d68120e5956fce5a79a5	[[42, 42, 5, 42, 4], A]	class A < Array\n        end\n        \n\n        a = A.new(4, 42)\n        
+d2dd6a660aa2f306d4fade3735511335	[[10, 0, 1, 100], [10, 0, 2, 101], [20, 1, 1, 100], [20, 1, 2, 101]]	out = []\n               [10, 20].each.with_index do |a, i|\n                 [1, 
+d2e3132d8485717e9e7b6c31358ee82f	[1, 2]	[->{ _1 }.arity, ->{ _1 + _2 }.arity]
+d30342d7b758abff40f7d6b3c8477b6b	[10, 20, 30]	class C\n              attr_accessor :x,:y,:z\n            end\n      
+d333b9dcc1340bcc14af5a43f9166fa7	["bb", "cc"]	"foo" =~ /(o+)/\n            e = Enumerator.new { |y| "bb" =~ /(b+)/
+d33d9a4d8c30a6c6ae6f174ccdc5dd45	true	GC.enable; GC.disable; GC.disable
+d35145572a23f1c9be8cde778c274d8a	10	a = 5\n        p = proc {\n          a = 10\n        }\n        a = 1\n     
+d368d68db28c315d554367c978f045d5	84	def bar(&)\n          yield 42\n        end\n\n        def foo(&)\n         
+d3861dd96a95e0c96f222a0649294cc2	[true, false]	class InstanceExecA; end\n            InstanceExecA.new.instance_exe
+d38763b6db5668e8a9221af0a0fe22f0	["constant", nil]	module M\n          C = 1\n        end\n    \n\n        [defined?(M::C), def
+d38a6188952e22ee5c8f4c60ce1a5ac1	true	require "json"\n            original = {"key" => [1, "two", nil, tru
+d38e6fd95270224ae4681f1f484197db	[:none, :none, :low, :mid, :low, :mid, :low, :mid, :high, :high, :high, :high, :none, :none]	def bucket(n)\n          case n\n          when 10, 12, 14 then :low\n    
+d3acb7d398b9ef1fed07541b51646641	[1, :a]	module M2; C = nil; end\n        x = 0\n        (x += 1; M2)::C ||= :a\n  
+d3b6f86401efda2e8d91b23f0ee0fc74	false	m = Module.new do\n              eval "module_function"\n            
+d41d12b7a01731a69b781898eb370912	[3, [:gt, :lt, :gt, :lt]]	class C\n              attr_reader :calls\n              def initiali
+d4217108da72ed932f312a232db996af	["method", nil, "method", "method", nil, nil]	module DefM1; end\n            class DefR\n              def respond_
+d4340baf53f6574d84b54cdb783df9b8	2	$x = 0\n            begin\n              $x += 1\n              raise 
+d4349d852cf60f39c3e6adcdc9ab0313	[:bar, [{a: 1, b: 2}]]	class Foo\n              def method_missing(name, *args)\n           
+d4446ffb96e085f7f76798c18cf331c5	:OVERRIDDEN	class Integer; def >=(o); :OVERRIDDEN; end; end; 3 >= 4
+d4718d9b7f7a7afcf1379197ca836a9a	[IO, true, [ArgumentError, "wrong number of arguments (given 3, expected 1..2)"], [ArgumentError, "wrong number of arguments (given 3, expected 1..2)"], [ArgumentError, "mode specified twice"], [ArgumentError, "invalid access mode "], [Errno::EINVAL, "Invalid argument"], [TypeError, "no implicit conversion of String into Integer"], [TypeError, "no implicit conversion of IO into Integer"], Errno::EBADF, :mode_kw, :int_mode, :toint_kw, ["UTF-8", "ISO-8859-1"], ["UTF-8", "ISO-8859-1"], ["UTF-8", "nil"], "nil", [ArgumentError, "encoding specified twice"], [true, "ASCII-8BIT"], [true, "ASCII-8BIT"], "ISO-8859-1", "ISO-8859-1", [ArgumentError, "binmode specified twice"], [ArgumentError, "both textmode and binmode specified"], [ArgumentError, "both textmode and binmode specified"], [ArgumentError, "both textmode and binmode specified"], false, 3, false, true, IO, :blockval, true, [ArgumentError, "boom"]]	require "tempfile"\n            t = Tempfile.new("mrb_ionew")\n      
+d48868180accf425c1cce5bbb37022fc	:OVERRIDDEN	class FalseClass; def ==(o); :OVERRIDDEN; end; end; false == false
+d4b11df043d7e94411357a9fb1a4b7b9	true	"hello".index(/z/); $~.nil?
+d4b1bfe9eda9533ed079348cdba23ae4	"abcaあ"	"あ".rjust(5, "abc")
+d506260ac377e92b5498fb8e6ec73750	true	GC.stat(nil).is_a?(Hash)
+d52efc39591dfa6b41cc1b74f647a5cf	["ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError"]	def g(a, b) = a + b\n        def f(...) = g(10, 20, 30, ...)\n        \n\n 
+d55e1c488a964698d1d9d4f121c8d95c	[["UTF-8", nil, nil, nil], ["ISO-8859-1", "nil"], ["ISO-8859-1", "UTF-8"], ["ISO-8859-1", "UTF-8"], ["UTF-8", "ISO-8859-1"], "nil", "ISO-8859-1", "ISO-8859-1", :tohash_ok, :blockresult, [true, true], [true, true], :inner_close_ok, [MrbPipeSub, MrbPipeSub], [:init, :init], [MrbPipeSub2, MrbPipeSub2], "through\\n"]	r = []\n            IO.pipe { |a, b| r << [a.external_encoding&.to_s
+d56f2419ff718092d450e601c3289b76	[nil, "a\\nb"]	$/ = nil; s = "a\\nb"; r = [s.chomp!, s]; $/ = "\\n"; r
+d580dc9cae27404632621b762b7de5a8	""	f = File.open("/dev/null")\n            f.read\n        
+d596c9980b2a827151179a99b5e3af5e	{"amount" => 1}	M = Data.define(:amount, :unit)\nM.new(1, "m").deconstruct_keys(["amount"])
+d5af874066319ba603a85fd17d84867b	[1, true, 15, false]	pid = fork { sleep 5 }\n            count = Process.kill("TERM", pid
+d5df22aa40370195aea7d6fbeed48540	[true, 0, false, 1]	IO.popen(["true"]) { |io| io.read }\n            a = [$?.exited?, $?
+d5eb36d331547e68e65b5e236315bb2c	false	File.exist?("../LICENCE-MIT")
+d5ec889974c38262d62062c5b088a2ff	"ASCII-8BIT"	"abc".b.reverse.encoding.to_s
+d5f2b019270b0aa4e77071d07cc78f9c	"secret"	class Foo\n          private\n          def secret; "secret"; end\n       
+d6091e4e156deac18f133b8aca6d3e2a	[[103, 111, 111, 100, 32, 100, 97, 121, 32, 128], "UTF-8", false, [103, 111, 111, 100, 32, 100, 97, 121, 32, 128], false, [103, 111, 111, 100, 32, 100, 97, 121, 32, 128], false]	a = sprintf("good day %{invalid}", invalid: "\\x80")\n            b =
+d66a6a23a3ed91b71d300b263592de36	[[1, 3], [2, 4]]	o = Object.new\n               def o.to_int; 3; end\n               r = []; [1, 2]
+d66e832dd58d8b0895c00647a07051e9	"ab"	r, w = IO.pipe\n            w.write("ab")\n            out = r.sysrea
+d68149041b7bd9d31e303f70e9b68d9e	[true, false, true, false, "closed stream"]	require 'fcntl'\n            require 'io/nonblock'\n            res =
+d6855dfda45a033f96e13fcd9718eeb2	[0, 1, -1, 2, -2, 3, -3, 1, 2, 3, 4, 5, 6, 7, "Infinity", "NaN"]	require "rubygems"\n        require "bigdecimal"\n        res = []\n      
+d69d2ef84b7ac3883da56b99ecdd1722	[nil, nil]	S = Struct.new(:name, :legs, keyword_init: true)\n            \n\n    
+d69feae00b538afc09fbb9f6341e403e	:OVERRIDDEN	class Integer; def >(o); :OVERRIDDEN; end; end; 3 > 4
+d6b1e91ca6f365857969484299ed0f51	nil	/(?<z>foo)/ =~ "nope"
+d6b954fc5289ea6d95ff086bc292725e	[1, 2, 3]	class A < Array; end\nA[1, 2, 3]
+d6bfe4296b93f2e640133c89a4ab8e47	false	def g; proc{ 1 }; end; g == g
+d6c0eb29e576b66ef1234e2d00a6f0b7	[[1, 0], [2, 1]]	r = []; [1, 2].each.with_index(nil) { |v, i| r << [v, i] }; r
+d6fd88af713f62b2a7bf0032d40dad05	6	def inner(&)\n          yield 1, 2, 3\n        end\n\n        def middle(&)
+d711a3f5a6c7df97c22c300e85978f40	nil	m = method(:gets)\n        m.source_location\n        
+d71c934480e135d29e482184c781d14a	[true, :PRIV]	module RcvV\n              class Base; PRIV = 1; private_constant :P
+d72491ac5b346cc00a4b205572a40779	false	ENV[""]      = nil\n            ENV["a=b"]   = nil\n            ENV.k
+d73852b1cc0988b573a8ac0d26714459	true	class C\n          def initialize; @percent = 7; @start = Time.now; end\n
+d743ebb1ae4f3634827d1cf257e34b99	[4, 8, 12, 16, 20]	(1..10).filter_map { |i| i * 2 if i.even? }
+d7727c6111808f529a320fda4e7cb48b	[[195]]	m = /#{/./}/s.match("\\303\\251".dup.force_encoding(Encoding::Windows_31J))\n      
+d774e46c066fe58e1b5886fed882b4a9	5	c = Class.new { def orig; 5; end }\n            c.class_eval { alias
+d77d6e3d33b3312be174ad8da7e0e5f2	100	::E = 100\n            \n\n          Object::E\n            
+d7a8eac3a6c15ba148aee3036a8d25e9	[1, 2]	class A\n              def initialize\n                @a = 1\n       
+d7b7a2adf595d788eafc6107fd926703	:ok	class C\n              def to_str\n                raise "to_str call
+d7cddd59ea5e58d2b97def80b58cf0b7	"bar"	class Foo\n              def bar; "bar"; end\n              x = "ba"\n
+d7fdb13d1246ad38b82fc7261735f109	"mm:baz:[10, 20, 30]"	class Foo\n              def method_missing(name, *args)\n           
+d803f34a97466662863ea8f41dca21cd	["wrapped", "the cause", ["/dir/foo.rb:10:in `raising'", "/dir/bar.rb:20:in `caller'"]]	wrapped = begin\n              begin\n                raise "the caus
+d8285233ef069114e2a828a15a93a579	[[1, 2, 7], [10, 8, 3], [1, 2, 3]]	def f(a:1,b:2,c:3)\n          [a, b, c]\n        end\n        \n\n        [f
+d83209b9961e083672b237cbc756ca17	14	b = binding\n            b.eval("y = 7")\n            b.eval("y * 2")
+d877a4927bccad0844990bad82525907	"US-ASCII"	"hello".encode("US-ASCII").capitalize.encoding.to_s
+d879edf56856687d0b1c88dcaebb0402	["C", "M2", "M1"]	module M1\n          def f\n            $res << "M1"\n          end\n      
+d889ad006dc6737982d507f7317622e8	[10, 20, 30]	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \n[s["a
+d8b0d018647384bbab864dd283908894	[:x, :y]	D = Data.define(:x, :y)\nClass.new(D).new(1, 2).members
+d8ec5385ee072765ba7b565e51313657	[777, 777]	class Integer\n          def sub_impl(o); 777; end\n        end\n        $
+d9300c97f073adabeb7a50ccd6acbd23	0..300	a=1\n            b = for a in 0..300 do\n            end\n            
+d937a0a05e129d6461564c4b72d2b8e9	[2, -1, [[:req, :a], [:req, :b]], true, 30]	class C\n              def f(a, b); a + b; end\n              def g(*
+d9392deb40395a4dd8b8c603adf94553	[["a", "b"], true]	require "open3"; oe, st = Open3.capture2e("sh", "-c", "echo a; echo b 1>&2"); [o
+d95cabdb6b92c504c151f149a6465413	"!dlroW ,olleH!dlroW ,olleH!dlroW ,olleH!dlroW ,olleH!dlroW ,olleH!dlroW ,olleH!dlroW ,olleH!dlroW ,olleH"	("Hello, World!" * 8).reverse
+d96d6c2d2ebdc06aa1ab3fb58f8bea51	""	"" * 1000000
+d983e7db9d163a4ca80f799fde2142df	[42, 42, 42, 42, 42, 42]	class C\n          def f(x)\n            $res << x\n          end\n        
+d9a13378cc29516431f2b68cb4b919b8	[{a: 1}, {"a" => 1}, "no keywords accepted", "no keywords accepted", "no keywords accepted", 7]	def rescue_msg\n              yield; :no_error\n            rescue Ar
+d9a94d316312aac17ec22c9acdb10a2b	""	"".capitalize
+d9aac8622fd7230af0d918b7a5becccb	"linux"	def f(x); end\n            x = " #{f 3} "\n            f("windows")\n 
+d9c21e9eac2ce2e0a734b0b423439482	["handler-on-main", 0]	r, w = IO.pipe\n            pid = fork do\n              r.close\n    
+d9ca212114c5295ffd282d0c61bddd6b	["Cargo.toml", true]	f = File.open("Cargo.toml")\n            f.close\n            [f.path
+d9d20af49fe37450af6f1dc79ef6ccc4	55	(1..5).inject(0) {|result, item| result + item ** 2 }
+d9de1a03f33b576a32ef1eb7f7a2e067	[false, true]	o = Object.new\n            def o.foo = 1\n            d = o.dup\n    
+d9f7b95eb0adc505bdb41061104b41e8	0	class C; def to_str; "hello"; end; end; o = C.new\n"hello" <=> o
+da071b966818f27d5bc0ddb0f84eb172	[false, true, true, true, false, true, false, true]	S = Struct.new(:a, :b)\n        T = Struct.new(:a, :b)\n        \n\n       
+da0f0adcfe40c1b122d44d207d5921fb	[[1, 2], [:scalar, nil], [:pk, :pv], [:s1, :s2], [nil, nil], [4.5, nil]]	def drive(a)\n              acc = []\n              a.each_with_yield
+da20ef8164c16f9d050189c7530ccdda	13	case 4\n        when 0\n          a = 10\n        when 1\n          a = 11\n
+da337801ffb5841d6913419d4806674b	[[1, 2, 3], [1, 2, 3], 1, 3, [1, 3]]	a = [3, 1, 2]\n            [\n              a.sort { |x, y| (x <=> y)
+da424b8ae2f6063fa60766fab8bac34a	false	t = Thread.new { sleep(2**62) }\n            Thread.pass while t.sta
+da5e06d1fe5eed1ee4258f71a99b2332	0	a = "abc".dup.force_encoding("UTF-8")\n              b = "abc".dup
+da64841b8187b9d8951f84703a56f5e9	[true, false]	$x = []\n            path = "/tmp/monoruby_test_mkdir_#{Process.pid}
+da6b246283b4f211581ca1d5eb140461	"a b\\n"	IO.popen(["echo", "a b"]) { |io| io.read }\n            
+daa7019f1dfb40422c47287a212b59ec	[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]	class C\n          def foo; 1; end\n        end\n        res = []\n        
+dae52af79f68fd59e79d94c60e7c3a75	"US-ASCII"	s = "abc".dup.force_encoding("ASCII-8BIT")\n              s.unpack
+dae678c7230abbc68fd9e71f3ce16a0c	8400	class Target\n          def value_plus(n) = 2 + n\n        end\n        cl
+db00180168f82ac3f47a720c4c80a330	[]	[] | []
+db1d122ccf500fce3b16c8ab7548f6cf	"ab"	$/ = "cdef"; r = "abcdef".chomp; $/ = "\\n"; r
+db1e8e1f47867fdb41ead37f6e942df5	[42, 42, 42, 42, 42, 42, 42, 42, 84, 84, 84]	class A\n              attr_accessor :w\n            end\n            
+db669eb4e1eed6b70dd2a9b3287338bb	[3, 5, 4]	class MyNum\n              include Comparable\n              attr_rea
+db677610a3328f0c2ee7403b32b3de80	["3:in 'Object#a'", "4:in 'Object#b'", "5:in 'Object#c'", "7:in '<main>'"]	def a; raise "x"; end\n        def b; a; end\n        def c; b; end\n     
+db8f70ed18c906c1d83c430b4c518b9c	48	class Integer; alias __orig :<<; def <<(o); __orig(o); end; end; 3 << 4
+dba2d7d71196ffa6ba5cc0dfc0c8e092	"!"	r, w = IO.pipe\n            begin\n              $\\ = "!"\n           
+dba8c999f223349114b2637336cb1407	true	Process.getpriority(Process::PRIO_PGRP, 0).is_a?(Integer)
+dbac611098d272f9af09e0a0f0872a71	7	obj = Object.new\n            obj.define_singleton_method(:add) { |a
+dbc18dfb07e0bf31beaad3fdb0a50b52	3	"hello".byteindex("lo", -3)
+dbc20278d0d856cfb185f95ac488161b	[nil, 3, 5, "abcde"]	path = "/tmp/mr_buf_points.txt"\n            res = []\n            f 
+dc0885a7e9180887b8b86834b910e71a	10	class A\n              @@shared = 10\n            end\n            cla
+dc345e0d19a0322fc6ca94e04b4104b0	"nil"	path = "/tmp/monoruby_io_bomg3_#{Process.pid}_#{rand(100000)}"\n    
+dc394b9cda9ab3b993fea72b28cac8a0	[:imported, "ArgumentError: #rm", "ArgumentError: #dm", :imported, "ArgumentError: #foo", "ArgumentError: #am", "ArgumentError: #kw"]	probe = lambda do |src|\n              begin\n                Module.
+dc3f2c1c601ee25acabb218a6cdbf2ba	"custom_argv0\\n"	r, w = IO.pipe\n            Process.wait Process.spawn(["/bin/sh", "
+dc46fc2af0d8cdf7f503978a0a044521	[{"a" => 100, "b" => 357, "c" => 300, "d" => 400}, {"a" => 100, "b" => 357, "c" => 300, "d" => 400}, {"a" => 100, "b" => 357, "c" => 300, "d" => 400}]	h1 = { "a" => 100, "b" => 200 }\n            h2 = { "b" => 246, "c" 
+dc4f9ee2cdc75359817229684847545b	[nil, nil, nil]	class C; def to_int; 3; end; end; o = C.new\nArray.new(o)
+dc8c0fed605309d0ac56a18fa4f96131	[1, -1, 2, -2]	class Foo\n              def a(x:); end\n              def b(x: 1); e
+dca050e66a831044f8036e5e5e53de5e	[true, false]	class ModEvalBlockA; end\n            ModEvalBlockA.module_eval {\n  
+dca1fe10428b94607119699e4536affd	77	module Foo\n          def self.Bar; yield; end\n        end\n        Foo::
+dcb299cee36b3bcad2f0615af4c007af	true	File.exist?("../LICENSE-MIT")
+dcc86ed827f6b6845b9c7cf7a78c4c2f	"ababxababa"	"x".center(10, "ab")
+dce9ecd5cb55866eac9f8003fbb5343b	"UTF-8"	/#{"あ"}/.encoding.to_s
+dcfeee4a0f36c226b961d97eee897e9b	true	(require "stringio"; old=$VERBOSE; $VERBOSE=true; s1=StringIO.new; $stderr=s1; f
+dd3c071c4a6f6953708de611a7d532e1	true	d = Dir.new("/tmp")\n            begin\n              fd = d.fileno\n 
+dd59ae7dd4e6777883a269edec790eb4	[[195], 2]	s = "\\303\\251\\303".dup.force_encoding(Encoding::Windows_31J)\n               m = 
+dd6ba415513db8cf6aad7ef750eaedc1	[99, 97, 102, 101, 204, 129]	s = "café".dup\n            s.unicode_normalize!(:nfd)\n            s
+dd7215ba379fc74d14dd5dd32b95ff3e	"circular causes"	begin\n              begin\n                raise "Error 1"\n         
+dd8750e730148376d88a9f3c0768a481	[true, true, true, true, true, true]	_r, w = IO.pipe\n            [\n              w.wait(:w, 0) == w,\n   
+dd9fdf5bf20e5c51c71f01d1236eba44	Array	class C < Array; end\n(C[1,2] + [3]).class
+ddf316887c271d6578314a6be120991f	[300, 300, 599, 0, 299]	h = { 0 => 0, 1 => 1, 2 => 2, 3 => 3, 4 => 4, 5 => 5, 6 => 6, 7 => 7, 8 => 8, 9 
+de101e25e7a853fe0c9708bc2adb754c	true	FileTest.executable?("/bin/sh")
+de380c92af41a21d06d2ec9ba8e97c01	[1, 2, 42]	def f\n          yield [1,2]\n        end\n        \n\n        f { |a,b,c=42
+de387ac8bf934d8f07086b9e2b4a50ed	42	$. = 42; $.
+de3f2322030d1ec856a9f41781bd41a8	[[:amount, :unit], [:amount, :unit]]	M = Data.define(:amount, :unit)\n[M.members, M.new(1, "m").members]
+de45ad555f2bc9cedadc3fa83f510527	:timeout_ok	m = Mutex.new\n            cv = ConditionVariable.new\n            m.
+de521c9dde3d5c4cdfdcda53477a4a7a	[7, 11, [:v, :v=, :w, :w=]]	c = class A\n          def f(x,y)\n            @v = x\n            @w = y\n
+de66948e25a28714509d336867317012	""	require 'stringio'\n            old_stderr = $stderr\n            old
+de798d02c5c298e75dec774c3d08450b	["REFINED", "1", "[1]", "REFINED"]	module BopToS\n              refine(Integer) { def to_s; "REFINED"; 
+de8f2a99d0a0ebbc8d17c6ce43050021	["line 1\\nline 2\\n", "a\\nb\\n", "ends\\n", "noend\\n", "1\\n2\\n3\\n", "\\n", ""]	require 'stringio'\n        def cap; $stderr = StringIO.new; yield; s = 
+de98b251e3ebf208ae7ea77852cdad4f	[true, true, true, nil, nil]	module Foo\n        end\n        class Bar\n          include Foo\n        
+dea62e9108f7ef43d5c3c4752f9330ed	"missing keywords: :amount, :unit"	M = Data.define(:amount, :unit)\nbegin; M.new; rescue ArgumentError => e; e.messa
+deafe62615f91940bdeda9cef75c0610	"strin!!"	buf = "string"; buf[-1]="!!"; buf
+deb1d91f607fb81fe26ecc9ca137d819	{life: 42}	fiber = Fiber.new(storage: {life: 42}) do\n              Thread.star
+deb8b733df4a5a9837f150a810bdbfe0	"/root"	Dir.home
+dec9ce41ee836366dedf2e5db7363e5b	"ok"	r, w = IO.pipe\n            w.close\n            w.close\n            
+ded6cc95036ce2f1c7d6ff7d5b3ae644	"/tmp/foo"	File.absolute_path("foo", "/tmp")
+dee21aeabe3cb960452b29b864aa6314	"1"	def foo\n          $b.call\n        end\n        \n\n        a = :a\n        
+dee5d1cd42abcbeb7d1aebf177fe0e8a	["a\\n", 1, "b\\n", nil, 2, []]	require 'tmpdir'\n            f = File.join(Dir.tmpdir, "kgets_#{Pro
+defa1145949f74e2ca84a6ddce5ee08d	"/tmp"	File.absolute_path("/tmp")
+df018ab2640c15dd463c238bcce26100	[[:arr, [1, 2]], [:hash, "Alice", 30], :num, [:find, [1, 2], [4, 5]], [:str, "s"], true, true, 7, nil, {b: 2, c: 3}, true, :one, :one, 2, [:ok, 200]]	$r = []\n        # array / find / hash / alternation / pin / capture / g
+df46158f126ca3ea051f9b218ab9105b	"/home/user/monoruby/monoruby"	Dir.getwd
+df48934b67ebb92f6a00864d45d57fbe	["b\\n", "c\\n", "stdin-data", "stdin-data", "stdin-data", "via-to-io\\n"]	require "tmpdir"\n            res = []\n            Dir.mktmpdir do |
+df69cc830a2b224352a7c2847dff058f	["No such file or directory - foo", "Permission denied - bar", "File exists"]	[\n              Errno::ENOENT.new("foo").message,\n              Err
+df85e93711d6910d9235fee67c3b3ad4	[1, 2, 42, 55, 3, 4, []]	def f(x,y,a=42,b=55,*z,c,d)\n            [x,y,a,b,c,d,z]\n        end\n   
+df9ef4247e8eb28799b29a3c0ceae30e	"US-ASCII"	"abc".dup.force_encoding("US-ASCII").gsub(/b/, "x").encoding.to_s
+dfa6493490a950a4a97d2766f58d2dd5	7	p = Proc.new { |x, y| x + y }\n            define_method(:bar, p)\n  
+dfb8f5dd8fef254047d34541fb3b1231	229	class C\n                def f(x,y,z,a:1000)\n                    x+y
+dfc42a777c7f83e4c7bf0de522556f8b	[ArgumentError, "boom"]	h = { "d" => 4, "b" => 2, "a" => 1, "c" => 3, "e" => 5 }\n          
+e025a42ea6959b901cc28694e25f35a9	true	Random.srand(42)\n        results = 10.times.map { Random.rand }\n       
+e04102db31563efacf03513f5ddbcdd6	{"MONORUBY_ENV_TEST_SL1" => "x", "MONORUBY_ENV_TEST_SL2" => "y"}	ENV["MONORUBY_ENV_TEST_SL1"] = "x"\n            ENV["MONORUBY_ENV_TE
+e0430993ff49221b4ff142a12a2d9ee6	[1, [:gt, :lt, :gt, :lt]]	class C\n              attr_reader :calls\n              def initiali
+e093793f4006c99f09965c6fde38e86b	42	class Foo\n          def initialize\n            @x = 42\n          end\n  
+e09c62f66a3c3f3ed8999368ae421637	[true, [Errno::ENOENT, "No such file or directory @ rb_check_realpath_internal - /no_such_dir_zzq/x"], Errno::ELOOP, Errno::ELOOP]	(d="/tmp/mono_rp_#{Process.pid}"; Dir.mkdir(d); File.write("#{d}/file", ""); a=(
+e0aaed5b5073da72fc373f05fb574de1	true	S = Struct.new(:a, :b)\n            \n\n            S.new(1, 2).hash !
+e0c2bb61aa5c5d76757d6084b37a58e5	[:a, :b, nil]	class K\n              def initialize(n); @n = n; end\n              
+e0f9f78e42b543aa7b6cc1f45ec6316a	[true, 9]	pid = fork { sleep 5 }\n            Process.kill(:KILL, pid)\n       
+e129819270670333ff373830f6061bd4	"ruby"	def name; "ruby"; end\n        def f(name:); name; end\n        \n\n       
+e13869548fa19a771b07f33adfda8184	[true, [1, 2, 3]]	acc = []\n            initial = []\n            e = [1, 2, 3].each_wi
+e154b3c6984d91ffa32cd89a1908494b	false	File.directory?("monoruby")
+e167a456c7b69a77638b0dd3c251ab26	true	"abc".casecmp?("ABC")
+e19e475a8598d24cded21068c47654dd	"abc"	"abc".rjust(3)
+e1b505f2197e0465fd5bc85b29e4ab80	[604, -1, -2, 1, -2]	n = 1; x = [-1, -2]; a = [*x, n + 0, n + 1, n + 2, n + 3, n + 4, n + 5, n + 6, n
+e1c2cb8e9e01d860acf3a63296e8f6a3	[nil, nil]	s = "\\303".dup.force_encoding(Encoding::Windows_31J)\n               [/z/s.match(
+e1d0e1049ee5298bcdc5c96d04a37dd7	[false, false, true]	res = [$DEBUG, $-d]\n        $DEBUG = true\n        res << $-d\n        $D
+e1dc59a25b246ef8aaa68515e60ea4a0	true	Process.getrlimit(Process::RLIMIT_STACK).is_a?(Array)
+e1e049bcd24042f78171ca96d4da9c05	false	class Foo\n              def bar; end\n            end\n            \n\n
+e216ce1e2b8ed4cd8ceaebfdb111d6fc	"US-ASCII"	("abc %s".dup.force_encoding("US-ASCII") % "x").encoding.to_s
+e226e478267e4a855c4aa2949e8e83a5	30	def add(x, y); x + y; end\n            m = method(:add)\n            
+e238574f11e692d806b7fdb19277fb61	[[:req, :x], [:opt, :y], [:rest, :rest], [:block, :blk]]	class Foo\n              def bar(x, y=1, *rest, &blk); end\n         
+e23cd2e86c80f810b83266eaf89e4c58	"abcdef"	r, w = IO.pipe\n            t = Thread.new { r.read(6) }\n           
+e2427c509b8a42e4e1c5bd0e4213c1c6	10	Enumerator.new { |y| y << 1; y << 2 }.each { |v| break v * 10 }
+e25b6ab9f7451f985278d1029bc64e90	"ABDG&0[]NIM"	class String\n              alias_method :foo, :upcase\n            e
+e272964346a1b0788c57ee89eb056d8a	[false, false]	M = Data.define(:amount, :unit)\n\n            other = Data.define(:amount, :unit)
+e275d5074e8ad9790d4b3e681c5d0b3c	""	"".swapcase
+e27e23d301e89cb2ebbff2416fdb793d	"ういあcba"	"abcあいう".reverse
+e2aabc9156279396c43d9f464d256920	[-1, 1]	a = [0xFF].pack("C").force_encoding("UTF-8")\n              b = [0
+e2b38a39e691cb690c90a70e6ffc1baf	["inner", "outer", "nil"]	log = []\n            begin\n              raise "outer"\n            
+e2c2808fdcfd4ffc06759284fa444bc6	[:a, :b]	S = Struct.new(:a, :b)\nClass.new(S).members
+e2f1f22033c587332b6550fbf0ad525b	42	__ENCODING__; 42
+e2f7855c9efc89267cc4efaf17ca2b83	[true, true]	[Thread.current == Thread.main, Thread.current.alive?]
+e30802fc039d0a7dafc2afa6978a2fd8	[true, true]	stop = false\n            t = Thread.new { stop = true }\n           
+e3153e08936de555d02588b7435ba4c8	nil	begin\n              raise "err"\n            rescue\n            end\n
+e358ab5ec7cd3f4599432855b55c2865	[[:ensure_ran], "reraised"]	$log = []\n            def m\n              raise "orig"\n            
+e383349a267c6ca9fda59d2f6df0e56c	[81, true]	require "stringio"\n            old = $stderr\n            begin\n    
+e3d5014354546675123f59bdf2d1daca	104	Const=4\n            Const+=100\n            a = Const\n        \n\n    
+e3dc251c39edf8fca9953b41f0868749	"self"	begin\n              Fiber.current.raise "self"\n            rescue =
+e403909aa1128050ff094c7e45c920db	["1234567890", "12345", "45678", "ASCII-8BIT", "", "ASCII-8BIT", nil, "67890", "1234567890", "ISO-8859-1", "EUC-JP", "US-ASCII", "UTF-8"]	File.write("/tmp/mr_cr.txt", "1234567890")\n            r = []\n     
+e40d3f8284923f9a5d0e3cb7bf4ebd90	:OVERRIDDEN	class String; def !=(o); :OVERRIDDEN; end; end; "a" != "b"
+e4389faf07c04c6c6c14f39e455deef9	"Object"	Enumerator::Yielder.superclass.to_s
+e441908e5db44ae55d2d4454aa1055a2	["hello", "HI"]	class A\n              def greet; "hello"; end\n            end\n     
+e44fe0e6159ead6593e9820b1014b08b	[:two_ensure, :three_post, :three_ensure]	class BT\n          def one; two { yield }; end\n          def two\n      
+e45448fbfd8f7f0f3eff2312a6288466	nil	begin\n              raise "original"\n            rescue => e\n      
+e45816cf8d4aeb4f460e318b767a5882	1	(1..).min
+e469c6a02fb5f97645ad6fbfae3d6cc2	["T", "F"]	class TrueClass; def label_t713; super rescue "T"; end; end\n        cla
+e47afc9bea872de2d1e41b256d5d2554	[true, 9, nil]	pid = fork { sleep 5 }\n            Process.kill("SIGKILL", pid)\n   
+e48337ae565a3904f3c01b8e583758d2	["C", "M2", "M1"]	module M1\n          def f\n            $res << "M1"\n          end\n      
+e4a701808e3a93ca91d9df6170eb2110	[["NestA::NestB", "NestA"], ["NestA::NestB", "NestA"], []]	module NestA\n              module NestB\n                def self.f;
+e4b07dfb345d9091378925364fd0c790	[8, [1, 3, 5], 50, 3, 10]	def first_even(a); a.each { |x| break x if x % 2 == 0 }; end\n        de
+e4c3805b5eda733c2c3b305a068dc955	"Cargo.toml"	File.open("Cargo.toml") { |f| f.path }
+e4e344de107f90e3a04f591c1d83fb9a	nil	Inner = Struct.new(:b)\n        Outer = Struct.new(:a)\n        o = Outer
+e4f68a2f5af719f7806b8131e1468888	[1, 2, 3]	def f(x,y,z=42)\n            [x,y,z]\n        end\n        \n\n        f(1,2
+e5006c1032b8867e3476898f3a7987dd	"not match (?-mix:regex)"	class Foo\n              def !~(other)\n                "not match #{
+e5100caa80d4f4b7d03f697cc77e1758	1	(0x8000_0000_0000_0000 + 39) <=> (0x8000_0000_0000_0000 + 39 + 0.0)
+e55de52bce1b084c98ae218eed849d1a	[StopIteration, :method_returned]	o = Object.new\n        def o.each\n          yield :a\n          yield :b
+e5949e2a7f7ad7762866cb540934d760	[4, 1, 7]	r = []\n        store_me = proc { |i| r << i if (i == 4)..(i == 7) }\n   
+e5a3f82fe99eb062a625f7d7fad989ef	[91, 112, 97]	f = File.open("Cargo.toml")\n            begin\n              [f.getb
+e5b6caddf0926a77ca0debe16a0d139d	:linux	def f(x); end\n            f(:windows)\n            a = :linux\n      
+e5f22b981e4a6ed9bfbde224b1a43306	"constant"	module AutoloadProbe\n          autoload :Bar, "/nonexistent/probe/file"
+e5fbcacb7034291e96616d4e0bf14525	[111, 999]	TOP_CONST = 999\n        class C\n          TOP_CONST = 111\n          def
+e60570cf39218d754a8da43cd162e6df	[1, 2, 3]	class C; def to_int; 3; end; end; o = C.new\n[1,2,3,4,5].take(o)
+e62defa8e78ced906f42efe00809d657	"true|TITLE|true|$$ is a read-only variable|true|true|true"	res = []\n        res << ($$ == Process.pid)\n        title = "mrb-title-
+e62e66ff0e391002ce507347414bd003	["2024", "04", "11"]	"2024-04-11" =~ /(\\d+)-(\\d+)-(\\d+)/\n            [$1, $2, $3]\n      
+e6482da349c182043f5fa0cd8447051a	[0, 0, 0, 0, true]	require "etc"\n            a = []\n            a << (Process.uid = Pr
+e6506a63c767f1ee5ca72f61264a77b7	"ababab"	"ab" * 3
+e6721b573894f02b7adbee10b796d8f8	300000	def osr_fold_sum\n          total = 0\n          i = 0\n          while i 
+e6776f2b7fcaf2ff1e06a04fbb44979f	["missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z"]	class Req\n          def initialize(a:, b: 2) = @x = [a, b]\n        end\n
+e6bd09ab564b813b9ee89a2c7bf7b3a8	["super", nil]	class A\n          def foo; end\n        end\n        class B < A\n        
+e6c74f68966fd6d56e95da511c39fa2c	nil	begin\n              nil.foo\n            rescue NoMethodError => e\n 
+e6cc0c3cfcb27d78b452cdf646d43af7	["a", "b", "c"]	class C; def to_str; ","; end; end; o = C.new\n"a,b,c".split(o)
+e6cc10ed70c7eca890adf13c9c87bf01	[[7], {}]	class A2; def a(*r, **k); [r, k]; end; end\n            class B2 < A
+e6d082318a4b595e9d869ba6901bd549	42	class A\n          class B\n            def f\n              42\n          
+e702963dfc31e6655d4b927cd37aa9ae	["ASCII-8BIT", [105, 108, 95, 195, 169, 116, 97, 105, 116], "ASCII-8BIT", "UTF-8", false]	require "tmpdir"\n        path = File.join(Dir.tmpdir, "mrb_binsym_#{Pro
+e70da8f5b71b1eca86c75f08aeb24750	true	class Holder\n              class << self\n                define_met
+e73b8bab78fa8b161426778e42f99938	[[["b\\n", :deprecated], ["c\\n", nil]], "b\\nc\\n"]	$c = []\n        Warning.singleton_class.prepend(Module.new do\n         
+e74e57427bab9d2903b1f09d7c43625c	[false, true]	GC.stress = false\n            before = GC.count\n            GC.stre
+e759b021311853223519b09db9019343	"foo12"	module Foo\n              def foo(x, y)\n                "foo" + x.to
+e76ab37d95fef8bab7fbc7bcae3ff1c2	[nil, nil, nil]	def f(a = nil, b = :sym, c = "s"); nil; end\n        [f, f(1), f(1, 2, 3
+e77ae56f033ce0b68786e4bf51e70c71	"foobar"	("foo" + "bar")
+e78241f23404fdda069ce1e1d3a9efc8	[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139]	class D\n          attr_reader :v\n          def initialize(k: 0) = @v = 
+e7c6302a9b297579c8e5ac35b76c1089	"1"	def foo \n          eval("a = 1", $b)\n        end\n        \n\n        $b =
+e7ca5b8d05bd3556a711daf23dfd10c6	nil	r, _w = IO.pipe\n            r.wait(IO::READABLE, 0)\n            
+e832c1ba769618395a505bd13bd3d3b7	"hi"	mod = Module.new do\n          def greet; "hi"; end\n        end\n        
+e841964d3dcfd7149202c80802373ee4	"Encoding::CompatibilityError"	(Regexp.new("".dup.force_encoding("US-ASCII"), Regexp::FIXEDENCODING) =~ "\\303\\2
+e8629d85bee1ecd0620fc7812cf440d4	"myfile.rb:42:"	b = binding\n            begin\n              b.eval("missing_method"
+e8663c97e820ca6aa3b720c87c95f4ff	"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"	r, w = IO.pipe\n            t = Thread.new { r.read }\n            w.
+e874e1da171336c766ccb7c7051d0664	true	e = Exception.new\n            r = Marshal.load(Marshal.dump([e, e])
+e8962f663b29be65e4e0dd56609acec4	[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 100]	def f\n                $res << 12.times { |x|\n                    $r
+e8ad34b388352ca80000e7df317bb41a	[42, true, true]	o = Object.new\n            def o.to_str; "value"; end\n            c
+e8bf25bb3eb8bcdf2410ac76264f9ea4	[1, 2]	Enumerator.new { |y| y << 1 << 2 }.to_a
+e8e220b680848457259609fb951e4dbd	["ensure in f", "ensure in g", 42]	def g\n          begin\n            yield\n          ensure\n            $r
+e8ea755b0d3d65aee46f4cca2a396948	["/root", ArgumentError, true, nil, [Errno::EBADF, "Bad file descriptor - fchdir"], true]	(a=Dir.home("root"); b=(begin; Dir.home("no_such_user_zzq"); rescue => e; e.clas
+e8f73c5ee545fe5b71d1c667d8bec38b	[3, [:gt, :gt]]	class Gt\n              attr_reader :calls\n              def initial
+e90638f8f74350ab109848abe99b3ee9	:from_emit	def emit(tag); throw tag, :from_emit; end\n            catch(:x) { e
+e95108f8dbf4714b38e0e2eeaeef2060	["one x\\n", "two x\\n", 2, 2, "one x\\ntwo x\\n\\n\\n\\nthree\\nfour\\n", "one x\\ntwo x\\n\\n", "three\\nfour\\n", nil, "one x", "\\nt", "one ", "", "x\\n", "one x", "two x", "one ", "\\ntwo x\\n\\n\\n\\nthree\\nfour\\n", "three\\n", "one x", "one x\\n", :eof, "one", " x\\n", :range, :tyerr, "one x\\n", "o", 26, [[230, 156, 157], [230, 151, 165]]]	require "tempfile"\n            t = Tempfile.new("mrb_gets")\n       
+e9579fc0c8b362d6be81fff6d2f5180c	[[1], false]	r = []\n            t = Thread.new { r << 1; Thread.exit; r << 2 }\n 
+e963bd998698b312c68f3775a2588785	[true, false]	class Foo\n              def bar; end\n            end\n            \n\n
+e984e74e084abe31a4e683d859f4c148	:OVERRIDDEN	class Integer; def >>(o); :OVERRIDDEN; end; end; 3 >> 4
+e992704edbab063479116ca53c9ebb40	21	class A\n          attr_accessor :v\n        end\n        a = A.new\n      
+e9d4802e950b78158c8e4240b64d6772	["127.0.0.1", true, true, :neg, true, true, :not_unix]	require "socket"\n            res = []\n            s = TCPServer.new
+e9dc5cc83c580492d481d015d537e291	["global-variable", nil, nil, nil, nil, "global-variable", "global-variable", "global-variable", "global-variable"]	[defined?($~), defined?($&), defined?($'), defined?($`),\n          
+e9e35f041d04e6d4499450a91957eaa7	5	class C\n              CONST = 1\n              def f\n               
+e9ed3c91c241cacff421ec62d7907898	"!"	$\\ = "!"; r = $\\; $\\ = nil; r
 ea07ecaa90c2d393514090eaf2eb6009	[1.0, -Infinity]	[1.0, -1.0 / 0.0]
+ea4e91b1bfa0887ef9ecf7398be00cf1	[:direct, :forwarded, :mapped, :enum, :hash, :sorted, :ewo, [1]]	res = []\n        res << [1,2].each { break :direct }\n        def fwd(&b
+ea543154e9094ead8bd5a8628be70621	false	File.file?("README.md")
+ea946aefd6f7e19064e3e6c18f306dd5	[1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2]	a = [1,2]\n        b = []\n        7.times do\n            b.prepend(*a)\n 
+eaad241eb694406f551d0dbb72925f9b	["matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other", "matcher", "symbol", "matcher", "other"]	matcher_a = Class.new do\n          def ===(x); x == :a; end\n          p
+eab3682bef9745a9bdc35589ab85d379	[false, true, 3, false, 3, 5]	path = "/tmp/mr_buf_sync.txt"\n            res = []\n            f = 
+eab54708ae29dd6658147eb4b5b22b5e	"fake_name"	m = Module.new\n            module m::N; end\n            m::N.set_te
+eabf9a2cd37caa66db02496f147f9c38	"ababababax"	"x".rjust(10, "ab")
+eac5ac27d0ec5d247be231335410fc77	:woke	t = Thread.new { sleep 0.01; :woke }\n            t.value\n          
+eaf566d81b387e50072b7ee75e9a9769	[true, true]	before = Dir.pwd\n            d = Dir.new("/tmp")\n            inside
+eb030791795360c8d2798e96c1b4c064	[:typeerr, :typeerr, :typeerr, :typeerr, :typeerr]	def t(x)\n              begin\n                Signal.signame(x)\n    
+eb0341a3d38f4211b05aabb593c43552	true	a=Object.new; a.instance_variable_set("@i", 42); a.instance_variable_defined?(:@
+eb08522009d362d68363c6fe111130db	[0, 1, 2, 3, 4, 5, [0, 5], 100, 1, 2, 3, 4, 5, [1, 4], 100, 2, 3, 4, 5, [2, 3], 100, 3, 4, 5, [3, 2], 100, 4, 5, [4, 1], 100, 5, [5, 0], 100, 6, [6, 0], 100, 200]	def f\n                7.times { |x|\n                    $res << 7.t
+eb1a1f13d83aba6d989327edc7aca2ee	[42, 42, 42, 42, 42, 42, 42, 42, 99, 99, 99]	class A\n          attr_accessor :w\n        end\n        a = A.new\n      
+eb480c65027479d5c43e622f7002a48d	true	"abc".force_encoding("ISO-8859-13").encoding == Encoding::ISO_8859_13
+eb95d935f094af9857548a9bc31a9d9c	[[1, 0, 97, 0, 98, 0], :nul, :too_long, :bad_family, :not_str, "AF_UNIX", "AF_UNIX", true]	require "socket"\n            require "tmpdir"\n            res = []\n
+eb964a5d470f9976795a0f65e5e4c883	[1, [2, 3]]	def f\n            \tyield [1,2,3]\n            end\n            \n\n    
+eb96d287979d11425dc718be5f2eff0c	["special yes", "plain no"]	klass = Class.new(StandardError)\n        class << klass\n          def =
+eb96fae2858b25333b4151464f9b58b1	1249925000.0	def f(n)\n          x = 0.0\n          i = 0\n          while i < n\n      
+eb9846edd037b0ce071948142b47a860	true	class Integer; alias __orig :<; def <(o); __orig(o); end; end; 3 < 4
+ebce509c6f0b68f1f3e18a26a8452e02	[10, 20, 30]	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \ns.dec
+ebcfc8794f2afa816e895c8221e183c1	["1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]", "1|[2]", "1|[{k: 9, m: 8}]"]	def real(a, *r) = "#{a}|#{r.inspect}"\n        def g(...) = real(...)\n  
+ebdbcc9624aa7a388b946aa43e54b139	[4611686018427388000, 4611686018427387903, -4611686018427388100, 4611686018427387799, 4611686018427388001, 4611686018427387904, -4611686018427388101, 4611686018427387800, 4611686018427388002, 4611686018427387905, -4611686018427388102, 4611686018427387801, 4611686018427388003, 4611686018427387906, -4611686018427388103, 4611686018427387802, 4611686018427388004, 4611686018427387907, -4611686018427388104, 4611686018427387803, 4611686018427388005, 4611686018427387908, -4611686018427388105, 4611686018427387804, 4611686018427388006, 4611686018427387909, -4611686018427388106, 4611686018427387805, 4611686018427388007, 4611686018427387910, -4611686018427388107, 4611686018427387806, 4611686018427388008, 4611686018427387911, -4611686018427388108, 4611686018427387807, 4611686018427388009, 4611686018427387912, -4611686018427388109, 4611686018427387808, 4611686018427388010, 4611686018427387913, -4611686018427388110, 4611686018427387809, 4611686018427388011, 4611686018427387914, -4611686018427388111, 4611686018427387810, 4611686018427388012, 4611686018427387915, -4611686018427388112, 4611686018427387811, 4611686018427388013, 4611686018427387916, -4611686018427388113, 4611686018427387812, 4611686018427388014, 4611686018427387917, -4611686018427388114, 4611686018427387813, 4611686018427388015, 4611686018427387918, -4611686018427388115, 4611686018427387814, 4611686018427388016, 4611686018427387919, -4611686018427388116, 4611686018427387815, 4611686018427388017, 4611686018427387920, -4611686018427388117, 4611686018427387816, 4611686018427388018, 4611686018427387921, -4611686018427388118, 4611686018427387817, 4611686018427388019, 4611686018427387922, -4611686018427388119, 4611686018427387818, 4611686018427388020, 4611686018427387923, -4611686018427388120, 4611686018427387819, 4611686018427388021, 4611686018427387924, -4611686018427388121, 4611686018427387820, 4611686018427388022, 4611686018427387925, -4611686018427388122, 4611686018427387821, 4611686018427388023, 4611686018427387926, -4611686018427388123, 4611686018427387822, 4611686018427388024, 4611686018427387927, -4611686018427388124, 4611686018427387823, 4611686018427388025, 4611686018427387928, -4611686018427388125, 4611686018427387824, 4611686018427388026, 4611686018427387929, -4611686018427388126, 4611686018427387825, 4611686018427388027, 4611686018427387930, -4611686018427388127, 4611686018427387826, 4611686018427388028, 4611686018427387931, -4611686018427388128, 4611686018427387827, 4611686018427388029, 4611686018427387932, -4611686018427388129, 4611686018427387828]	def drive\n              res = []\n              i = 4611686018427387
+ebe0ff80bc75796e6952268415562c02	79758732	a = 0\n        20.times do |x|\n          20.times do |y|\n            20.
+ec17cc112d34937041f056e2b23a6485	[10, 20, 30]	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \ns.val
+ec3412505f146b21a6888012a86820f2	[true, ["1", "2"]]	r = ENV.merge!("MONORUBY_ENV_TEST_M1" => "1",\n                     
+ec3b6db701fd7dc4a8aef71dcf7cdc12	[[[1, nil], nil], [[1, nil], nil], [:args, :block], [[1, nil, 2], nil], [1, 2], [[1, 2], nil]]	def m(*args, &block); [args, block]; end\n        res = []\n        args 
+ec4849e638b2a7db1b2adfd4bf8183c9	[[1, nil, nil], []]	S = Struct.new(:a, :b, :c)\n            \n\n            s = S.new(1)\n 
+ec4d377c4801643f31efc8302cd3d528	[true, TypeError, ArgumentError]	(h=ENV.to_h{|k,v| [k.to_sym, v.length]}; a=h.keys.all?{|x| x.is_a?(Symbol)}; b=(
+ec4dde8b7008f35b2cfd35d0cd16f7e3	[true, true]	a = 1356\n            id = a.object_id\n            \n\n            [id
+ec53acd05c0089d09f7e0996b605ab08	false	(0x8000_0000_0000_0000 + 39 + 0.0) == (0x8000_0000_0000_0000 + 39)
+ec616c74470bcaec129ac19540047a93	["method", "nil", nil, "outer", ["a_file", "10"]]	h = {}\n        res = [defined?(h[]), $!.inspect]\n        begin\n        
+ec6e08886fb1c676139aa0cb92bb4296	["extend_object:C", "hello"]	$res = []\n        module M\n          def self.extend_object(obj)\n      
+ec75362ae6eb794adfccd5ea2fd87a71	["Infinity", "NaN", "Infinity", "-Infinity", true, "-0.314e1", "0.314e1", "0.314e1"]	require "rubygems"\n        require "bigdecimal"\n        res = []\n      
+ec7990294dac7ac2a637929f23760d95	[42, 42, 42, 42, 42, 42, 42, 42, 100, 100, 100]	class A\n                attr_accessor :w\n            end\n          
+ec84a8df82f97b16fdedf56efbc6ad35	"hello"	path = "/tmp/monoruby_test_filewrite_perm_#{Process.pid}_#{rand(100
+ecb0c2530aa824ca3b58cd269e696cd6	"xy"	def m; /(\\w)(\\w)/ =~ "xy"; -> { $~[0] }.call; end; m
+ecf0e0788d956837326285cb5c6fe318	[[0, 1, 2, 3, 4, 5, 6], 7, 8]	def f(*x,a,b)\n          [x,a,b]\n        end\n        \n\n        f(0,1,2,3
+ed06e4b3aaaf57db436613d3ad55b04a	[["EUC-JP"], ["ISO-8859-1"], ["ISO-8859-1"], ["ISO-8859-1"], ["UTF-8"]]	(d="/tmp/mono_de_#{Process.pid}"; Dir.mkdir(d); File.write("#{d}/a", ""); a=Dir.
+ed1b9d1127bc95203a639e5a1aec8a0c	false	(0x8000_0000_0000_0000 + 39) == (0x8000_0000_0000_0000 + 39 + 0.0)
+ed21697a03332cf5034e4574459d9bdf	[:ok, [:x, :y]]	A = Struct.new(nil, :x, :y)\n            \n\n            [A.name.nil? 
+ed2d1c8786b057689885f97c2f7a6f93	[(5+2i), (-3+2i), "-1-2i", "-1-2i", ["R+0i", "3+4i"], "1.0+2i", "2+0.0i", "1+0.0i"]	class R < Numeric\n              def real?; true; end\n              
+ed336c80176b4b3f5030b6fb67c77122	[:foo, :foo=, :bar]	c = Class.new\n            r1 = c.send(:attr, :foo, true)\n          
+ed70b3c2874dc48238a111c40621917a	[true, [".", "..", "x"], nil, [Errno::EBADF, "Bad file descriptor - closedir"], TypeError]	(d="/tmp/mono_ff_#{Process.pid}"; Dir.mkdir(d); File.write("#{d}/x", ""); dir=Di
+ed7e2764b0810a82bc9f23ba3fff72a7	[nil, [:a, :b]]	S = Struct.new(:a, :b, keyword_init: nil)\n            \n\n           
+ed8c3ce68eb282255788408da9a12b8a	"UTF-8"	Encoding.default_internal = Encoding::UTF_8\n              res = E
+ed9d8e2f202ed982f57795adbdcbe43f	3	File.write("/tmp/foo", "woo")
+ed9eb5bf08edb4fb19ef55071777ac61	["a", "b"]	def foo(&block)\n        ["a","b"].each { |e| block.call(e) }\n\t    end\n    
+eda7a759e9b973f854bd82f3e9fc91f6	"nil"	begin; raise "a"; rescue; end\n            begin; raise "b"; rescue 
+edb5dbcaeaf97748d60848f2d876bf85	87520950	a = 0\n        for x in 0..20\n          for y in 0..20\n            for z
+edd1509e17b572726a0168869ff6ef86	"/root"	File.expand_path("~")
+edd7521592e8b800133323de5557ca5d	[[1, 0], [2, 1]]	r = []; [1, 2].each.with_index { |v, i| r << [v, i] }; r
+edfa5f14dfb3ce9aa5f33fbf8b2f4c1f	[3, 3]	class C\n              def each_twice(n); r = []; 2.times { r << (yi
+ee0ddcc65de084a835c47f1e8ef4b537	true	Process.clock_gettime(Process::CLOCK_REALTIME, nil).is_a?(Float)
+ee146e8d938f3b561b5e6f4d0f2d700f	"kept\\n"	# close_others: true still keeps the redirected fds.\n            r,
+ee30ce31ba98f69ce2f87b6e3dee696e	Hash	GC.stat.class
+ee43c89f3fd8c1689768af1466ea40b9	"HELL world"	s = "hello world"; s.bytesplice(0..4, "HELLO WORLD", 0...-7); s
+ee4468681c7b58ee75906f6a92294651	true	class Float; alias __orig :<; def <(o); __orig(o); end; end; 3.0 < 4.0
+ee506f7a4e17e46a218f4c08e690d77c	[:bar, true]	class Foo\n              def bar; 1; end\n            end\n           
+ee9c2499ceaa7c8febe00ce67d194d40	[:c, :m2, :m1]	m1 = Module.new { def chain; super << :m1; end }\n            m2 = M
+eea84468101cbf88d3da51526fc75b65	["s1\\n", "s2\\n", "s3\\ns4\\n", "s5\\n"]	require "tmpdir"\n            res = []\n            Dir.mktmpdir do |
+eeb0097de3c9743d1d61f248aa33cb35	[[10, "abcdefghij", true, true, true, false, false], "#<IO::Buffer 0xA+10 EXTERNAL MAPPED FILE SHARED>", "XYcdefghij", [4, "XYcd"], [true, [IO::Buffer::AccessError, "Buffer is not writable!"]], [true, false], "XYcdefghij", true, "XY", [ArgumentError, "Invalid negative or zero file size!"], [904, "zzz"], true, [TypeError, "expected IO or #fileno, String given"], ["0\\x020\\x040", true, 5], "\\xF9\\xBF\\xFB\\xBF\\xFD", "\\xC9\\xBD\\xCB\\xBB\\xCD", ["\\xCE\\xCD\\xCC\\xCB\\xCA", true], "12345", [true, "0\\x020\\x040", true], "\\xF9\\xBF\\xFB\\xBF\\xFD", "\\xC9\\xBD\\xCB\\xBB\\xCD", "\\xCE\\xCD\\xCC\\xCB\\xCA", [TypeError, "wrong argument type String (expected IO::Buffer)"], [TypeError, "wrong argument type nil (expected IO::Buffer)"], [IO::Buffer::MaskError, "Zero-length mask given!"], [IO::Buffer::MaskError, "Zero-length mask given!"], [IO::Buffer::AccessError, "Buffer is not writable!"], "`\\x02"]	require "tempfile"\n            r = []\n            er = ->(&blk) { b
+eee6d3392081cf48009c24d5b945eb51	["ping", "AF_INET", "127.0.0.1", true]	require "socket"\n            s = UDPSocket.new\n            s.bind("
+eef0723453d8a81dddb6e9b4111dad43	["$stdout must have write method, NilClass given", "$stderr must have write method, Integer given"]	res = []\n        begin; $stdout = nil; rescue TypeError => e; res << e.
+eef5a7312d9578ef7fe31f7e31091e21	nil	def m(a = a); a; end; m
+ef1e12a9b30d1bb651da8afa02c9ed6f	"out\\nerr\\n"	IO.popen(["sh", "-c", "echo out; echo err 1>&2"], err: [:child, :ou
+ef28a05aa1775528a6177475feb794a5	[true, "/no/such/path/at/all"]	m = Module.new\n        m.autoload :Foo, "/no/such/path/at/all"\n        
+ef32d22779cedffe0f701504d427c05e	true	b = nil\n        line = nil\n        1.times do\n          line = __LINE__
+ef3e0b34557338d464351f96f18853dd	"exception object expected"	begin; raise "m", cause: Object.new; rescue TypeError => e; e.messa
+ef5dfdebe963dd72e995bc3deed2f86d	["hello", "world", "Addrinfo", "UNIXSocket"]	require "socket"\n            a, b = UNIXSocket.pair\n            a.s
+ef6e901117e21756738320abd8a842eb	"US-ASCII"	"a".encode("US-ASCII").succ.encoding.to_s
+ef731e0d5eee1968eb1204321c4f743e	"boom"	t = Thread.new { raise ArgumentError, "boom" }\n            begin\n  
+ef9eae4bb22bcd7cab82ca0055ddcb28	[4, true]	_r, w = IO.pipe\n            [w.wait(IO::WRITABLE, 0), w.wait_writab
+efa7697984f335d655c682cfd15b66ef	["RuntimeError", "", "#<RuntimeError: RuntimeError>", "RuntimeError", "#<RuntimeError: msg>"]	res = []\n        begin; raise; rescue => e; res << e.inspect << e.messa
+efee58d26b26212a55202a9cf2bc294e	[:a, :b, :c]	Struct.new(:a, :b, :c).new.members\n        
+f02372e49e9616a18cf3432bddd7f5f4	[1, :done]	t = Thread.new do\n              f = Fiber.new { Fiber.yield 1; :don
+f053ea7381008dbc0e2209151231a4ec	4	a=3;\n        if a==1;\n          3\n        else\n          4\n        end
+f06768860864e9c94d5eda4e8a2fa12d	[42, true]	module Foo\n          BAR = 42\n        end\n        def baz(x)\n          
+f090d1117e83eac6fc71416bd205423e	[[195, 169], "Windows-31J", true]	s = "\\303\\251".dup.force_encoding(Encoding::Windows_31J)\n               m = /./s
+f098937c1782ad342405a495ac2f0063	true	class Foo\n              def bar; end\n            end\n            \n\n
+f0c50bd8de554c94bd61a098ac6b9b78	"#<data M amount=42, unit=\\"km\\">"	M = Data.define(:amount, :unit)\nM.new(42, "km").to_s
+f0e946f362739bd5f3dcdd127d2dbfe2	[:toa, :single]	class E1 < StandardError; end\n            class Custom; def to_a; [
+f12165564d922cbb529013b962e93e50	11	b = for a in 0..300 do\n                if a == 77 then break a/7 en
+f136d929a1afe530249c3828dc16d2d3	"hi********"	class Foo; def to_str; "*"; end; end\n            "hi".ljust(10, Foo
+f137e5150f7ecf2f213388be98ce909f	[1, 2, 3, 4, 5, 6, 7, 8]	class C\n          def initialize\n            @a = 1\n            @b = 2\n
+f1443f24a111ef2b12274668b17f02be	[["TypeError", "exception class/object expected"], ["a.rb:1"], ["single.rb:2"], "Array", "TypeError", ["newmsg", ["b.rb:2"], false], ["StandardError", "[\\"foo\\"]"], ["TypeError", "exception object expected"], ["TypeError", "exception class/object expected"], "StopIteration", ["StopIteration", "m"]]	def t; yield; rescue Exception => e; [e.class.to_s, e.message[0, 60
+f167361721c3652dc52d4b8e72006f82	[1, 3, 5, 7]	(1..7).filter { |x| x.odd? }
+f1babbbb29fbb271146a71d94071fa7c	[Module, Module]	module M\n            end\n        \n[M.class, M.singleton_class.super
+f1cb099660b804e23a65b0ec39a9e7c4	[nil, true, true, nil]	a = Signal.trap(:EXIT, proc { })\n            b = Signal.trap('EXIT'
+f1d0da92c682d95eff2dcfbc176360b2	[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100]	module M\n          def bar; 100; end\n        end\n        class C\n      
+f1f99292a19c224bf421c10f4f3f5e0d	[:g, :f]	class C; def f; 1; end; alias g f; end\n            m = C.new.method
+f1f9e965f806a00af003025c4a4f9cbc	"foo"	class C\n          def foo; "foo"; end\n        end\n        C.new.public_
+f204bc56aff4f18e6318986b82635d39	[2, true, 1]	m = Module.new\n            name = "CS_CONST\\u{3bb}".encode("euc-jp"
+f207225de8922e18548ba76eddb18719	true	GC.count.is_a?(Integer)
+f2104384e6be9965ec5da4ad860b37f4	[1, 4, 2]	[IO::READABLE, IO::WRITABLE, IO::PRIORITY]\n            
+f212deed776e67ad2663d333efdef52c	true	b = binding\n            b.eval("z = 1")\n            b.local_variabl
+f216b4de4c4cc3516688e358d154cc58	[{k: 0}, 1, {a: 1, b: 0}, [:a, :b], [1, 0], false, true, {k: 1}, 1, {a: 1, b: 1}, [:a, :b], [1, 1], false, true, {k: 2}, 1, {a: 1, b: 2}, [:a, :b], [1, 2], false, true, {k: 3}, 1, {a: 1, b: 3}, [:a, :b], [1, 3], false, true, {k: 4}, 1, {a: 1, b: 4}, [:a, :b], [1, 4], false, true, {k: 5}, 1, {a: 1, b: 5}, [:a, :b], [1, 5], false, true, {k: 6}, 1, {a: 1, b: 6}, [:a, :b], [1, 6], false, true, {k: 7}, 1, {a: 1, b: 7}, [:a, :b], [1, 7], false, true, {k: 8}, 1, {a: 1, b: 8}, [:a, :b], [1, 8], false, true, {k: 9}, 1, {a: 1, b: 9}, [:a, :b], [1, 9], false, true, {k: 10}, 1, {a: 1, b: 10}, [:a, :b], [1, 10], false, true, {k: 11}, 1, {a: 1, b: 11}, [:a, :b], [1, 11], false, true, {k: 12}, 1, {a: 1, b: 12}, [:a, :b], [1, 12], false, true, {k: 13}, 1, {a: 1, b: 13}, [:a, :b], [1, 13], false, true, {k: 14}, 1, {a: 1, b: 14}, [:a, :b], [1, 14], false, true, {k: 15}, 1, {a: 1, b: 15}, [:a, :b], [1, 15], false, true, {k: 16}, 1, {a: 1, b: 16}, [:a, :b], [1, 16], false, true, {k: 17}, 1, {a: 1, b: 17}, [:a, :b], [1, 17], false, true, {k: 18}, 1, {a: 1, b: 18}, [:a, :b], [1, 18], false, true, {k: 19}, 1, {a: 1, b: 19}, [:a, :b], [1, 19], false, true]	res = []\n        20.times do |i|\n            h = {}\n            h[:k] =
+f27aef0e47e3354ce496c90299f462ea	[["x\\ny\\nz\\n"], ["x\\n", "y\\n", "z\\n"], ["x\\n", "y\\n", "z\\n"], "ASCII-8BIT"]	File.write("/tmp/mr_rlf4.txt", "x\\ny\\nz\\n")\n            r = []\n    
+f2899713941ee3ed54e30d3b5b785abc	[1, true]	module MSx; end\n            SX = Struct.new(:a)\n            s = SX.
+f2e470589175775eee4819e2df92057b	true	v = "MONORUBY_TEST_VAL"\n            r = ENV.send(:[]=, "MONORUBY_EN
+f2f61ae8dbed2bff4eb6e1bb603b94d5	5	(..5).max
+f3176371966e0240a645893d31e35731	[1, 2]	module M\n              def a; 1; end\n              def b; 2; end\n  
+f329ce2071115a197fe643cb17ed55d7	[]	S = Struct.new(:a, :b, :c)\n            \n\n            s = S.new(1, 2
+f3438f2eabc960c10ac335f28ee99149	[7, true]	def m\n              y = 7\n              binding\n            end\n   
+f3589c2c91bf82dc12fed5baea30a57d	99	class C\n          def call_prot(other)\n            other.prot_method\n  
+f3721217a679982e77a9c5218846d937	[[:protected_self, :public_self], [:protected_bar, :protected_self, :public_bar, :public_self], [:protected_self, :public_self], [:protected_bar, :protected_self, :public_bar, :public_self], [:protected_class_foo, :public_class_foo], [:protected_class_foo, :protected_class_parent, :public_class_foo, :public_class_parent]]	Parent = Class.new\n\n        class <<Parent\n          private;   def pri
+f37f75d816f7de7ab35ce9ab0baf5471	:te	begin; [1].product(5); rescue TypeError; :te; end
+f395d6cc6a5bc2438f2cb34beb91e56e	["foo", 7]	bytes = "\\x04\\x08\\x49\\x2f\\x08\\x66\\x6f\\x6f\\x07\\x06\\x3a\\x06\\x45\\x46"\n
+f3b173af20b26ff206d110a916736145	[1700000000, 1700000000]	path = "/tmp/monoruby_test_utime_#{Process.pid}_#{rand(100000)}"\n  
+f3b9f4a0cf1f84a3e76c27417526e8b3	["fooAAAbar", "AA"]	eval("/foo(A{0,1}+)Abar/").match("fooAAAbar").to_a
+f3be9b473b8a1d4782be1ddf9d5fca5e	:ok	chained = begin\n              begin\n                raise "the caus
+f3c24129da4b4ab0d76c5206404cda90	{amount: 42, unit: "km"}	M = Data.define(:amount, :unit)\nM.new("amount" => 42, "unit" => "km").to_h
+f3d5861c3b1efb0fd9acb13c5674596f	nil	Inner = Struct.new(:b)\n        Outer = Struct.new(:a)\n        o = Outer
+f3e0ea39509c579fda3f8ff9c32a770f	1	a = ""\n            a << 1\n            a << "Ruby"\n            a.ord
+f3f43b1263309f03c9d276dfc64a0967	[[], {a: 1, b: 2}]	D = Data.define(:a, :b) do\n              def initialize(*rest, **kw
+f3f4d5ad2f3d7c0efe9baf43f157cc3a	[nil, nil]	[Complex("a", "b", exception: false), Complex("a", 0, exception: false)]
+f40ce886b72f5217bc31de73015cbb2d	[true, true]	# 'M' + length(6 ⇒ marshal_int 0x0b) + "String"\n            class_b
+f40d66b495e8cfc92317f5249b69ee31	[4, 8, 73, 34, 6, 97, 6, 58, 13, 101, 110, 99, 111, 100, 105, 110, 103, 34, 11, 69, 85, 67, 45, 74, 80]	Marshal.dump("a".encode("EUC-JP")).bytes
+f4101d236b633fea5a8e14b9620d27bb	false	c = Class.new do\n              def bar; end\n              undef :"#
+f417b46ed1c24ffbbc6d828e0035f712	"aXXde"	class C; def to_str; "bc"; end; end; o = C.new\n"abcde".sub(o, "XX")
+f4581c269c9086996dbf942d463dfa96	:ok	obj = Object.new\n            def obj.inspect; self; end\n           
+f45a984e81852dd82ce24d6cb475566a	[[[], {}], [[1, 2], {}], [[1], {x: 3}], [[5], {y: 6}], [[], {}], [7, {}], [7, {z: 8}]]	class K; def initialize(*a, **kw); @a = a; @kw = kw; end\n          
+f45ca1bbef67b0bd784d12241e1f0ab4	[:foo, [1, 2, 3]]	class C\n          def method_missing(name, *args)\n            [name, ar
+f4666e0beb4a9dba2624be2b8454a53a	[[8080, "127.0.0.1"], "/tmp/x.sock", "ASCII-8BIT", :bad_family]	require "socket"\n            sa = Socket.pack_sockaddr_in(8080, "12
+f497000bb152f7f24a2088c903bb0ecf	Array	class C < Array; end\nC[1,2].union([3]).class
+f4ad36c6de81d987a04ca9991fdecec4	["NilClass", "nil", "outer", "again"]	res = []\n        def f(res)\n          begin\n            raise "x"\n     
+f4ae9a977bb37e4a32deda5423c008ac	[[[], {}], false, [[{}], {}], [[], {a: 1}], [[{a: 1}], {}], [[], {a: 1}], [[{a: 1}], {}], [[], {a: 1}], [[{a: 1}], {}], [[], {a: 1}], [[{a: 1}], {}]]	def target(*args, **kw); [args, kw]; end\n        class << self\n        
+f4cc159c69dc86f34d5c5c1a1739908b	nil	$!\n        
+f4dbd65859826724c9fb5648c3f84c3a	[:re]	def m\n              re = /(?<matched>foo)/\n              re =~ "foo
+f4e35e264294b3bd8913c077f24dea7a	[{"a" => 10, "b" => 20}, {1 => :a, 2 => :b}, {}]	h = { a: 1, b: 2 }\n            [h.to_h { |k, v| [k.to_s, v * 10] },
+f4ef37c05309c4811b6d78d2a1b7c9ce	[true, true]	S = Struct.new(:a, :b)\n            \n\n            a = S.new(1, "x")\n
+f4f318253ef6eda2bd57d54a445dae64	[1, 2, [3, 4], 5, [6], 7, 8, [9, 10]]	f = ->((a, b, *c, d), (*e, f, g), (*h)) { [a, b, c, d, e, f, g, h] }\n  
+f54dcd2ea5a345f130209fcaaafe0294	"US-ASCII"	"abc".encode("US-ASCII").center(5).encoding.to_s
+f5694c7e392bbf1dd23065cde514678b	[["plain"], [".", ".dot", "plain"], [".", ".dot", "plain"], ["EUC-JP"], ["plain"]]	(d="/tmp/mono_ge_#{Process.pid}"; Dir.mkdir(d); File.write("#{d}/.dot", ""); Fil
+f57a8409c183d2a681df3ee5b1b1cc9c	true	begin\n              eval("if true", nil, "speccing.rb", 88)\n       
+f5a61986f5353c0de48f8e3b3ed48156	true	r, w = IO.pipe\n            io2 = IO.new(w.fileno)\n            same 
+f5c6861369396fd2b7db1278c67909a5	:type_error	o = Object.new\n            def o.to_int; "2"; end\n            begin
+f5e03d8f6d5d5992d558dca53e905cac	[["initial", [], nil], ["after-match", ["a", "a"], "a"], ["after-nested-block", "zzz"], ["in-method", "q"], ["after-method-call", "zzz"], ["spawner-after-join", ["oo", "oo"], "oo"]]	"foo" =~ /(o+)/\n            r = []\n            t = Thread.new do\n  
+f5f8658034fd67958fbbe44ae02b4545	6765.0	def fib(x)\n                if x<3 then\n                    1.0\n    
+f600c4b6bccc1d5883d6b763a2dd876b	[4, "ka"]	f = File.open("Cargo.toml")\n            begin\n              f.pos =
+f603e3f7573b653274804205c0c9c888	["US-ASCII"]	s = "ab12cd34".dup.force_encoding("US-ASCII")\n              s.sca
+f62113ff8d7e91bafa61a23fc88a57ff	[[:req, :a]]	class C; define_method(:m) { |a,| a }; end\n            C.new.method
+f635d2b04e7d853cebc06ba31f5c8a82	20	class C; def to_int; 1; end; end; o = C.new\n[10, 20, 30][o]
+f65b176caaf8d76c616a0ef5ed8857e9	[1, 1000, 2, 1001, 3, 1002, 5, 1003, 8, 1004, 13, 1005, 21, 1006, 34, 1007, 55, 1008, 89, 1009, nil]	fib = Enumerator.new do |y|\n                a = b = 1\n             
+f666332b734a470db3c29c7d1c1fcbda	true	require "json"\n            s = "tab\\there\\nnewline\\r\\nand\\\\backslas
+f677948e40b8cdfc7bd01fe6eddf352e	[true, false, false]	File.open("Cargo.toml") do |f|\n              before = f.autoclose?\n
+f68ec4570fce796ce1f3fb8aef0cb21e	"あabca"	"あ".ljust(5, "abc")
+f692d7c01396875808d70ca97155bd6f	[1, 2, 3, 4, 5, 6, 7, 8]	class C < Array\n          def initialize\n            @a = 1\n           
+f6a5ba1237d7cfc8990854f9a869a012	true	Thread.current.equal?(Thread.current)
+f6b2f5848e7295cbc532e6f89aae0054	[true, true, true, true, true]	(a=(File.method(:unlink)==File.method(:delete)); b=(File.method(:empty?)==File.m
+f6b8ba5c363ede98f3ac55cfd3ae8594	[[:keyreq, :a], [:keyreq, :b]]	def only_req_kw(a:, b:); end\n            method(:only_req_kw).param
+f6cc6145b95584bf04b9e5b0c112640c	[:a, :b, :block, :x, :z]	a = 1\n        b = 2\n        def f(x, &block)\n          z = nil\n        
+f736ab01b7f73c593f6fc9713eeae554	["boom", false, "boom"]	require "tmpdir"\n        # Use a per-process unique path so parallel te
+f75daf748ad804574801fd5e35cb2793	"1/2"	Rational(0.5).to_s
+f764ebb9096219e5a3a63fbfc98f2cbf	[1, {m: 2}]	def fwd(&b); b.call(1, m: 2); end; fwd { |*a| a }
+f7728cae6b9fca64329411d13ab7c727	[false]	log = []\n            parent = nil\n            parent = Fiber.new do
+f79396dd4b40a9d34cb7688bdc4dd72e	"ASCII-8BIT"	Regexp.allocate.encoding.to_s
+f7958c63c76b683a379585ed3ded1785	[:foo]	$res = []\n            class C\n              def self.method_added(n
+f7d278b559874b37f2add51cdb46b5d5	"US-ASCII"	"abc".encode("US-ASCII").rjust(2).encoding.to_s
+f7dc493dafb3ba5197dd0389905a0b2f	[true, true, true, true, false, [:mp2, :mp3], :mp1, false]	def mp1; 1; end\n            def mp2; 2; end\n            def mp3; 3;
+f7def5e956befcf960758ab5702f9e69	[[["x", "y"]], ["x"]]	cls = Class.new(Hash) do\n              def each\n                sup
+f7e776bb10e4af66fcf286090cd8667f	[[[[:a, 1], [:b, 2]], [39, 117], [[:x, 1], [:y, 2]], []], 2, 40, 2, 0]	def entries(h)\n              return h.to_a unless h.respond_to?(:__
+f7e9c268010e0b7cba0749999aca06e9	Array	class C < Array; end\nC[1,nil,2].compact.class
+f7fda309a2cddb02c53a68d5e37f646d	:OVERRIDDEN	class Complex; def -(o); :OVERRIDDEN; end; end; Complex(1,2) - Complex(3,4)
+f82a7e53e5b4c9005508afdb8ccf08bd	["Shift_JIS", "Shift_JIS", [130, 160]]	s = "\\x82\\xa0".dup.force_encoding(Encoding::Shift_JIS); r = Regexp.new(s);\n     
+f84400191eda84ab1fc835694d236552	[:bar, [{a: 1, b: 2}]]	class Foo\n              def method_missing(name, *args)\n           
+f846da7a353005966938355c81f0122a	""	f = File.open("/dev/null", "r+")\n            f.read(nil)\n        
+f86fcaca6e079b0178148790a1c61b5d	[200, 300, 400, 200, 300, 400]	class S\n            def f(x, y, z:10)\n                $res << x\n      
+f877dfe80be1fef652e8ae2a2601c3d0	[:foo, :foo, :foo]	$res = []\n        def foo\n            3.times do\n                $res <
+f88cf193629825654491ec6b99b61207	[true, false, true, true, true, true, -1, 0, 1, true]	require "rubygems"\n        require "bigdecimal"\n        res = []\n      
+f8ca927bc2a92f537ed873ec7c445f36	[2, 4, 6]	[1, 2, 3].each.with_object([]) { |v, m| m << v * 2 }
+f8cdd223f55f34a3772b5ad1f97093a1	[[0], 1, "Array", false, [1], 1, "Array", false, [2], 1, "Array", false, [3], 1, "Array", false, [4], 1, "Array", false, [5], 1, "Array", false, [6], 1, "Array", false, [7], 1, "Array", false, [8], 1, "Array", false, [9], 1, "Array", false, [10], 1, "Array", false, [11], 1, "Array", false, [12], 1, "Array", false, [13], 1, "Array", false, [14], 1, "Array", false, [15], 1, "Array", false, [16], 1, "Array", false, [17], 1, "Array", false, [18], 1, "Array", false, [19], 1, "Array", false]	res = []\n        20.times do |i|\n            a = []\n            a << i\n
+f8e4e019b1c98b83b08b89e4234268af	"Complex"	42ri.class.to_s
+f8ee041a7b36abcbf71c922f732ccda8	[1, 2, nil, nil, 42]	def f\n          yield 1,2\n        end\n        \n\n        f {|a,b,c,d|\n  
+f8f7d25a130c15077496df45569e65db	3	pids = [fork { sleep 5 }, fork { sleep 5 }, fork { sleep 5 }]\n     
+f90d89ac19b47d099f3c42109cfd6933	[true, true, true]	mod = Module.new\n            mod.const_set(:MyConst, 1)\n           
+f920671d8af53a1b15e29336a169d4d6	true	Time.local(2000).utc_offset.is_a?(Integer)
+f94ee8b65d6ef4f7409f36e4cca6cd66	[:b1, [:b2], :noblock, :literal]	c1 = Class.new { def m; block_given? ? yield : :noblock; end }\n        
+f9541731ec020fa942ed54ddfd8d35f2	""	require "socket"\n            s = TCPServer.new("127.0.0.1", 0)\n    
+f957b11550b5b47da91b8eb1a748df50	"US-ASCII"	"\\x01".unpack("B")[0].encoding.to_s
+f9606e08f3f732cbad28d5fb612a67bd	["to_str: 42/A", "to_str: 42/A"]	class Fmt\n              def to_str = "to_str: %i/%c"\n            en
+f96c57687c616d93148714a83b1154d5	[true, true, true, -1]	[Thread.instance_method(:terminate) == Thread.instance_method(:kill),\n          
+f9753df55ca02e85298ba3037065394b	true	class A; end\n        class B < A\n          def foo; super; end\n        
+f97a3c1533bab985c4e4a17d0d0e6546	[true, [IO::Buffer::LockedError, "Buffer already locked!"], false, [IO::Buffer::LockedError, "Cannot resize locked buffer!"], true, [IO::Buffer::LockedError, "Buffer is locked!"], [IO::Buffer::LockedError, "Cannot transfer ownership of locked buffer!"], :ret, [true, true, 4], [4, "\\x00\\x00\\x00\\x00"], [IO::Buffer::AccessError, "Cannot resize external buffer!"], [4, true], [true, 0], [false, -1], [TypeError, "wrong argument type String (expected IO::Buffer)"]]	r = []\n            er = ->(&blk) { begin; blk.call; :no_raise; resc
+f981198b05794e558868cf5544fa9b88	[99, 99]	$a = 10\n            alias $b $a\n            $b = 99\n            [$a
+f9843389511d15fa6d856351a7f3000b	["Mod-Parent", "Mod-Parent"]	module Mod\n              def foo_super; "Mod-" + super; end\n       
+f991ea366558cbeb02b13d2f5a671d4d	[1, 3]	class C; def to_ary; [2]; end; end; o = C.new\n[1, 2, 3] - o
+f9bd6b4338c4b0d51b05730024cea911	[20, 10, 52]	$res = []\n        def f(x)\n          binding\n        end\n        b = f(
+f9e2ff5c15a628ba0c0c0e3ecb0620a9	[true, true]	klass = Class.new do\n              define_method(:bar) { :bar }\n   
+f9f55e3d74d8690d687b64db069b8892	[:baz, true]	class Foo\n              def method_missing(name, *args, &blk)\n     
+f9f99c93173a012d54a69a45e15215e8	false	File.file?("monoruby")
+f9fa14a275f704ee73210dcb18d2784d	{"x" => 1, "y" => 2}	S = Struct.new(:x, :y, :z)\n        s = S.new(1, 2, 3)\n        \ns.decons
+f9fab5f087a78b8a69b7a50182209e75	false	File.absolute_path?("tmp")
+fa095bf0fa81fb0d8dba5ea996dd4a85	"a\\\\.b"	o = Object.new\n            def o.to_str; "a.b"; end\n            Reg
+fa18bc1056456d7e5cc4f8f09ad84803	"hello world"	class C; def to_str; " world"; end; end; o = C.new\ns = "hello"; s << o; s
+fa47fb1c9e7a32070609887554293ca5	5	def f; a=5; return a; end; f
+fa5055ac8d08b36b7be1b47119fa4188	[10, 20, 30, 40, 50, 60, 70, 80, 1, 2, 3, 4, 5, 6, 7, 8]	class S < Array\n                def initialize\n                    
+fa598aef00ea6f2cda2486c0aa4ccb14	"symbol"	case :symbol\n        when Integer then 'integer'\n        when Float the
+fab7eee9f4b515894936ad084738442b	[1, 99]	S = Struct.new(:a, :b)\n            \n\n            a = S.new(1, 2)\n  
+fabcf80a8ddf458378128e8d7505cb2e	"/"	File.expand_path("..", "/tmp")
+fac27574a461779f2a50d6859c18ec7b	[[[true, true], [false, true], [true, true], [false, true]], 200, [true, true, true, true, true, true, true, false, true, false], :nope]	def fro(x) = x.frozen?\n            def oid(x) = x.object_id\n       
+fac9bf918d6cefc7590454e6cac04dc2	"abc"	"abc".ljust(-5)
+faf2d0672d70ae819b5f4e530350f3ce	[["a\\n", "b\\n", "c\\n"], ["ISO-8859-1"], ["a\\nb\\nc\\n"], ["a\\n", "b\\n", "c\\n"], "EUC-JP", [["a\\n", "ISO-8859-1"], ["b\\n", "ISO-8859-1"], ["c\\n", "ISO-8859-1"]], ["UTF-16LE"]]	File.write("/tmp/mr_rlf.txt", "a\\nb\\nc\\n")\n            r = []\n     
+fafb2306f5998b1a5d3fd37189e39235	"hello"	class HasToS; def to_s; "hello"; end; end\n            sprintf("%s",
+fb19b9db3ad873510aed81f16b1dbcd9	["ISO-8859-1", "UTF-8"]	(d="/tmp/mono_rpe_あ_#{Process.pid}"; Dir.mkdir(d); a=File.realpath(".".encode(En
+fb34f21f962af0c522442f03bd1d5c04	["ab", "ab"]	$/ = "cde"; s = +"abcde"; r = s.chomp!; $/ = "\\n"; [r, s]
+fb39dbdb558be25e38526a8809edbaac	3	->((*, a)) { a }.call([1, 2, 3])
+fb5ca5680002838248335aca3324daec	[true, true]	f = File.open("Cargo.toml")\n            begin\n              [f.set_
+fb7515015bb0bb626fed9f090adde701	["elefant", 4]	S = Struct.new(:name, :legs, keyword_init: true)\n            \n\n    
+fb83f0f3c5d9a742d3d64fea1049e98f	"abc"	"abc".ljust(3)
+fb85b2dce678ed41a0929ae0e5b0932c	"Kernel"	Kernel.eval("self").to_s
+fb898a4fb6c1f14cbb3b58b90c238f52	[]	mod_p = Module.new { def mspec_test_prepended_probe; end }\n        
+fb9529273f11c1528afb6a800e0aa32c	:arg_error	begin\n          NameError.new.receiver\n          :no_raise\n        resc
+fb9df3e5d8ac26f84e71588e0b39e86a	["line1\\n", "line2\\n", "line3\\n"]	path = "/tmp/monoruby_io_readlines_#{Process.pid}_#{rand(100000)}"\n
+fbb5ae93ec763bbd96e01d2ae35f7d2f	["x", nil]	ENV["MONORUBY_ENV_TEST_DEL"] = "x"\n            before = ENV["MONORU
+fbb6a99a9e767f50065c0f1b714f7960	["RuntimeError", "boom", false]	f = Fiber.new { Fiber.yield :first; :second }\n            f.resume\n
+fc2292041cacaef7aa439e177107ed46	[42, 90, 15, "1/2", "7:8", "argerr"]	def a0; 42; end\n        def a1(x); x * 10; end\n        def a5(a, b, c, 
+fc22a4cd64bea4559dace662cad4cc26	[[1, 2]]	r = []; Enumerator.new { |y| y.yield 1, 2 }.each { |*a| r << a }; r
+fc3d5bf1ce71d212ebacaaf185815390	["RuntimeError", "parent 42", "parent 5"]	parent = Class.new { def m(a) = "parent #{a}" }\n        res = []\n      
+fc49adcb727ee87209fa4da1d578751d	["a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_"]	res = []\n        require "strscan"\n        20.times do\n            s = 
+fc66d3daba82671e0fb10c0ef2627879	16	def fn(x) x*2 end; a=42; c=b=a+7; d=b-a; e=b*d; d=f=fn(e); f=d/a
+fc7b08d7cac4a6e291336d442c5bbc6f	42	def foo\n              1\n            ensure\n              return 42\n
+fc8f36eddd9f77e32d48b729d1924b39	42	Thread.new { 42 }.value
+fcabe82763893dc2d6db35a3fde124a3	[1, [2, 3], 10, 20, 2]	def f(a, *rest, x:, y:, &blk)\n          [a, rest, x, y, blk.call(a)]\n  
+fcc2445d136f04c9f8396ef686f6d60d	[3.14, 3, 0.0, 0, -3.14, -3]	require "rubygems"\n        require "bigdecimal"\n        res = []\n      
+fcc4fbd00ca1fcc2c7411a0e23655985	:x	def go(&block)\n              t = Thread.new { block.call { :x } }\n 
+fccd9b2af4da5e98101a1de27a70a160	true	nil.method(:^) == nil.method(:|)
+fcdcca2a3a76656bb6ca5cc341439c4c	"Struct::Foo"	Struct.new("Foo", :a, :b).to_s\n        
+fce4975816ba52d11476c4911b0ae231	[["Encoding::UndefinedConversionError", "\\"\\\\xC3\\" from ASCII-8BIT to UTF-8"], ["Encoding::UndefinedConversionError", "\\"\\\\xC3\\" to UTF-8 in conversion from ASCII-8BIT to UTF-8 to UTF-16BE"]]	(a = (begin; "\\xC3\\xA9".b.encode("UTF-8"); rescue => e; [e.class.to_s, e.message
+fd03192e84c5725a37498c242306a4f6	[nil, nil, "$! is a read-only variable", "clean"]	res = []\n        Fiber.new do\n          raise "hi"\n        rescue\n     
+fd3802cafa2a8bb073e7a7b5d24fb307	1	case 9\n        when 0,4,8\n          0\n        when 1,5,9\n          1\n  
+fd3ef4cb297b9a0b3056de6c29187e1b	[[0, 1], [2, 3, 4], [100, 200], [1, 2], [3, 4, 5], [100, 200], [2, 3], [4, 5, 6], [100, 200], [3, 4], [5, 6, 7], [100, 200], [4, 5], [6, 7, 8], [100, 200], [5, 6], [7, 8, 9], [100, 200], [6, 7], [8, 9, 10], [100, 200], [7, 8], [9, 10, 11], [100, 200], [8, 9], [10, 11, 12], [100, 200], [9, 10], [11, 12, 13], [100, 200], [10, 11], [12, 13, 14], [100, 200], [11, 12], [13, 14, 15], [100, 200], [12, 13], [14, 15, 16], [100, 200], [13, 14], [15, 16, 17], [100, 200], [14, 15], [16, 17, 18], [100, 200], [15, 16], [17, 18, 19], [100, 200], [16, 17], [18, 19, 20], [100, 200], [17, 18], [19, 20, 21], [100, 200], [18, 19], [20, 21, 22], [100, 200], [19, 20], [21, 22, 23], [100, 200], [20, 21], [22, 23, 24], [100, 200], [21, 22], [23, 24, 25], [100, 200], [22, 23], [24, 25, 26], [100, 200], [23, 24], [25, 26, 27], [100, 200], [24, 25], [26, 27, 28], [100, 200], [25, 26], [27, 28, 29], [100, 200], [26, 27], [28, 29, 30], [100, 200], [27, 28], [29, 30, 31], [100, 200], [28, 29], [30, 31, 32], [100, 200], [29, 30], [31, 32, 33], [100, 200], [30, 31], [32, 33, 34], [100, 200], [31, 32], [33, 34, 35], [100, 200], [32, 33], [34, 35, 36], [100, 200], [33, 34], [35, 36, 37], [100, 200], [34, 35], [36, 37, 38], [100, 200], [35, 36], [37, 38, 39], [100, 200], [36, 37], [38, 39, 40], [100, 200], [37, 38], [39, 40, 41], [100, 200], [38, 39], [40, 41, 42], [100, 200], [39, 40], [41, 42, 43], [100, 200], [40, 41], [42, 43, 44], [100, 200], [41, 42], [43, 44, 45], [100, 200], [42, 43], [44, 45, 46], [100, 200], [43, 44], [45, 46, 47], [100, 200], [44, 45], [46, 47, 48], [100, 200], [45, 46], [47, 48, 49], [100, 200], [46, 47], [48, 49, 50], [100, 200], [47, 48], [49, 50, 51], [100, 200], [48, 49], [50, 51, 52], [100, 200], [49, 50], [51, 52, 53], [100, 200]]	def run\n              out = []\n              50.times do |k|\n      
+fd568c0534228d89142ef4754da5cd21	[A, C]	class Recorder\n          RECORDS = []\n        end\n\n        module X\n   
+fd67bec60fd8f1e0e4e27bcd0a3675a3	[100, 200]	def f(&p)\n            g(&p)\n        end\n                \n        def g(
+fde9c01977b03195091b314bb13afc2f	true	old_stderr = $stderr\n            captured = String.new\n            
+fe1d12a770bcd49e6528c05052a7fe89	[[42], [7]]	$log = []\n            def g(x) = 42\n            def f(...) = g(...)
+fe35ca4f16663c5f99f379b4c63b25e1	:echild	pid = spawn("true")\n            Process.detach(pid).join\n          
+fe6f90f2c79933a3f1d357d607b6b6fa	[true, true, true, "007"]	(a=Kernel.instance_method(:format)==Kernel.instance_method(:sprintf); b=Kernel.m
+fefd9e3b7d143c7b4ef7f710db1241da	"<STDOUT>"	$stdout.path
+ff6ed5a6bc5556996f38110444ed4f1b	1	class Integer; alias __orig :%; def %(o); __orig(o); end; end; 13 % 4
+ff9e2498040dab7413f767cd46c78f25	[0, 1, 1, 1, 4611686018427387902, 4611686018427387905, 4611686018427387900, 3, 4, 7, 6, 4611686018427387903, 4611686018427387906, 4611686018427387901, 6, 7, 13, 11, 4611686018427387904, 4611686018427387907, 4611686018427387902, 9, 10, 19, 16, 4611686018427387905, 4611686018427387908, 4611686018427387903, 12, 13, 25, 21, 4611686018427387906, 4611686018427387909, 4611686018427387904, 15, 16, 31, 26, 4611686018427387907, 4611686018427387910, 4611686018427387905, 18, 19, 37, 31, 4611686018427387908, 4611686018427387911, 4611686018427387906, 21, 22, 43, 36, 4611686018427387909, 4611686018427387912, 4611686018427387907, 24, 25, 49, 41, 4611686018427387910, 4611686018427387913, 4611686018427387908, 27, 28, 55, 46, 4611686018427387911, 4611686018427387914, 4611686018427387909, 30, 31, 61, 51, 4611686018427387912, 4611686018427387915, 4611686018427387910, 33, 34, 67, 56, 4611686018427387913, 4611686018427387916, 4611686018427387911, 36, 37, 73, 61, 4611686018427387914, 4611686018427387917, 4611686018427387912, 39, 40, 79, 66, 4611686018427387915, 4611686018427387918, 4611686018427387913, 42, 43, 85, 71, 4611686018427387916, 4611686018427387919, 4611686018427387914, 45, 46, 91, 76, 4611686018427387917, 4611686018427387920, 4611686018427387915, 48, 49, 97, 81, 4611686018427387918, 4611686018427387921, 4611686018427387916, 51, 52, 103, 86, 4611686018427387919, 4611686018427387922, 4611686018427387917, 54, 55, 109, 91, 4611686018427387920, 4611686018427387923, 4611686018427387918, 57, 58, 115, 96, 4611686018427387921, 4611686018427387924, 4611686018427387919, 60, 61, 121, 101, 4611686018427387922, 4611686018427387925, 4611686018427387920, 63, 64, 127, 106, 4611686018427387923, 4611686018427387926, 4611686018427387921, 66, 67, 133, 111, 4611686018427387924, 4611686018427387927, 4611686018427387922, 69, 70, 139, 116, 4611686018427387925, 4611686018427387928, 4611686018427387923, 72, 73, 145, 121, 4611686018427387926, 4611686018427387929, 4611686018427387924, 75, 76, 151, 126, 4611686018427387927, 4611686018427387930, 4611686018427387925, 78, 79, 157, 131, 4611686018427387928, 4611686018427387931, 4611686018427387926, 81, 82, 163, 136, 4611686018427387929, 4611686018427387932, 4611686018427387927, 84, 85, 169, 141, 4611686018427387930, 4611686018427387933, 4611686018427387928, 87, 88, 175, 146, 4611686018427387931, 4611686018427387934, 4611686018427387929]	def drive\n              res = []\n              j = 0\n              
+ffab0594ecbb10ffe2bbe69dcb755491	[[1, 2], [1, nil], [3, 4], 9, 8, 42, "struct size differs", false]	S = Struct.new(:a, :b)\n            K = Struct.new(:x, keyword_init:
+ffc098432e042caf6d133cc71c10f21b	1	->((a, *)) { a }.call([1, 2, 3])
+ffdb24889c89007dbdeeef12634ddfcf	[:after, "VSChild", true]	class VSParent\n              private\n              def m; :before; 
+ffdd37a11749e039dc0a5ce43f52d1ed	[0, 1, 2, 3, 4, 5, 6, 7, 8]	def f(*x)\n          x\n        end\n        \n\n        f(*[0,1,2,3,4,5,6,7
+ffde28977dbecc25c890234d824d2303	"US-ASCII"	s = "hello".dup.force_encoding("US-ASCII")\n              s[/ell/]


### PR DESCRIPTION
# Summary

The `run_test`-family helpers spawned a reference CRuby process per call — roughly 2900 spawns across the suite — dominating wall-clock time and memory. Yet the expected output (the final `p` line) for a given code string is a constant for a given CRuby version. This PR memoizes that mapping in a checked-in snapshot file, `monoruby/tests/ruby_oracle.tsv`, and switches the single-code helpers to compare against the recorded string instead.

## How it works

- **Covered**: `run_test` / `run_test_once` / `run_test2` / `run_test_with_prelude`. A cache hit spawns no Ruby at all.
- **Not covered (still live CRuby)**: the batched helpers `run_tests` / `run_tests2` (and the binop/unop generators on top of them). Their auto-generated concatenated code strings change with every tweak of the combination tables, so snapshotting them would only bloat the oracle file without a stable benefit.
- **File format**: `truncated SHA-256 of code TAB escaped p-output TAB code-prefix snippet (human context)`. Entries are key-sorted so diffs stay clean. Tabs/newlines are escape-protected so exotic inspect output can never break the TSV framing (round-trip covered by the `oracle_escape_roundtrip` self-test).
- **Self-healing on miss**: an unrecorded code string spawns CRuby once, uses the live answer, and merges the fresh entry into the file under an flock'd read-modify-rename (safe under nextest's process-per-test parallelism). Recording is best-effort — on a read-only checkout only the caching is lost, never the test.

## Handling CRuby version upgrades (modes)

Selected via the `MONORUBY_TEST_ORACLE` environment variable:

- unset / `snapshot` (default): replay stored entries; `rm monoruby/tests/ruby_oracle.tsv && cargo test` regenerates the file from scratch (also dropping orphaned entries).
- `ruby`: always spawn a live CRuby, compare against its answer, and refresh stale entries in place — the mode for re-verifying the whole suite after a CRuby version bump.
- Any other value panics, so typos are caught.

## Verification

- A recording run from an empty oracle (CRuby 4.0.2, ~2900 spawns) recorded 2931 entries in ~50 minutes.
- A second full-suite run passed **3343 tests in 5m43s** with the oracle file byte-identical — every entry hit the cache and all outputs are deterministic.
- Separately confirmed that `ruby` mode really spawns live CRuby for every call and that `snapshot` mode serves every call from the cache.
- Updated the CLAUDE.md testing section and gotchas.

## Notes

The snapshots pin CRuby 4.0.2 output. If a future test's expected output is platform-dependent, the darwin CI job could diverge from snapshots recorded on Linux; in that case setting `MONORUBY_TEST_ORACLE=ruby` on that job restores the previous live-comparison behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM