### PR TITLE
JIT: end the block on an uncached binary op in both passes

### DIFF
--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -167,41 +167,6 @@ const OPT_EQ_IMMEDIATE_CLASSES: &[ClassId] = &[
 
 impl<'a> JitContext<'a> {
     ///
-    /// Outcome of a binary op whose operand class is unknown *and* whose
-    /// inline cache is empty (`Other(None, _)` / the Shl-group `None`).
-    ///
-    /// - **codegen pass**: deopt + recompile this single instruction. Only
-    ///   this path bails at runtime; the rest of the loop stays JIT-compiled,
-    ///   and once the inline cache warms the method recompiles cleanly.
-    /// - **loop-analysis pass**: do *not* abort the block. Aborting drops the
-    ///   loop's back-edge fix-point, which leaves the loop head un-widened —
-    ///   a constant `C` that cannot be reconciled with the runtime `G` value
-    ///   the real back-edge delivers, hitting the `(G, C)` `unreachable!` in
-    ///   `bridge`. Widen the result to a typeless stack value (`S`) and
-    ///   continue so the fix-point converges; the loop head is then widened
-    ///   consistently and the real (codegen) pass emits the per-instruction
-    ///   deopt above.
-    ///
-    /// In `CmpBr` mode the widening is not available: continuing past a fused
-    /// compare-and-branch would need the branch itself, and no arm emitted
-    /// one. That block ceases under loop analysis as it always has.
-    fn binop_uncached(
-        &self,
-        state: &mut AbstractState,
-        dst: Option<SlotId>,
-        mode: BinaryInlineMode,
-    ) -> CompileResult {
-        if self.codegen_mode() || matches!(mode, BinaryInlineMode::CmpBr { .. }) {
-            CompileResult::Recompile(RecompileReason::NotCached)
-        } else {
-            if let Some(dst) = dst {
-                state.def_S(dst);
-            }
-            CompileResult::Continue
-        }
-    }
-
-    ///
     /// May the guard-free inline implementation of `class#op` be emitted?
     ///
     /// It may while `class#op` is still the builtin. Answering `false` sends
@@ -611,9 +576,28 @@ impl<'a> JitContext<'a> {
             return Ok(BinaryLowering::Emitted);
         }
 
-        // ---- 3. Neither the state nor the cache knows the receiver class.
+        // ---- 3. Neither the state nor the cache knows the receiver class
+        // (`Other(None, _)`, or the Shl-group `None`). There is nothing to
+        // compile: deopt and recompile, so the block ends here.
+        //
+        // Both passes end it. In the codegen pass this is an *unconditional*
+        // deopt — `recompile_and_deopt` emits `RecompileDeopt`, which always
+        // exits to the interpreter — so the block never reaches whatever
+        // follows, including a back-edge. The loop-analysis pass has to model
+        // exactly that, and modelling it any other way is what makes the two
+        // disagree: an analysis that continued past this point would record a
+        // back-edge the codegen pass will not emit, or (worse) widen the loop
+        // head for a body that never runs.
+        //
+        // Ending the *analysis* mid-block leaves the loop with no proven
+        // back-edge, which `analyse_backedge_fixpoint` must not confuse with
+        // "this loop always exits" — see the give-up handling there. A loop
+        // whose back-edge is unreachable for want of a compilable instruction
+        // is simply not a loop this JIT can compile.
         let Some(lhs_class) = lhs_class else {
-            return Ok(BinaryLowering::Ceased(self.binop_uncached(state, dst, mode)));
+            return Ok(BinaryLowering::Ceased(CompileResult::Recompile(
+                RecompileReason::NotCached,
+            )));
         };
 
         // ---- 4. One path for every operator: guard the receiver, run the

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -1147,6 +1147,43 @@ mod tests {
         );
     }
 
+    /// A loop the compiler only ever sees pass straight through, because the
+    /// one instruction in its body is uncached — `Mutex#lock`'s
+    /// `until try_lock` is the shape in the wild, and it is the reason both
+    /// passes must end the block here rather than one of them widening on.
+    ///
+    /// With both ending it, the analysis records no back-edge, so the loop
+    /// head keeps its precise pre-header types and the body compiles to a
+    /// deopt: the "loop" becomes the straight-line code it has actually been
+    /// observed to be. What this pins is the other half — that the back-edge
+    /// still works when it finally *is* taken. The deopt recompiles the
+    /// method against a now-warm cache, and the real loop has to produce the
+    /// same answers as the interpreter.
+    #[test]
+    fn uncached_body_loop_compiles_straight_then_loops() {
+        run_test(
+            r#"
+            def probe(a, obj)
+              i = 0
+              until a[i]
+                i = obj + i
+              end
+              i
+            end
+            # Warm it with the body never entered: `obj + i` stays uncached
+            # and `probe` compiles with that block as a deopt.
+            res = []
+            300.times { res << probe([true], nil) }
+            # Now take the back-edge that was never compiled.
+            [res.uniq,
+             probe([false, true], 1),
+             probe([false, false, true], 1),
+             probe([false, false, false, true], 1),
+             probe([true], nil)]
+            "#,
+        );
+    }
+
     #[test]
     fn binop_overflow_deopt_dirty_operand() {
         // Regression: an Add whose lhs is a *dirty* GP resident (a prior

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -63,6 +63,7 @@
 0417499cdc3487266e491725b65dcd89	[43, 42]	f = Fiber.new(storage: {life: 42}) do\n              inner = Fiber.n
 042067cf8df83644b7cd370ce04a55db	100	class C\n            class D\n              E = 1\n              def sel
 042531956d7a960e0bfee8fa3360dc99	["ASCII-8BIT", true]	begin\n              begin\n                File.stat("/missing\\xE3E4
+044076512bb7513e712f132ac825e216	[[0], 1, 2, 3, 0]	def probe(a, obj)\n              i = 0\n              until a[i]\n    
 0459d7cb4f158e142736bf52fff36347	[Hash, {x: 1}, false]	sub = Class.new(Hash)\n            o = sub.new\n            o[:x] = 1
 046110996c8a0ca3802aa257c29bd814	["class variable", true]	class DefCV\n              @@v = 1\n              def t; [defined?(@@
 04960a654db6978cf6c1b2b82065abdf	[1, 2, 3, 4, 5, 6, 7, 8]	class C < Array\n          attr_reader :a, :b, :c, :d, :e, :f, :g, :h\n  


### PR DESCRIPTION
`binop_uncached` gave the analysis pass a different answer from the codegen pass: codegen deopted, analysis widened `dst` to `S` and kept going.

The justification in its doc comment no longer holds. It cites the `(G, C)` `unreachable!` in `bridge`, and `LinkMode::G` has since been abolished — `None`/`MaybeNone`/`V`/`S`/`F`/`Sf`/`C` is the whole lattice now.

## Why ending the block is right

The codegen pass emits `RecompileDeopt` here, which **always** exits to the interpreter, so the block never reaches whatever follows it. The analysis pass has to model the code that will actually exist, and widening past the instruction models code that will not: it records a back-edge the codegen pass never emits, and widens a loop head for a body that never runs.

Both passes now end the block, and `binop_uncached` — whose only content was that disagreement — is gone.

## What it buys

`Mutex#lock` is the shape in the wild:

```ruby
until try_lock
  ...        # uncontended, this never runs, so it stays uncached
end
```

The analysis records no back-edge, so the loop head keeps its precise pre-header types and the body compiles to a deopt. The "loop" becomes the straight-line code it has actually been observed to be — which is exactly what that method wants. If contention ever appears, the body's deopt recompiles it against a warm cache as a real loop.

It is also what makes the two passes agree. With no back-edge there is no join, so the loop-head target **is** the pre-header state — the same state the analysis's first iteration ran from. Both passes therefore decide from the same types and end the block at the same instruction, which is the `S -> C` mismatch (loop head left at a stale concrete type while the forward pass delivers a stack value) the old comment was guarding against. Widening per-instruction was never the thing keeping that away.

The `CmpBr` special case goes with it. It read as a third policy ("widening is not available here") when it was really the same one: that opcode has no branch to continue past, so ending the block is all it could ever do.

## The test

Pins the half that this design actually risks. Compiling a loop as straight-line code is only safe if the back-edge still works when it is finally taken, so the test warms the straight-through path 300 times and only then feeds inputs that iterate — the deopt has to recompile against the now-warm cache and agree with the interpreter.

## An approach that did not work, recorded for the next reader

An earlier attempt made the analysis report *why* it stopped and declined to compile a loop whose back-edge it never reached. That is unshippable, for a reason worth writing down: `analyse_backedge_fixpoint` is reached from `incoming_context` during **whole-method** compilation, so answering `CompileError` there aborts the enclosing method, not just the loop. `Mutex#lock` was then never compiled at all, and — since the loop-start counter retries on every entry past the threshold (`jae`, not `je`) and a body that never runs never warms its cache — every call re-ran the whole analysis. A microbenchmark of that shape went from 1ms to 588ms at N=20,000, superlinearly.

With this PR `Mutex#lock` compiles as a whole method (1461 → 3792 bytes).

## Verification

- Full suite green, plain and with `--features stress-spill-pool`
- `cargo check --target aarch64-unknown-linux-gnu` clean
- ruby/spec `core/{array,string,hash,integer,float,nil,symbol,comparable,numeric}`: **137F/62E, identical** to master
- rubykon / etanni / erubi / binarytrees and optcarrot: flat within noise, and correct output

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_