### PR TITLE
JIT: guard the receiver in the binop dispatcher, and fire every generator from it

### DIFF
--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -84,17 +84,27 @@ impl<'a> JitContext<'a> {
     /// Attempt guard-free inline emission of `lhs_class#op` at this binop /
     /// comparison site through the registered binary inline generator.
     ///
-    /// Returns `None` when the method doesn't resolve, has no binary
-    /// generator, the basic-op license is gone (redefinition / refinement in
-    /// scope), or the generator declined — the caller falls back to the
-    /// ordinary path. **No class-version guard and no receiver-slot guard**
-    /// are emitted: soundness comes from the recorded bop_dep (redefinition
-    /// evicts every dependent body via `set_bop_redefine`), and the operand
-    /// guards are emitted by the generator itself, only for operands not
-    /// already proven (`gp_ensure` / the float-load discipline). The dep is
-    /// recorded only when the generator emitted (`Done`) or folded
-    /// (`Folded` — a fold bakes in the builtin's semantics just the same),
-    /// so a declined generator leaves no spurious dependency.
+    /// The shape is the one every operator dispatcher now shares: resolve
+    /// `lhs_class#op`, **guard the receiver**, run the generator (which
+    /// dispatches on the argument class — `Integer#+` emits the fixnum path
+    /// for an Integer rhs and the xmm path for a Float one), and let anything
+    /// it declines fall back to the ordinary method call.
+    ///
+    /// Returns `None` when the method doesn't resolve, has no generator, the
+    /// basic-op license is gone (redefinition / refinement in scope, or a
+    /// pair the eviction machinery doesn't track), or the generator declined.
+    /// **No class-version guard** is emitted: soundness comes from the
+    /// recorded bop_dep (a redefinition evicts every dependent body via
+    /// `set_bop_redefine`). The dep is recorded only when the generator
+    /// emitted (`Done`) or folded (`Folded` — a fold bakes in the builtin's
+    /// semantics just the same), so a declined generator leaves no spurious
+    /// dependency.
+    ///
+    /// The receiver guard is emitted here rather than inside each generator
+    /// so that a generator may simply assume its receiver class — which is
+    /// what lets the plain [`InlineFuncInfo::InlineGen`] operators
+    /// (`Integer#% ** << >>`, whose code reads the receiver unguarded) fire
+    /// from here too.
     ///
     /// Visibility is deliberately not consulted, matching the ad-hoc fast
     /// paths this replaces (the interpreter's fast paths don't consult it
@@ -114,9 +124,15 @@ impl<'a> JitContext<'a> {
         mode: BinaryInlineMode,
     ) -> Option<BinaryInlineOutcome> {
         let (fid, _visibility) = self.jit_check_method(lhs_class, op)?;
-        let InlineFuncInfo::InlineGenBinary(f) = self.store.inline_info.get_inline(fid)? else {
+        let inline = self.store.inline_info.get_inline(fid)?;
+        if !matches!(
+            inline,
+            InlineFuncInfo::InlineGenBinary(_) | InlineFuncInfo::InlineGen(_)
+        ) {
+            // `Float#%` / `Float#**` are `CFunc_FF_F`, which the ordinary
+            // call path already lowers to an inline xmm C call.
             return None;
-        };
+        }
         if !self.basic_op_assumable(lhs_class, op) {
             return None;
         }
@@ -126,8 +142,32 @@ impl<'a> JitContext<'a> {
         debug_assert_eq!(self.store[callid].recv, lhs);
         debug_assert_eq!(self.store[callid].args, rhs);
         debug_assert!(self.store[callid].block_fid.is_none());
-        match self.inline_asm_binary(state, ir, f, callid, lhs_class, rhs_class, mode) {
-            BinaryInlineOutcome::Declined => None,
+        // The receiver guard and the generator emit as one unit: a generator
+        // that declines after the guard was emitted must leave no trace.
+        let state_save = state.clone();
+        let ir_save = ir.save();
+        state.guard_recv_class(ir, lhs, lhs_class);
+        let outcome = match self.store.inline_info.get_inline(fid).unwrap() {
+            InlineFuncInfo::InlineGenBinary(f) => {
+                self.inline_asm_binary(state, ir, f, callid, lhs_class, rhs_class, mode)
+            }
+            // The plain generators (`Integer#% ** << >>`) have no fused
+            // compare-and-branch form, so they only serve `Value` mode.
+            InlineFuncInfo::InlineGen(f) if matches!(mode, BinaryInlineMode::Value) => {
+                if self.inline_asm(state, ir, f, callid, lhs_class, rhs_class) {
+                    BinaryInlineOutcome::Done
+                } else {
+                    BinaryInlineOutcome::Declined
+                }
+            }
+            _ => BinaryInlineOutcome::Declined,
+        };
+        match outcome {
+            BinaryInlineOutcome::Declined => {
+                *state = state_save;
+                ir.restore(ir_save);
+                None
+            }
             outcome => {
                 self.record_bop_dep(lhs_class, op);
                 Some(outcome)
@@ -147,66 +187,43 @@ impl<'a> JitContext<'a> {
         ic: Option<(ClassId, ClassId)>,
         bc_pos: BcIndex,
     ) -> JitResult<CompileResult> {
-        match kind {
-            // These ops are always compiled as method calls.
-            // The InlineGen registered on Integer#<< / Integer#>> /
-            // Integer#** / Integer#% / Float#** / Float#% handles code
-            // generation using both-side class info from the BinOp inline
-            // cache (Integer#| / #& / #^ moved to the binary-generator
-            // direct-fire arm below).
-            BinOpK::Shl | BinOpK::Shr | BinOpK::Exp | BinOpK::Rem => {
-                // Dispatched through `call_binary_method`. No flush here: a
-                // register-only inline (e.g. `Integer#<<`) reads its operands
-                // GP-resident-aware and keeps the residents live, while any C-ABI
-                // call (a clobbering inline like `Array#<<`, or the cached
-                // method-call path) flushes them at its `get_using_fpr` chokepoint.
-                let (lhs_class, rhs_class) = state.binary_class(lhs, rhs, ic);
-                match lhs_class {
-                    None => Ok(self.binop_uncached(state, dst)),
-                    Some(lhs_class) => self.call_binary_method(
-                        state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos, false,
-                    ),
-                }
-            }
-            _ => {
-                let (lhs_class, rhs_class) = state.binary_class(lhs, rhs, ic);
-                let Some(lhs_class) = lhs_class else {
-                    // Recompiles (deopts) — its write-back re-homes the residents.
-                    return Ok(self.binop_uncached(state, dst));
-                };
-                // The binary inline generator (`Integer#+`'s fixnum path,
-                // `Float#+`'s xmm path, the mixed pairs) emits the constant
-                // fold or the register fast path with no per-op runtime
-                // guard. A basic-op redefinition is instead handled
-                // method-wide by `set_bop_redefine`, identically on both
-                // arches: compiled method entries are reverted (x86
-                // `apply_jmp_patch_address` to `vm_entry`; aarch64
-                // dispatch-slot zeroing in `invalidate_jit_code`), the VM's
-                // `loop_start` handler is swapped for the no-opt one so
-                // stale OSR loop bodies are never re-entered, and on-stack
-                // frames deopt on return via `immediate_eviction`'s
-                // return-address patching (both arches; see `emit_call`). A
-                // `def` executed *inside* JIT code is caught by the
-                // `check_bop` after `MethodDef`/`SingletonMethodDef`.
-                if let Some(BinaryInlineOutcome::Done) = self.fire_binary_inline(
-                    state,
-                    ir,
-                    kind.into(),
-                    lhs,
-                    rhs,
-                    lhs_class,
-                    rhs_class,
-                    bc_pos,
-                    BinaryInlineMode::Value,
-                ) {
-                    return Ok(CompileResult::Continue);
-                }
-                // Any C-ABI call flushes at its `get_using_fpr` chokepoint.
-                self.call_binary_method(
-                    state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos, false,
-                )
-            }
+        let (lhs_class, rhs_class) = state.binary_class(lhs, rhs, ic);
+        let Some(lhs_class) = lhs_class else {
+            // Recompiles (deopts) — its write-back re-homes the residents.
+            return Ok(self.binop_uncached(state, dst));
+        };
+        // One path for every operator: guard the receiver, run the generator
+        // registered on `lhs_class#op`, and fall back to the method call for
+        // whatever it declines. The generator picks its emission from the
+        // argument class — `Integer#+` computes in GP registers for an
+        // Integer rhs and in xmm for a Float one — so the Integer/Float pairs
+        // are no longer a case the dispatcher knows about.
+        //
+        // The emitted arithmetic carries no per-op check that the operator is
+        // still the builtin: a basic-op redefinition is handled method-wide
+        // by `set_bop_redefine`, identically on both arches. Compiled method
+        // entries are reverted (x86 `apply_jmp_patch_address` to `vm_entry`;
+        // aarch64 dispatch-slot zeroing in `invalidate_jit_code`), the VM's
+        // `loop_start` handler is swapped for the no-opt one so stale OSR
+        // loop bodies are never re-entered, and on-stack frames deopt on
+        // return via `immediate_eviction`'s return-address patching (see
+        // `emit_call`). A `def` executed *inside* JIT code is caught by the
+        // `check_bop` after `MethodDef`/`SingletonMethodDef`.
+        if let Some(BinaryInlineOutcome::Done) = self.fire_binary_inline(
+            state,
+            ir,
+            kind.into(),
+            lhs,
+            rhs,
+            lhs_class,
+            rhs_class,
+            bc_pos,
+            BinaryInlineMode::Value,
+        ) {
+            return Ok(CompileResult::Continue);
         }
+        // Any C-ABI call flushes at its `get_using_fpr` chokepoint.
+        self.call_binary_method(state, ir, lhs, rhs, lhs_class, rhs_class, kind, bc_pos, false)
     }
 
     pub(super) fn binary_cmp(

--- a/monoruby/src/codegen/jitgen/state/binop.rs
+++ b/monoruby/src/codegen/jitgen/state/binop.rs
@@ -774,6 +774,59 @@ impl AbstractFrame {
         }
     }
 
+    ///
+    /// Guard the receiver's class ahead of an inline generator, so the
+    /// generator may assume it (the direct-fire dispatchers call this before
+    /// firing, mirroring the guard `compile_method_call` emits on the
+    /// ordinary path).
+    ///
+    /// Emits nothing when the class is already proven (a constant operand, or
+    /// a slot an earlier guard already refined — so a foldable site never
+    /// materializes anything).
+    ///
+    /// Otherwise the guard is emitted **through the primitive that class's
+    /// generators use to hold the value**, so that establishing the receiver
+    /// costs nothing beyond what the generator was going to pay anyway:
+    ///
+    /// * `Integer` — `gp_ensure`, which brings the value into an
+    ///   allocator-chosen GP register and reports whether it still needs the
+    ///   fixnum guard. Guard-then-refine keeps the resident, so the
+    ///   generator's own `gp_ensure` is a pure hit: same register, no reload,
+    ///   no second guard. (Materializing into `Rdi` instead would make the
+    ///   generator reload the value into a pool register — measurably slower
+    ///   on integer-heavy code.)
+    /// * `Float` — `load_fpr`, whose guarded unbox *is* the class check; the
+    ///   generator's later `load_fpr` then finds the slot already in an fpr
+    ///   and emits nothing.
+    /// * anything else — materialize into `Rdi` and compare the class id.
+    ///
+    pub(crate) fn guard_recv_class(&mut self, ir: &mut AsmIr, slot: SlotId, class: ClassId) {
+        if self.class(slot) == Some(class) {
+            return;
+        }
+        match class {
+            INTEGER_CLASS => {
+                let (gp, needs_guard) = self.gp_ensure(ir, slot, &[]);
+                if needs_guard {
+                    let deopt = ir.new_deopt(self);
+                    ir.push(AsmInst::GuardClass(gp, INTEGER_CLASS, deopt));
+                    self.refine_S_fixnum(slot);
+                }
+            }
+            FLOAT_CLASS => {
+                self.load_fpr(ir, slot);
+            }
+            _ => {
+                // Snapshot before the guard: the side exit re-reads the
+                // operands from their stack homes, so the write-back must be
+                // the pre-guard placement.
+                let deopt = ir.new_deopt(self);
+                self.load(ir, slot, GP::Rdi);
+                self.guard_class(ir, slot, GP::Rdi, class, deopt);
+            }
+        }
+    }
+
     /// The compile-time comparison fold shared by the primitives and the
     /// binary inline generators' `CmpBr`-mode constant resolution.
     pub(crate) fn fold_cmp<T>(kind: CmpKind, lhs: T, rhs: T) -> bool


### PR DESCRIPTION
## Summary

Completes the operator unification (#1116 / #1117 / #1119): the binop dispatcher no longer knows anything about Fixnum/Float pairs, and no operator has a special arm any more. `binary_op` is one path:

```
resolve lhs_class#op  →  guard the receiver  →  run that method's generator
   →  the generator dispatches on the argument class
        (Integer#+ : GP registers for an Integer rhs, xmm for a Float one)
   →  anything it declines falls back to the ordinary method call
```

which is exactly the shape `[]` / `[]=` use.

## Moving the receiver guard to the caller

Previously the receiver was guarded *inside* the generator, as a side effect of its operand handling (`gp_ensure`'s fixnum guard). Emitting it in the dispatcher instead means a generator may simply **assume its receiver class** — and that is what unblocks the plain `InlineGen` operators.

**`guard_recv_class` emits the guard through the primitive that class's generators hold the value in.** A naive "load into `Rdi`, compare the class" cost **app_fib 7.6%**, because `Rdi` is outside the GP allocator pool (`[R8, R9, R10, R11]`) so the generator promptly reloaded the value into a pool register. Instead:

| receiver class | primitive used | result |
|---|---|---|
| `Integer` | `gp_ensure` + guard-then-refine | the generator's own `gp_ensure` is a pure hit — same register, no reload, no second guard |
| `Float` | `load_fpr` | its guarded unbox *is* the class check; the generator's later `load_fpr` emits nothing |
| anything else | `Rdi` + class-id compare | same as the index path |

Nothing is emitted at all when the class is already proven, so constant-folding sites are untouched.

## The last special case is gone

With the receiver established by the caller, `Integer#% ** << >>` — whose generators read the receiver **unguarded**, relying on `compile_method_call` having guarded it — became direct-fireable. `fire_binary_inline` now fires both `InlineGenBinary` (mode-aware, for the comparisons) and plain `InlineGen` (Value mode only, since they have no fused compare-and-branch form), and `binary_op`'s `Shl | Shr | Exp | Rem` arm is deleted.

`Float#%` / `Float#**` stay `CFunc_FF_F`: they decline direct-fire and take the ordinary call path, which already lowers them to an inline xmm C call — unchanged behavior.

## Tests

- Full suite green on x86-64 (`--features stress-spill-pool`, 61 test binaries), including the binop register-file regression tests (dirty-operand overflow deopt, shared-operand register, resident transfer, immediate-form boundaries) and the BOP-redefinition suite. `cargo check --target aarch64-unknown-linux-gnu` passes.
- **ruby/spec**: `core/integer` (598 examples), `core/float` (260), `core/numeric` (326), `core/array` (2892) — all 0 failures.

## Performance

Interleaved A/B of the pre- and post-change binaries, min of 5:

| bench | before | after |
|---|---|---|
| so_mandelbrot | 2.98s | **2.75s** (−7%, reproduced across two independent rounds) |
| binarytrees | 0.242s | **0.231s** (−4.5%) |
| integer `% << >>` microbench | 11ms | **10ms** (−10%, these now direct-fire) |
| app_fib | 0.174s | 0.173s (neutral) |
| so_nbody | 0.251s | 0.254s (~1%, within noise) |
| float microbench | 23ms | 23ms (neutral) |

The Float path was the one I expected to pay for a caller-side guard — routing it through `load_fpr` rather than a separate class check avoided that, and `so_mandelbrot` came out ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_