### PR TITLE
GC: keep the old generation across a major collection

### DIFF
--- a/doc/gc.md
+++ b/doc/gc.md
@@ -276,8 +276,36 @@ old_count >= old_major_threshold  ||  minors_since_major >= MAX_MINORS_PER_MAJOR
 
 | kind | 操作 |
 | --- | --- |
-| **Major** | `clear_mark()`(mark_bits=0)+ `clear_old()`(old_bits=0, `old_count=0`)+ `remembered.clear()`。全オブジェクトが収集候補に戻り、ルートから再マーク・全スイープ。 |
+| **Major** | `clear_mark()`(mark_bits=0)のみ。全オブジェクトが収集候補に戻り、ルートから再マーク・全スイープ。**`old_bits` と remembered set は保持**する(下記)。 |
 | **Minor** | `seed_marks()`。各ページで `mark_bits ← old_bits` をコピー(`seed_mark_from_old`)。old オブジェクトは**最初からマーク済み**とみなされ、再走査もスイープもされない。 |
+
+#### メジャーは old 世代を維持する
+
+メジャー GC は old を**降格しない**。old だったオブジェクトがメジャーを生き延びたら
+old のままで、remembered / armed の区別(ヘッダの OLD + WB_ARMED、および
+`remembered`)もそのまま引き継ぐ。
+
+降格していた頃は、生きている old 世代**全件**が毎メジャーで
+「`aging` への push → age 加算 → `promote_to_old` → `young_child_exists` の全子走査」
+をやり直していた(age は飽和済みなので昇格自体は同じサイクル内で完了するが、
+old 世代の参照辺をもう一度全走査するコストがそのまま乗る)。さらにメジャー直後の
+マイナーは old 世代が空の状態から始まるため、シードマークの利得も失われていた。
+
+維持に伴い、**死んだ old セルのビットを畳む場所**が変わる:
+
+- `sweep`:各ビットマップ語で `old_bits &= mark_bits` とし、落ちたビット数を
+  `old_count` から引く(`retire_dead_old`)。解放セルは free list 経由で
+  **若い**オブジェクトとして再利用されるので、古いビットが残っていると次のマイナーで
+  seed-mark され、新しいオブジェクトの子が一度も走査されない。
+- `salvage_empty_pages`:全セルが死んだページは `sweep` の前に `pages` から外れる
+  ため、ここで `old_count` を減らし `clear_old_bits()` する。
+- 適応的メジャー閾値 `old_major_threshold` の再計算は**スイープ後**に行う
+  (生きている old 世代を基準にするため)。
+
+remembered set は、マイナーの `mark_remembered` に加えて、メジャーでは
+`reclassify_remembered`(§6.4)が young の子を失った entry を落として `arm_barrier`
+する。コストは remembered set のサイズ(生きた old→young 辺)に比例し、
+old 世代全体には比例しない。
 
 ### 6.3 マークフェーズ
 
@@ -287,6 +315,9 @@ old_count >= old_major_threshold  ||  minors_since_major >= MAX_MINORS_PER_MAJOR
 3. `gc_check_and_mark`(`alloc.rs:1007`)は、初めてマークしたセルが `promoting` かつ
    `is_promotable()` なら `aging` に積む(昇格候補の収集)。ヘッダ書き換えは
    マーク走査が握る `&self` とエイリアスしないよう**マーク後に遅延**する。
+   ただし**既に old のセルは積まない**:マイナーではシードマーク済みでそもそも
+   ここに来ないが、メジャーは old も普通にマークするため `old_bits` の確認が要る
+   (`major_mark` フラグで、この余分なビットマップ読みをマイナー側に持ち込まない)。
 4. **Minor のみ** `mark_remembered()`:remembered set の各 old オブジェクトの
    *子だけ*を `mark_children` で辿る(親 old は既にシードマーク済み)。これにより
    「old からしか参照されていない young オブジェクト」に到達する。走査後、若い子が
@@ -307,6 +338,17 @@ old_count >= old_major_threshold  ||  minors_since_major >= MAX_MINORS_PER_MAJOR
   いる**(`young_child_exists`)なら remembered set に追加(バリア導入前から存在した
   old→young 辺をカバー)。young 参照が無ければ `arm_barrier` して以後の young ストアに
   備える。
