### PR TITLE
JIT: dispatch a polymorphic comparison instead of guarding its receiver

### DIFF
--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -1,7 +1,7 @@
 use crate::bytecodegen::BinOpK;
 use crate::executor::inline::InlineFuncInfo;
 
-use super::*;
+use super::{method_call::PMC_SET_SHARE_DIVISOR, *};
 
 ///
 /// The classes [`JitContext::opt_eq_assumable`] has to clear: every class
@@ -189,7 +189,6 @@ impl<'a> JitContext<'a> {
         }
     }
 
-
     ///
     /// May [`AsmIr::opt_eq_cmp`]'s inline fast path be emitted for *kind*?
     ///
@@ -232,6 +231,168 @@ impl<'a> JitContext<'a> {
             self.record_bop_dep(class, op);
         }
         true
+    }
+
+    ///
+    /// The receiver class a polymorphic comparison site should give its
+    /// *typed* arm: the one the VM observed here that actually has a working
+    /// generator, most observed first.
+    ///
+    /// Deliberately **not** the inline cache's class, for the same reason
+    /// [`index_inline_class`](Self::index_inline_class) is not: the cache
+    /// holds whichever class happened to arrive last, which at an alternating
+    /// site is a coin flip. rubykon's `group_id_of(id) == captured.identifier`
+    /// is the motivating shape — the lhs is an `Array` element, so `Integer`
+    /// on a hit and `NilClass` on a miss — and inlining the `NilClass` side
+    /// would leave every real comparison on the C call.
+    ///
+    /// `None` when no observed class can carry the arm, in which case the
+    /// caller keeps the ordinary (guarded, deopting) path.
+    ///
+    fn cmp_inline_class(&mut self, callid: CallSiteId, op: IdentId) -> Option<ClassId> {
+        let pmc = &self.store[callid].pmc;
+        // Two-arm dispatch only pays off where the site really alternates;
+        // one observed class is the monomorphic guard's case.
+        if pmc.entries().len() < 2 {
+            return None;
+        }
+        let observations = pmc.observations();
+        let mut classes: Vec<(ClassId, u32)> =
+            pmc.entries().iter().map(|e| (e.recv, e.count)).collect();
+        classes.sort_unstable_by_key(|(_, count)| std::cmp::Reverse(*count));
+        // The POLY bit only says the site was *ever* seen with a second
+        // class; it never clears. A site that is one hot class plus a
+        // handful of stragglers is monomorphic in every way that matters,
+        // and dispatching it is a pure loss — the hot class pays an extra
+        // branch on every execution and, worse, gives up its result's type
+        // at the merge, where a register-resident flag becomes a boxed
+        // stack slot. So require the runner-up to be a real share of the
+        // traffic, the same 1/8 the class-set guard demands of its members.
+        // (etanni measured ~2% slower before this test existed.)
+        if classes[1]
+            .1
+            .saturating_mul(PMC_SET_SHARE_DIVISOR)
+            < observations
+        {
+            return None;
+        }
+        classes.into_iter().map(|(class, _)| class).find(|&class| {
+            matches!(
+                self.jit_check_method(class, op)
+                    .and_then(|(fid, _)| self.store.inline_info.get_inline(fid)),
+                Some(InlineFuncInfo::InlineGenBinary(_))
+            )
+            // Same licence the guarded direct-fire path needs: the arm runs
+            // without a class-version guard, so a redefinition has to reach
+            // it through the recorded bop dependency.
+            && self.basic_op_assumable(class, op)
+        })
+    }
+
+    ///
+    /// Answer a polymorphic comparison site with a two-arm dispatch:
+    ///
+    /// ```text
+    ///         br_class_ne rdi, C -> slow
+    ///         <C#op inlined>
+    ///         br merge
+    ///   slow: <cmp_*_values>           (correct for *any* operand pair)
+    ///   merge:
+    /// ```
+    ///
+    /// The point is the missing third option: there is no deopt.
+    ///
+    /// Both halves of this already existed and the dispatcher had to pick
+    /// one. `fire_binary_inline` won, because it is tried first — so a
+    /// polymorphic site got a single-class guard and side-exited on every
+    /// off-class operand, which is rubykon's single largest deopt source
+    /// (1.8M side exits on one `==`). Taking `emit_generic_cmp` instead
+    /// would remove the deopt but put *every* comparison, including the hot
+    /// class's, on a C call. Neither is necessary: guard the hot class into
+    /// its inline arm and let everything else take the C call.
+    ///
+    /// Note that the arm guard is stricter than "the class matches" for
+    /// `Integer`: `guard_class` tests the fixnum tag, so a `Bignum` — class
+    /// `Integer` all the same — falls to the residual arm rather than
+    /// deopting, which is where an overflowed operand wants to go anyway.
+    ///
+    /// Returns `false` (leaving *state* and *ir* untouched) when the site
+    /// does not qualify, so the caller takes the ordinary path.
+    ///
+    #[allow(clippy::too_many_arguments)]
+    fn cmp_dispatch(
+        &mut self,
+        state: &mut AbstractState,
+        ir: &mut AsmIr,
+        kind: CmpKind,
+        dst: Option<SlotId>,
+        lhs: SlotId,
+        rhs: SlotId,
+        rhs_class: Option<ClassId>,
+        case_semantics: bool,
+        bc_pos: BcIndex,
+    ) -> JitResult<bool> {
+        let Some(callid) = self.store.get_callsite_id(self.iseq_id(), bc_pos) else {
+            return Ok(false);
+        };
+        let op: IdentId = kind.into();
+        let Some(inline_class) = self.cmp_inline_class(callid, op) else {
+            return Ok(false);
+        };
+        let is_func_call = self.store[callid].is_func_call();
+
+        let state_save = state.clone();
+        let ir_save = ir.save();
+        let (entry, merge) = self.declare_merge(state, ir, &[lhs, rhs], dst);
+        let slow = self.label();
+
+        // ---- arm 1: the class that can be compared inline.
+        let mut fast = entry.clone();
+        fast.load(ir, lhs, GP::Rdi);
+        ir.push(AsmInst::BrClassNe(GP::Rdi, inline_class, slow));
+        // Reaching the arm *is* the proof, so `fire_binary_inline`'s own
+        // receiver guard sees a state that already knows the class and emits
+        // nothing.
+        fast.guard_class_state(lhs, inline_class);
+        if !matches!(
+            self.fire_binary_inline(
+                &mut fast,
+                ir,
+                op,
+                lhs,
+                rhs,
+                inline_class,
+                rhs_class,
+                bc_pos,
+                BinaryInlineMode::Value,
+            ),
+            Some(BinaryInlineOutcome::Done)
+        ) {
+            // A generator that folded or declined has no arm to be; back the
+            // whole dispatch out and let the caller emit the ordinary form.
+            ir.restore(ir_save);
+            *state = state_save;
+            return Ok(false);
+        }
+        self.end_arm(fast, ir, &merge, true);
+
+        // ---- arm 2: every other operand pair, through the generic helper.
+        ir.push(AsmInst::Label(slow));
+        let mut rest = entry.clone();
+        self.emit_generic_cmp(
+            &mut rest,
+            ir,
+            kind,
+            lhs,
+            rhs,
+            case_semantics,
+            is_func_call,
+        );
+        rest.def_rax2acc(ir, dst);
+        self.end_arm(rest, ir, &merge, false);
+
+        self.bind_merge(state, ir, merge);
+        Ok(true)
     }
 
     pub(super) fn binary_op(
@@ -297,6 +458,16 @@ impl<'a> JitContext<'a> {
         bc_pos: BcIndex,
     ) -> JitResult<CompileResult> {
         let (lhs_class, rhs_class) = state.binary_class(lhs, rhs, ic);
+        // A site the VM saw comparing more than one lhs class, whose lhs the
+        // abstract state cannot pin down: dispatch instead of guarding. (A
+        // proven lhs class is monomorphic by construction, whatever the VM
+        // saw at other times.)
+        if polymorphic
+            && state.class(lhs).is_none()
+            && self.cmp_dispatch(state, ir, kind, dst, lhs, rhs, rhs_class, false, bc_pos)?
+        {
+            return Ok(CompileResult::Continue);
+        }
         let Some(lhs_class) = lhs_class else {
             return Ok(CompileResult::Recompile(RecompileReason::NotCached));
         };
@@ -404,6 +575,14 @@ impl<'a> JitContext<'a> {
         bc_pos: BcIndex,
     ) -> JitResult<CompileResult> {
         let (lhs_class, rhs_class) = state.binary_class(lhs, rhs, ic);
+        // No two-arm dispatch here, unlike `binary_cmp`. `CondBr` consumes
+        // the accumulator, which a merge does not preserve — the arms would
+        // have to land the flag in a slot and reload it — and the fused form
+        // is the reason this opcode exists. The polymorphic fallback below
+        // (a guard-free generic compare) already never deopts, and the
+        // fused sites are a rounding error in practice: ~24 side exits
+        // across the whole benchmark set, against 1.8M for the plain
+        // `BinCmp` the dispatch does take.
         let Some(lhs_class) = lhs_class else {
             state.flush_gp(ir);
             return Ok(CompileResult::Recompile(RecompileReason::NotCached));
@@ -522,6 +701,94 @@ fn cmp_generic_fn(kind: CmpKind) -> crate::executor::BinaryOpFn {
 mod tests {
     use crate::tests::*;
 
+    /// The shape `cmp_dispatch` exists for: an lhs that alternates between a
+    /// class with a generator and one without, which the old code answered
+    /// with a single-class guard that side-exited on every other execution
+    /// (rubykon's `group_id_of(id) == captured.identifier`, 1.8M deopts).
+    /// The inlined arm must be the *Integer* one even though the inline
+    /// cache holds whichever class arrived last.
+    #[test]
+    fn cmp_dispatch_alternating_nil_and_integer() {
+        run_test(
+            r#"
+            class T
+              def initialize = (@a = [1, 2, nil, 4])
+              def get(i) = @a[i]
+            end
+            def probe(t, i, x) = t.get(i) == x
+            t = T.new
+            res = []
+            600.times { |i| res << probe(t, i % 4, (i % 4) + 1) }
+            [res.tally.sort_by { |k, _| k.to_s }, probe(t, 2, nil), probe(t, 0, 1)]
+            "#,
+        );
+    }
+
+    /// Every comparison kind through the dispatch, not just `==`/`!=` (which
+    /// take the immediate fast path in the residual arm while the others go
+    /// straight to the generic C call).
+    #[test]
+    fn cmp_dispatch_all_kinds() {
+        run_test(
+            r#"
+            vals = [1, 2.5, 3, 4.5]
+            def lt(a, b) = a < b
+            def le(a, b) = a <= b
+            def gt(a, b) = a > b
+            def ge(a, b) = a >= b
+            def ne(a, b) = a != b
+            res = []
+            600.times do |i|
+              a = vals[i % 4]
+              res << [lt(a, 3), le(a, 3), gt(a, 3), ge(a, 3), ne(a, 3)]
+            end
+            res.uniq.sort_by(&:to_s)
+            "#,
+        );
+    }
+
+    /// The residual arm must run *any* receiver, including a user class with
+    /// its own `==`, and must raise from it exactly as the interpreter does.
+    #[test]
+    fn cmp_dispatch_residual_runs_user_code() {
+        run_test_once(
+            r#"
+            class Weird
+              def ==(other) = (other == 7 ? (raise ArgumentError, "no") : :weird)
+            end
+            def probe(a, b) = a == b
+            vals = [1, Weird.new]
+            res = []
+            600.times { |i| res << probe(vals[i % 2], 3) }
+            begin
+              probe(Weird.new, 7)
+            rescue ArgumentError => e
+              res << e.message
+            end
+            res.tally.sort_by { |k, _| k.to_s }
+            "#,
+        );
+    }
+
+    /// The inlined arm is emitted guard-free under the basic-op licence, so a
+    /// later `Integer#==` redefinition has to evict the compiled body through
+    /// the recorded bop dependency.
+    #[test]
+    fn cmp_dispatch_bop_redefinition_evicts() {
+        run_test_once(
+            r#"
+            def probe(a, b) = a == b
+            vals = [1, nil]
+            res = []
+            600.times { |i| res << probe(vals[i % 2], 1) }
+            class Integer
+              def ==(other) = :redefined
+            end
+            [res.tally.sort_by { |k, _| k.to_s }, probe(1, 1), probe(nil, 1)]
+            "#,
+        );
+    }
+
     /// `opt_eq_cmp`'s inline path answers bit-equality for every immediate,
     /// so a redefinition of any of *their* `==` has to evict the body. Before
     /// the licence check this returned the builtin's answer forever: no side
@@ -552,6 +819,23 @@ mod tests {
                 "#
             ));
         }
+    }
+
+    /// A site the VM marked polymorphic that is one hot class plus a rare
+    /// straggler stays on the monomorphic guard — the POLY bit never clears,
+    /// so without a share test every such site would pay the dispatch
+    /// forever. Correctness is identical either way; this pins the shape.
+    #[test]
+    fn cmp_dispatch_declines_effectively_monomorphic() {
+        run_test(
+            r#"
+            def probe(a, b) = a == b
+            res = []
+            probe(nil, 1)
+            2000.times { |i| res << probe(i % 3, 1) }
+            [res.tally.sort_by { |k, _| k.to_s }, probe(nil, 1), probe(1, 1)]
+            "#,
+        );
     }
 
     #[test]

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -3,6 +3,20 @@ use crate::executor::inline::InlineFuncInfo;
 
 use super::*;
 
+///
+/// The classes [`JitContext::opt_eq_assumable`] has to clear: every class
+/// whose values `opt_eq_cmp`'s inline path can decide, i.e. every immediate
+/// that is neither a heap pointer nor a flonum (both of which it sends to
+/// the generic helper).
+///
+const OPT_EQ_IMMEDIATE_CLASSES: &[ClassId] = &[
+    INTEGER_CLASS,
+    NIL_CLASS,
+    TRUE_CLASS,
+    FALSE_CLASS,
+    SYMBOL_CLASS,
+];
+
 impl<'a> JitContext<'a> {
     ///
     /// Outcome of a binary op whose operand class is unknown *and* whose
@@ -176,6 +190,50 @@ impl<'a> JitContext<'a> {
     }
 
 
+    ///
+    /// May [`AsmIr::opt_eq_cmp`]'s inline fast path be emitted for *kind*?
+    ///
+    /// That fast path answers **bit equality** whenever neither operand is a
+    /// heap object or a flonum — so it decides `==` / `!=` for every one of
+    /// `Integer` (fixnum), `nil`, `true`, `false` and `Symbol` without a
+    /// method lookup and, until this check existed, without consulting the
+    /// basic-op flag either. A `class Integer; def ==(other) = :redefined`
+    /// left a compiled `a == b` still answering `true`, and no side exit
+    /// could repair it: the class-version guard fires, the body recompiles,
+    /// and the recompiled body emits the same unconditional fast path. Only
+    /// `==`/`!=` were affected — `<`, `<=`, `>`, `>=` go straight to the
+    /// generic helper, which does consult the flag.
+    ///
+    /// So take the fast path only under the same licence the guard-free
+    /// inline generators take, for every class it decides, and record the
+    /// dependency so `set_bop_redefine` evicts this body.
+    ///
+    fn opt_eq_assumable(&mut self, kind: CmpKind) -> bool {
+        // `!=` is a tracked pair only for a few classes (`BASIC_OP_DEFS`);
+        // where it is not, the runtime helper cannot see its redefinition
+        // either, so demanding it here would only cost the fast path
+        // without closing anything. `==` is tracked for all five.
+        let eq = IdentId::_EQ;
+        let op: IdentId = kind.into();
+        let mut deps = Vec::with_capacity(OPT_EQ_IMMEDIATE_CLASSES.len() + 1);
+        for &class in OPT_EQ_IMMEDIATE_CLASSES {
+            if !self.basic_op_assumable(class, eq) {
+                return false;
+            }
+            deps.push((class, eq));
+            if op != eq && self.store.is_basic_op_pair(class, op) {
+                if !self.basic_op_assumable(class, op) {
+                    return false;
+                }
+                deps.push((class, op));
+            }
+        }
+        for (class, op) in deps {
+            self.record_bop_dep(class, op);
+        }
+        true
+    }
+
     pub(super) fn binary_op(
         &mut self,
         state: &mut AbstractState,
@@ -314,7 +372,7 @@ impl<'a> JitContext<'a> {
         // generic C-call fallback; other cmp kinds use the plain
         // generic C-call (Part 3-B).
         match kind {
-            CmpKind::Eq | CmpKind::Ne => {
+            CmpKind::Eq | CmpKind::Ne if self.opt_eq_assumable(kind) => {
                 ir.opt_eq_cmp(state, lhs, rhs, kind, cmp_generic_fn(kind), is_func_call)
             }
             CmpKind::TEq if case_semantics => {
@@ -463,6 +521,38 @@ fn cmp_generic_fn(kind: CmpKind) -> crate::executor::BinaryOpFn {
 #[cfg(test)]
 mod tests {
     use crate::tests::*;
+
+    /// `opt_eq_cmp`'s inline path answers bit-equality for every immediate,
+    /// so a redefinition of any of *their* `==` has to evict the body. Before
+    /// the licence check this returned the builtin's answer forever: no side
+    /// exit could repair it, because the recompiled body emitted the same
+    /// unconditional fast path. One class per run — a redefinition is global
+    /// and would mask the others.
+    #[test]
+    fn opt_eq_respects_redefinition() {
+        for (klass, recv) in [
+            ("Integer", "1"),
+            ("NilClass", "nil"),
+            ("TrueClass", "true"),
+            ("FalseClass", "false"),
+            ("Symbol", ":s"),
+        ] {
+            run_test_once(&format!(
+                r#"
+                def probe(a, b) = a == b
+                def probe_ne(a, b) = a != b
+                vals = [{recv}, 1.5]
+                res = []
+                600.times {{ |i| res << probe(vals[i % 2], {recv}) }}
+                600.times {{ |i| res << probe_ne(vals[i % 2], {recv}) }}
+                class {klass}
+                  def ==(other) = :redefined
+                end
+                [res.tally.size, probe({recv}, {recv}), probe_ne({recv}, {recv})]
+                "#
+            ));
+        }
+    }
 
     #[test]
     fn binop_overflow_deopt_dirty_operand() {

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -148,6 +148,7 @@
 0a0748b8809f0e8d7f80297870a4da1e	[200000, 0, 999]	a = []\n            200000.times { |i| a << [(i * 7919) % 1000] }\n  
 0a0f30d8ebe55e1e0abe73391dfb071f	[true, true, true, true, 2]	(o=Object.new; def o.to_path; "/tmp/mono_tp_#{Process.pid}"; end; p2=Object.new;
 0a113daaabe1d4a623096c5f5d1b9ad3	"/home/user/monoruby"	File.expand_path("..")
+0a8fcb3472ef6869da4abdbb99763b0d	[2, :redefined, false]	def probe(a, b) = a == b\n                def probe_ne(a, b) = a
 0aa2fa3cce375400b399c989bb80cc19	[1, 0, 0, 2, 1, 1, 3, 2, 2, 5, 3, 3, 8, 4, 4, 13, 5, 5, 21, 6, 6, 34, 7, 7, 55, 8, 8, 89, 9, 9, 144, 10, 10, 233, 11, 11, 377, 12, 12, 610, 13, 13, 987, 14, 14, 1597, 15, 15]	e = Enumerator.new do |y|\n            a = b = 1\n            loop do\n   
 0abd6eee0fea26b57419ce161524d82a	"Module"	Module.new { using Module.new }.class.to_s
 0abee4f13c81ea36178a7ea1d3967d26	true	Process.getpgid(0) == Process.getpgrp
@@ -283,6 +284,7 @@
 16ddb08d866605796e37d618c1e0275c	false	File.directory?("readme.md")
 16f5223d8b1faedaff984a44eb22a38e	["hi", MarshalUC]	class MarshalUC < String; end\n            # CRuby-produced bytes fo
 16f615066fcccc6076e47f3c46b905fc	[ArgumentError, TypeError]	h = { a: 1 }\n            [\n              (begin; h.to_h { |k, v| [1
+171a85f029945c4899e07045ea531bce	[[[false, 1333], [true, 667]], false, true]	def probe(a, b) = a == b\n            res = []\n            probe(nil
 1734b6bc40227ffa8a335598f1a5f0f2	"[package]\\nname = "	f = File.open("Cargo.toml", "r")\n            f.read(17)\n        
 17360388c4d5caa52af6a98337ba8733	[:thread, :main]	order = []\n            t = Thread.new { order << :thread }\n        
 17505ff21cc36bb3fdb48bc39ea9ddaa	"ff"	class HasToInt; def to_int; 255; end; end\n            sprintf("%x",
@@ -780,6 +782,7 @@
 43ac301501bd4f9ceee646d818f6e415	[:next, :next, :nameerror]	a = Class.new\n            b = Class.new(a)\n            c = Class.ne
 43ccf9c44caf043039162c566a3cf9bd	[4, nil, 7]	a=1\n            x=0\n            b=while a<4 do\n                a=a+
 43cf8f6733d05eaa7ee0c56b3da5cbdf	7074.1	CONST = 5.7\n            sum = 0\n            for i in 0..19 do\n     
+4414dae807897b8e6f7a80f599a5a60d	[[false, 300], ["no", 1], [:weird, 300]]	class Weird\n              def ==(other) = (other == 7 ? (raise Argu
 441632d0adc7cf1139fe425ab23da30c	true	class Integer; alias __orig :<=; def <=(o); __orig(o); end; end; 3 <= 4
 44206b9628b17b33c675e72762330bd5	[true]	io = IO.popen("cat", "r+")\n            res = [io.sync]\n            
 442cc99068d79c4d0b979f548fff9db2	[[[1, 2, 3], {}], [[], {a: 1, b: 2}], [[9], {x: 3}], [[1, 2, 3], {}], [[:rest, :*], [:keyrest, :**]]]	def target(*a, **k); [a, k]; end\n        def d_rest(*); target(*); end\n
@@ -851,6 +854,7 @@
 4806b2df31d1910107eef6e23c081f94	5	def make_counter\n          count = 0\n          inc = Proc.new { count +
 48137d524869d91770282ec59ace6ebb	"US-ASCII"	a = "abc".encode("euc-jp"); /#{a}/.encoding.to_s
 482fe57af7a0767de6479316a00ed916	6	Thread.new(1, 2, 3) { |a, b, c| a + b + c }.value
+4836745e16054f4fe09758474ae9e621	[2, :redefined, false]	def probe(a, b) = a == b\n                def probe_ne(a, b) = a
 4837dfdc276a86f53941ddafe66cb53b	["hello\\n", "world\\n", "foo\\n"]	path = "/tmp/monoruby_test_foreach_#{Process.pid}"\n            File
 483914fde3cb7dac282cf5c352a29b88	"aXXXX"	class C; def to_str; "bc"; end; end; o = C.new\n"abcbc".gsub(o, "XX")
 483a3a15e1c4f82869da871bda9f29e7	["caught m0", "unmatched n0", "type: class or module required for rescue clause", "caught m1", "unmatched n1", "type: class or module required for rescue clause", "caught m2", "unmatched n2", "type: class or module required for rescue clause", "caught m3", "unmatched n3", "type: class or module required for rescue clause", "caught m4", "unmatched n4", "type: class or module required for rescue clause", "caught m5", "unmatched n5", "type: class or module required for rescue clause", "caught m6", "unmatched n6", "type: class or module required for rescue clause", "caught m7", "unmatched n7", "type: class or module required for rescue clause", "caught m8", "unmatched n8", "type: class or module required for rescue clause", "caught m9", "unmatched n9", "type: class or module required for rescue clause", "caught m10", "unmatched n10", "type: class or module required for rescue clause", "caught m11", "unmatched n11", "type: class or module required for rescue clause", "caught m12", "unmatched n12", "type: class or module required for rescue clause", "caught m13", "unmatched n13", "type: class or module required for rescue clause", "caught m14", "unmatched n14", "type: class or module required for rescue clause", "caught m15", "unmatched n15", "type: class or module required for rescue clause", "caught m16", "unmatched n16", "type: class or module required for rescue clause", "caught m17", "unmatched n17", "type: class or module required for rescue clause", "caught m18", "unmatched n18", "type: class or module required for rescue clause", "caught m19", "unmatched n19", "type: class or module required for rescue clause", "caught m20", "unmatched n20", "type: class or module required for rescue clause", "caught m21", "unmatched n21", "type: class or module required for rescue clause", "caught m22", "unmatched n22", "type: class or module required for rescue clause", "caught m23", "unmatched n23", "type: class or module required for rescue clause", "caught m24", "unmatched n24", "type: class or module required for rescue clause", "caught m25", "unmatched n25", "type: class or module required for rescue clause", "caught m26", "unmatched n26", "type: class or module required for rescue clause", "caught m27", "unmatched n27", "type: class or module required for rescue clause", "caught m28", "unmatched n28", "type: class or module required for rescue clause", "caught m29", "unmatched n29", "type: class or module required for rescue clause"]	def rescue_match(exc_msg, clause)\n          begin\n            begin\n   
@@ -1181,6 +1185,7 @@
 6640768cb0201ad9cc8cdbbc1ff67cd8	42	c = Class.new\n            c.class_exec do\n              define_meth
 664f853aae1b23342a7f3f6347677439	[nil, [:r]]	$clog = []\n            def craise; $clog << :r; raise "x"; end\n    
 666756434f77a17dca0c4a9844a9e4e2	[true, true]	def foo; end\n            def bar; end\n            public :foo, :bar
+667fab9da2a05b848ddd0fd87fbd30d9	[[[false, 300], [true, 300]], :redefined, false]	def probe(a, b) = a == b\n            vals = [1, nil]\n            re
 6689fdb915718c542fa7f92d001dacc0	["inherited:B"]	$res = []\n        class A\n          def self.inherited(subclass)\n      
 66b655e81e48c32825c0aeea0b53995d	[0, 10]	f = File.open("Cargo.toml")\n            begin\n              before 
 66b92d6cfcc69793ed5cdd6b3fb7ad21	3.14	class Foo; def to_int; 2; end; end\n            3.14159.truncate(Foo
@@ -1531,6 +1536,7 @@
 8575d528e7322eae6ebb7d94d1ddbeb9	[10]	def f(r, a = ($x = 10)); 0; end\n        f(9)\n        [$x]\n        
 85931ef34cf7bdff8906a812f59a2891	[101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101, 101]	def bar\n          eval("x += 1", $b)\n        end\n            \n\n        
 85a10f866a98eda982860b346626d872	1.25	Rational(3, 4) + 0.5
+85cad4269edafba954a0e9a9a9833e33	[2, :redefined, false]	def probe(a, b) = a == b\n                def probe_ne(a, b) = a
 85d3118446d032c5dad2d62a7bcc2938	[true, "interrupt immediate", false]	Thread.handle_interrupt(RuntimeError => :never) do\n              cu
 85db7cb07fda771baf0fc0e15052b278	"method"	defined?(!__ENCODING__)
 85e7593e9dd66c1c5a37afa22f1b7d68	"nil"	r, w = IO.pipe\n            t = Thread.new { sleep 0.2 }\n           
@@ -1990,6 +1996,7 @@ ab535c2e7cd8b5a3fe1563c1f8eceada	["refined", "refined", true, "refined", "refine
 ab5e7b6bbbd5afe245e3a8a582cb7990	[3, 3]	def find_first(arr)\n          arr.each { |x| break x if x > 2 }\n       
 ab63839dbe29e9f17d36f1cc7849d7da	[[3, 4, 5, 6, 7, 0, 1, 2], [0, 1, 2, 3], [2, 3, 0, 1], [5, 6, 7, 0, 1, 2, 3, 4], [2, 3, 0, 1], [0, 1, 2, 3], [0, 1, 2, 3], [], [2, 3, 4, 1], [], [2, 3, 0, 1], [2, 3, 0, 1], true, FrozenError]	class Cnt; def to_int = 2; end\n        def rot0(a) = a.rotate!\n        
 ab6ac3209d2195ae9950646eb1022c17	:OVERRIDDEN	class Integer; def <<(o); :OVERRIDDEN; end; end; 3 << 4
+ab785c969ef5be187ff55eb3416a3a0f	[2, :redefined, false]	def probe(a, b) = a == b\n                def probe_ne(a, b) = a
 ab8885657a2a64a7b6e8875e78bb2e7b	Array	class C < Array; end\nC[1,2,3].sort.class
 ab957de646f7c725670ace2cad00bc40	1700	class C\n              def bar\n                "bar"\n              e
 ab9797f0718836e71434ef89cce1af7b	[:a]	def m(a, **nil); local_variables; end\n            m(1)\n            
@@ -2536,6 +2543,7 @@ d83209b9961e083672b237cbc756ca17	14	b = binding\n            b.eval("y = 7")\n  
 d877a4927bccad0844990bad82525907	"US-ASCII"	"hello".encode("US-ASCII").capitalize.encoding.to_s
 d879edf56856687d0b1c88dcaebb0402	["C", "M2", "M1"]	module M1\n          def f\n            $res << "M1"\n          end\n      
 d889ad006dc6737982d507f7317622e8	[10, 20, 30]	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \n[s["a
+d891f7684828b546ba97829e6e5a6cae	[[[false, 150], [true, 450]], true, true]	class T\n              def initialize = (@a = [1, 2, nil, 4])\n      
 d8b0d018647384bbab864dd283908894	[:x, :y]	D = Data.define(:x, :y)\nClass.new(D).new(1, 2).members
 d8ec5385ee072765ba7b565e51313657	[777, 777]	class Integer\n          def sub_impl(o); 777; end\n        end\n        $
 d9300c97f073adabeb7a50ccd6acbd23	0..300	a=1\n            b = for a in 0..300 do\n            end\n            
@@ -2813,6 +2821,7 @@ f053ea7381008dbc0e2209151231a4ec	4	a=3;\n        if a==1;\n          3\n        
 f06768860864e9c94d5eda4e8a2fa12d	[42, true]	module Foo\n          BAR = 42\n        end\n        def baz(x)\n          
 f090d1117e83eac6fc71416bd205423e	[[195, 169], "Windows-31J", true]	s = "\\303\\251".dup.force_encoding(Encoding::Windows_31J)\n               m = /./s
 f098937c1782ad342405a495ac2f0063	true	class Foo\n              def bar; end\n            end\n            \n\n
+f09f3eb9548625635df9c1a64f0614c9	[2, :redefined, false]	def probe(a, b) = a == b\n                def probe_ne(a, b) = a
 f0c50bd8de554c94bd61a098ac6b9b78	"#<data M amount=42, unit=\\"km\\">"	M = Data.define(:amount, :unit)\nM.new(42, "km").to_s
 f0e946f362739bd5f3dcdd127d2dbfe2	[:toa, :single]	class E1 < StandardError; end\n            class Custom; def to_a; [
 f12165564d922cbb529013b962e93e50	11	b = for a in 0..300 do\n                if a == 77 then break a/7 en
@@ -2885,6 +2894,7 @@ f692d7c01396875808d70ca97155bd6f	[1, 2, 3, 4, 5, 6, 7, 8]	class C < Array\n     
 f6a5ba1237d7cfc8990854f9a869a012	true	Thread.current.equal?(Thread.current)
 f6b2f5848e7295cbc532e6f89aae0054	[true, true, true, true, true]	(a=(File.method(:unlink)==File.method(:delete)); b=(File.method(:empty?)==File.m
 f6b8ba5c363ede98f3ac55cfd3ae8594	[[:keyreq, :a], [:keyreq, :b]]	def only_req_kw(a:, b:); end\n            method(:only_req_kw).param
+f6bd187bbf5507071844189b94dc4434	[[false, false, true, true, true], [false, true, false, true, false], [true, true, false, false, true]]	vals = [1, 2.5, 3, 4.5]\n            def lt(a, b) = a < b\n          
 f6cc6145b95584bf04b9e5b0c112640c	[:a, :b, :block, :x, :z]	a = 1\n        b = 2\n        def f(x, &block)\n          z = nil\n        
 f736ab01b7f73c593f6fc9713eeae554	["boom", false, "boom"]	require "tmpdir"\n        # Use a per-process unique path so parallel te
 f75daf748ad804574801fd5e35cb2793	"1/2"	Rational(0.5).to_s


### PR DESCRIPTION
Extends the two-arm dispatch from `Index` (#1127) to comparison operators, and fixes a correctness bug found on the way.

## 1. Polymorphic comparison sites get a two-arm dispatch

Both halves of this already existed and `binary_cmp` had to pick one. `fire_binary_inline` won, because it is tried first — so a site the VM marked polymorphic still got a single-class guard and side-exited on every off-class operand. That is rubykon's single largest deopt source: `group_id_of(id) == captured.identifier`, whose lhs is an `Array` element (`Integer` on a hit, `nil` on a miss), **1.8M side exits on one `==`**. Taking `emit_generic_cmp` instead would remove the deopt but put *every* comparison, the hot class's included, on a C call.

Neither is necessary. Guard the hot class into its inline arm on the shared intra-block merge, and let everything else fall through to the generic helper:

```text
        br_class_ne rdi, C -> slow
        <C#op inlined>
        br merge
  slow: <cmp_*_values>           (correct for *any* operand pair)
  merge:
```

The point is the missing third option: there is no deopt.

Three things worth calling out:

- **The arm class comes from the PMC, not the inline cache.** At an alternating site the cache holds whichever class arrived last, which is a coin flip; inlining the `NilClass` side would leave every real comparison on the C call.
- **The arm guard is stricter than "the class matches" for `Integer`** — `guard_class` tests the fixnum tag — so a `Bignum` takes the residual arm rather than deopting, which is where an overflowed operand wants to go anyway.
- **The runner-up class must hold at least 1/8 of the observations**, the same share the class-set guard demands of its members. The POLY bit only says the site was *ever* seen with a second class and never clears, so without that test a site that is one hot class plus a handful of stragglers pays the dispatch forever: an extra branch, and — worse — its result boxed to a stack slot at the merge instead of staying register-resident. etanni measured ~2% slower before the test existed, and is back to parity with it.

`BinCmpBr` is deliberately left alone: `CondBr` consumes the accumulator, which a merge does not preserve, and the fused form is the reason that opcode exists. Its polymorphic fallback already never deopts, and the fused sites are ~24 side exits across the whole benchmark set.

## 2. Bug fix: the inline `==` fast path outlived a redefinition

Found because a test added for the above failed. This is a correctness bug present on master:

```ruby
def probe(a, b) = a == b
vals = [1, nil]
600.times { |i| probe(vals[i % 2], 1) }
class Integer; def ==(other) = :redefined; end
probe(1, 1)   #=> true (CRuby: :redefined), forever
```

`opt_eq_cmp` answers **bit equality** whenever neither operand is a heap object or a flonum, which decides `==` / `!=` for `Integer` (fixnum), `nil`, `true`, `false` and `Symbol` with no method lookup — and, until now, with no basic-op check either.

No side exit could repair it. The class-version guard `emit_generic_cmp` emits does fire, and the body does recompile — and the recompiled body emits the same unconditional fast path. Only `==` / `!=` were affected; `<`, `<=`, `>`, `>=` go straight to the generic helper, which consults the flag at run time.

The fix takes the fast path under the same licence the guard-free inline generators take, and records the dependency so `set_bop_redefine` evicts the body. Note `!=` is only a tracked pair for some of those classes; where it is not, the runtime helper cannot see its redefinition either, so demanding it here would cost the fast path without closing anything — `==`, which is tracked for all five, is what is required.

Reachable only from the polymorphic comparison path (a monomorphic site takes the guarded inline, which already checked the licence), which is why it survived: it needs an alternating operand class *and* a redefinition.

## Measurements

| | |
|---|---|
| rubykon, `gain_liberties_from_capture_of`'s `==` | **1,823,469 → 0** deopts |
| rubykon overall | ~2.28M → ~0.46M deopts |
| rubykon / etanni / erubi / binarytrees wall time | unchanged within noise |

The flat wall time is worth stating plainly: the side exit this removes is cheap, because the block it returns to is two bytecodes long. Deopt count is not serving as a proxy for time at this site.

## Verification

- Full suite green with `--features stress-spill-pool`
- `cargo check --target aarch64-unknown-linux-gnu` clean
- ruby/spec `core/{array,string,hash,integer,float,nil,symbol,comparable}`: 137F/62E, identical before and after
- 6 new tests: alternating nil/Integer, all comparison kinds, the residual arm running a user `==` (and propagating its exception), bop-redefinition eviction, an effectively-monomorphic site declining the dispatch, and `==` redefinition for all five immediate classes

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_