### PR TITLE
JIT: dispatch polymorphic sites instead of guarding them — widened class-set guard, Index/send arms, const-version recompile

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -867,6 +867,10 @@ impl Codegen {
             // Conditional branch on the preceding `Cmp` (mirrors
             // `bcond_label(a64_cond_for_cmp(..), dest)`; the BrKind inversion is
             // folded into `cond` by the builder).
+            // Unconditional branch (a dispatch arm funnelling into its merge).
+            LInst::Br(target) => {
+                monoasm_arm64!(&mut self.jit, b target;);
+            }
             LInst::CondBr { cond, target } => {
                 let c = match cond {
                     LCond::Eq => monoasm::Cond::Eq,

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -924,6 +924,14 @@ impl Codegen {
             LInst::GuardClass { reg, class, deopt } => {
                 self.a64_guard_class(reg, class, &deopt);
             }
+            // Dispatch arm: the miss is the next arm, not a side exit. aarch64
+            // has no `jit_class_guard_fail` stub (the profile table is fed by
+            // the x86 dispatch stub only), so guards and arms lower alike
+            // here — the ops stay distinct so the distinction survives if
+            // aarch64 grows the recorder.
+            LInst::BrClassNe { reg, class, target } => {
+                self.a64_guard_class(reg, class, &target);
+            }
             // Class-set guard: membership chain built from the single-class
             // guard — each class's check falls through on match (branch to
             // ok) and moves to the next candidate on mismatch; the last

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -51,6 +51,8 @@ impl Codegen {
             | AsmInst::LitToStack(..)
             | AsmInst::CondBr(..)
             | AsmInst::NilBr(..)
+            | AsmInst::Br(..)
+            | AsmInst::BrClassNe(..)
             | AsmInst::CheckLocal(..)
             | AsmInst::OptCase { .. }
             | AsmInst::GuardClass(..)
@@ -551,6 +553,8 @@ impl Codegen {
             // Signed conditional branch on the preceding `Cmp` (mirrors
             // `condbr_int`; the BrKind inversion is folded into `cond` by the
             // builder).
+            // Unconditional branch (a dispatch arm funnelling into its merge).
+            LInst::Br(target) => monoasm! { &mut self.jit, jmp target; },
             LInst::CondBr { cond, target } => match cond {
                 LCond::Eq => monoasm! { &mut self.jit, jeq target; },
                 LCond::Ne => monoasm! { &mut self.jit, jne target; },

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -605,7 +605,11 @@ impl Codegen {
                 }
             }
             // Type / class guards: deopt (jump to the side-exit) on a mismatch.
-            LInst::GuardClass { reg, class, deopt } => self.guard_class(reg, class, &deopt),
+            LInst::GuardClass { reg, class, deopt } => {
+                self.guard_class_deopt(reg, class, &deopt)
+            }
+            // Dispatch arm: the miss is the next arm, not a side exit.
+            LInst::BrClassNe { reg, class, target } => self.guard_class(reg, class, &target),
             LInst::GuardClassIn {
                 reg,
                 classes,
@@ -626,7 +630,9 @@ impl Codegen {
                         );
                         self.jit.bind_label(next);
                     } else {
-                        self.guard_class(reg, *class, &deopt);
+                        // Only the last candidate's miss is the real guard
+                        // failure; the earlier ones are chain steps.
+                        self.guard_class_deopt(reg, *class, &deopt);
                     }
                 }
                 self.jit.bind_label(ok);
@@ -784,6 +790,13 @@ impl Codegen {
                     FPRegLoc::Xmm(p) => (p, None),
                     FPRegLoc::Spill(off) => (0u64, Some(off)),
                 };
+                // A float unbox is a Float class guard in all but name — it is
+                // what `guard_recv_class` emits for a `FLOAT_CLASS` receiver —
+                // and its miss paths leave the offending value in rdi, so book
+                // it alongside the `GuardClass` misses. This is the guard the
+                // mixed Integer/Float arithmetic sites fail on.
+                #[cfg(feature = "profile")]
+                let deopt = self.class_guard_fail_recorder(&deopt);
                 self.float_to_f64(src, work, &deopt);
                 if let Some(off) = spill_off {
                     monoasm!( &mut self.jit,

--- a/monoruby/src/codegen/arch/x86_64/guard.rs
+++ b/monoruby/src/codegen/arch/x86_64/guard.rs
@@ -170,6 +170,84 @@ impl Codegen {
     }
 
     ///
+    /// Route a class-guard miss through the `profile` recorder, then on to
+    /// *deopt*.
+    ///
+    /// The dispatch stub's entry guard has always fed
+    /// `jit class guard failed stats` (`class_guard_stub` jumps to
+    /// `jit_class_guard_fail`), but an in-body guard just took its side exit,
+    /// so the table only ever showed entry misses. That made it actively
+    /// misleading: a site deopting millions of times on a receiver-class
+    /// check read as "no class guard ever failed here". Now both are counted,
+    /// against the class of the value that actually failed.
+    ///
+    /// The recorder is a C call sitting *before* the side exit's write-back,
+    /// which still reads the register file, so every caller-saved register is
+    /// preserved across it — `rax` included (`save_registers` deliberately
+    /// skips it, and the write-back may hold a value there), and `rdi` above
+    /// all, since the deopt reads it back as the reason value.
+    ///
+    /// Emitted on the cold page, and only under `profile`.
+    ///
+    #[cfg(feature = "profile")]
+    pub(super) fn class_guard_fail_recorder(&mut self, deopt: &DestLabel) -> DestLabel {
+        let entry = self.jit.label();
+        let deopt = deopt.clone();
+        let inline = self.jit.get_page() != 0;
+        let skip = self.jit.label();
+        if inline {
+            monoasm!( &mut self.jit, jmp skip; );
+        } else {
+            self.jit.select_page(1);
+        }
+        monoasm!( &mut self.jit,
+        entry:
+            subq rsp, 16;
+            movq [rsp], rax;
+        );
+        self.save_registers();
+        monoasm!( &mut self.jit,
+            movq rdx, rdi;      // the value that failed the guard
+            movq rdi, rbx;      // &mut Executor
+            movq rsi, r12;      // &mut Globals
+            movq rax, (guard_fail);
+            subq rsp, 4088;
+            call rax;
+            addq rsp, 4088;
+        );
+        self.restore_registers();
+        monoasm!( &mut self.jit,
+            movq rax, [rsp];
+            addq rsp, 16;
+            jmp deopt;
+        );
+        if inline {
+            self.jit.bind_label(skip);
+        } else {
+            self.jit.select_page(0);
+        }
+        entry
+    }
+
+    ///
+    /// [`Self::guard_class`] for a guard whose miss is a real side exit, as
+    /// opposed to a dispatch arm's miss (`LInst::BrClassNe`). Identical code
+    /// except that under `profile` the miss is recorded first — see
+    /// [`Self::class_guard_fail_recorder`].
+    ///
+    pub(crate) fn guard_class_deopt(&mut self, reg: GP, class_id: ClassId, deopt: &DestLabel) {
+        #[cfg(feature = "profile")]
+        {
+            let recorder = self.class_guard_fail_recorder(deopt);
+            self.guard_class(reg, class_id, &recorder);
+        }
+        #[cfg(not(feature = "profile"))]
+        {
+            self.guard_class(reg, class_id, deopt);
+        }
+    }
+
+    ///
     /// Class guard used in JIT dispatch stub.
     ///
     /// if *reg* is Bignum, always dispatched to VM entry.

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1407,6 +1407,27 @@ pub(super) enum AsmInst {
     ///
     CondBr(BrKind, JitLabel),
     NilBr(JitLabel),
+    ///
+    /// Unconditional branch to *dst*.
+    ///
+    /// Unlike [`Self::Deopt`] this targets ordinary code, so it is *not* an
+    /// `is_unconditional_terminator`: a class-dispatch arm ends with one to
+    /// funnel into the shared merge point, and the merge label that follows
+    /// is reached by fall-through from the last arm.
+    ///
+    Br(JitLabel),
+    ///
+    /// Class dispatch arm: fall through when *r*'s runtime class is *class*,
+    /// branch to *dst* otherwise.
+    ///
+    /// The same comparison [`Self::GuardClass`] emits, but the miss lands on
+    /// an ordinary label — the next arm of a class dispatch, e.g. the
+    /// polymorphic `[]` in `compile/index.rs` — rather than a side exit.
+    /// Unlike a guard it therefore proves nothing about the value on the
+    /// *branch-taken* path; the taken path's state is the caller's
+    /// business.
+    ///
+    BrClassNe(GP, ClassId, JitLabel),
     CheckLocal(JitLabel),
     CheckKwRest(SlotId),
     OptCase {
@@ -2544,6 +2565,10 @@ impl AsmInst {
 
             Self::CondBr(kind, label) => format!("condbr {:?} {:?}", kind, label),
             Self::NilBr(label) => format!("nil_br {:?}", label),
+            Self::Br(label) => format!("br {:?}", label),
+            Self::BrClassNe(gpr, class, label) => {
+                format!("br_class_ne {:?} {:?} {:?}", gpr, class, label)
+            }
             Self::CheckLocal(label) => format!("check_local {:?}", label),
             Self::OptCase {
                 max,

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -87,6 +87,22 @@ impl Codegen {
                 let target = frame.resolve_label(&mut self.jit, dest);
                 self.encode_linst(LInst::BranchIfNil { target });
             }
+            // Unconditional branch (a dispatch arm funnelling into its merge).
+            AsmInst::Br(dest) => {
+                let target = frame.resolve_label(&mut self.jit, dest);
+                self.encode_linst(LInst::Br(target));
+            }
+            // Class dispatch arm. `LInst::GuardClass`'s miss target is an
+            // ordinary `DestLabel`, so the same comparison serves a dispatch
+            // arm by pointing it at the next arm instead of a side exit.
+            AsmInst::BrClassNe(r, class, dest) => {
+                let target = frame.resolve_label(&mut self.jit, dest);
+                self.encode_linst(LInst::GuardClass {
+                    reg: r,
+                    class,
+                    deopt: target,
+                });
+            }
             // Branch to dest if the local (accumulator) is already set (non-zero).
             AsmInst::CheckLocal(dest) => {
                 let target = frame.resolve_label(&mut self.jit, dest);

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -92,15 +92,16 @@ impl Codegen {
                 let target = frame.resolve_label(&mut self.jit, dest);
                 self.encode_linst(LInst::Br(target));
             }
-            // Class dispatch arm. `LInst::GuardClass`'s miss target is an
-            // ordinary `DestLabel`, so the same comparison serves a dispatch
-            // arm by pointing it at the next arm instead of a side exit.
+            // Class dispatch arm: the same comparison a guard emits, but the
+            // miss is ordinary control flow, so it lowers through its own LIR
+            // op rather than `GuardClass` (which books a miss as a guard
+            // failure under `profile`).
             AsmInst::BrClassNe(r, class, dest) => {
                 let target = frame.resolve_label(&mut self.jit, dest);
-                self.encode_linst(LInst::GuardClass {
+                self.encode_linst(LInst::BrClassNe {
                     reg: r,
                     class,
-                    deopt: target,
+                    target,
                 });
             }
             // Branch to dest if the local (accumulator) is already set (non-zero).

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -3,6 +3,7 @@ use crate::codegen::jitgen::state::LinkMode;
 use super::*;
 
 mod binary_op;
+mod dispatch;
 mod unary_op;
 #[cfg(feature = "emit-cfg")]
 mod dump_cfg;

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -10,6 +10,7 @@ mod dump_cfg;
 mod index;
 mod loop_analysis;
 mod method_call;
+mod pic;
 mod variables;
 
 impl<'a> JitContext<'a> {

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -566,8 +566,8 @@ impl<'a> JitContext<'a> {
                 base,
                 idx,
                 class: ic,
-                _polymorphic: _,
-            } => return self.index(state, ir, base, idx, ic, bc_pos),
+                polymorphic,
+            } => return self.index(state, ir, base, idx, ic, polymorphic, bc_pos),
             TraceIr::IndexAssign {
                 base,
                 idx,

--- a/monoruby/src/codegen/jitgen/compile/dispatch.rs
+++ b/monoruby/src/codegen/jitgen/compile/dispatch.rs
@@ -1,0 +1,142 @@
+//! Intra-block dispatch: several arms inside one basic block, rejoined.
+//!
+//! The CFG-driven merge machinery (`branch_map` / `gen_bridges_for_branches`)
+//! keys on `BasicBlockId`, so it cannot describe a merge *inside* a block.
+//! That is what a class dispatch needs — the arms are not basic blocks, they
+//! are alternatives within one instruction's lowering:
+//!
+//! ```text
+//!         br_class_ne recv, C0 -> L1
+//!         <arm 0>              ; state refined to C0
+//!         br merge
+//!   L1:   br_class_ne recv, C1 -> L2
+//!         <arm 1>
+//!         br merge
+//!   L2:   <residual>           ; guard -> deopt, or a generic call
+//!   merge:
+//! ```
+//!
+//! **The merge state is declared, not computed.** A true join would have to
+//! see every arm's exit state, which means compiling them all before deciding
+//! what to bridge to — and the arms have already been emitted by then. So the
+//! merge is fixed up front, conservatively: the operands are flushed to their
+//! stack homes before the split, `dst` becomes an unknown `Value`, and every
+//! cached invariant is dropped because any arm may have run arbitrary Ruby.
+//! Each arm then bridges from wherever it happens to have landed
+//! ([`SlotState::gen_bridge`] handles the rest).
+//!
+//! Declaring rather than joining costs precision, and only that: `S(Value)` is
+//! the top of the lattice, so every arm can reach it. Two arms that both left
+//! a `Fixnum` in a register have it boxed at the merge where a real join would
+//! have kept the type. For the dispatches built on this so far — a polymorphic
+//! `[]` and a polymorphic send, both of which end in a call whose result is an
+//! opaque `Value` anyway — that costs nothing. A *numeric* dispatch (fixnum
+//! arm / float arm / generic residual) would care, and the lattice already has
+//! the element it wants: `LinkMode::Sf(fpr, SfGuarded::FixnumOrFloat)`, a
+//! boxed slot with a live float shadow. Teaching `declare_merge` to take a
+//! caller-supplied merge shape is the natural next step.
+
+use super::*;
+
+///
+/// The merge point of an intra-block dispatch, declared before the arms are
+/// emitted. Threaded from [`JitContext::declare_merge`] through each
+/// [`JitContext::end_arm`] to [`JitContext::bind_merge`].
+///
+pub(super) struct DispatchMerge {
+    /// The state every arm bridges to.
+    target: AbstractState,
+    /// Where the arms converge.
+    merge: JitLabel,
+    /// The bytecode position the bridges are emitted at.
+    pc: BytecodePtr,
+}
+
+impl<'a> JitContext<'a> {
+    ///
+    /// Open an intra-block dispatch.
+    ///
+    /// Flushes *operands* to their stack homes — the arms diverge, so a value
+    /// left in a register by one of them is not where the next one, or the
+    /// merge, expects it — and returns the entry state each arm should clone
+    /// plus the declared merge.
+    ///
+    pub(super) fn declare_merge(
+        &mut self,
+        state: &mut AbstractState,
+        ir: &mut AsmIr,
+        operands: &[SlotId],
+        dst: Option<SlotId>,
+    ) -> (AbstractState, DispatchMerge) {
+        let pc = state.pc();
+        state.write_back_slots(ir, operands);
+        state.flush_gp(ir);
+        let entry = state.clone();
+
+        let mut target = entry.clone();
+        if let Some(dst) = dst {
+            target.def_S(dst);
+        }
+        // `next_sp` is the *post*-instruction stack top (the compile loop sets
+        // it before lowering and clears above it afterwards), so the operand
+        // slots an arm consumed are already dead at the merge. Kill them here
+        // too: an arm that dropped one — `send` frees everything above sp —
+        // would otherwise have to bridge `V` back to a live mode, which is not
+        // a direction the lattice has.
+        target.clear_above_next_sp();
+        // Any arm may have called into Ruby, so nothing cached survives the
+        // merge. Conservative in the same direction as `send`.
+        target.unset_class_version_guard();
+        target.unset_const_version_guard();
+        target.unset_side_effect_guard();
+
+        let merge = self.label();
+        (
+            entry,
+            DispatchMerge {
+                target,
+                merge,
+                pc,
+            },
+        )
+    }
+
+    ///
+    /// Close one arm: bridge its state to the declared merge, and jump there.
+    ///
+    /// The last arm may fall through instead (`jump` false), which saves a
+    /// branch when the merge label is emitted immediately after it.
+    ///
+    pub(super) fn end_arm(
+        &mut self,
+        mut arm: AbstractState,
+        ir: &mut AsmIr,
+        m: &DispatchMerge,
+        jump: bool,
+    ) {
+        // The GP-pool residency is a layer *below* the link modes, and
+        // `gen_bridge` does not see it: a slot both states call `S` bridges to
+        // nothing even when this arm's only copy of its value is parked in a
+        // pool register (which is exactly where a call result lands). The
+        // merge state inherited an empty file from `declare_merge`, so every
+        // arm has to pay its own residents back to their stack homes first.
+        arm.flush_gp(ir);
+        arm.gen_bridge(ir, m.target.slot_state(), m.pc);
+        if jump {
+            ir.push(AsmInst::Br(m.merge));
+        }
+    }
+
+    ///
+    /// Close the dispatch: bind the merge label and install the merge state.
+    ///
+    pub(super) fn bind_merge(
+        &mut self,
+        state: &mut AbstractState,
+        ir: &mut AsmIr,
+        m: DispatchMerge,
+    ) {
+        ir.push(AsmInst::Label(m.merge));
+        *state = m.target;
+    }
+}

--- a/monoruby/src/codegen/jitgen/compile/index.rs
+++ b/monoruby/src/codegen/jitgen/compile/index.rs
@@ -76,6 +76,172 @@ impl<'a> JitContext<'a> {
         }
     }
 
+    ///
+    /// The receiver class a polymorphic index site should give its *inlined*
+    /// arm: the one the VM observed here that actually has a generator, most
+    /// observed first.
+    ///
+    /// Deliberately **not** the inline cache's class. optcarrot's
+    /// `@fetch[addr][addr]` is the motivating shape — `@fetch` holds the RAM
+    /// `Array` for `0x0000..0x07ff` and a `Method` for every I/O register, so
+    /// the site alternates — and its cache happens to hold `Method`, which
+    /// has no generator. Inlining "the cached class" there would leave the
+    /// Array arm (every RAM read) on the C call, which is backwards. The
+    /// other arm is a C call either way, so preferring the class that can be
+    /// inlined is unambiguous.
+    ///
+    fn index_inline_class(&mut self, callid: CallSiteId) -> Option<(ClassId, FuncId)> {
+        let callsite = &self.store[callid];
+        let name = IdentId::_INDEX;
+        let pmc = &callsite.pmc;
+        // Two-arm dispatch only pays off where the site really alternates;
+        // one observed class is the monomorphic guard's case.
+        if pmc.entries().len() < 2 {
+            return None;
+        }
+        let mut classes: Vec<(ClassId, u32)> =
+            pmc.entries().iter().map(|e| (e.recv, e.count)).collect();
+        classes.sort_unstable_by_key(|(_, count)| std::cmp::Reverse(*count));
+        for (class, _) in classes {
+            let Some((fid, visibility)) = self.jit_check_method(class, name) else {
+                continue;
+            };
+            if !matches!(
+                self.store.inline_info.get_inline(fid),
+                Some(InlineFuncInfo::InlineGen(_))
+            ) {
+                continue;
+            }
+            // Same licence the guarded direct-fire path needs: the arm runs
+            // without a class-version guard, so a redefinition has to reach
+            // it through the recorded bop dependency.
+            if !self.basic_op_assumable(class, name)
+                || self.jit_visibility_blocks(callid, visibility)
+                || self.store[fid].possibly_capture_without_block()
+            {
+                continue;
+            }
+            return Some((class, fid));
+        }
+        None
+    }
+
+    ///
+    /// Answer a polymorphic `[]` site with a two-arm dispatch:
+    ///
+    /// ```text
+    ///         br_class_ne rdi, C -> slow
+    ///         <C#[] inlined>
+    ///         br merge
+    ///   slow: <runtime::get_index>      (correct for *any* receiver)
+    ///   merge:
+    /// ```
+    ///
+    /// The point is the missing third option: there is no deopt. A class
+    /// guard has to send every off-class receiver back to the interpreter,
+    /// which is what makes optcarrot's `@fetch[addr][addr]` the single
+    /// largest deopt source in its hot loop; here the off-class receiver
+    /// takes a C call instead, and `runtime::get_index` handles it — it
+    /// re-checks the basic-op licence itself and falls back to
+    /// `invoke_method(:[])`, so `Method#[]` dispatches correctly.
+    ///
+    /// The merge needs no state join machinery, unusually: both arms leave
+    /// the element as a plain `Value` in `dst`, so the merge state can be
+    /// *declared* up front and each arm bridged to it.
+    ///
+    /// Returns `false` (leaving `state` and `ir` untouched) when the site
+    /// does not qualify, so the caller takes the ordinary path.
+    ///
+    fn index_dispatch(
+        &mut self,
+        state: &mut AbstractState,
+        ir: &mut AsmIr,
+        base: SlotId,
+        idx: SlotId,
+        idx_class: Option<ClassId>,
+        bc_pos: BcIndex,
+    ) -> JitResult<bool> {
+        let Some(callid) = self.store.get_callsite_id(self.iseq_id(), bc_pos) else {
+            return Ok(false);
+        };
+        if self.store[callid].block_fid.is_some() {
+            return Ok(false);
+        }
+        let Some((inline_class, fid)) = self.index_inline_class(callid) else {
+            return Ok(false);
+        };
+        let dst = self.store[callid].dst;
+        // For an index site `is_func_call` means "the base is literally
+        // `self`" (`bypass_visibility` is only ever set on the `__builtin_*`
+        // method-call spelling), which `gen_index` keeps at slot 0 so a
+        // private `#[]` stays reachable as in CRuby. It is therefore always
+        // `false` *here*: the gate below only takes sites whose receiver
+        // class the abstract state cannot pin down, and `self`'s class is
+        // seeded by `SlotState::new` for every `JitType` and never cleared.
+        // Passed through rather than hard-coded so the residual arm's
+        // visibility stays correct if that gate is ever widened.
+        let is_func_call = self.store[callid].is_func_call();
+        let pc = state.pc();
+        let state_save = state.clone();
+        let ir_save = ir.save();
+
+        // The arms diverge, so both operands must be in their stack homes
+        // before the branch: the slow arm reads them from there, and the
+        // merge has to describe one placement for both.
+        state.write_back_slots(ir, &[base, idx]);
+        state.flush_gp(ir);
+        let entry = state.clone();
+
+        // The declared merge state. `dst` is an unknown `Value`, and either
+        // arm may have run arbitrary Ruby (`Method#call`, a user `#[]`), so
+        // none of the cached invariants survive.
+        let mut target = entry.clone();
+        if let Some(dst) = dst {
+            target.def_S(dst);
+        }
+        target.unset_class_version_guard();
+        target.unset_const_version_guard();
+        target.unset_side_effect_guard();
+
+        let slow = self.label();
+        let merge = self.label();
+
+        // ---- arm 1: the inlinable receiver class.
+        let mut fast = entry.clone();
+        fast.load(ir, base, GP::Rdi);
+        ir.push(AsmInst::BrClassNe(GP::Rdi, inline_class, slow));
+        // Reaching the arm *is* the proof, so refine without a second guard.
+        fast.guard_class_state(base, inline_class);
+        let Some(InlineFuncInfo::InlineGen(f)) = self.store.inline_info.get_inline(fid) else {
+            unreachable!("index_inline_class only answers InlineGen targets")
+        };
+        if !self.inline_asm(&mut fast, ir, f, callid, inline_class, idx_class) {
+            ir.restore(ir_save);
+            *state = state_save;
+            return Ok(false);
+        }
+        self.record_bop_dep(inline_class, IdentId::_INDEX);
+        fast.unset_side_effect_guard();
+        fast.gen_bridge(ir, target.slot_state(), pc);
+        ir.push(AsmInst::Br(merge));
+
+        // ---- arm 2: every other receiver, through the generic helper.
+        ir.push(AsmInst::Label(slow));
+        let mut rest = entry.clone();
+        let error = ir.new_error(&rest);
+        ir.generic_binop(&rest, base, idx, runtime::get_index, is_func_call);
+        ir.handle_error(error);
+        rest.def_rax2acc(ir, dst);
+        rest.unset_class_version_guard();
+        rest.unset_const_version_guard();
+        rest.unset_side_effect_guard();
+        rest.gen_bridge(ir, target.slot_state(), pc);
+
+        ir.push(AsmInst::Label(merge));
+        *state = target;
+        Ok(true)
+    }
+
     pub(super) fn index(
         &mut self,
         state: &mut AbstractState,
@@ -83,9 +249,20 @@ impl<'a> JitContext<'a> {
         base: SlotId,
         idx: SlotId,
         ic: Option<(ClassId, ClassId)>,
+        polymorphic: bool,
         bc_pos: BcIndex,
     ) -> JitResult<CompileResult> {
         let (base_class, idx_class) = state.binary_class(base, idx, ic);
+        // A site the VM saw indexing more than one receiver class, whose
+        // receiver the abstract state cannot pin down: dispatch instead of
+        // guarding. (A proven receiver class is monomorphic by construction,
+        // whatever the VM saw at other times.)
+        if polymorphic
+            && state.class(base).is_none()
+            && self.index_dispatch(state, ir, base, idx, idx_class, bc_pos)?
+        {
+            return Ok(CompileResult::Continue);
+        }
         let Some(base_class) = base_class else {
             return Ok(CompileResult::Recompile(RecompileReason::NotCached));
         };
@@ -247,6 +424,70 @@ mod tests {
             res << set(h, :k, 1)
             res << h
             res
+        "##,
+        );
+    }
+
+    /// optcarrot's `@fetch[addr][addr]` shape: one `[]` site whose receiver
+    /// is an `Array` for most addresses and a `Method` for the rest, so a
+    /// class guard would deopt on every alternation. The two-arm dispatch
+    /// must answer both — and keep answering after `Array#[]` is redefined,
+    /// which the inlined arm's recorded bop dependency has to catch.
+    #[test]
+    fn index_polymorphic_array_and_method() {
+        run_test_once(
+            r##"
+            class Io
+              def initialize(v) = (@v = v)
+              def read(addr) = @v + addr
+            end
+            ram = [0, 1, 2, 3, 4, 5, 6, 7]
+            io  = Io.new(100).method(:read)
+            fetch = Array.new(16) { |i| i < 8 ? ram : io }
+            def loop_fetch(fetch, n)
+              s = 0
+              i = 0
+              while i < n
+                s += fetch[i & 15][i & 7]
+                i += 1
+              end
+              s
+            end
+            res = [loop_fetch(fetch, 2000)]
+            class Array
+              def [](i) = :redefined
+            end
+            res << (begin; loop_fetch(fetch, 16); rescue => e; e.class; end)
+            res
+        "##,
+        );
+    }
+
+    /// A polymorphic site where *neither* observed receiver has an inline
+    /// generator, and one where the receivers are heap objects with their
+    /// own `#[]` — the dispatch must decline or dispatch correctly, never
+    /// answer with the wrong body.
+    #[test]
+    fn index_polymorphic_user_classes() {
+        run_test_with_prelude(
+            r##"
+            drive
+        "##,
+            r##"
+            class Ba; def [](i) = [:a, i]; end
+            class Bb; def [](i) = [:b, i]; end
+            class Bc < Array; end
+            def get(o, i) = o[i]
+            def drive
+              vals = [Ba.new, Bb.new, [10, 20, 30, 40], { 0 => :h0, 1 => :h1 }, Bc.new(4, 9)]
+              res = []
+              j = 0
+              while j < 60
+                res << get(vals[j % 5], j % 4)
+                j += 1
+              end
+              res
+            end
         "##,
         );
     }

--- a/monoruby/src/codegen/jitgen/compile/index.rs
+++ b/monoruby/src/codegen/jitgen/compile/index.rs
@@ -181,30 +181,10 @@ impl<'a> JitContext<'a> {
         // Passed through rather than hard-coded so the residual arm's
         // visibility stays correct if that gate is ever widened.
         let is_func_call = self.store[callid].is_func_call();
-        let pc = state.pc();
         let state_save = state.clone();
         let ir_save = ir.save();
-
-        // The arms diverge, so both operands must be in their stack homes
-        // before the branch: the slow arm reads them from there, and the
-        // merge has to describe one placement for both.
-        state.write_back_slots(ir, &[base, idx]);
-        state.flush_gp(ir);
-        let entry = state.clone();
-
-        // The declared merge state. `dst` is an unknown `Value`, and either
-        // arm may have run arbitrary Ruby (`Method#call`, a user `#[]`), so
-        // none of the cached invariants survive.
-        let mut target = entry.clone();
-        if let Some(dst) = dst {
-            target.def_S(dst);
-        }
-        target.unset_class_version_guard();
-        target.unset_const_version_guard();
-        target.unset_side_effect_guard();
-
+        let (entry, merge) = self.declare_merge(state, ir, &[base, idx], dst);
         let slow = self.label();
-        let merge = self.label();
 
         // ---- arm 1: the inlinable receiver class.
         let mut fast = entry.clone();
@@ -222,8 +202,7 @@ impl<'a> JitContext<'a> {
         }
         self.record_bop_dep(inline_class, IdentId::_INDEX);
         fast.unset_side_effect_guard();
-        fast.gen_bridge(ir, target.slot_state(), pc);
-        ir.push(AsmInst::Br(merge));
+        self.end_arm(fast, ir, &merge, true);
 
         // ---- arm 2: every other receiver, through the generic helper.
         ir.push(AsmInst::Label(slow));
@@ -232,13 +211,9 @@ impl<'a> JitContext<'a> {
         ir.generic_binop(&rest, base, idx, runtime::get_index, is_func_call);
         ir.handle_error(error);
         rest.def_rax2acc(ir, dst);
-        rest.unset_class_version_guard();
-        rest.unset_const_version_guard();
-        rest.unset_side_effect_guard();
-        rest.gen_bridge(ir, target.slot_state(), pc);
+        self.end_arm(rest, ir, &merge, false);
 
-        ir.push(AsmInst::Label(merge));
-        *state = target;
+        self.bind_merge(state, ir, merge);
         Ok(true)
     }
 

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -19,7 +19,7 @@ use super::{
 /// quad while rejecting the "one hot class plus a handful of stragglers"
 /// shape that a way count alone cannot tell apart.
 ///
-const PMC_SET_SHARE_DIVISOR: u32 = 8;
+pub(super) const PMC_SET_SHARE_DIVISOR: u32 = 8;
 
 impl<'a> JitContext<'a> {
     pub(super) fn method_call(
@@ -50,6 +50,14 @@ impl<'a> JitContext<'a> {
             if ambiguous {
                 return Ok(CompileResult::Deopt);
             }
+        }
+        // A site the VM saw reaching several *different* targets: dispatch on
+        // the receiver class instead of guarding it against the one class the
+        // inline cache happens to hold (see `compile/pic.rs`). Only when the
+        // class is not already proven — a proven class is monomorphic here
+        // whatever the VM observed elsewhere.
+        if recv_class.is_none() && self.compile_pic_call(state, ir, callid)? {
+            return Ok(CompileResult::Continue);
         }
         let (recv_class, func_id, visibility) = if let Some(recv_class) = recv_class {
             // the receiver class is known.
@@ -604,8 +612,12 @@ impl<'a> JitContext<'a> {
                 // Method specialization (inlining a callee iseq) and block-
                 // argument inlining (`iseq_block`, which drives specialized
                 // `yield`) are both lowered on x86 and aarch64 now.
-                if ((specializable || forwarded_initialize) && self.specialize_level() < 5)
-                    || iseq_block.is_some()
+                // Inside a dispatch arm, specialization is off: the arm
+                // cannot back out of a `CompileError`, and a `Cease` return
+                // would leave it with no path to the merge.
+                if (((specializable || forwarded_initialize) && self.specialize_level() < 5)
+                    || iseq_block.is_some())
+                    && !self.in_dispatch_arm()
                 {
                     return self.specialized_iseq(
                         state,

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -8,6 +8,19 @@ use super::{
     *,
 };
 
+///
+/// Minimum share of a call site's slow-path observations a receiver class
+/// must hold to earn a slot in the `GuardClassIn` membership chain: a way
+/// below `1 / PMC_SET_SHARE_DIVISOR` of the total is treated as a rare tail
+/// and left to deopt (see [`JitContext::pmc_same_target_classes`]).
+///
+/// The chain is a linear compare sequence, so every member taxes the classes
+/// ahead of it on each dispatch; 1/8 keeps a genuinely alternating pair or
+/// quad while rejecting the "one hot class plus a handful of stragglers"
+/// shape that a way count alone cannot tell apart.
+///
+const PMC_SET_SHARE_DIVISOR: u32 = 8;
+
 impl<'a> JitContext<'a> {
     pub(super) fn method_call(
         &mut self,
@@ -111,13 +124,31 @@ impl<'a> JitContext<'a> {
     /// classes the VM observed at this call site (its polymorphic method
     /// cache plus the current inline-cache class — the PMC alone can miss a
     /// pair the fixnum fast path stamped and never displaced), and answer
-    /// the set when **every** class re-resolves the called name to
-    /// `func_id`. Resolution is re-computed per class with `jit_check_call`
-    /// under the already-emitted class version guard; the FuncId the PMC
-    /// recorded is deliberately not trusted (it may predate a
-    /// redefinition). A megamorphic site (PMC overflow) has an incomplete
-    /// observation set, so it never qualifies; nor does a class whose
-    /// resolution's visibility would block this call site.
+    /// the subset that re-resolves the called name to `func_id`. Resolution
+    /// is re-computed per class with `jit_check_call` under the
+    /// already-emitted class version guard; the FuncId the PMC recorded is
+    /// deliberately not trusted (it may predate a redefinition).
+    ///
+    /// The set is a **subset**, not an all-or-nothing test: `GuardClassIn`
+    /// deopts on any class outside the set, so leaving a class out is always
+    /// sound and never worse than the single-class guard it replaces. Two
+    /// kinds of class are dropped rather than disqualifying the whole site:
+    ///
+    /// - one that re-resolves elsewhere (or whose resolution's visibility
+    ///   would block this call site) — it cannot share this body;
+    /// - one whose share of the site's observations is below
+    ///   `1 / PMC_SET_SHARE_DIVISOR` — a rare tail. Every member costs a
+    ///   compare on the membership chain that the hot classes pay on every
+    ///   dispatch, so a class that shows up once in a hundred misses is not
+    ///   worth the width. `recv_class` is exempt: the rest of the compile is
+    ///   arranged for it, so a set without it would deopt on the very class
+    ///   it was compiled for.
+    ///
+    /// A megamorphic site therefore qualifies now (the overflow counts
+    /// toward the denominator, so it makes the surviving ways look *less*
+    /// dominant, and the unobserved fifth-and-later classes deopt as they
+    /// always did) — the previous outright rejection left those sites with a
+    /// single-class guard, which is the worst of both.
     ///
     /// The classes are ordered most-observed-first so the emitted
     /// membership chain tests the hottest class first.
@@ -142,9 +173,7 @@ impl<'a> JitContext<'a> {
         let callsite = &self.store[callid];
         let name = callsite.name?;
         let pmc = &callsite.pmc;
-        if pmc.overflow() != 0 {
-            return None;
-        }
+        let observations = pmc.observations();
         let mut classes: Vec<(ClassId, u32)> = pmc
             .entries()
             .iter()
@@ -160,12 +189,26 @@ impl<'a> JitContext<'a> {
         }
         classes.sort_unstable_by_key(|(_, count)| std::cmp::Reverse(*count));
         let mut set = Vec::with_capacity(classes.len());
-        for (class, _) in classes {
-            let (fid, visibility) = self.jit_check_call(class, Some(name))?;
+        for (class, count) in classes {
+            if class != recv_class
+                && count.saturating_mul(PMC_SET_SHARE_DIVISOR) < observations
+            {
+                // A rare tail: not worth a compare on the hot path.
+                continue;
+            }
+            let Some((fid, visibility)) = self.jit_check_call(class, Some(name)) else {
+                continue;
+            };
             if fid != func_id || self.jit_visibility_blocks(callid, visibility) {
-                return None;
+                continue;
             }
             set.push(class);
+        }
+        // `recv_class` resolved to `func_id` by construction, so it survives
+        // the loop; guard the invariant anyway, because a set that omits it
+        // would deopt on every receiver this compile was specialized for.
+        if set.len() < 2 || !set.contains(&recv_class) {
+            return None;
         }
         Some(set.into_boxed_slice())
     }
@@ -260,6 +303,27 @@ impl<'a> JitContext<'a> {
                 // on every off-class receiver; an unobserved class still
                 // deopts, and a redefinition recompiles via the class
                 // version guard above.
+                //
+                // Every member of the set reaches the cached `func_id`
+                // through this body, so every member needs its own
+                // inline-cache record. `update_inline_cache` re-asks the
+                // resolution question once per recorded entry when the
+                // class version moves; a member missing from the map would
+                // let a redefinition of *that* class pass the repair
+                // untouched, and the body would keep calling the target it
+                // resolved at compile time. Only `recv_class` was recorded
+                // above, so add the rest.
+                //
+                for &class in classes.iter() {
+                    if class != recv_class {
+                        self.inline_method_cache.push(InlineCacheEntry {
+                            recv_class: class,
+                            name: callsite.name,
+                            refinements: self.refinements(),
+                            func_id,
+                        });
+                    }
+                }
                 let deopt = ir.new_deopt(state);
                 state.load(ir, recv, GP::Rdi);
                 ir.push(AsmInst::GuardClassIn(GP::Rdi, classes, deopt));
@@ -1888,9 +1952,9 @@ mod tests {
     }
 
     /// A megamorphic site (a fifth distinct receiver class overflows the
-    /// 4-way PMC) must NOT take the same-target set guard — the observation
-    /// set is incomplete, so `pmc_same_target_classes` rejects it and the
-    /// site keeps the ordinary single-class guard. Also exercises the PMC
+    /// 4-way PMC) takes the same-target set guard over the ways it *did*
+    /// observe; the unobserved classes deopt, which is what the ordinary
+    /// single-class guard did for all of them. Also exercises the PMC
     /// overflow counter itself, and a float-typed branch behind a
     /// polymorphic `nil?` (the receiver state stays unrefined after the set
     /// guard, so the Float conversions downstream must still be correct).
@@ -1957,6 +2021,103 @@ mod tests {
               def frozen? = :nope
             end
             [q, n, res, fro(FrozenLiar.new)]
+            "#,
+        );
+    }
+
+    /// A megamorphic site whose observed receiver classes converge on one
+    /// builtin target takes the set guard over the ways the PMC kept; the
+    /// overflowed classes deopt. In one hot rotation: six classes that
+    /// converge on `Kernel#is_a?` (two of them answering `true`), one that
+    /// overrides the name — it must be kept out of the set and dispatch its
+    /// own body — and a rare receiver reached once every 131 iterations.
+    /// Then a set member gains an override after warmup, which the class
+    /// version guard must catch.
+    #[test]
+    fn polymorphic_megamorphic_same_target() {
+        run_test(
+            r#"
+            class A; end
+            class B; end
+            class C; end
+            class D; end
+            class E; end
+            class Own
+              def is_a?(k) = :own
+            end
+            def check(x) = x.is_a?(Numeric)
+            hot = [A.new, B.new, C.new, D.new, E.new, 1, 2.5, Own.new]
+            t = 0
+            o = 0
+            n = 0
+            400.times do |i|
+              case check(hot[i % 8])
+              when true then t += 1
+              when :own then o += 1
+              else n += 1
+              end
+              check(nil) if i % 131 == 0
+            end
+            res = [t, o, n]
+            class C
+              def is_a?(k) = :c
+            end
+            res << check(C.new) << check(A.new) << check(1) << check(nil)
+            res
+            "#,
+        );
+    }
+
+    /// Redefining a **member of the class-set guard other than the compiled
+    /// receiver class** must invalidate the body. The set guard lets three
+    /// classes reach one cached target, so all three are recorded in the
+    /// inline cache map; recording only `recv_class` (as the set guard first
+    /// shipped) let `update_inline_cache` confirm the stale resolution and
+    /// stamp the new class version into a body that kept calling
+    /// `Kernel#is_a?` / `Kernel#frozen?`. Covers both the ordinary
+    /// set-guarded builtin call (`is_a?`) and the class-independent inline
+    /// generator that fires behind the same guard (`frozen?`).
+    #[test]
+    fn polymorphic_set_member_redefined() {
+        run_test_once(
+            r#"
+            class A; end
+            class B; end
+            class C; end
+            def check(x) = x.is_a?(Numeric)
+            def fro(x) = x.frozen?
+            hot = [A.new, B.new, C.new]
+            300.times { |i| v = hot[i % 3]; check(v); fro(v) }
+            class C
+              def is_a?(k) = :c
+              def frozen? = :cf
+            end
+            [check(A.new), check(C.new), fro(A.new), fro(C.new), C.new.is_a?(Numeric)]
+            "#,
+        );
+    }
+
+    /// The share threshold: a site dominated by two alternating classes
+    /// plus a handful of stragglers keeps the set to the dominant pair, and
+    /// the stragglers deopt. Only correctness is asserted here — the width
+    /// of the membership chain is not observable from Ruby — so this pins
+    /// that excluding a class from the set never changes its answer.
+    #[test]
+    fn polymorphic_rare_tail() {
+        run_test(
+            r#"
+            class Tail1; end
+            class Tail2; end
+            class Tail3; end
+            def probe(x) = x.is_a?(String)
+            hot = ["a", :b]
+            tail = [Tail1.new, Tail2.new, Tail3.new]
+            t = 0
+            300.times do |i|
+              t += 1 if probe(hot[i % 2])
+              probe(tail[i % 3]) if i % 89 == 0
+            end
+            [t, probe(Tail1.new), probe("z"), probe(:z), probe(nil)]
             "#,
         );
     }

--- a/monoruby/src/codegen/jitgen/compile/pic.rs
+++ b/monoruby/src/codegen/jitgen/compile/pic.rs
@@ -1,0 +1,359 @@
+//! Polymorphic inline cache: an N-way class dispatch for a send the VM saw
+//! reaching several *different* targets.
+//!
+//! The class-set guard (`GuardClassIn`, emitted by `pmc_same_target_classes`)
+//! already covers polymorphic sites whose classes all resolve to **one**
+//! method — `Kernel#is_a?`, `Kernel#nil?` and friends. It cannot cover a site
+//! whose classes resolve to different bodies: one guard admitting the whole
+//! set would then run the wrong one. Those sites keep a single-class guard and
+//! deopt on every off-class receiver, for the rest of the run.
+//!
+//! ```text
+//!         load recv -> rdi
+//!         guard_class_version                 (one, dominating every arm)
+//!         br_class_ne rdi, C0 -> L1
+//!         <call C0#name>
+//!         br merge
+//!   L1:   br_class_ne rdi, C1 -> L2
+//!         <call C1#name>
+//!         br merge
+//!   L2:   guard_class rdi, C2 -> deopt        (last arm; a miss here is a
+//!         <call C2#name>                       class the VM never observed)
+//!   merge:
+//! ```
+//!
+//! The merge is the shared intra-block one (`compile/dispatch.rs`): declared
+//! before the arms, bridged to from each. An earlier version of this file
+//! had no such merge and instead demanded that every arm land in an
+//! *equivalent* state, backing the whole chain out when they did not. That
+//! restriction is what forced the gate down to argument-less sends — and it
+//! still let sites through whose arms diverged in practice (a const-folding
+//! `def v = 1` against a calling one), which then simply declined. With a
+//! declared merge the arms may differ freely, so the gate only has to exclude
+//! shapes that are unsound or that would abort the compile.
+//!
+//! **Scope.** Method-call deopts are a small share of what the JIT actually
+//! loses: across optcarrot, rubykon, rubyboy, erubi, etanni and plb2 they are
+//! ~15k against ~4.1M for binary operators. This is not where the time is —
+//! the same dispatch shape applied to `+` / `<` / `==` is. What this buys is
+//! the mechanism, and `compile/dispatch.rs` is deliberately the part that
+//! generalizes.
+//!
+//! The gate is correspondingly quiet in practice: a run of rubykon compiles
+//! 12 chains, of which the one that matters is `MCTS::Node#backpropagate`'s
+//! `node.root?` (5,101 deopts before, none after). The dominant refusal is
+//! not any of the shape rules below but "the PMC holds one class" — a site
+//! whose receiver the abstract state cannot pin down, yet which the VM only
+//! ever saw take one class, is monomorphic and rightly keeps its single
+//! guard.
+
+use super::{method_call::PMC_SET_SHARE_DIVISOR, *};
+
+///
+/// Maximum number of dispatch arms.
+///
+/// The chain is a linear compare sequence, so every arm taxes the ones ahead
+/// of it; and the observation source cannot describe more classes than the
+/// [`PMC_WAYS`] it keeps.
+///
+const PIC_WAYS: usize = PMC_WAYS;
+
+///
+/// One dispatch arm: a receiver class and the target it resolves to.
+///
+struct PicWay {
+    class: ClassId,
+    func_id: FuncId,
+    visibility: Visibility,
+}
+
+impl<'a> JitContext<'a> {
+    ///
+    /// The dispatch arms for *callid*, or `None` when the site is not a
+    /// polymorphic-inline-cache candidate.
+    ///
+    /// Every refusal happens here, before a single instruction is emitted.
+    /// That is a requirement, not tidiness: once the chain is under way an arm
+    /// that bailed would leave the emitted arms ahead of it stranded, and
+    /// unlike the class-set guard there is no single-instruction fallback to
+    /// rewrite it as.
+    ///
+    fn pic_ways(&mut self, callid: CallSiteId) -> Option<Vec<PicWay>> {
+        let callsite = &self.store[callid];
+        let name = callsite.name?;
+        // A block argument makes the callee able to capture the frame, and
+        // `locals_to_S` inside one arm would describe a frame layout the other
+        // arms do not share.
+        if callsite.block_fid.is_some() {
+            return None;
+        }
+        let pmc = &callsite.pmc;
+        let observations = pmc.observations();
+        let mut classes: Vec<(ClassId, u32)> =
+            pmc.entries().iter().map(|e| (e.recv, e.count)).collect();
+        if classes.len() < 2 {
+            return None;
+        }
+        classes.sort_unstable_by_key(|(_, count)| std::cmp::Reverse(*count));
+        let mut ways: Vec<PicWay> = Vec::with_capacity(classes.len());
+        for (class, count) in classes {
+            if ways.len() == PIC_WAYS {
+                break;
+            }
+            // A rare tail is not worth an arm — the classes ahead of it pay
+            // its compare on every dispatch. Same threshold the class-set
+            // guard uses.
+            if count.saturating_mul(PMC_SET_SHARE_DIVISOR) < observations {
+                continue;
+            }
+            // A class that cannot have an arm is dropped, not fatal to the
+            // site: it falls past the last arm's guard and deopts, which is
+            // exactly what the single-class guard did for it anyway. That
+            // covers a name this class does not resolve (`jit_check_call`), a
+            // resolution this call site's visibility blocks (the VM then
+            // raises `NoMethodError`, as before), and the two shapes
+            // `compile_method_call` answers with `CompileError` — which must
+            // not be allowed to fire mid-chain, where there is nothing to
+            // back out to.
+            let Some((func_id, visibility)) = self.jit_check_call(class, Some(name)) else {
+                continue;
+            };
+            if self.jit_visibility_blocks(callid, visibility)
+                || self.store[func_id].possibly_capture_without_block()
+            {
+                continue;
+            }
+            if let Some(iseq) = self.store[func_id].is_iseq()
+                && self.store[iseq].has_block_arg()
+            {
+                continue;
+            }
+            ways.push(PicWay {
+                class,
+                func_id,
+                visibility,
+            });
+        }
+        if ways.len() < 2 {
+            return None;
+        }
+        // All arms sharing one target is the class-set guard's case, and one
+        // membership guard over the set beats a chain of compares around
+        // duplicate call sequences.
+        let first = ways[0].func_id;
+        if ways.iter().all(|w| w.func_id == first) {
+            return None;
+        }
+        Some(ways)
+    }
+
+    ///
+    /// Try to compile *callid* as a polymorphic inline cache.
+    ///
+    /// Answers `true` when the chain was emitted and *state* describes the
+    /// merge point.
+    ///
+    pub(super) fn compile_pic_call(
+        &mut self,
+        state: &mut AbstractState,
+        ir: &mut AsmIr,
+        callid: CallSiteId,
+    ) -> JitResult<bool> {
+        let Some(ways) = self.pic_ways(callid) else {
+            return Ok(false);
+        };
+        let CallSiteInfo {
+            recv,
+            args,
+            pos_num,
+            dst,
+            ..
+        } = self.store[callid];
+
+        // One class-version guard dominates the whole chain: the arms are
+        // mutually exclusive, so at most one call executes under it.
+        self.guard_class_version(state, ir, true);
+
+        // The receiver and every argument are read by each arm's own call
+        // sequence, so they have to be at their stack homes before the split.
+        let mut operands = Vec::with_capacity(pos_num + 1);
+        operands.push(recv);
+        operands.extend((0..pos_num).map(|i| args + i));
+        let (entry, merge) = self.declare_merge(state, ir, &operands, dst);
+
+        // The chain compares out of rdi, which is also where each arm's call
+        // sequence wants the receiver.
+        let mut probe = entry.clone();
+        probe.load(ir, recv, GP::Rdi);
+        let entry = probe;
+
+        let mut miss: Option<JitLabel> = None;
+        for (i, way) in ways.iter().enumerate() {
+            let last = i + 1 == ways.len();
+            if let Some(miss) = miss.take() {
+                ir.push(AsmInst::Label(miss));
+            }
+            let mut arm = entry.clone();
+            if last {
+                // A miss on the last arm is a class the VM never observed
+                // here: deopt, exactly as the monomorphic guard did for every
+                // off-class receiver.
+                //
+                // `guard_class` emits nothing when the state already proves
+                // the class, which would leave the arm reachable by *any*
+                // receiver that missed the ones before it. The entry state
+                // cannot prove it (the site is only tried when the receiver's
+                // class is unknown), but the arm is a miscompile if that ever
+                // stops holding, so say so.
+                debug_assert_ne!(arm.class(recv), Some(way.class));
+                let deopt = ir.new_deopt(&arm);
+                arm.guard_class(ir, recv, GP::Rdi, way.class, deopt);
+            } else {
+                let next = self.label();
+                ir.push(AsmInst::BrClassNe(GP::Rdi, way.class, next));
+                miss = Some(next);
+                // Reaching this arm *is* the proof, so refine without a
+                // second guard — which is also what lets the arm's inline
+                // generators fire.
+                arm.guard_class_state(recv, way.class);
+            }
+            // Specialization is suppressed inside an arm (see
+            // `JitContext::in_dispatch_arm`), and every other way out of
+            // `compile_method_call` was hoisted into `pic_ways`, so the arm
+            // always lands on the merge.
+            let outcome = self.with_dispatch_arm(|this| {
+                this.compile_method_call(
+                    &mut arm,
+                    ir,
+                    way.class,
+                    None,
+                    way.func_id,
+                    way.visibility,
+                    callid,
+                    false,
+                )
+            })?;
+            debug_assert!(matches!(outcome, CompileResult::Continue));
+            self.end_arm(arm, ir, &merge, !last);
+        }
+        self.bind_merge(state, ir, merge);
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::*;
+
+    /// A site whose receiver classes resolve to *different* bodies — the case
+    /// the class-set guard cannot take. Each class must dispatch its own
+    /// method with no deopt, including a class arriving only after warmup (it
+    /// misses every arm and deopts) and a redefinition of one arm's target
+    /// (caught by the shared class-version guard).
+    #[test]
+    fn pic_distinct_targets() {
+        run_test(
+            r#"
+            class Aa; def tag = :a; end
+            class Bb; def tag = :b; end
+            class Cc; def tag = :c; end
+            def probe(x) = x.tag
+            vals = [Aa.new, Bb.new, Cc.new]
+            res = []
+            300.times { |i| res << probe(vals[i % 3]) }
+            tally = res.tally.sort_by { |k, _| k.to_s }
+            class Dd; def tag = :d; end
+            class Bb; def tag = :b2; end
+            [tally, probe(Aa.new), probe(Bb.new), probe(Cc.new), probe(Dd.new)]
+            "#,
+        );
+    }
+
+    /// Arms that leave *different shapes* behind: one folds to a constant
+    /// (`ISeqHint::ConstReturn`), one returns self, one really calls. The
+    /// declared merge has to absorb all three — the earlier equivalence-based
+    /// version refused this site outright.
+    #[test]
+    fn pic_divergent_arm_shapes() {
+        run_test(
+            r#"
+            class Ka; def v = 1; end
+            class Kb; def v = 2; end
+            class Kc; def initialize = (@n = 0); def v = (@n += 1); end
+            def probe(x) = x.v
+            vals = [Ka.new, Kb.new, Kc.new]
+            n = 0
+            300.times { |i| n += probe(vals[i % 3]) }
+            [n, probe(Ka.new), probe(Kb.new)]
+            "#,
+        );
+    }
+
+    /// Arms with arguments, which the equivalence-based version could not
+    /// take at all. Covers a differing arity per arm and an argument that is
+    /// a compile-time constant at the call site.
+    #[test]
+    fn pic_arms_with_arguments() {
+        run_test(
+            r#"
+            class Wa; def f(a, b) = a + b; end
+            class Wb; def f(a, b) = a * b; end
+            class Wc; def f(a, b) = a - b; end
+            def probe(x, i) = x.f(i, 3)
+            vals = [Wa.new, Wb.new, Wc.new]
+            acc = 0
+            300.times { |i| acc += probe(vals[i % 3], i % 7) }
+            [acc, probe(Wa.new, 10), probe(Wb.new, 10), probe(Wc.new, 10)]
+            "#,
+        );
+    }
+
+    /// Mixed method kinds behind one site: an attr_reader, a plain method and
+    /// a builtin, plus a receiver whose `size` resolves per class.
+    #[test]
+    fn pic_mixed_kinds() {
+        run_test(
+            r#"
+            class Ra
+              attr_reader :tag
+              def initialize = (@tag = :attr)
+            end
+            class Rb
+              def tag = :plain
+            end
+            def probe(x) = x.tag
+            def sizer(x) = x.size
+            vals = [Ra.new, Rb.new]
+            sized = [[1, 2, 3], "abcd", { a: 1 }]
+            res = []
+            300.times do |i|
+              res << probe(vals[i % 2])
+              res << sizer(sized[i % 3])
+            end
+            res.tally.sort_by { |k, _| k.to_s }
+            "#,
+        );
+    }
+
+    /// A private target on one of the arms must not be reachable without an
+    /// explicit `self` receiver: the site is refused outright, and a plain
+    /// `x.hidden` raises NoMethodError as CRuby does.
+    #[test]
+    fn pic_private_arm() {
+        run_test_once(
+            r#"
+            class Pa; def hidden = :a; end
+            class Pb; private def hidden = :b; end
+            def probe(x) = x.hidden
+            res = []
+            300.times { res << probe(Pa.new) }
+            begin
+              probe(Pb.new)
+            rescue NoMethodError
+              res << :nome
+            end
+            [res.tally.sort_by { |k, _| k.to_s }]
+            "#,
+        );
+    }
+}

--- a/monoruby/src/codegen/jitgen/compile/variables.rs
+++ b/monoruby/src/codegen/jitgen/compile/variables.rs
@@ -107,12 +107,63 @@ impl<'a> JitContext<'a> {
                     return Ok(CompileResult::Recompile(RecompileReason::NotCached));
                 }
             }
+            self.guard_const_version(state, ir, cache.version);
             state.load_constant(ir, dst, cache);
             state.unset_side_effect_guard();
             Ok(CompileResult::Continue)
         } else {
             Ok(CompileResult::Recompile(RecompileReason::NotCached))
         }
+    }
+
+    ///
+    /// Constant version guard.
+    ///
+    /// The global constant version is monotonic and every folded constant is
+    /// gated on the compile-time snapshot, so one guard per trace covers them
+    /// all (`AbstractState::const_version_guard` skips the rest).
+    ///
+    /// A miss takes the **counter-gated recompile** side exit rather than a
+    /// plain deopt. That distinction is the whole point: the fold is only
+    /// valid at the snapshot version, so once the version moves the guard can
+    /// never pass again and a plain deopt fires on *every* subsequent
+    /// execution, forever — a single `CONST = ...` anywhere in the program
+    /// permanently unwinds every body that folded a constant. Recompiling
+    /// re-reads the constant at the new version. The counter
+    /// (`COUNT_DEOPT_RECOMPILE`) bounds the cost for programs that keep
+    /// assigning constants: at worst 10 deopts and one recompile per version
+    /// move, instead of one deopt per call for the rest of the run.
+    ///
+    fn guard_const_version(&self, state: &mut AbstractState, ir: &mut AsmIr, version: usize) {
+        if state.const_version_guard() {
+            return;
+        }
+        // Two shapes stay on the plain deopt. A specialized (inlined-frame)
+        // compile recompiles via an idx, not a position, so it has no
+        // recompile side exit to take — the same restriction the
+        // receiver-class guard makes in `compile_method_call`. And a *block*
+        // body must not take it either: the side exit recompiles whatever
+        // `lfp.func_id()` names, and `Codegen::recompile_method` re-enters
+        // the compiler as if that were a method — for a block frame that
+        // rebuilds the body under the wrong argument convention, which showed
+        // up as `Kernel#caller_locations`' block losing the argument it
+        // forwards to `Thread::Backtrace::Location.new`.
+        let deopt = if matches!(self.jit_type(), JitType::Specialized { .. })
+            || self.store[self.func_id()].is_block_style()
+        {
+            ir.new_deopt(state)
+        } else {
+            ir.new_recompile_deopt(
+                state,
+                RecompileReason::ConstVersionGuardFailed,
+                self.position(),
+            )
+        };
+        ir.push(AsmInst::GuardConstVersion {
+            const_version: version,
+            deopt,
+        });
+        state.set_const_version_guard();
     }
 
     pub(super) fn load_dynvar(&self, state: &AbstractState, ir: &mut AsmIr, src: DynVar) {
@@ -161,22 +212,11 @@ impl<'a> JitContext<'a> {
 
 impl AbstractState {
     fn load_constant(&mut self, ir: &mut AsmIr, dst: SlotId, cache: &ConstCache) {
-        let ConstCache { version, value, .. } = cache;
-        // The caller (`JitContext::load_constant`) has already verified
-        // `cache.version == compile-time const version`, and the global
-        // const version is monotonic, so one guard against that snapshot
-        // covers the whole trace until something that could change it
-        // executes (StoreConst, a class/method def, a non-specialized
-        // call, ...). Skip the redundant guard once emitted; see
-        // `unset_const_version_guard` call sites for what invalidates it.
-        if !self.const_version_guard() {
-            let deopt = ir.new_deopt(self);
-            ir.push(AsmInst::GuardConstVersion {
-                const_version: *version,
-                deopt,
-            });
-            self.set_const_version_guard();
-        }
+        let ConstCache { value, .. } = cache;
+        // The version guard is emitted by the caller
+        // (`JitContext::guard_const_version`), which knows the JIT type and
+        // so can pick the recompiling side exit; by here it is in place.
+        debug_assert!(self.const_version_guard());
         // Heap-allocated Float: keep the Sf optimization so subsequent
         // float ops can read the f64 from fpr without re-extracting it
         // from the RValue. Immediate flonums skip this path because
@@ -271,5 +311,43 @@ impl AbstractState {
             using_fpr,
         });
         ir.handle_error(error);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::*;
+
+    /// A body that folded a constant must survive a later constant
+    /// assignment. The fold is only valid at the compile-time constant
+    /// version, so once the global version moves the guard can never pass
+    /// again — before the guard recompiled, one `CONST = ...` anywhere in
+    /// the program left the body deopting on *every* call for the rest of
+    /// the run. Covers a constant read after an unrelated assignment, one
+    /// whose own value is reassigned, and a namespaced read.
+    #[test]
+    fn const_fold_survives_a_later_assignment() {
+        run_test_once(
+            r##"
+            class Foo
+              BAR = 42
+              def get = BAR
+              def qux = Foo::BAR
+            end
+            f = Foo.new
+            res = []
+            200.times { res << f.get }
+            UNRELATED = 1
+            200.times { res << f.get }
+            res << f.qux
+            class Foo
+              remove_const(:BAR)
+              BAR = 99
+            end
+            200.times { res << f.get }
+            res << f.qux
+            res.tally.sort_by { |k, _| k.to_s }
+        "##,
+        );
     }
 }

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -647,6 +647,20 @@ pub(crate) struct JitContext<'a> {
     pub(super) fused_skip: Option<BcIndex>,
 
     ///
+    /// Set while an intra-block dispatch arm is being emitted
+    /// (`compile/pic.rs`), which suppresses callee specialization.
+    ///
+    /// An arm is emitted after its predecessors are already in the
+    /// instruction stream, so it has no way to back out: a
+    /// `compile_specialized_func` that answers `CompileError` would abandon
+    /// the whole compile, and one that answers `Cease` would leave the arm
+    /// with no path to the merge. Specialization is also the wrong shape
+    /// here — a dispatch arm exists to keep the chain short, and inlining a
+    /// callee body into each of up to four arms is the opposite.
+    ///
+    in_dispatch_arm: bool,
+
+    ///
     /// Class version at compile time.
     ///
     class_version: u32,
@@ -718,6 +732,7 @@ impl<'a> JitContext<'a> {
             store,
             codegen_mode,
             fused_skip: None,
+            in_dispatch_arm: false,
             class_version,
             const_version,
             refinements,
@@ -736,6 +751,7 @@ impl<'a> JitContext<'a> {
             store: self.store,
             codegen_mode: false,
             fused_skip: None,
+            in_dispatch_arm: false,
             class_version: self.class_version,
             const_version: self.const_version,
             refinements: self.refinements,
@@ -752,6 +768,20 @@ impl<'a> JitContext<'a> {
 
     pub(super) fn codegen_mode(&self) -> bool {
         self.codegen_mode
+    }
+
+    pub(super) fn in_dispatch_arm(&self) -> bool {
+        self.in_dispatch_arm
+    }
+
+    ///
+    /// Run *f* with the dispatch-arm flag set, restoring it afterwards.
+    ///
+    pub(super) fn with_dispatch_arm<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        let saved = std::mem::replace(&mut self.in_dispatch_arm, true);
+        let r = f(self);
+        self.in_dispatch_arm = saved;
+        r
     }
 
     pub(super) fn iseq_id(&self) -> ISeqId {

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -430,6 +430,16 @@ pub(in crate::codegen) enum LInst {
         class: ClassId,
         deopt: DestLabel,
     },
+    /// Class *dispatch arm*: fall through when `reg`'s runtime class is
+    /// `class`, branch to `target` otherwise. The same comparison
+    /// `GuardClass` emits, kept separate because the miss is ordinary
+    /// control flow (the next arm) rather than a side exit — so it must not
+    /// be booked as a guard failure by the `profile` recorder.
+    BrClassNe {
+        reg: GP,
+        class: ClassId,
+        target: DestLabel,
+    },
     /// Class-set guard: pass when `reg`'s runtime class is any of `classes`,
     /// branch to `deopt` otherwise.
     GuardClassIn {

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1257,7 +1257,7 @@ impl AbstractFrame {
     /// `GuardClass` with the `deopt`, which it (the caller) created *before* this
     /// runs so the deopt's write-back snapshot is the pre-guard placement.
     ///
-    pub(super) fn guard_class_state(&mut self, slot: SlotId, class: ClassId) -> bool {
+    pub(in crate::codegen::jitgen) fn guard_class_state(&mut self, slot: SlotId, class: ClassId) -> bool {
         if self.class(slot) == Some(class) {
             return false;
         }

--- a/monoruby/src/codegen/jitgen/trace_ir.rs
+++ b/monoruby/src/codegen/jitgen/trace_ir.rs
@@ -210,8 +210,11 @@ pub(crate) enum TraceIr {
         idx: SlotId,
         class: Option<(ClassId, ClassId)>, // (base_class, idx_class)
         /// The VM observed operand-class variance at this site
-        /// (`opcode_sub`) — see `UnOp::_polymorphic`.
-        _polymorphic: bool,
+        /// (`opcode_sub`) — see `UnOp::_polymorphic`. Consumed by
+        /// `JitContext::index`, which answers a polymorphic site with a
+        /// two-arm dispatch instead of a class guard that would deopt on
+        /// every off-class receiver.
+        polymorphic: bool,
     },
     IndexAssign {
         base: SlotId,
@@ -597,7 +600,7 @@ impl TraceIr {
                     } else {
                         None
                     },
-                    _polymorphic: pc.opcode_sub() == 1,
+                    polymorphic: pc.opcode_sub() == 1,
                 },
                 133 => TraceIr::IndexAssign {
                     base: SlotId::new(op2_w2),
@@ -934,7 +937,7 @@ impl TraceIr {
                 base,
                 idx,
                 class,
-                _polymorphic: _,
+                polymorphic: _,
             } => {
                 let op1 = format!("{:?} = {:?}.[{:?}]", dst, base, idx);
                 fmt(store, op1, class)

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -1574,15 +1574,21 @@ pub(super) extern "C" fn get_index(
     globals: &mut Globals,
     base: Value,
     index: Value,
-    // Non-zero when the base operand is slot 0 (a literal `self[i]`), which
-    // reaches a private `#[]`; zero for any other receiver, which enforces
+    // True when the base operand is slot 0 (a literal `self[i]`), which
+    // reaches a private `#[]`; false for any other receiver, which enforces
     // visibility. Only consulted on the user-class fallback below —
     // Array/Hash slice with no visibility gate. The operand classes are
     // recorded into the inline cache (with polymorphic detection) by the
     // VM's `vm_save_binary_class` before this call, not here.
-    is_func_call: usize,
+    //
+    // The parameter is a `bool` rather than the flag word the VM's call
+    // sequence builds so that this helper's type *is* `BinaryOpFn` — that
+    // is what lets the JIT emit it through the existing `GenericBinOp`
+    // instruction as the residual arm of a polymorphic index dispatch
+    // (`compile/index.rs`). Both `vm_index` sequences already materialize
+    // the flag as 0/1, so the ABI is unchanged.
+    is_func_call: bool,
 ) -> Option<Value> {
-    let is_func_call = is_func_call != 0;
     let base_classid = base.class();
     // `Array#[]` / `Hash#[]` below bypass method lookup, so they are only
     // sound while those are still the builtins. Unlike the dispatch-table

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -4661,6 +4661,15 @@ pub enum RecompileReason {
     /// generic-C-call path. Monotone & one-shot: the recompiled site
     /// has no receiver-class guard, so it can never re-trigger.
     BecamePolymorphic = 4,
+    /// A body that folded a constant found the global constant version
+    /// moved. Without a recompile the fold is dead weight: the guard can
+    /// never pass again, so *every* subsequent execution deopts — one
+    /// `CONST = ...` anywhere in the program used to poison the body for
+    /// good. Recompiling re-reads the constant at the new version and
+    /// bakes that in. Counter-gated (`COUNT_DEOPT_RECOMPILE`) because,
+    /// unlike the class version, the constant version keeps moving in
+    /// programs that assign constants at run time.
+    ConstVersionGuardFailed = 5,
 }
 
 struct Root<'a, 'b> {

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -1956,6 +1956,23 @@ impl PolyCache {
         self.overflow
     }
 
+    ///
+    /// Every slow-path observation this site made, the megamorphic overflow
+    /// included. A way's `count` divided by this is its **share** of the
+    /// site's misses — the signal a consumer needs to tell "two classes in
+    /// steady alternation" from "one class plus a rare tail", which the way
+    /// count alone cannot distinguish.
+    ///
+    /// Like [`PolyCacheEntry::count`] this is a miss count, not a call
+    /// count, so it says nothing about how hot the site is — only about how
+    /// the misses are distributed across the classes.
+    ///
+    pub fn observations(&self) -> u32 {
+        self.entries
+            .iter()
+            .fold(self.overflow, |acc, e| acc.saturating_add(e.count))
+    }
+
     /// Two or more ways (or an overflow) were observed.
     pub fn is_polymorphic(&self) -> bool {
         self.entries.len() >= 2 || self.overflow != 0

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -1328,6 +1328,7 @@
 73b5b9f7068d2f4d7eb3c69976ab650d	1	class C\n              @@x = 1\n            end\n        
 73c9dec5b896221d19b6233b9db54621	[:rescued, "caught"]	f = Fiber.new do\n              begin\n                Fiber.yield :a
 73cf450d13041a7f92cc5202727762b7	"/"	File.realpath("..", "/tmp")
+73e27e81e87093c61641bec1ab3aa95d	[[:a, 0], [:b, 1], 30, nil, 9, [:a, 1], [:b, 2], 40, :h0, 9, [:a, 2], [:b, 3], 10, :h1, 9, [:a, 3], [:b, 0], 20, nil, 9, [:a, 0], [:b, 1], 30, nil, 9, [:a, 1], [:b, 2], 40, :h0, 9, [:a, 2], [:b, 3], 10, :h1, 9, [:a, 3], [:b, 0], 20, nil, 9, [:a, 0], [:b, 1], 30, nil, 9, [:a, 1], [:b, 2], 40, :h0, 9, [:a, 2], [:b, 3], 10, :h1, 9, [:a, 3], [:b, 0], 20, nil, 9]	class Ba; def [](i) = [:a, i]; end\n            class Bb; def [](i) 
 7416b95f5e87edec12c271dfa849a210	[200, [:body, :ensure_start, :ensure]]	def baz\n              $x = []\n              $x << :body\n           
 74265315f293e83823e6e37edea00c74	[true, true, true, true, true, 1.0, 42, nil, nil]	srand(42)\n            a = rand\n            srand(42)\n            [\n
 742cf7259eae88dd4512794b3c9d16ad	[:i, :j]	def m; [1].each { |i| j = i * 2; return local_variables.sort }; end; m
@@ -2845,6 +2846,7 @@ f40ce886b72f5217bc31de73015cbb2d	[true, true]	# 'M' + length(6 ⇒ marshal_int 0
 f40d66b495e8cfc92317f5249b69ee31	[4, 8, 73, 34, 6, 97, 6, 58, 13, 101, 110, 99, 111, 100, 105, 110, 103, 34, 11, 69, 85, 67, 45, 74, 80]	Marshal.dump("a".encode("EUC-JP")).bytes
 f4101d236b633fea5a8e14b9620d27bb	false	c = Class.new do\n              def bar; end\n              undef :"#
 f417b46ed1c24ffbbc6d828e0035f712	"aXXde"	class C; def to_str; "bc"; end; end; o = C.new\n"abcde".sub(o, "XX")
+f42d6a1e9248b98021fa9c9e4500834f	[107000, TypeError]	class Io\n              def initialize(v) = (@v = v)\n              d
 f4581c269c9086996dbf942d463dfa96	:ok	obj = Object.new\n            def obj.inspect; self; end\n           
 f45a984e81852dd82ce24d6cb475566a	[[[], {}], [[1, 2], {}], [[1], {x: 3}], [[5], {y: 6}], [[], {}], [7, {}], [7, {z: 8}]]	class K; def initialize(*a, **kw); @a = a; @kw = kw; end\n          
 f45ca1bbef67b0bd784d12241e1f0ab4	[:foo, [1, 2, 3]]	class C\n          def method_missing(name, *args)\n            [name, ar

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -357,6 +357,7 @@
 1c55df1a2ab9f2b7ce881cce3520b3da	["File::Stat", 8, true, false, true, true, true, true, true, "file", false, 8, true, true, true, true, true]	path = "/tmp/monoruby_test_stat_#{Process.pid}_#{rand(100000)}"\n   
 1c6926fa6e1462140ee74bc77342fcc8	[nil, :nme, true]	module PrivC\n              class Sec; end\n              private_con
 1c6d7d2ee7c5c48ff5b7040293a055f2	[42, 42, 2]	module BopPlus\n              refine(Integer) { def +(o); 42; end }\n
+1c925daf4080da92af318381f15467e0	[[[:a, 100], [:b, 100], [:c, 100]], :a, :b2, :c, :d]	class Aa; def tag = :a; end\n            class Bb; def tag = :b; end
 1c979897435ff61b3d8ac16af24e1019	[3, 5, 7, nil, 7, 42, 101, :new, {a: 101, b: :new}]	res = []\n        a = 1; a += 2; res << a\n        b = nil; b ||= 5; res 
 1ca7fb21e8495566f40650238bdfc1f6	[false, true, false, true, false, true, false, true, true, false, false, true, true, true, false, true, false, false]	class C\n            include Comparable\n            attr_accessor :x\n 
 1cb0fc8d0cfb3a0a2c9e0ed0438fb68d	[true, "payload", true, true]	base = "/tmp/monoruby_test_link_#{Process.pid}_#{rand(100000)}"\n   
@@ -585,6 +586,7 @@
 3216e8a4e5532edd1d8a9a107a61cb60	"nil"	def t; end; (public).inspect
 323248fe474a5afa887e12205ed145d2	C	a = class C\n          self\n        end\n        a\n        
 3241d752b39412d4f6c02d9dd853ba08	["foo"]	class A; def a(*r); r; end; end\n            class B < A; def a(*r);
+3279027e38a42e302879e0467940338a	[[1, 100], [3, 100], [4, 100], [:attr, 150], [:plain, 150]]	class Ra\n              attr_reader :tag\n              def initializ
 3285c4fda20a8f8870e882093119ec6c	[1, 10, 20, 30]	def f(p, x:, y:, z:)\n          [p, x, y, z]\n        end\n        \n\n     
 3295f884bc7723fc9fb6dbf1936f7316	[-7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5]	def drive\n              res = []\n              j = 0\n              
 329b7b68cb4c629adc01345e10da9fbc	[false, false]	t = Thread.new { :body }\n            t.kill\n            t.join\n    
@@ -952,6 +954,7 @@
 50508f5aac8320c0afe66c4ad76cad0e	["EQ-RAW", false, "NE-RAW", true, true, false, "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW", "EQ-RAW", "NE-RAW"]	class CustomEq; def ==(o); "EQ-RAW"; end; end\n        class CustomNe; d
 50630a61a4b6d776c5dc73a592df1d53	[:a, :a, [:a, :b, :c], :a, ["NameError", "implicit parameter '_1' is not defined"], ["NameError", "implicit parameter '_1' is not defined"], ["NameError", "'a' is not an implicit parameter"], ["TypeError", "1 is not a symbol nor a string"]]	def try; yield; rescue => e; [e.class.to_s, e.message.split(" for "
 506afd7190c9d45ecdef2e801c939176	:te	begin; 1.instance_eval { undef to_s }; :no; rescue TypeError; :te; end
+5078669efc5be0d889fb3ff62604139e	[5350, 1, 2]	class Ka; def v = 1; end\n            class Kb; def v = 2; end\n     
 507f32e0a72a071583d973ffea3c15c7	["Hello Dave at New York!", "Hello Gave at Hawaii!"]	Customer = Struct.new(:name, :address) do\n            def greeting\n    
 509d9bea76f0e1d8349ff37b354accf3	2	k = Class.new { define_method(:m) { [1, 2, 3].each { |x| return x i
 50a5f1523f40c371eae52d5bdb271289	[:@b]	class Foo\n              def initialize\n                @a = 1\n     
@@ -2222,6 +2225,7 @@ bf43e4b5ea5dc43387ed9bdbb1d33e91	["A", 49, "\\n", 65, nil, nil, "end of file rea
 bf642b858ac68f1754855ea56af9f010	["inherited"]	$res = []\n        class A\n          def self.inherited(subclass)\n      
 bf69a12e40aa6429315d6d5c29ddfe91	[0, 5, 5, 0]	f = File.open("Cargo.toml")\n            begin\n              a = f.p
 bf79cea739fcb7a0ec6546a5b4e6528a	[Encoding::CompatibilityError, Encoding::CompatibilityError, Encoding::CompatibilityError, Encoding::CompatibilityError, "incompatible character encodings: UTF-16BE and US-ASCII"]	(f = ->(x) { begin; x.call; rescue => e; e.class; end }; [f.(-> { File.basename(
+bf960838169f3fd4f0850862d278a5e7	[1495, 13, 30, 7]	class Wa; def f(a, b) = a + b; end\n            class Wb; def f(a, b
 bf9d53c3fd6b4e9d4cb7eef1119ed43f	[false, nil, true, 15, nil, false]	pid = fork { sleep 5 }\n            Process.kill("TERM", pid)\n      
 bfb3c432ce87e3afc690e1a4090e98dd	1	e = [1,2,3,4,5].to_enum\n        e.next\n        
 bfb74f48cb5d72df6c677a6148c66445	[12, 12, 12, 12]	p = Proc.new {|x,y| x * y} \n        \n\n        [p.call(3,4), p.yield(3,4
@@ -2684,6 +2688,7 @@ e62defa8e78ced906f42efe00809d657	"true|TITLE|true|$$ is a read-only variable|tru
 e62e66ff0e391002ce507347414bd003	["2024", "04", "11"]	"2024-04-11" =~ /(\\d+)-(\\d+)-(\\d+)/\n            [$1, $2, $3]\n      
 e6482da349c182043f5fa0cd8447051a	[0, 0, 0, 0, true]	require "etc"\n            a = []\n            a << (Process.uid = Pr
 e6506a63c767f1ee5ca72f61264a77b7	"ababab"	"ab" * 3
+e6665fd325619df8d6decf9e59065acd	[[[:a, 300], [:nome, 1]]]	class Pa; def hidden = :a; end\n            class Pb; private def hi
 e6721b573894f02b7adbee10b796d8f8	300000	def osr_fold_sum\n          total = 0\n          i = 0\n          while i 
 e6776f2b7fcaf2ff1e06a04fbb44979f	["missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z", "missing keyword: :a", "unknown keyword: :z"]	class Req\n          def initialize(a:, b: 2) = @x = [a, b]\n        end\n
 e6bd09ab564b813b9ee89a2c7bf7b3a8	["super", nil]	class A\n          def foo; end\n        end\n        class B < A\n        

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -551,6 +551,7 @@
 2dd04b99ea4c74004cb7f6ebf42c571c	"ASCII-8BIT"	Regexp.new('([\\x00-\\xFF])', Regexp::IGNORECASE | Regexp::NOENCODING).encoding.to
 2de87dc95cc7a1a9c4edb24ea1657ff8	:nonpositive	begin; SizedQueue.new(0); rescue ArgumentError; :nonpositive; end\n 
 2e1334cbf1ce1ad1f0ead6825d8ea907	[nil, true, true, true, "", "x"]	require "io/wait"\n            r, w = IO.pipe\n            res = []\n 
+2e2f576be92d459836040d95a711ae05	[[42, 401], [99, 201]]	class Foo\n              BAR = 42\n              def get = BAR\n      
 2e419be22648471b9d426d0e2b7fe4a8	[[FrozenError, true], FrozenError]	class Foo\n              def initialize\n                @a = 1\n     
 2e520c993c13bf6afbdcfa9de96cc277	["A", "overridden", "can't create instance of singleton class", "allocator undefined for Integer"]	class A; end\n        class B; def self.allocate; :overridden; end; end\n
 2e9e5cdf982a6b277e6559a8a489f9a7	["Process::Status", 0, true]	`echo hi`; [$?.class.to_s, $?.exitstatus, $?.success?]

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -1016,6 +1016,7 @@
 576157356419a5741dbdbde29df95789	true	GC.stat.values.all? { |v| v.is_a?(Integer) }
 57bd29081de5740463b29a1c3ee0ef00	"US-ASCII"	s = "hello".dup.force_encoding("US-ASCII")\n              s[/(ll)/
 57f002dbbc2a38d20a751f8e1d4218fe	[255, 15, 240, -1, 15, -16, 42, 0, 42, 42, -43, 244837815148286, 304366200, 244837510782086]	def or_a; 0xFF | 0x0F; end\n            def and_a; 0xFF & 0x0F; end\n
+57f22a05e8acf18b24e3a1c7b3e4f9a8	[false, :c, false, :cf, :c]	class A; end\n            class B; end\n            class C; end\n    
 5802c597582fbeab79b6c6ee6bfe6fed	[true, false]	a = ["a","b","c"]\n        \n\n            [a.include?("b"), a.include
 581a9eeda65b4118ca39d22e6e34f801	[:caught, "boom"]	class C\n              def initialize; @h = {}; end\n              de
 582de92dfc668c66f3fca99c56ea0221	9	M = Data.define(:amount, :unit)\nM.new("amount" => 1, amount: 9, unit: "m").amoun
@@ -1853,6 +1854,7 @@ a164c646ebdbe3551b16c27fa5e2aab0	5	def f; return 5; end; f
 a189356012c67f14ffd149bedd2d23b2	nil	$/ = "xyz"; r = "abcde".chomp!; $/ = "\\n"; r
 a1a984bb2edd75a78229a94547d15825	[true, true, :outer, "nil", ["NoMethodError", "RuntimeError"], "RuntimeError"]	def restore_check(log)\n          outer = StandardError.new "outer"\n    
 a1c461fb313f0da82569acd28c4ca299	[1, 3, 5, 7]	(1..7).filter(&:odd?)
+a1e955df00a16906b87178a40bfe7105	[100, 50, 250, :c, false, true, false]	class A; end\n            class B; end\n            class C; end\n    
 a204f15cf81d104e4412940bba47afbb	[[5, 5], [9, nil, 9], [nil, nil], nil, [7, 1, 7], 42, "FrozenError"]	def drive(n)\n              r = nil\n              n.times { r = yiel
 a207205e2108ee451fae4d6f0df8308a	nil	File.open("Cargo.toml") { |f| f.ungetc(100) }
 a21ceda5ef436f9167f0988b18686885	[true, true, "backtrace must be an Array of String or an Array of Thread::Backtrace::Location", true]	def probe = caller_locations\n        locs = probe\n        e = RuntimeEr
@@ -1948,6 +1950,7 @@ a93aff5f67ff2713cf29404f5b2f4a64	42	class C\n          def call_priv\n          
 a93f36f86e60d2939747b3460e0e9680	[["A", "B"], ["-", "-"], ["A", "-"], ["A", "B"]]	module SnapA\n              refine(String) { def tag;  "A"; end }\n  
 a94375bbeca8fabd095d830c8dca16dd	["Y", "Y"]	$-0 = "Y"; r = [$/, $-0]; $/ = "\\n"; r
 a966ff673f0471a0f7996609730def4c	"missing keyword: :x"	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; def m(x:)
+a96f44dffe64892feff990050d690d94	[150, false, true, false, false]	class Tail1; end\n            class Tail2; end\n            class Tai
 a98bef4ea7d42ca9b3589602d2392195	[[5, 6], [0, 0], [5, 6], [1, 1], [5, 6], [2, 2], [5, 6], [3, 3], [5, 6], [4, 4], [5, 6], [5, 5], [5, 6], [6, 6], [5, 6], [7, 7], [5, 6], [8, 8], [5, 6], [9, 9], [5, 6], [10, 10], [5, 6], [11, 11], [5, 6], [12, 12], [5, 6], [13, 13], [5, 6], [14, 14], [5, 6], [15, 15], [5, 6], [16, 16], [5, 6], [17, 17], [5, 6], [18, 18], [5, 6], [19, 19], [5, 6], [20, 20], [5, 6], [21, 21], [5, 6], [22, 22], [5, 6], [23, 23], [5, 6], [24, 24], [5, 6], [25, 25], [5, 6], [26, 26], [5, 6], [27, 27], [5, 6], [28, 28], [5, 6], [29, 29]]	class N\n          attr_reader :v\n          def initialize(a: 0, b: 1) =
 a9a64f0fa64e4bb1ec264c4f7c86df8b	:OVERRIDDEN	class Integer; def *(o); :OVERRIDDEN; end; end; 3 * 4
 a9b082961457f87dd5dd3df08a2bc22e	"CAFÉ"	"Café".upcase


### PR DESCRIPTION
Cut the paths where a polymorphic call site gets pinned to "one class guard, deopt forever on anything else" by actually consuming what the PMC observed. Along the way, two holes in the measurement are closed.

## Changes

### 1. Widen the PMC class-set guard to the dominant subset, and make it invalidation-safe (`ac2b171b`)

`pmc_same_target_classes` required *every* way to converge on one FuncId, which threw away the whole "effectively 1–2 classes plus a rare tail" shape. Take the converging dominant subset into the set guard and let the rare classes deopt — `GuardClassIn` deopts on anything outside the set, so dropping a class is always sound and never worse than the single-class guard it replaces. The threshold is 1/8 of the site's observations (`PMC_SET_SHARE_DIVISOR`).

This also fixes a **pre-existing bug**. Only `recv_class` was recorded in `inline_method_cache`, so redefining a *different* member of the set left `update_inline_cache` confirming a stale resolution, and the body kept calling the target it resolved at compile time. Every set member now gets its own `InlineCacheEntry`.

### 2. Dispatch a polymorphic `[]` site instead of guarding its receiver (`99ad9c8b`)

optcarrot's `@fetch[addr][addr]` (`Array` for RAM, `Method` for every I/O register) was the single largest deopt source in the run loop. Split it into an inlined arm plus a `runtime::get_index` residual arm — **the point is the missing third option: there is no deopt**. The inlined arm is chosen by "the observed class that has a generator", deliberately *not* the inline cache's class: this site's cache happens to hold `Method`, and inlining that would leave every RAM read on the C call, which is backwards.

`runtime::get_index`'s `is_func_call` changes `usize` → `bool` so its type *is* `BinaryOpFn`, letting the existing `AsmInst::GenericBinOp` emit the residual arm as-is.

**optcarrot `run [:05699]` 828 → 81 deopts; run-loop total 1006 → 273 (3.7×).**

### 3. Recompile on a constant-version miss instead of deopting forever (`3f594ab3`)

`guard_const_version` had no `gen_recompile` recovery of the kind `guard_class_version` has, so a site whose constant was ever reassigned deopted for the rest of the run. Added `RecompileReason::ConstVersionGuardFailed`: ten misses buy one recompile.

Block bodies are excluded. The recompile side exit rebuilds `lfp.func_id()` **as a method**, so firing it in a block body reconstructs under the wrong argument convention — it surfaced as an `ArgumentError` on the path where `Kernel#caller_locations`'s block loads `Thread::Backtrace::Location`. `BecamePolymorphic` has the same latent hazard.

Minimal repro 1,000,000 → 10 deopts; rubyboy 4,584,294 → 4,577; erubi 5,470 → 3,320; etanni 1,310 → 313. **Wall time unchanged** (rubyboy median 1078 → 1069 ms over 8 pairs).

### 4. Count in-body class-guard misses, not just the dispatch stub's (`5ebd853c`)

`jit class guard failed stats` only counted the JIT dispatch stub's entry guard; deopts from `GuardClass` inside a body were never counted at all. Added a cold-page trampoline `class_guard_fail_recorder` on x86-64 and routed `LInst::GuardClass`, the last arm of `GuardClassIn`, and `FloatToFpr`'s deopt through it.

This hole is what made me misread rubykon's 2.28M deopts as "not receiver-class polymorphism". After the fix `Object#acc / Integer 999,981` matches the deopt count exactly, and rubykon correctly reports NilClass 1,898,747 / Float 405,168 / Integer 57,072.

### 5. A shared, declared merge point for intra-block dispatch (`ff895355`)

Lifted the merge `index_dispatch` had grown inline into `compile/dispatch.rs` (`declare_merge` / `end_arm` / `bind_merge`). The CFG-side merge machinery keys on `BasicBlockId`, so it cannot describe a merge *inside* a block.

Not a pure refactor — it carries **two bugs the inline version had**, both of which become immediate as soon as an arm is anything other than a call whose result is consumed right away:

- **GP-pool residency was dropped.** The GP register file is a layer below the link modes and `gen_bridge` does not see it, so a slot both states call `S` bridged to nothing even when the arm's only copy of its value was parked in a pool register — which is exactly where a call result lands. `end_arm` now flushes each arm.
- **Slots above `next_sp` were treated as live.** The merge inherited the operands as they were *before* the instruction, but `send` frees everything above `next_sp`, leaving an arm to bridge `V` back to a live mode. `declare_merge` now clears above `next_sp` the way the compile loop does after every instruction.

Neither is reachable through `index_dispatch` alone (its dst is consumed by the next index, and its two operands are not freed by the call), which is why the existing tests were green.

### 6. Dispatch a polymorphic send instead of guarding its receiver (`092de8d0`)

A site reaching several **different** targets is beyond the class-set guard: one guard admitting the whole set would run the wrong body. Emit a compare chain instead — one class-version guard dominating it, `br_class_ne` per arm, and the last arm keeping the ordinary guard → deopt so a class the VM never observed behaves exactly as before.

```text
        load recv -> rdi
        guard_class_version                 (one, dominating every arm)
        br_class_ne rdi, C0 -> L1
        <call C0#name>
        br merge
  L1:   br_class_ne rdi, C1 -> L2
        <call C1#name>
        br merge
  L2:   guard_class rdi, C2 -> deopt        (last arm)
        <call C2#name>
  merge:
```

The declared merge lets the arms leave wildly different states behind, so a const-folding arm and a real call can share a chain, and arms may take arguments. Every refusal is hoisted into `pic_ways`, before an instruction is emitted — mid-chain there is nothing to back out to. A class that cannot have an arm is dropped rather than sinking the site: it falls past the last guard and deopts, which is what the single-class guard did for it anyway. Callee specialization is suppressed inside an arm (`in_dispatch_arm`), because `compile_specialized_func` can answer `CompileError` or `Cease` and an arm can survive neither.

## Measurements

| | Result |
|---|---|
| optcarrot `run [:05699]` (Index) | 828 → 81 deopts |
| optcarrot run-loop total | 1006 → 273 deopts (3.7×) |
| rubyboy const-version deopts | 4,584,294 → 4,577 |
| erubi / etanni const-version deopts | 5,470 → 3,320 / 1,310 → 313 |
| rubykon `MCTS::Node#backpropagate`'s `node.root?` | 5,101 → 0 deopts |

Wall time shows no significant change on the main benchmarks (rubykon median 10.48 → 10.59 s, inside a 10.31–10.67 range; optcarrot fps varies 949–1145 run to run, no signal). That is expected from the share of the total these sites hold: across six benchmarks, method-call deopts are ~0.35% of the total and binary operators ~99%.

| | binop | method call | index | const load | other |
|---|---:|---:|---:|---:|---:|
| rubykon | 2,366,944 | 12,796 | 43 | 820 | 0 |
| plb2-bedcov | 1,776,912 | 0 | 0 | 0 | 0 |
| rubyboy | 225 | 741 | 153 | 808 | 2,650 |
| optcarrot | 131 | 785 | 186 | 11 | 0 |
| erubi | 0 | 229 | 40 | 1,296 | 2,650 |
| etanni | 0 | 116 | 10 | 779 | 0 |

`compile/dispatch.rs` is factored out as a shared component precisely so it generalizes to the numeric dispatch (fixnum arm / float arm / generic residual) that this table says is where the time actually is. For the record, plb2-bedcov's 1.78M is fixnum **overflow** (`(z^(z>>15))*0x735a2d97` = 8.31e18 > the fixnum max 4.61e18), a shape a residual arm would absorb.

## Verification

- Full suite `cargo test --features stress-spill-pool` green (2,333 + integration tests, 0 failures)
- `cargo check --target aarch64-unknown-linux-gnu` passes
- ruby/spec `core/{array,string,hash,integer,float}`: 137F/62E, identical before and after
- New tests: the class-set invalidation regression, polymorphic Index sites (Array|Method and user classes), constant folding surviving a later assignment, and 5 PIC cases (distinct targets / divergent arm shapes / arms with arguments / mixed method kinds / a private arm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU