### PR TITLE
CI: rerun the Rust workflow server-side when the runner is lost

### DIFF
--- a/.github/workflows/rerun-lost-runner.yml
+++ b/.github/workflows/rerun-lost-runner.yml
@@ -1,0 +1,101 @@
+name: Rerun lost runners
+
+# The `darwin` job runs on a GitHub-hosted Apple Silicon runner that
+# intermittently *disappears* mid-`bin/test`. GitHub records it as
+#
+#   The hosted runner lost communication with the server.
+#
+# and the job's streamed logs never get uploaded (the log download 404s).
+# Six such deaths on master between 2026-08-01 and 2026-08-15; the
+# `darwin-heartbeat` check run — which survives the death — shows the
+# machine was healthy right up to the moment it went (3.7 GB free, 93 MB
+# across all monoruby processes, tests passing at 1456/3162), and then
+# both the test progress AND the independent heartbeat loop stopped in
+# the same instant. It is the runner going away, not anything under test.
+#
+# The `nick-fields/retry` wrapper around `bin/test` CANNOT recover this:
+# it runs *on* the runner, so when the runner dies the retry logic dies
+# with it (which is why the second attempt never starts, and the job just
+# fails at the per-attempt cap). Recovery has to happen server-side —
+# hence this workflow.
+#
+# It reruns the failed jobs of a `Rust` run exactly when GitHub itself
+# blamed the runner, and never otherwise: a genuine test failure carries
+# a different annotation and is left red.
+
+on:
+  workflow_run:
+    workflows: ["Rust"]
+    types: [completed]
+
+# Least privilege: rerunning jobs needs `actions: write`; reading the
+# failure annotations that gate it needs `checks: read`.
+permissions:
+  actions: write
+  checks: read
+
+jobs:
+  rerun:
+    # Only failures, and only the first attempt — the rerun below produces
+    # attempt 2, whose completion fires this workflow again, and this
+    # condition is what stops that from looping.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt == 1
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Rerun failed jobs if the runner was lost
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          REPO: ${{ github.repository }}
+          API: https://api.github.com
+        run: |
+          set -euo pipefail
+          api() { curl -sS --fail-with-body -H "Authorization: Bearer $GH_TOKEN" \
+                    -H "Accept: application/vnd.github+json" "$@"; }
+
+          echo "inspecting failed jobs of run $RUN_ID"
+          # `filter=latest` is the default, but be explicit: we want this
+          # attempt's jobs, not every attempt's.
+          jobs_json=$(api "$API/repos/$REPO/actions/runs/$RUN_ID/jobs?filter=latest&per_page=100")
+
+          # A job's annotations live on its check run, not on the job.
+          failed=$(echo "$jobs_json" | jq -r '.jobs[] | select(.conclusion=="failure") | "\(.name)\t\(.check_run_url)"')
+          if [ -z "$failed" ]; then
+            echo "no failed jobs (the run may have failed before any job started) — nothing to do"
+            exit 0
+          fi
+
+          lost=""
+          while IFS=$'\t' read -r name check_url; do
+            [ -n "$check_url" ] || continue
+            msgs=$(api "$check_url/annotations" \
+                     | jq -r '.[] | select(.annotation_level=="failure") | .message' || true)
+            echo "--- $name"
+            echo "$msgs" | sed 's/^/    /'
+            # Match GitHub's own wording for a runner that went away. Kept
+            # deliberately narrow: anything else (a real test failure, a
+            # timeout, a brew install exiting 100) must stay red.
+            if echo "$msgs" | grep -qi "lost communication with the server"; then
+              lost="$lost $name"
+            fi
+          done <<< "$failed"
+
+          if [ -z "$lost" ]; then
+            echo "no runner-loss annotation — leaving the run red"
+            echo "Not rerun: the failure was not a lost runner." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "lost runner(s):$lost — rerunning failed jobs"
+          api -X POST "$API/repos/$REPO/actions/runs/$RUN_ID/rerun-failed-jobs" >/dev/null
+          {
+            echo "Rerunning failed jobs of [run $RUN_ID](${RUN_URL:-})."
+            echo
+            echo "Reason: GitHub reported \`The hosted runner lost communication with the server\` for:$lost"
+            echo
+            echo "Only this one rerun is attempted; if attempt 2 fails too, the run stays red."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -155,6 +155,11 @@ jobs:
         #     cap carries ~1.5x headroom. (An earlier 35-min cap timed out
         #     healthy runs once the bin/test scope grew; do not shrink this
         #     without re-measuring a healthy pass.)
+        #     NOTE: this covers a HANG, not the runner going away. When the
+        #     runner is lost the retry action is lost with it (it runs on
+        #     that machine), which is why the second attempt never starts.
+        #     That case is recovered server-side by
+        #     .github/workflows/rerun-lost-runner.yml.
         #   * a background memory watchdog: watches every monoruby AND ruby
         #     process (bin/test diffs against CRuby and runs mspec) plus the
         #     system-wide free memory; fires at >3 GB per process / >4 GB


### PR DESCRIPTION
## What is actually failing

The `darwin` job keeps taking master red with GitHub's own annotation:

```
The hosted runner lost communication with the server.
```

Six times between 2026-08-01 and 2026-08-15 — `a802d837`, `941cecd2`, `91fabdca`, `1cebe60a`, `a85f66b0`, `2a9d617e`. The job's streamed logs never reach GitHub, so the log download 404s and the artifact step never runs.

## What the heartbeat caught

The `darwin-heartbeat` check run (restored in #1124 precisely because it survives the runner) has now caught one in the act. On `2a9d617e` its last update was **10.7 minutes into the step**:

```
[hb 09:42:57 +644s] sys_free_kb=3745120  disk_free_kb=98372192
                    watched_sum_kb=93472  top=monoruby(33808KB)
tail: PASS (1456/3162) integer_chr_default_internal
```

3.7 GB free memory, 93 MB across *every* monoruby process, 94 GB free disk, tests passing normally — and then the test progress **and** the heartbeat loop stopped in the same instant, with nothing recorded for the 45 minutes before GitHub declared the job failed (10:27:45).

The heartbeat is an independent background loop, so a monoruby hang would have kept it posting "same tail, no progress" for those 45 minutes. Both stopping together is the machine going away. `MONORUBY_MALLOC_HARD_LIMIT=3G` never fired, which rules out the memory-blowup hypothesis this instrumentation was built to catch.

## Not a regression, and not the test parallelism

Three of the six deaths happened while the job still ran `NEXTEST_TEST_THREADS: "2"`, so halving the thread count never prevented it — which is what #1124 assumed when it declined to restore that setting. For contrast, the `bench-arm64` job of the same push ran **113 minutes** on the same `macos-latest` image and passed.

The other `darwin` failures in the same window are unrelated and correctly stay red: `c0d9738c` / `271a6ead` (setup exiting 100), `0d806aba` (a real test failure), `3eed0988` (a per-attempt timeout).

## Why the existing retry cannot fix it

`nick-fields/retry` runs **on** the runner, so when the runner dies the retry logic dies with it — which is why the second attempt never starts and the job simply fails at the per-attempt cap. #1124's description claimed the retry would keep a runner death off master; that is true of a *hang*, and false of the failure actually occurring. The comment in `rust.yml` is corrected to say so and to point here.

## The change

A `workflow_run` job watches `Rust` runs. On a failure it re-reads each failed job's check-run annotations; if GitHub blamed the runner it POSTs `rerun-failed-jobs`, and otherwise leaves the run red and says why in the step summary. It only ever acts on `run_attempt == 1`, so the rerun it triggers cannot loop. Permissions are `actions: write` + `checks: read` and nothing else.

## Verification

The gate was replayed against five real runs, and behaves exactly as intended:

| run | annotation | verdict |
| --- | --- | --- |
| `2a9d617e` | lost communication | rerun |
| `a85f66b0` | lost communication | rerun |
| `91fabdca` | lost communication | rerun |
| `3eed0988` | `Timeout of 2100000ms hit` | left red |
| `0d806aba` | `exited with error code 1` | left red |

Both workflow files parse (`yaml.safe_load`) and the step's script passes `bash -n`.

Note that `workflow_run` workflows only fire once the file is on the default branch, so this starts working after merge, not on this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_