### PR TITLE
GC: scale the allocation budget with the heap; restore the darwin CI instrumentation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,6 +62,12 @@ jobs:
           fail_ci_if_error: false
 
   darwin:
+    # checks: write lets the in-step heartbeat publish a `darwin-heartbeat`
+    # check run that SURVIVES runner death (see the Test step); contents:
+    # read is for checkout. Everything else needs no token.
+    permissions:
+      checks: write
+      contents: read
     # Native Apple Silicon (arm64-apple-darwin) runner, exercising the VM and
     # the AArch64 JIT (the AsmIR→A64 backend under codegen/arch/aarch64/, which
     # lowers the full AsmInst set). It runs the same `bin/test` as the Linux
@@ -77,9 +83,11 @@ jobs:
     # specific to native-M1 + coverage instrumentation and is tracked
     # separately. The Linux `amd64` job owns the Codecov upload.
     runs-on: macos-latest
-    # Plain backstop: a healthy pass is ~34 min on this runner, so cancel
-    # cleanly here rather than sitting on GitHub's 6-hour default.
-    timeout-minutes: 90
+    # Backstop: if a hung attempt somehow escapes the per-attempt cap on the
+    # Test step below, GitHub cancels the job cleanly here (2 attempts x
+    # 55 min + setup/clone overhead) rather than letting the runner die with
+    # "lost communication".
+    timeout-minutes: 120
     env:
       CARGO_TERM_COLOR: always
       SKIP_COV: "1"
@@ -125,4 +133,150 @@ jobs:
         run: git clone --depth 1 https://github.com/ruby/ruby-bench.git ../ruby-bench
 
       - name: Test (VM + AArch64 JIT, arm64-apple-darwin)
