### PR TITLE
Startup: index the source line tops, and stop resolving every def's location

### DIFF
--- a/monoruby/src/ast/source_info.rs
+++ b/monoruby/src/ast/source_info.rs
@@ -33,6 +33,59 @@ impl Line {
     }
 }
 
+/// Byte offset of every line top in the source, ascending, so that a
+/// position → line-number answer is a binary search rather than a scan
+/// from the top of the file.
+///
+/// `line_tops[0]` is always 0, and each `'\n'` at byte *p* contributes
+/// *p + 1*; index *i* therefore holds the top of line *i + 1*. Built once
+/// per `SourceInfo`, which is immutable after construction.
+///
+/// The scan it replaces was quadratic in aggregate: [`SourceInfo::get_line`]
+/// is called once per `def` executed (`Executor::invoke_method_added`), per
+/// class body entered, and per constant store, so loading the ~10k lines of
+/// `builtins/*.rb` at every interpreter boot re-walked those files ~1200
+/// times — about 30% of startup.
+#[derive(Clone, PartialEq)]
+struct LineTops(Vec<usize>);
+
+impl LineTops {
+    fn new(code: &str) -> Self {
+        // A `'\n'` byte cannot occur inside a multi-byte UTF-8 sequence
+        // (continuation bytes are all >= 0x80), so scanning bytes finds
+        // exactly the newlines `char_indices()` would.
+        let mut tops = Vec::with_capacity(code.len() / 24 + 1);
+        tops.push(0);
+        tops.extend(
+            code.as_bytes()
+                .iter()
+                .enumerate()
+                .filter(|(_, b)| **b == b'\n')
+                .map(|(pos, _)| pos + 1),
+        );
+        Self(tops)
+    }
+
+    /// 1-based number of the line holding byte *pos*. A `'\n'` belongs to
+    /// the line it terminates.
+    fn line_no(&self, pos: usize) -> usize {
+        self.0.partition_point(|&top| top <= pos)
+    }
+
+    /// Number of `'\n'` in the source.
+    fn newlines(&self) -> usize {
+        self.0.len() - 1
+    }
+}
+
+/// Printed as a summary: the offsets themselves are noise in the debug
+/// output of an error or an iseq, and there is one per line of the file.
+impl std::fmt::Debug for LineTops {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "LineTops({} lines)", self.0.len())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct SourceInfo {
     /// directory path of the source code.
@@ -54,6 +107,10 @@ pub struct SourceInfo {
     /// Stored verbatim as written in the source so consumers can
     /// resolve aliases through their own normaliser.
     pub source_encoding: Option<String>,
+    /// Line-start index over `code`, built at construction. Private, so
+    /// the only way to build a `SourceInfo` stays the constructors below
+    /// and the index can never disagree with `code`.
+    line_tops: LineTops,
     /// Value of the `# frozen_string_literal:` magic comment, if present
     /// (`None` = not specified → string literals are mutable, Ruby's
     /// default). When `Some(true)`, every string literal in the file is a
@@ -79,6 +136,7 @@ impl SourceInfo {
         SourceInfo {
             path: path.into(),
             absolute_path: None,
+            line_tops: LineTops::new(&code),
             code,
             line_offset: 0,
             source_encoding: None,
@@ -104,6 +162,7 @@ impl SourceInfo {
         SourceInfo {
             path: path.into(),
             absolute_path: None,
+            line_tops: LineTops::new(&code),
             code,
             line_offset,
             source_encoding: None,
@@ -126,32 +185,13 @@ impl SourceInfo {
     }
 
     pub fn get_line(&self, loc: &Loc) -> i64 {
+        // A position past the end of the source reports the *last* line
+        // rather than one past it — the shape a `Loc` synthesised at EOF
+        // (an unterminated construct) needs.
         if loc.0 >= self.code.len() {
-            return self
-                .code
-                .char_indices()
-                .filter_map(|(pos, ch)| if ch == '\n' { Some(pos) } else { None })
-                .count() as i64
-                + self.line_offset;
+            return self.line_tops.newlines() as i64 + self.line_offset;
         }
-        let mut line_top = 0;
-        self.code
-            .char_indices()
-            .filter_map(|(pos, ch)| if ch == '\n' { Some(pos) } else { None })
-            .enumerate()
-            .map(|(idx, pos)| {
-                let top = line_top;
-                line_top = pos + 1;
-                Line::new(idx + 1, top, pos)
-            })
-            .find_map(|line| {
-                if line.end >= loc.0 && line.top <= loc.0 {
-                    Some(line.line_no as i64 + self.line_offset)
-                } else {
-                    None
-                }
-            })
-            .unwrap()
+        self.line_tops.line_no(loc.0) as i64 + self.line_offset
     }
 
     /// Get file name.
@@ -257,6 +297,74 @@ impl SourceInfo {
 
 fn text_width(s: &str) -> usize {
     console::measure_text_width(s) + s.chars().filter(|c| c == &'\t').count() * 7
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The scan [`SourceInfo::get_line`] used to perform, kept as the
+    /// oracle the binary search is checked against.
+    fn get_line_by_scan(info: &SourceInfo, loc: &Loc) -> i64 {
+        if loc.0 >= info.code.len() {
+            return info
+                .code
+                .char_indices()
+                .filter_map(|(pos, ch)| if ch == '\n' { Some(pos) } else { None })
+                .count() as i64
+                + info.line_offset;
+        }
+        let mut line_top = 0;
+        info.code
+            .char_indices()
+            .filter_map(|(pos, ch)| if ch == '\n' { Some(pos) } else { None })
+            .enumerate()
+            .map(|(idx, pos)| {
+                let top = line_top;
+                line_top = pos + 1;
+                Line::new(idx + 1, top, pos)
+            })
+            .find_map(|line| {
+                if line.end >= loc.0 && line.top <= loc.0 {
+                    Some(line.line_no as i64 + info.line_offset)
+                } else {
+                    None
+                }
+            })
+            .unwrap()
+    }
+
+    /// Every byte offset of a few awkward sources — an empty file, one
+    /// with blank lines, one with multi-byte characters (a `'\n'` byte
+    /// never occurs inside a UTF-8 sequence, which is what lets the
+    /// index scan bytes), one without a trailing newline, and an eval'd
+    /// one carrying a `line_offset` — must answer exactly what the scan
+    /// answered, including one position past the end.
+    #[test]
+    fn get_line_matches_the_scan_it_replaced() {
+        for (code, line_offset) in [
+            ("", 0),
+            ("\n", 0),
+            ("\n\n\n", 0),
+            ("a", 0),
+            ("a\nbb\n\nccc\n", 0),
+            ("a\nbb\n\nccc", 0),
+            ("日本語\nと\n改行\n", 0),
+            ("# コメント\ndef f(x) = x + 1\nf(2)\n", 0),
+            ("a\nbb\nccc\n", 41),
+            ("a\nbb\nccc\n", -1),
+        ] {
+            let info = SourceInfo::new_eval("(test)", code, line_offset);
+            for pos in 0..=info.code.len() {
+                let loc = Loc(pos, pos);
+                assert_eq!(
+                    get_line_by_scan(&info, &loc),
+                    info.get_line(&loc),
+                    "code {code:?}, offset {line_offset}, pos {pos}"
+                );
+            }
+        }
+    }
 }
 
 impl SourceInfo {

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -1362,10 +1362,13 @@ fn caller_frames(
                     // invoker boundary the hook was dispatched across: the
                     // definition site it carries is this frame's line.
                     .or_else(|| {
-                        hook_site.take().filter(|(file, _)| {
-                            *file == crate::globals::display_path(&info.sourceinfo)
-                        })
-                        .map(|(_, line)| line as i64)
+                        hook_site
+                            .take()
+                            .filter(|(source, _)| {
+                                crate::globals::display_path(source)
+                                    == crate::globals::display_path(&info.sourceinfo)
+                            })
+                            .map(|(source, loc)| source.get_line(&loc))
                     })
                     .unwrap_or_else(|| info.sourceinfo.get_line(&info.loc));
                 Some((info.sourceinfo.clone(), line))

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -281,7 +281,7 @@ pub struct Executor {
     /// immediately after, on every arch and in both tiers) has it, so
     /// the location is recorded there.
     pending_const_loc: Option<(ClassId, IdentId)>,
-    /// Stack of definition sites (`file`, `line`) for the
+    /// Stack of definition sites (source, `Loc`) for the
     /// `method_added` / `singleton_method_added` / `const_added` hooks
     /// currently running.
     ///
@@ -292,7 +292,13 @@ pub struct Executor {
     /// enclosing body's own line instead. The backtrace walk consults
     /// this for the first frame whose pc it cannot resolve, which is
     /// exactly that invoker boundary.
-    hook_sites: Vec<(String, u32)>,
+    ///
+    /// The site is kept unresolved (an `Rc` clone and two `usize`s)
+    /// rather than as a formatted path and line: a site is pushed for
+    /// *every* `def` executed but is only ever read by
+    /// `caller_locations`, so resolving it eagerly charged the file/line
+    /// lookup to every definition in the program.
+    hook_sites: Vec<(SourceInfoRef, Loc)>,
     temp_stack: Vec<Value>,
     /// How the method_missing dispatch currently being set up was
     /// called. Consumed (read-and-cleared) by the default
@@ -2372,10 +2378,7 @@ impl Executor {
             .and_then(|func_id| globals.store[func_id].is_iseq())
             .map(|iseq| {
                 let info = &globals.store[iseq];
-                (
-                    crate::globals::display_path(&info.sourceinfo).into_owned(),
-                    info.sourceinfo.get_line(&info.loc) as u32,
-                )
+                (info.sourceinfo.clone(), info.loc)
             });
         let pushed = pushed.is_some_and(|site| {
             self.hook_sites.push(site);
@@ -2616,8 +2619,10 @@ impl Executor {
     }
 
     /// The definition site of the innermost `method_added`-style hook
-    /// currently running, if any. See [`Self::hook_sites`].
-    pub(crate) fn hook_site(&self) -> Option<&(String, u32)> {
+    /// currently running, if any. Unresolved: the caller turns it into a
+    /// file and a line only if the backtrace walk actually needs it. See
+    /// [`Self::hook_sites`].
+    pub(crate) fn hook_site(&self) -> Option<&(SourceInfoRef, Loc)> {
         self.hook_sites.last()
     }
 

--- a/monoruby/tests/begin_end.rs
+++ b/monoruby/tests/begin_end.rs
@@ -8,7 +8,9 @@ use std::process::Command;
 fn run_both(script: &str) {
     let mono = Command::new(env!("CARGO_BIN_EXE_monoruby"))
         .env_remove("RUBYOPT")
-        .args(["-e", script])
+        // Same flags as the `ruby` side below: no gem is needed for these
+        // scripts, and the rubygems boot is most of a spawn's startup cost.
+        .args(["--disable=gems", "-e", script])
         .output()
         .unwrap();
     let ruby = Command::new("ruby")

--- a/monoruby/tests/command_line.rs
+++ b/monoruby/tests/command_line.rs
@@ -12,6 +12,12 @@ fn monoruby() -> Command {
     cmd.env_remove("RUBYOPT")
         .env_remove("RUBYLIB")
         .env_remove("RUBYPATH");
+    // None of the switches under test needs a gem, so skip the rubygems
+    // boot — it is most of a spawn's startup cost, and this file spawns
+    // the binary a few dozen times. It goes in first so a test's own
+    // switches still come after it (and can still override it: the
+    // `--enable`/`--disable` parsing tests append their own).
+    cmd.arg("--disable=gems");
     cmd
 }
 

--- a/monoruby/tests/hash_seed.rs
+++ b/monoruby/tests/hash_seed.rs
@@ -10,6 +10,11 @@ fn monoruby(script: &str) -> Output {
     Command::new(env!("CARGO_BIN_EXE_monoruby"))
         .env_remove("RUBYOPT")
         .env_remove("RUBYLIB")
+        // No gem is needed here, so skip the rubygems boot — the same
+        // `--disable=gems` the in-process harness (`Globals::new_test`)
+        // and the reference-CRuby spawns already run with. It is most of
+        // a spawn's startup cost.
+        .arg("--disable=gems")
         .arg("-e")
         .arg(script)
         .output()

--- a/monoruby/tests/install_root.rs
+++ b/monoruby/tests/install_root.rs
@@ -11,7 +11,15 @@ use std::process::Command;
 /// the install root actually points at an installed `v<version>` tree.
 fn require_json(install_root: Option<&str>) -> std::process::Output {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_monoruby"));
-    cmd.args(["-e", r#"require "json"; puts JSON.generate({"ok" => 1})"#]);
+    // `json` comes from the install root's `lib/`, not from a gem, so the
+    // rubygems boot — most of a spawn's startup cost — is skipped. It also
+    // keeps the bogus-root case failing on the `require` under test rather
+    // than on rubygems' own load.
+    cmd.args([
+        "--disable=gems",
+        "-e",
+        r#"require "json"; puts JSON.generate({"ok" => 1})"#,
+    ]);
     if let Some(root) = install_root {
         cmd.env("MONORUBY_INSTALL_ROOT", root);
     } else {

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -3237,6 +3237,10 @@ fn toplevel_return_argument_warns() {
     drop(f);
     for bin in ["ruby", env!("CARGO_BIN_EXE_monoruby")] {
         let out = std::process::Command::new(bin)
+            // The script needs no gem, and both interpreters take the
+            // flag — skipping the rubygems boot is most of a spawn's
+            // startup cost.
+            .arg("--disable=gems")
             .arg(&script)
             .output()
             .unwrap();

--- a/monoruby/tests/rbconfig.rs
+++ b/monoruby/tests/rbconfig.rs
@@ -11,6 +11,10 @@ extern crate monoruby;
 // reproducible in CI (where a host Ruby is installed).
 #[test]
 fn rbconfig_prefix_falls_back_to_install_root() {
+    // One of the few spawns that deliberately keeps the rubygems boot
+    // (every other integration test passes `--disable=gems`): the
+    // regression is about what rubygems resolves `RbConfig`'s prefix to,
+    // so booting it is the point.
     let out = std::process::Command::new(env!("CARGO_BIN_EXE_monoruby"))
         .env("MONORUBY_GEM_PATH", "")
         .arg("-e")

--- a/monoruby/tests/require.rs
+++ b/monoruby/tests/require.rs
@@ -344,6 +344,10 @@ fn require_removes_loaded_feature_on_failure() {
 #[test]
 fn unloadable_program_file_prints_loaderror() {
     let out = std::process::Command::new(env!("CARGO_BIN_EXE_monoruby"))
+        // The failure happens before the program file is even opened, so
+        // no gem is involved — skip the rubygems boot, which is most of a
+        // spawn's startup cost.
+        .arg("--disable=gems")
         .arg("/no/such/monoruby_program.rb")
         .output()
         .unwrap();
@@ -356,6 +360,7 @@ fn unloadable_program_file_prints_loaderror() {
 
     // A directory is not loadable either (CRuby: `Is a directory -- ...`).
     let out = std::process::Command::new(env!("CARGO_BIN_EXE_monoruby"))
+        .arg("--disable=gems")
         .arg("/etc")
         .output()
         .unwrap();

--- a/monoruby/tests/require_option.rs
+++ b/monoruby/tests/require_option.rs
@@ -11,7 +11,12 @@ use std::io::Write;
 use std::process::Command;
 
 fn monoruby() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_monoruby"))
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_monoruby"));
+    // The libraries required below are local temp files, never gems, so
+    // skip the rubygems boot (see `hash_seed.rs`) — it is most of a
+    // spawn's startup cost.
+    cmd.arg("--disable=gems");
+    cmd
 }
 
 /// Write `body` to a uniquely-named file under the system temp dir and

--- a/monoruby/tests/signal_handling.rs
+++ b/monoruby/tests/signal_handling.rs
@@ -13,6 +13,9 @@ fn monoruby(script: &str) -> Output {
     Command::new(env!("CARGO_BIN_EXE_monoruby"))
         .env_remove("RUBYOPT")
         .env_remove("RUBYLIB")
+        // No gem is needed here, so skip the rubygems boot (see
+        // `hash_seed.rs`) — it is most of a spawn's startup cost.
+        .arg("--disable=gems")
         .arg("-e")
         .arg(script)
         .output()

--- a/monoruby/tests/signal_trap.rs
+++ b/monoruby/tests/signal_trap.rs
@@ -22,7 +22,11 @@ const SIGUSR1: i32 = 10;
 const SIGUSR1: i32 = 30;
 
 fn monoruby() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_monoruby"))
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_monoruby"));
+    // No gem is needed here, so skip the rubygems boot (see
+    // `hash_seed.rs`) — it is most of a spawn's startup cost.
+    cmd.arg("--disable=gems");
+    cmd
 }
 
 /// A trapped, self-delivered SIGUSR1 runs the Ruby handler at the next

--- a/monoruby/tests/system_exit_status.rs
+++ b/monoruby/tests/system_exit_status.rs
@@ -7,7 +7,9 @@ use std::process::Command;
 fn exit_code(script: &str) -> Option<i32> {
     Command::new(env!("CARGO_BIN_EXE_monoruby"))
         .env_remove("RUBYOPT")
-        .args(["-e", script])
+        // No gem is needed here, so skip the rubygems boot (see
+        // `hash_seed.rs`) — it is most of a spawn's startup cost.
+        .args(["--disable=gems", "-e", script])
         .output()
         .expect("spawn monoruby")
         .status

--- a/monoruby/tests/watchdog.rs
+++ b/monoruby/tests/watchdog.rs
@@ -9,7 +9,12 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 
 fn monoruby() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_monoruby"))
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_monoruby"));
+    // No gem is needed here, so skip the rubygems boot (see
+    // `hash_seed.rs`) — it is most of a spawn's startup cost, and the
+    // watchdog budget below is measured against wall-clock.
+    cmd.arg("--disable=gems");
+    cmd
 }
 
 /// A non-allocating infinite loop never reaches the GC poll point, so an


### PR DESCRIPTION
## What

Interpreter boot spent about a third of its time answering "which line is this byte on?".

`SourceInfo::get_line` walked the file from the top with `char_indices()` on **every** call, and a bare boot made **1170** such calls while loading the ~10k lines of `builtins/*.rb` — quadratic in aggregate. Measured with `perf` (~33% of a debug boot) and counted with a gdb breakpoint:

| caller | calls per boot |
|---|---|
| `Executor::invoke_method_added` (once per `def` executed) | 931 |
| `codegen::runtime::enter_classdef` | 139 |
| `BytecodeGen::inst_to_bc` (`StoreConst`) | 100 |

## Changes

**1. `SourceInfo` carries a line-top index.** `LineTops` holds the byte offset of every line top, built once at construction — the struct is immutable afterwards, and the field is private so no construction path can disagree with `code`. `get_line` becomes a `partition_point`. Its `Debug` prints `LineTops(N lines)` so error/iseq dumps don't fill with offsets.

A unit test keeps the old scan as an oracle and checks **every byte position** (plus one past the end) of an empty file, blank lines, multi-byte text, a source without a trailing newline, and an eval'd one carrying a `line_offset`. (A `'\n'` byte never occurs inside a UTF-8 sequence, which is what lets the index scan bytes.)

**2. `method_added` hook sites stay unresolved.** `invoke_method_added` formatted a file and a line for every `def` executed, so that `caller_locations` inside a `method_added` hook could report the definition site. The hook is almost never defined and the site almost never read, so `hook_sites` now holds `(SourceInfoRef, Loc)` and `caller_frames` resolves it only on the path that consumes it.

**3. Binary-spawning integration tests skip the rubygems boot.** The in-process harness (`Globals::new_test` → `no_gems`) and the reference-CRuby spawns (`--disable=gems,rubyopt`) already did; the 12 test files that spawn the binary did not. `rbconfig.rs` is the one deliberately left booting gems — the regression it guards (#772) is about what rubygems resolves `RbConfig`'s prefix to.

## Numbers

Debug build, idle machine, empty script, mean of 10 spawns:

| | before | after |
|---|---|---|
| boot, gems disabled | 84ms | **69ms** |
| boot, gems enabled | 227ms | **183ms** |

The test suite pays this per case, since each `run_test*` call builds a fresh interpreter. `basic_op_redefinition_is_honored_per_pair` boots 60 of them: **6.4s → 4.2s**. The 78 spawn-based integration tests now run in 2.4s total.

## Testing

`cargo nextest run --no-fail-fast`: **3148/3148 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)