+
+メジャーではこの後に `reclassify_remembered`(`filter_remembered` で死んだ entry を
+落とした後)が走る。生き残った entry のうち young の子を失ったもの
+(この収集で子が昇格した/死んだ)を set から外し `arm_barrier` する — マイナーの
+`mark_remembered` に内蔵された自己クリーニングと同じ役割で、メジャーが set を
+作り直さなくなった分をここで担保する。
+
+> **注**: 以前はメジャーが remembered set を毎回ゼロから作り直していたため、
+> 書き込みバリアの漏れがあってもメジャーごとに自己修復されていた。維持方式では
+> それが無いので、バリア契約(§7.3 の `is_promotable`)の破れはマスクされずに
+> 顕在化する。`gc-stress` + `gc-verify` で検証すること。
 
 ### 6.5 マイナー後の検証(`gc-verify` フィーチャ)
 
@@ -582,5 +624,9 @@ stderr へ出力して abort する(`alloc.rs` の `malloc_hard_limit`)。OOM �
 - 世代別の心臓部は、**3 回生存で昇格(aging)**・**適応的メジャー閾値**・
   **1 ビット高速パスの書き込みバリア + remembered set(自己クリーニング付き)**。
   マイナーは old をシードマークして young + old→young 辺だけを辿る。
+- **メジャーも old 世代を維持する**(降格して作り直さない)。old のビットと
+  remembered/armed の区別はオブジェクトと寿命を共にし、死んだ old セルの後始末は
+  スイープとページ回収が担う。old 世代が大きいほどメジャーが安くなる
+  (old 61 万で 1 回あたり 74ms → 27ms)。
 - 外部 malloc 圧・シグナル・`GC.start` も同じ poll ワード経由で同一のセーフ
   ポイント収集に集約される(レーン分割は `poll_flag.rs` / `doc/safepoint.md` §3)。

--- a/monoruby/src/alloc.rs
+++ b/monoruby/src/alloc.rs
@@ -444,6 +444,12 @@ pub struct Allocator<T> {
     /// real mark of a GC cycle; cleared so the `gc-verify` re-mark has
     /// no promotion side effects.
     promoting: bool,
+    /// Whether the mark phase currently running belongs to a *major*
+    /// collection. A major keeps the old generation (`old_bits` is not
+    /// cleared) and marks old objects along with everything else, so it
+    /// is the only phase that has to test `old_bits` before treating a
+    /// freshly marked cell as an aging candidate.
+    major_mark: bool,
     /// Promotable objects marked (survived) this cycle. Their age is
     /// incremented in the post-mark `apply_aging` pass, and those
     /// reaching `RGENGC_OLD_AGE` are promoted there (old_bits + header
@@ -707,6 +713,7 @@ impl<T: GCBox> Allocator<T> {
             old_count: 0,
             old_major_threshold: OLD_OBJECT_FLOOR,
             promoting: false,
+            major_mark: false,
             aging: Vec::new(),
             remembered: Vec::new(),
             pages_since_gc: 0,
@@ -1226,23 +1233,32 @@ impl<T: GCBox> Allocator<T> {
             );
         }
         // Prepare the mark bitmaps:
-        // - Major: zero `mark_bits` and `old_bits`; every object becomes
-        //   a collection candidate and is re-marked from the roots.
+        // - Major: zero `mark_bits` only; every object becomes a
+        //   collection candidate and is re-marked from the roots, but
+        //   `old_bits` is *kept* — an object that was old and survives a
+        //   major stays old (see below).
         // - Minor: seed `mark_bits` from `old_bits`, so old objects start
         //   "already marked" and are skipped by mark and sweep.
-        // (Currently `old_bits` is always empty — nothing is promoted —
-        // so the two paths are equivalent. See gc.md.)
         match kind {
-            GcKind::Major => {
-                self.clear_mark();
-                self.clear_old();
-                // Every object is demoted and re-aged from scratch, so the
-                // remembered set is rebuilt by this cycle's `apply_aging`.
-                // (Demoted objects are young again — fully scanned — so
-                // their now-stale OLD/WB_ARMED header bits are
-                // harmless until re-promotion resets them.)
-                self.remembered.clear();
-            }
+            // Surviving old objects keep their generation across a major:
+            // demoting them would make the whole live old set re-age and
+            // re-promote (an `aging` entry, three header writes and a
+            // `young_child_exists` scan each), and would leave the minors
+            // right after a major scanning a heap with no old generation
+            // at all. Their `old_bits` therefore stay set here; the bits
+            // of the ones that turn out to be *dead* are cleared where
+            // their cells are actually reclaimed (`sweep` /
+            // `salvage_empty_pages`), which is also where `old_count` is
+            // decremented.
+            //
+            // Their remembered/armed classification (header OLD +
+            // WB_ARMED, mirrored by `remembered`) is preserved for the
+            // same reason: the write barrier keeps it correct for new
+            // stores, entries that lost their young children are dropped
+            // by `reclassify_remembered` below, and dead entries by
+            // `filter_remembered` — so the set stays bounded without a
+            // full-old-generation rescan.
+            GcKind::Major => self.clear_mark(),
             GcKind::Minor => self.seed_marks(),
         }
         // Skip all heap-frame bookkeeping entirely when nothing has
@@ -1256,6 +1272,7 @@ impl<T: GCBox> Allocator<T> {
         }
         // Surviving objects may be promoted during the real mark.
         self.promoting = true;
+        self.major_mark = kind == GcKind::Major;
         root.mark(self);
         // A minor GC must also reach young objects referenced only from
         // old (already-marked) objects, via the remembered set.
@@ -1263,18 +1280,14 @@ impl<T: GCBox> Allocator<T> {
             self.mark_remembered();
         }
         self.promoting = false;
+        self.major_mark = false;
         // Age this cycle's promotable survivors and promote those old
         // enough (deferred from the mark phase to avoid aliasing). Safe:
         // marking is complete.
         self.apply_aging();
-        // After a major rebuilds the old generation, re-arm the adaptive
-        // trigger relative to this baseline: major again once the old gen
-        // has grown by `OLD_GROWTH_FACTOR` (floored).
-        if kind == GcKind::Major {
-            self.old_major_threshold = (self.old_count * OLD_GROWTH_FACTOR).max(OLD_OBJECT_FLOOR);
-        }
         // The incrementally maintained `old_count` must equal the actual
-        // number of old cells (popcount of `old_bits`).
+        // number of old cells (popcount of `old_bits`). Dead old cells are
+        // still counted in both here; sweep drops them from each together.
         #[cfg(feature = "gc-debug")]
         debug_assert_eq!(self.old_count, self.old_count_popcount());
         #[cfg(feature = "gc-debug")]
@@ -1284,9 +1297,25 @@ impl<T: GCBox> Allocator<T> {
         // Drop dead entries from the remembered set before sweep frees
         // them: keep only objects still marked this cycle.
         self.filter_remembered();
+        // A major keeps the old generation, so nothing else would ever
+        // re-examine entries whose young children have since been
+        // promoted or died. Re-classify the (small) surviving set here —
+        // the minor path does the same in `mark_remembered`.
+        if kind == GcKind::Major {
+            self.reclassify_remembered();
+        }
         let mark_elapsed = clock.map(|(_, t)| t.elapsed());
         self.salvage_empty_pages();
         self.sweep();
+        // Re-arm the adaptive trigger relative to the *live* old
+        // generation: major again once it has grown by
+        // `OLD_GROWTH_FACTOR` (floored). Computed after sweep, which is
+        // where dead old cells leave `old_count`.
+        if kind == GcKind::Major {
+            self.old_major_threshold = (self.old_count * OLD_GROWTH_FACTOR).max(OLD_OBJECT_FLOOR);
+        }
+        #[cfg(feature = "gc-debug")]
+        debug_assert_eq!(self.old_count, self.old_count_popcount());
         if has_heap_frames {
             self.sweep_heap_frames();
         }
@@ -1389,8 +1418,17 @@ impl<T: GCBox> Allocator<T> {
             // ones old enough are promoted) after marking, in
             // `apply_aging`, to avoid aliasing the `&self` the mark
             // traversal holds. Already-old objects never reach here in a
-            // minor GC (they are seeded-marked and return early above).
-            if self.promoting && ptr.is_promotable() {
+            // minor GC (they are seeded-marked and return early above),
+            // but a major marks them like everything else — and they are
+            // old already, so aging them again would only re-do the
+            // promotion they have long since made. `major_mark` keeps the
+            // extra bitmap read off the minor path, where it can never
+            // find anything.
+            if self.promoting
+                && ptr.is_promotable()
+                && !(self.major_mark
+                    && unsafe { (*page_ptr).old_bits[index / 64] } & bit_mask != 0)
+            {
                 self.aging.push(p as *mut T);
             }
         }
@@ -1505,19 +1543,39 @@ impl<T: GCBox> Allocator<T> {
     }
 
     ///
-    /// Clear all old-generation bitmaps (major GC demotes every object
-    /// to a collection candidate). See `doc/gc.md`.
+    /// Major GC: re-classify the surviving remembered set, dropping the
+    /// entries that no longer reference the young generation (their
+    /// children died, or were promoted by this very cycle) and arming
+    /// their barrier again.
     ///
-    fn clear_old(&mut self) {
-        unsafe {
-            self.current_page.as_mut().clear_old_bits();
-            self.pages
-                .iter_mut()
-                .for_each(|heap| heap.as_mut().clear_old_bits());
+    /// This is the major-GC counterpart of the self-cleaning built into
+    /// `mark_remembered`, and it is what keeps the set from growing
+    /// monotonically now that a major no longer rebuilds it from
+    /// scratch. Its cost is proportional to the remembered set — the
+    /// live old→young edges — not to the whole old generation, which is
+    /// exactly what the old rebuild-everything path cost.
+    ///
+    /// Must run after `apply_aging` (so this cycle's promotions are
+    /// visible) and after `filter_remembered` (so every entry is live).
+    /// Marking is complete, so every child of a live old object is live
+    /// too: reading them before sweep is sound.
+    ///
+    fn reclassify_remembered(&mut self) {
+        if self.remembered.is_empty() {
+            return;
         }
-        // Every object is demoted; `apply_aging` re-promotes the survivors
-        // this cycle and counts them back up.
-        self.old_count = 0;
+        let remembered = std::mem::take(&mut self.remembered);
+        let mut kept = Vec::with_capacity(remembered.len());
+        for ptr in remembered {
+            // SAFETY: entries are live (dead ones were just filtered out)
+            // and sweep has not run, so the cell is valid here.
+            if unsafe { ptr.as_ref().young_child_exists(self) } {
+                kept.push(ptr);
+            } else {
+                unsafe { (*ptr.as_ptr()).arm_barrier() };
+            }
+        }
+        self.remembered = kept;
     }
 
     ///
@@ -1606,6 +1664,15 @@ impl<T: GCBox> Allocator<T> {
                 // We must check from the last page, because the page can be removed during iteration.
                 if self.pages[len - i - 1].as_ref().all_dead() {
                     let mut page = self.pages.remove(len - i - 1);
+                    // Every cell here is dead, and the page leaves
+                    // `self.pages` before `sweep` runs — so this is the
+                    // only chance to retire the old-generation accounting
+                    // of the old cells that died on it. (`sweep` does the
+                    // same for dead old cells on pages that stay.)
+                    let stale_old = page.as_ref().old_count();
+                    debug_assert!(stale_old <= self.old_count);
+                    self.old_count = self.old_count.saturating_sub(stale_old);
+                    page.as_mut().clear_old_bits();
                     page.as_mut().drop_inner_cells();
                     self.free_pages.push_back(page);
                     self.total_freed_pages += 1;
@@ -1650,7 +1717,27 @@ impl<T: GCBox> Allocator<T> {
             c
         }
 
+        /// Retire the old-generation bits of the dead cells in one
+        /// bitmap word, returning how many there were.
+        ///
+        /// A dead cell goes on the free list and is handed out again as a
+        /// fresh *young* object, so its `old_bits` entry must not
+        /// survive it: a stale bit would seed-mark the reused cell in the
+        /// next minor GC, which would then never scan the new object's
+        /// children. Now that a major keeps `old_bits`, sweep is where
+        /// dead old cells leave both the bitmap and `old_count`.
+        #[inline]
+        fn retire_dead_old(old: &mut u64, live: u64) -> usize {
+            let dead_old = *old & !live;
+            if dead_old == 0 {
+                return 0;
+            }
+            *old &= live;
+            dead_old.count_ones() as usize
+        }
+
         let mut c = 0;
+        let mut demoted = 0;
         let mut anchor = T::new_invalid();
         let head = &mut ((&mut anchor) as *mut T);
         let mut log = if free_log_enabled() {
@@ -1661,9 +1748,12 @@ impl<T: GCBox> Allocator<T> {
 
         for pinfo in self.pages.iter_mut() {
             unsafe {
-                let mut ptr = pinfo.as_ref().get_first_cell();
-                for map in pinfo.as_mut().mark_bits.iter() {
-                    c += sweep_bits(64, *map, &mut ptr, head, &mut log);
+                let page = pinfo.as_mut();
+                let mut ptr = page.get_first_cell();
+                for w in 0..SIZE - 1 {
+                    let map = page.mark_bits[w];
+                    demoted += retire_dead_old(&mut page.old_bits[w], map);
+                    c += sweep_bits(64, map, &mut ptr, head, &mut log);
                 }
             }
         }
@@ -1672,16 +1762,25 @@ impl<T: GCBox> Allocator<T> {
         assert!(self.used_in_current <= DATA_LEN);
         let i = self.used_in_current / 64;
         let bit = self.used_in_current % 64;
-        let bitmap = unsafe { self.current_page.as_mut().mark_bits };
+        let page = unsafe { self.current_page.as_mut() };
 
-        for map in bitmap.iter().take(i) {
-            c += sweep_bits(64, *map, &mut ptr, head, &mut log);
+        for w in 0..i {
+            let map = page.mark_bits[w];
+            demoted += retire_dead_old(&mut page.old_bits[w], map);
+            c += sweep_bits(64, map, &mut ptr, head, &mut log);
         }
 
         if i < SIZE - 1 {
-            c += sweep_bits(bit, bitmap[i], &mut ptr, head, &mut log);
+            let map = page.mark_bits[i];
+            // Cells at or past `used_in_current` have never been handed
+            // out, so their old bits are clear and the whole-word mask is
+            // as accurate as the partial sweep below it.
+            demoted += retire_dead_old(&mut page.old_bits[i], map);
+            c += sweep_bits(bit, map, &mut ptr, head, &mut log);
         }
 
+        debug_assert!(demoted <= self.old_count);
+        self.old_count = self.old_count.saturating_sub(demoted);
         self.free = anchor.next();
         // Cells that were already on the free list are swept again (the
         // sweep is idempotent), so they appear in both counts: what this
@@ -1879,7 +1978,6 @@ impl<T: GCBox> Page<T> {
     ///
     /// Number of old-generation cells in this page (popcount of `old_bits`).
     ///
-    #[cfg(any(feature = "gc-log", feature = "gc-debug"))]
     fn old_count(&self) -> usize {
         self.old_bits.iter().map(|w| w.count_ones() as usize).sum()
     }

--- a/monoruby/src/builtins/gc.rs
+++ b/monoruby/src/builtins/gc.rs
@@ -713,6 +713,47 @@ mod tests {
     }
 
     #[test]
+    fn old_generation_retires_with_its_objects() {
+        // A major GC keeps the old generation across the cycle, so the
+        // only place an old cell leaves `old_bits`/`old_objects` is where
+        // it is actually reclaimed (sweep, or a salvaged all-dead page).
+        // If either accounting path were missing, `old_objects` would
+        // ratchet upwards instead of following the live old set down.
+        let n = if cfg!(feature = "gc-stress") { 2_000 } else { 50_000 };
+        run_test_once(&format!(
+            r##"
+            big = Array.new({n}) {{ |i| [i] }}
+            5.times {{ GC.start }}
+            high = GC.stat(:old_objects)
+            big = nil
+            5.times {{ GC.start }}
+            low = GC.stat(:old_objects)
+            [high > {n} * 4 / 5, low + {n} * 4 / 5 < high]
+            "##
+        ));
+    }
+
+    #[test]
+    fn old_to_young_edges_survive_across_a_major() {
+        // The remembered set is no longer rebuilt from scratch by every
+        // major, so a store into an object that was old *before* that
+        // major has to be covered by the write barrier alone. Attach the
+        // young children after the majors, then collect only the young
+        // generation: each child is reachable from an old parent and
+        // nothing else.
+        let n = if cfg!(feature = "gc-stress") { 200 } else { 2_000 };
+        run_test_once(&format!(
+            r##"
+            parents = Array.new({n}) {{ [] }}
+            5.times {{ GC.start }}
+            parents.each_with_index {{ |a, i| a << "child#{{i}}" }}
+            2.times {{ GC.start(full_mark: false) }}
+            [parents.map {{ |a| a[0] }}.uniq.size, parents.all? {{ |a| a.size == 1 }}]
+            "##
+        ));
+    }
+
+    #[test]
     fn gc_garbage_collect() {
         run_test("o = Object.new; o.extend(GC); o.garbage_collect");
     }


### PR DESCRIPTION
## Problem

A major GC demoted every object (`clear_old` + `remembered.clear`) and rebuilt the old generation from scratch. Survivors were re-promoted in the same cycle — their age is long since saturated — so the demotion bought nothing and charged the whole live old generation, **per major**, for:

- an `aging` entry (plus a second `promoted` entry),
- three header writes (age, OLD, WB_ARMED),
- a scattered `old_bits` set,
- a full `young_child_exists` scan of its children — a second traversal of every outgoing reference the old generation has.

It also left the minors right after a major scanning a heap with no old generation at all.

## Change

An object that was old and survives a major **stays old**, and its remembered/armed classification travels with it. `old_bits` and the remembered set are no longer cleared at the start of a major.

- **Retiring dead old cells** moves to where they are actually reclaimed. `sweep` folds `old_bits &= mark_bits` per bitmap word and subtracts what it dropped from `old_count`; `salvage_empty_pages` does the same for an all-dead page (which leaves `pages` before sweep runs). This is a correctness requirement, not just accounting: a freed cell is handed out again as a fresh *young* object, and a stale old bit would seed-mark it in the next minor, whose children would then never be scanned.
- **Remembered set** stays bounded without a full-old-generation rescan: the write barrier covers new stores, the new `reclassify_remembered` drops entries whose young children were promoted or died (the major-GC counterpart of the self-cleaning already built into `mark_remembered`), and `filter_remembered` drops dead ones. Its cost is proportional to the live old→young edges.
- The **adaptive major threshold** is recomputed after sweep, so it keys off the live old generation.
- The mark phase **skips already-old cells** when collecting aging candidates, gated on a new `major_mark` flag so minors do not pay the extra bitmap read (old objects are seed-marked there and never reach that point anyway).

## Measurements

| workload | before | after |
|---|---|---|
| one major GC, 610k-object old generation | ~74 ms | **~27 ms (−63%)** |
| churn over that heap — GC time / wall | 716 ms / 1.06 s | **523 ms / 0.97 s** |
| continuously growing long-lived set — GC time | 455 ms | **391 ms** |
| optcarrot fps, binarytrees, aobench, nbody | — | unchanged within noise |

Object-level statistics are identical across the change (`old_objects` 610205, remembered 50, minor/major 198:7), as they should be — this is a pure cost reduction, not a policy change.

## Trade-off

The old rebuild re-derived the remembered set every major, which silently repaired a missed write barrier once per major. A barrier-contract violation now surfaces instead of being masked — which is what `gc-stress` and `gc-verify` exist to find. Noted in `doc/gc.md` §6.4.

## Verification

- Full nextest: **3173/3173 passed**
- `gc-verify` + `gc-debug` (the `old_count == popcount` assertion active): passed
- `MONORUBY_GC_ALL_MAJOR=1` + `gc-debug` over 929 tests: passed (the 2 excluded assert that a major is *not* self-chosen, which that diagnostic switch overrides by design)
- `gc-stress` + `gc-verify` over the GC-heavy subset: 380 passed; the one timeout (`sample_cruby_parity`) reproduces identically on the unmodified build
- ruby/spec `core`: 363 failures / 223 errors — **identical to the same run on the unmodified build**
- optcarrot output matches CRuby exactly

Two new tests pin the behaviour: `old_objects` follows the live old set back down (exercising the sweep/salvage retirement paths, which would otherwise ratchet upwards), and old→young edges created *after* a major survive a young-generation collection.

`doc/gc.md` §6.2/§6.3/§6.4 and the summary are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_