-        run: bin/test
+        # The arm64 runner intermittently dies mid-`bin/test`: it "loses
+        # communication", and when it goes the job's streamed logs AND the
+        # artifact step go with it, so the failure leaves nothing behind
+        # (2026-08-15: two such deaths on master, one of them on a tree that
+        # had passed this same job 2 minutes earlier — the job ran 62 min
+        # with the Test step never completing and the log download 404ing).
+        # Guards, in order of importance:
+        #   * MONORUBY_MALLOC_HARD_LIMIT=3G (env below): monoruby's global
+        #     allocator aborts WITH a size report + backtrace the moment an
+        #     allocation would exceed 3 GB. Unlike any polling watchdog this
+        #     also catches a single multi-GB request, and nextest then names
+        #     the aborted test. This is the primary defense.
+        #   * a `darwin-heartbeat` check run updated every ~60 s from inside
+        #     the step (last log lines + memory trajectory + any watchdog
+        #     forensics). It lives on the GitHub side, so it SURVIVES runner
+        #     death — the progress log of record for silent hangs.
+        #   * retry — cap each attempt at 55 min and retry once, so a clean
+        #     hang fails fast and the rerun recovers. Sizing: a healthy pass
+        #     is ~33-37 min on this runner at full test parallelism, so the
+        #     cap carries ~1.5x headroom. (An earlier 35-min cap timed out
+        #     healthy runs once the bin/test scope grew; do not shrink this
+        #     without re-measuring a healthy pass.)
+        #   * a background memory watchdog: watches every monoruby AND ruby
+        #     process (bin/test diffs against CRuby and runs mspec) plus the
+        #     system-wide free memory; fires at >3 GB per process / >4 GB
+        #     watched sum / <700 MB free, logs the last [phase] marker + the
+        #     culprit's command line, `sample`s its stack, kills it;
+        #   * a 30-second heartbeat line in the streamed log, and bin/test
+        #     output tee'd to $RUNNER_TEMP + uploaded as an artifact when the
+        #     runner survives (preserves the log of a timed-out attempt that
+        #     the retry then recovered).
+        # Per-test hangs inside the nextest phase are additionally named and
+        # killed by .config/nextest.toml (slow-timeout terminate-after).
+        # Test parallelism is deliberately left at the runner default: the
+        # halved NEXTEST_TEST_THREADS this instrumentation once carried was
+        # an experiment in the parallel-interaction hypothesis, and it cost
+        # ~40% of the nextest phase for no established benefit.
+        uses: nick-fields/retry@v3
+        env:
+          MONORUBY_MALLOC_HARD_LIMIT: 3G
+          GH_TOKEN: ${{ github.token }}
+        with:
+          timeout_minutes: 55
+          max_attempts: 2
+          command: |
+            set -o pipefail
+            LOG="$RUNNER_TEMP/bin-test-attempt-$(date -u +%H%M%S).log"
+            FORENSICS="$RUNNER_TEMP/watchdog-forensics.log"
+            CR_ID_FILE="$RUNNER_TEMP/hb-checkrun-id"
+            echo "attempt log: $LOG"
+            # Durable heartbeat: a neutral check run on the head commit,
+            # PATCHed with the latest progress. It survives runner death.
+            HB_SHA=$(jq -r '.pull_request.head.sha // .after // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || true)
+            HB_SHA=${HB_SHA:-$GITHUB_SHA}
+            hb_post() {
+              [ -n "${GH_TOKEN:-}" ] || return 0
+              if [ ! -s "$CR_ID_FILE" ]; then
+                curl -sf -X POST -H "Authorization: Bearer $GH_TOKEN" \
+                  -H "Accept: application/vnd.github+json" \
+                  "https://api.github.com/repos/$GITHUB_REPOSITORY/check-runs" \
+                  -d "{\"name\":\"darwin-heartbeat\",\"head_sha\":\"$HB_SHA\",\"status\":\"completed\",\"conclusion\":\"neutral\"}" \
+                  | jq -r '.id // empty' > "$CR_ID_FILE" 2>/dev/null || true
+              fi
+              hbid=$(cat "$CR_ID_FILE" 2>/dev/null || true)
+              [ -n "$hbid" ] || return 0
+              { echo '### in-flight monoruby/ruby processes (nextest passes the test name in argv)'
+                echo '```'
+                ps -Ao pid,rss,etime,command | awk 'NR>1 { n=split($4,a,"/"); b=a[n]; if (b ~ /^(monoruby|ruby)/) print }' | head -30
+                echo '```'
+                if [ -s "$FORENSICS" ]; then
+                  echo '### watchdog forensics'; echo '```'; tail -c 18000 "$FORENSICS"; echo '```'
+                fi
+                echo '### bin/test log tail'; echo '```'; tail -n 100 "$LOG" 2>/dev/null || true; echo '```'
+              } > "$RUNNER_TEMP/hb-body.md"
+              jq -n --arg s "$1" --rawfile t "$RUNNER_TEMP/hb-body.md" \
+                '{output:{title:"darwin bin/test heartbeat (survives runner death)",summary:$s,text:($t|.[0:60000])}}' \
+                | curl -sf -X PATCH -H "Authorization: Bearer $GH_TOKEN" \
+                    -H "Accept: application/vnd.github+json" \
+                    "https://api.github.com/repos/$GITHUB_REPOSITORY/check-runs/$hbid" \
+                    -d @- > /dev/null 2>&1 || true
+            }
+            RSS_LIMIT_KB=3000000
+            SUM_LIMIT_KB=4000000
+            SYS_FREE_FLOOR_KB=700000
+            ( t0=$(date +%s); pass=0
+              while true; do
+                snap=$(ps -Ao pid,rss,comm \
+                  | awk 'NR>1 { n=split($3,a,"/"); b=a[n]; if (b ~ /^(monoruby|ruby)/) print $1, $2, b }')
+                sum=0; toppid=0; toprss=0; topcmd=-
+                if [ -n "$snap" ]; then
+                  sum=$(echo "$snap" | awk '{s+=$2} END{print s+0}')
+                  set -- $(echo "$snap" | awk '{if($2>m){m=$2;p=$1;c=$3}} END{print p+0, m+0, c}')
+                  toppid=$1; toprss=$2; topcmd=${3:--}
+                fi
+                # System-wide reclaimable memory (free+inactive+purgeable, 16 KB
+                # pages on Apple Silicon): the runner dies silently when this
+                # runs out, whichever process is responsible.
+                freekb=$(vm_stat | awk -F'[: .]+' \
+                  '/Pages free/ {f=$3} /Pages inactive/ {i=$3} /Pages purgeable/ {p=$3} END {print (f+i+p)*16}')
+                if [ "${toprss:-0}" -gt "$RSS_LIMIT_KB" ] || [ "${sum:-0}" -gt "$SUM_LIMIT_KB" ] \
+                   || { [ "${freekb:-999999999}" -lt "$SYS_FREE_FLOOR_KB" ] && [ "${toppid:-0}" -gt 0 ]; }; then
+                  { echo "==================== MEMORY WATCHDOG fired @ $(date -u +%H:%M:%S) ===================="
+                    echo "sys_free_kb=$freekb sum_rss_kb=$sum top=$topcmd pid=$toppid rss_kb=$toprss"
+                    echo "(caps: per-proc=$RSS_LIMIT_KB sum=$SUM_LIMIT_KB sys-floor=$SYS_FREE_FLOOR_KB)"
+                    echo "---- last phase reached ----"; grep '^\[phase' "$LOG" 2>/dev/null | tail -1 || true
+                    echo "---- watched processes (pid rss_kb etime command) ----"
+                    ps -Ao pid,rss,etime,command | awk 'NR>1 { n=split($4,a,"/"); b=a[n]; if (b ~ /^(monoruby|ruby)/) print }'
+                    echo "---- CULPRIT command line (pid $toppid) ----"; ps -p "$toppid" -o command= 2>/dev/null || true
+                    echo "---- sample pid $toppid (2s) ----"; /usr/bin/sample "$toppid" 2 2>&1 | sed -n '1,160p' || true
+                    echo "---- killing pid $toppid ----"; kill -9 "$toppid" 2>/dev/null || true
+                  } 2>&1 | tee -a "$FORENSICS"
+                  hb_post "WATCHDOG FIRED $(date -u +%H:%M:%S): top=$topcmd rss_kb=${toprss:-0} sys_free_kb=${freekb:-?}"
+                  sleep 8
+                fi
+                pass=$((pass+1))
+                if [ $((pass % 8)) -eq 0 ]; then
+                  gtop=$(ps -Ao pid,rss,comm -m 2>/dev/null | awk 'NR==2 {n=split($3,a,"/"); print a[n]"("$2"KB)"}')
+                  diskfree=$(df -k / 2>/dev/null | awk 'NR==2 {print $4}')
+                  hbline=$(printf '[hb %s +%ss] sys_free_kb=%s disk_free_kb=%s watched_sum_kb=%s top=%s(%sKB) global_top=%s tail: %s' \
+                    "$(date -u +%H:%M:%S)" "$(( $(date +%s) - t0 ))" "${freekb:-?}" "${diskfree:-?}" "$sum" \
+                    "$topcmd" "${toprss:-0}" "${gtop:--}" \
+                    "$(tail -c 400 "$LOG" 2>/dev/null | tr '\n' ' ' | tail -c 160)")
+                  echo "$hbline"
+                  # Death leaves at most ~30 s of blind window; the posted
+                  # body names the tests in flight via their argv.
+                  hb_post "$hbline"
+                fi
+                sleep 4
+              done ) &
+            WATCHDOG_PID=$!
+            trap 'kill "$WATCHDOG_PID" 2>/dev/null || true' EXIT
+            bin/test 2>&1 | tee "$LOG"
+
+      - name: Upload darwin test logs (hang forensics)
+        # Preserves the tee'd bin/test log of every attempt — including a
+        # first attempt that hit the per-attempt cap and was then recovered by
+        # the retry, whose hang would otherwise leave no trace in a green run.
+        # (If the runner itself dies, this step never runs; that case is
+        # covered by the heartbeat check run and the watchdog killing the
+        # culprit first.)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: darwin-bin-test-logs-run${{ github.run_id }}-attempt${{ github.run_attempt }}
+          path: ${{ runner.temp }}/bin-test-attempt-*.log
+          if-no-files-found: ignore
+          retention-days: 14

--- a/doc/gc.md
+++ b/doc/gc.md
@@ -74,7 +74,7 @@ thread_local! { pub static ALLOC: RefCell<Allocator<RValue>> }   // alloc.rs
 | `promoting` | マーク中に昇格候補を収集するか(実マーク中のみ true) |
 | `aging` | 今サイクルで生存した昇格候補(マーク後に加齢) |
 | `remembered` | remembered set(old→young 参照を持つ old オブジェクト) |
-| `pages_since_gc` | 前回の収集以降に `THRESHOLD` まで充填したページ数(8 で GC レーンを立てる) |
+| `pages_since_gc` | 前回の収集以降に `THRESHOLD` まで充填したページ数(`gc_trigger_pages()` で GC レーンを立てる。§4.1) |
 | `heap_frames` | ヒープに退避したフレームバッファの登録表(§9) |
 
 ### 2.2 アリーナとページ
@@ -120,7 +120,8 @@ mark-external 方式なので、生存中のオブジェクト内容を汚さな
    スイープされたセルの再利用。
 2. 空でなければ**現ページのバンプ割り当て**。
    - `used_in_current == THRESHOLD`(3968)に達したら `on_page_pressure()` で
-     `pages_since_gc += 1`、8 ページ目で poll ワードの GC レーンを立てる(GC を要求;§4)。
+     `pages_since_gc += 1`、`gc_trigger_pages()` に達したら poll ワードの GC レーンを
+     立てる(GC を要求;§4)。
    - `used_in_current == DATA_LEN`(4032)でページ満杯 → `free_pages` から再利用、
      なければ `new_page()` で新規ページ。新ページは `clear_old_bits()` で
      old ビットマップを 0 初期化(マイナー GC のシード整合性のため)。
@@ -151,7 +152,7 @@ VM/JIT が参照する poll ワード(`u32`、8bit×4 レーン。全体像は `
 
 | 経路 | 実装 | 操作 |
 | --- | --- | --- |
-| ページ圧力 | `on_page_pressure`(`alloc.rs`) | `pages_since_gc` が 8 に達したら `set_gc()` |
+| ページ圧力 | `on_page_pressure`(`alloc.rs`) | `pages_since_gc` が `gc_trigger_pages()`(下記)に達したら `set_gc()` |
 | malloc 圧(§8) | `request_gc_if_malloc_over` | `set_gc()` |
 | `GC.start` | `request_gc(true)` | `set_gc()` + メジャー強制 |
 | `GC.stress` | `set_stress(true)` / 各収集の末尾 | `set_gc()`(再武装) |
@@ -162,6 +163,28 @@ byte が分かれているため互いを踏み潰す競合は原理的にない
 収集の完了時は `ack_gc_request`(`alloc.rs`)が **GC レーンの byte だけ**を落とし、
 `pages_since_gc` を 0 に戻す(並行して立った他レーンは保存される)。`--no-gc` 時の
 空収集も同じ経路で要求を無効化するため、レーンが立ちっぱなしで poll が空回りすることはない。
+
+#### 収集間隔はヒープに比例する(`gc_trigger_pages`)
+
+ページ圧力の閾値は固定値ではなく、**稼働中ページ数の一定割合**:
+
+```
+gc_trigger_pages() = max(PAGES_PER_GC_TRIGGER, 稼働ページ数 / GC_HEAP_FRACTION)
+                   = max(8, pages / 16)
+```
+
+収集 1 回のコスト(ルート走査・remembered set 走査・ビットマップ走査)は**生存量**で
+決まるのに対し、固定予算はそれを一定量の確保にしか償却しない。生存量が増え続ける
+プログラムでは総 GC コストが O(生存量 × 総確保量) になってしまうため、予算をヒープに
+比例させてコレクタ/ミュータタ比を有界に保つ。
+
+- 128 ページ(32MB)未満のヒープでは `max` の下限が効き、**従来と完全に同一挙動**
+  (optcarrot・aobench・sudoku 等はページ数・収集回数・RSS すべて不変)。
+- 代償は浮遊ゴミで、ヒープの最大 1/16 が回収を先送りされる。plb2 bedcov(生存 270 万
+  オブジェクト)では マイナー 202 → 83 回、GC 時間 −35%、実行時間 −12%、RSS +23%
+  (それでも同プログラムの CRuby の RSS より小さい)。
+- 収集で全滅したページは `pages` を離れて `free_pages` に移るため、生存量が落ちた
+  ヒープは自動的に予算も縮む。
 
 ### 4.2 poll のコード生成
 

--- a/monoruby/src/alloc.rs
+++ b/monoruby/src/alloc.rs
@@ -240,10 +240,31 @@ const PAGE_LEN: usize = 64 * SIZE;
 const DATA_LEN: usize = 64 * (SIZE - 1);
 const THRESHOLD: usize = 64 * (SIZE - 2);
 
-/// Pages filling to `THRESHOLD` before the arena requests a collection
-/// (~8 pages ≈ 32K `RValue`s between GCs, matching the old `>= 8` poll
-/// band that accumulated `+1` per page).
+/// Floor for the allocation budget between collections: pages filling to
+/// `THRESHOLD` before the arena requests a collection (~8 pages ≈ 32K
+/// `RValue`s, matching the old `>= 8` poll band that accumulated `+1` per
+/// page). Small heaps use exactly this; see [`GC_HEAP_FRACTION`].
 const PAGES_PER_GC_TRIGGER: u32 = 8;
+
+/// Above `PAGES_PER_GC_TRIGGER * GC_HEAP_FRACTION` pages in service, the
+/// budget instead scales with the heap: a collection is requested once
+/// `1/GC_HEAP_FRACTION` of the pages in service have filled since the last
+/// one.
+///
+/// What a collection costs is set by how much is *live* — the root scan,
+/// the remembered-set scan and the bitmap walk are all proportional to it
+/// — while a fixed budget amortises that over a constant amount of
+/// allocation, so a program whose live set keeps growing pays
+/// O(live × total allocation). Tying the budget to the heap keeps the
+/// ratio of collector work to mutator work bounded instead.
+///
+/// The cost is floating garbage: up to a `1/GC_HEAP_FRACTION` of the heap
+/// is retained longer than it needs to be, which is what the constant
+/// trades. 1/16 measured as the knee on a large-heap workload (plb2
+/// bedcov: 202 → 83 minor GCs, GC time −32%, RSS +23% and still below
+/// CRuby's on the same program); a smaller divisor buys less and less time
+/// for steeply more memory.
+const GC_HEAP_FRACTION: u32 = 16;
 const ALLOC_SIZE: usize = PAGE_LEN * GCBOX_SIZE; // 2^18 = 256kb
 const MALLOC_THRESHOLD: usize = 256 * 1024;
 const MAX_PAGES: usize = 8192;
@@ -878,9 +899,24 @@ impl<T: GCBox> Allocator<T> {
     ///
     fn on_page_pressure(&mut self) {
         self.pages_since_gc += 1;
-        if self.pages_since_gc >= PAGES_PER_GC_TRIGGER {
+        if self.pages_since_gc >= self.gc_trigger_pages() {
             crate::poll_flag::set_gc();
         }
+    }
+
+    ///
+    /// How many pages may fill between collections: a fixed floor for
+    /// small heaps, `1/GC_HEAP_FRACTION` of the pages in service once the
+    /// heap outgrows it. See [`GC_HEAP_FRACTION`].
+    ///
+    /// Pages salvaged by a collection have left `pages` for `free_pages`,
+    /// so a heap that drops its live set shrinks its own budget back
+    /// without any extra bookkeeping.
+    ///
+    fn gc_trigger_pages(&self) -> u32 {
+        // `+1` for `current_page`, which is in service but not in `pages`.
+        let in_service = (self.pages.len() as u32).saturating_add(1);
+        PAGES_PER_GC_TRIGGER.max(in_service / GC_HEAP_FRACTION)
     }
 
     ///

--- a/monoruby/src/builtins/gc.rs
+++ b/monoruby/src/builtins/gc.rs
@@ -713,6 +713,32 @@ mod tests {
     }
 
     #[test]
+    fn gc_budget_scales_with_the_heap() {
+        // The same amount of garbage, churned once against a small live
+        // set and once against a large one. What a collection costs is
+        // set by how much is live, so the allocation it is amortised over
+        // has to grow with the heap: the big-heap run must collect
+        // *fewer* times than the small-heap one, not more. Under a fixed
+        // budget the second run collects at least as often as the first.
+        if cfg!(feature = "gc-stress") {
+            // Every safepoint collects, so `GC.count` measures the stress
+            // mode rather than the trigger policy.
+            return;
+        }
+        run_test_once(
+            r##"
+            def churn(n) = n.times { |i| [i, i] }
+            churn(50_000); GC.start
+            b = GC.count; churn(400_000); small = GC.count - b
+            keep = Array.new(1_500_000) { |i| [i] }
+            GC.start
+            b = GC.count; churn(400_000); large = GC.count - b
+            [small > 0, large < small, keep.size == 1_500_000]
+            "##,
+        );
+    }
+
+    #[test]
     fn old_generation_retires_with_its_objects() {
         // A major GC keeps the old generation across the cycle, so the
         // only place an old cell leaves `old_bits`/`old_objects` is where

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -555,6 +555,7 @@
 2e520c993c13bf6afbdcfa9de96cc277	["A", "overridden", "can't create instance of singleton class", "allocator undefined for Integer"]	class A; end\n        class B; def self.allocate; :overridden; end; end\n
 2e9e5cdf982a6b277e6559a8a489f9a7	["Process::Status", 0, true]	`echo hi`; [$?.class.to_s, $?.exitstatus, $?.success?]
 2ea8cf14ab55d43b075b91985f056e0e	42	class C\n          def bar(x); x * 2; end\n        end\n        C.new.publ
+2ed29b5af9876d57b370c87bbfaa07be	[true, true, true]	def churn(n) = n.times { |i| [i, i] }\n            churn(50_000); GC
 2ef23e171ea7c4b8e44c86a9f992d408	[true, true, true, true, true]	r, w = IO.pipe\n            w.write("x")\n            [\n             
 2eff8aa6beb24cd1e30d17ca832d901e	[ArgumentError, "ASCII incompatible encoding: UTF-16LE"]	(Regexp.union("a".encode("UTF-16LE"), "b".encode("UTF-8")); nil) rescue [$!.clas
 2f052ab414e3e11032af6e0e3daffec3	[true, false, false, true]	class D\n          def m; end\n          private def p_m; end\n        end
@@ -2155,6 +2156,7 @@ ba7058a9f888bace3485573d10433a9e	true	M = Data.define(:amount, :unit)\nm = M.new
 ba73e17b465fecb689735f04e9f7047e	[1, 2, "l1\\nl2\\n"]	path = "/tmp/mr_gvar_lines.txt"\n            File.write(path, "l1\\nl
 ba8132b4a761c3cc445f79982ea307f1	[:frozen, :frozen, 1]	klass = Class.new; klass.freeze\n            r1 = begin; klass.class
 ba8abe11f8c7c450d64cf7c0c8aaeef7	:finished	ec = Encoding::Converter.new("UTF-8", "ISO-8859-1")\n             
+ba906fabc9ac8a0dfc95e62cc80c80bd	[true, true]	big = Array.new(50000) { |i| [i] }\n            5.times { GC.start }
 baac0bfbcda44d7ed24d7aedf15dba23	["0.1e1", "0.2e1", "0.1024e4", "0.98596e1"]	require "rubygems"\n        require "bigdecimal"\n        res = []\n      
 bab29f9aef949a72c454db04f4b8ae98	["10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30], "10:[20, 30, 999]", [10, 20, 30]]	def real(a, *r)\n          r << 999\n          "#{a}:#{r.inspect}"\n      
 baf2588a6b03f124f0c0206d4f3549b8	[:foo, true, [:one, :two]]	receiver = Object.new\n        begin\n          receiver.foo(:one, :two)\n
@@ -2401,6 +2403,7 @@ cdd817bbe04dcccd5789be10d0c9e391	true	module MBSpec2; end\n            name = "W
 cde7486a8ec494a41cd937151aeb8979	["global", false]	Thread.abort_on_exception = true\n            t = Thread.new { sleep
 cde8be92d24d46ac492d28d94cf6baa4	false	Float::NAN > (1 << 100)
 cdfb00531284d4111c26a83cd032ad5a	["iberico", true, true, "gouda", "stilton"]	module MM\n          class C\n            class << self\n              cla
+ce3ab0576ab0634aa202676d23eff78c	[2000, true]	parents = Array.new(2000) { [] }\n            5.times { GC.start }\n 
 ce3cb44e401aaa8cd3345ff6d95183b6	12	class Integer; alias __orig :*; def *(o); __orig(o); end; end; 3 * 4
 ce4131c8f9a4a5e155b38f61bca917e4	[[100, 2, 3, 100, 200, 70], [100, 2, 3, 100, 200, 70]]	class C\n              def f(a,(b,c),d,e:30,f:40)\n                $r
 ce62ddea72f477fdc9d5919218bb9a1c	"missing keyword: :x"	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; def m(x:)


### PR DESCRIPTION
Two independent commits (say the word and I will split the second into its own PR — they share a branch only because this session develops on one).

---

# 1. GC: scale the allocation budget between collections with the heap

## Problem

The arena requested a collection every 8 filled pages (~32K `RValue`s) — a fixed budget, whatever the heap size:

```rust
const PAGES_PER_GC_TRIGGER: u32 = 8;
```

What a collection *costs* is set by how much is **live** (root scan, remembered-set scan, bitmap walk all scale with it), so a fixed budget amortises that over a constant amount of allocation. A program whose live set keeps growing pays O(live × total allocation). On plb2 bedcov (2.7M live objects) monoruby ran **202 minor GCs where CRuby ran 62**, and spent 27% of its time in GC against CRuby's 10%.

## Change

```rust
gc_trigger_pages() = max(PAGES_PER_GC_TRIGGER, pages_in_service / GC_HEAP_FRACTION)   // = max(8, pages / 16)
```

Below 128 pages in service (32MB) the floor wins and behaviour is byte-for-byte what it was. Above it, the collector's share of the work stays bounded rather than growing with the heap. Pages emptied by a collection leave `pages` for `free_pages`, so a heap that drops its live set shrinks its own budget back with no extra bookkeeping.

## Measurements

plb2 bedcov (the workload that exposed this), interleaved runs:

| | run time | GC time | minor / major | peak RSS |
|---|---|---|---|---|
| master | 17.9 s | 4.8 s (27%) | 202 / 8 | 233 MB |
| **this PR** | **15.9 s (−12%)** | **3.1 s (−35%)** | **83 / 6** | 286 MB |
| ruby --yjit (reference) | ~19–23 s | 2.4 s | 62 / 11 | 350 MB |

The floating garbage the constant admits is bounded at a sixteenth of the heap, and the resulting RSS is still below CRuby's on the same program. 1/16 was the knee — 1/4 bought only another ~1.5 s for 432 MB.

Small-heap programs are unaffected, verified rather than assumed — identical page counts, minor/major counts and RSS:

| | pages | minor / major | RSS |
|---|---|---|---|
| aobench | 11 | 1222 / 19 (both) | 30 MB (both) |
| sudoku | 10 | 6 / 0 (both) | 27 MB (both) |
| binarytrees | 29 | 62 / 1 (both) | 35/36 MB |

optcarrot, nqueen, matmul and nbody are unchanged within noise.

## What profiling says *not* to change

- **Sweep does no redundant work.** Its cost tracked the cells it actually freed (271K per collection on average, of which only 512 were cells already on the free list) — a collection only happens once the free list is exhausted, so nothing is re-swept. All-live bitmap words are already skipped in O(1).
- **The remaining hot spot is the remembered-set scan**: 60M child visits over the run, 86% of them re-testing already-marked old cells. An entry is remembered as a whole object, so a 1M-element array with one young store gets rescanned in full on every minor (`child_visits` was exactly 2,001,336 per collection — a1 and a2 end to end). That wants card marking, a separate change; this PR cuts how often it is paid.

## Verification

- Full nextest: **3174/3174 passed**
- ruby/spec `core`: 363 failures / 223 errors — **identical to master**
- optcarrot: output matches CRuby exactly, fps unchanged

The new test pins the property that a large live set collects *less* often than a small one for the same amount of churn. It fails on the fixed budget — `[true, false, true]` where CRuby returns all true — confirmed by reverting `alloc.rs` and re-running.

---

# 2. CI: restore the darwin retry, memory watchdog and heartbeat

The instrumentation removed in 102b99e0 was retired on the grounds that the intermittent arm64 macOS runner death was understood. It is still happening, and without the scaffolding each occurrence costs a red master with no evidence at all:

- **a85f66b0** (08-15 05:49): Test step never completed, job failed at **62 min** — under the 90-minute job cap, so not the workflow timeout — and the log download **404s**, i.e. the runner went away without uploading anything.
- The **identical tree passed this same job 2 minutes earlier** as PR #1123 (Test step 32.7 min, success), so it is not the code under test.
- **1cebe60a** (08-14 23:02) shows the same signature at 66 min on an unrelated commit.

Restored on the `darwin` job:

- `nick-fields/retry@v3` around `bin/test`, 2 attempts — a clean hang fails its attempt and the rerun recovers the run instead of leaving master red.
- The background **memory watchdog** (per-process RSS, watched sum, system-wide reclaimable memory via `vm_stat`), which logs the last `[phase]` marker and the culprit's command line, `sample`s its stack and kills it — plus `MONORUBY_MALLOC_HARD_LIMIT=3G`, the allocator-side cap that turns a single runaway allocation into a named abort with a backtrace.
- The **`darwin-heartbeat` check run** (and the `checks: write` permission it needs), PATCHed every ~60 s with the in-flight monoruby/ruby processes, the memory trajectory and the tail of the tee'd log. It lives on the GitHub side, so it is the one record that survives the runner dying.
- The tee'd per-attempt log and its artifact upload.

**Deliberately not restored:** the halved `NEXTEST_TEST_THREADS`. It was an experiment in the parallel-interaction hypothesis, cost ~40% of the nextest phase and established nothing; the job runs at the runner's default parallelism.

Sizing: per-attempt cap 55 min (was 50), job timeout 120 (was 110, then 90). A healthy pass measured 32.7 and 37.0 min on this runner today, so the cap keeps ~1.5× headroom — an earlier 35-minute cap timed out healthy runs once the `bin/test` scope grew.

The workflow parses (`yaml.safe_load`), the retry command block passes `bash -n`, and the heartbeat's check-run payload and `jq` body construction were smoke-tested locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA