### PR TITLE
JIT: dispatch a polymorphic arithmetic site when both arms agree

### DIFF
--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -90,41 +90,6 @@ impl BinaryOp {
 }
 
 ///
-/// What a site does with the VM's "more than one operand class here" bit.
-///
-/// This is the one place the arithmetic and comparison families still differ,
-/// and stating it as a policy keeps the difference to a single argument
-/// instead of three divergent function tails — flipping arithmetic over is
-/// then one word, once the merge shape below is in place.
-///
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub(super) enum PolymorphicPolicy {
-    ///
-    /// Ignore it: guard the receiver class and deopt on a miss, always.
-    ///
-    /// Arithmetic's position today. Going guard-free unconditionally would
-    /// remove the deopt but put every operation — the hot class's included —
-    /// on a C call, giving up the inline numeric paths at exactly the sites
-    /// that execute most. The answer there is the two-arm dispatch
-    /// [`JitContext::binary_dispatch`] already implements for comparisons,
-    /// which first needs a merge shape that keeps a numeric result unboxed
-    /// (the `LinkMode::Sf(fpr, SfGuarded::FixnumOrFloat)` note in
-    /// `compile/dispatch.rs`) — declaring `S(Value)` at the merge would box
-    /// every arm's result and hand back the gain.
-    ///
-    Ignore,
-    ///
-    /// Honour it: try the two-arm dispatch, and fall back to the guard-free
-    /// generic helper rather than a guarded call.
-    ///
-    /// While the site is still monomorphic the guarded call recompiles on a
-    /// receiver-class miss, so it flips to this treatment as soon as class
-    /// variance shows up rather than side-exiting forever.
-    ///
-    Dispatch,
-}
-
-///
 /// How far [`JitContext::compile_binary`] got, and what the caller must still
 /// do to sink the result.
 ///
@@ -411,6 +376,47 @@ impl<'a> JitContext<'a> {
     }
 
     ///
+    /// Did the VM only ever see one argument class at this site?
+    ///
+    /// The two-arm dispatch resolves the receiver; the argument is still
+    /// handled by a guard inside the arm. So a varying argument is a deopt
+    /// the dispatch cannot remove, and the site is better left alone.
+    ///
+    /// `None` (an argument whose class the VM did not record) counts as
+    /// variation: it is exactly the case there is no evidence for.
+    ///
+    fn pmc_arg_is_stable(&self, callid: CallSiteId) -> bool {
+        let mut args = self.store[callid]
+            .pmc
+            .entries()
+            .iter()
+            .map(|e| e.arg);
+        let Some(Some(first)) = args.next() else {
+            return false;
+        };
+        args.all(|a| a == Some(first))
+    }
+
+    ///
+    /// Would every arm of this site answer the same *kind* of value?
+    ///
+    /// A numeric operator answers a float when either operand is one, and the
+    /// arms differ only in the receiver. So they agree when the argument is a
+    /// float — every arm answers a float — or when no receiver the VM observed
+    /// is one, in which case every arm answers an integer. A site that mixes
+    /// them can only merge as `S(Value)`, boxing the float arm's result for
+    /// the next instruction to decode again.
+    ///
+    fn pmc_arms_agree_on_float(&self, callid: CallSiteId, rhs_class: Option<ClassId>) -> bool {
+        rhs_class == Some(FLOAT_CLASS)
+            || !self.store[callid]
+                .pmc
+                .entries()
+                .iter()
+                .any(|e| e.recv == FLOAT_CLASS)
+    }
+
+    ///
     /// Answer a polymorphic comparison site with a two-arm dispatch:
     ///
     /// ```text
@@ -460,6 +466,36 @@ impl<'a> JitContext<'a> {
         let Some(inline_class) = self.dispatch_inline_class(callid, op) else {
             return Ok(false);
         };
+        // The dispatch guards the *receiver*. An arithmetic arm still guards
+        // its own argument internally — `Integer#+` takes a different path for
+        // an Integer rhs than for a Float one — so at a site whose argument
+        // class varies, that inner guard keeps failing however the receiver is
+        // resolved. Dispatching such a site buys nothing and costs the extra
+        // branch plus a `dst` boxed at the merge; measured at +10% on a hot
+        // `Float + (Float | Integer)` site whose deopt count did not move.
+        //
+        // The inline cache cannot see this: it holds the last pair only, so a
+        // site with an alternating argument and one whose argument is always
+        // the same both report `rhs_class: Float`. The PMC keeps the whole
+        // distribution, so ask it.
+        //
+        // Comparisons are exempt. Their generators answer any operand pair
+        // without an inner guard, and their result is a flag that costs
+        // nothing to merge.
+        // And the arms have to agree on the *kind* of result. Numeric `op`
+        // answers a float when either operand is one, and the arms differ only
+        // in the receiver — so they agree when the argument is a float (both
+        // answer floats) or when no observed receiver is (both answer
+        // integers). When they disagree, `dst` is a float on one side and a
+        // fixnum on the other, the merge can only be `S(Value)`, and the float
+        // arm pays a box the next float instruction has to undo. That measured
+        // +62%.
+        if matches!(binop, BinaryOp::Arith(_))
+            && (!self.pmc_arg_is_stable(callid)
+                || !self.pmc_arms_agree_on_float(callid, rhs_class))
+        {
+            return Ok(false);
+        }
         let is_func_call = self.store[callid].is_func_call();
 
         let state_save = state.clone();
@@ -522,7 +558,8 @@ impl<'a> JitContext<'a> {
     /// 3. give up (deopt, or widen under loop analysis) when the receiver
     ///    class is unknown *and* uncached;
     /// 4. fire the registered inline generator for `lhs_class#op`;
-    /// 5. fall back per [`PolymorphicPolicy`].
+    /// 5. fall back: the guard-free generic helper once the VM has marked
+    ///    the site polymorphic, a guarded call while it is still monomorphic.
     ///
     /// What is genuinely per-opcode is the *sink* — a slot, or a fused
     /// branch — and that is what the caller gets back in [`BinaryLowering`]
@@ -543,17 +580,12 @@ impl<'a> JitContext<'a> {
         polymorphic: bool,
         bc_pos: BcIndex,
         mode: BinaryInlineMode,
-        policy: PolymorphicPolicy,
     ) -> JitResult<BinaryLowering> {
         // `BinCmpBr` is the case/when and rescue-matching opcode, and
         // dispatches `===` with funcall semantics; every other form is a
         // public-only call. The mode identifies the opcode, so the two need
         // not be threaded separately.
         let case_semantics = matches!(mode, BinaryInlineMode::CmpBr { .. });
-        // One reading of the VM's bit for both the dispatch and the residual,
-        // so a family cannot end up dispatching but still deopting (or the
-        // reverse) through an edit to only one of them.
-        let polymorphic = polymorphic && policy == PolymorphicPolicy::Dispatch;
         let (lhs_class, rhs_class) = state.binary_class(lhs, rhs, ic);
 
         // ---- 2. A site the VM saw comparing more than one lhs class, whose
@@ -647,14 +679,10 @@ impl<'a> JitContext<'a> {
             self.emit_generic_binary(state, ir, binop, lhs, rhs, case_semantics, is_func_call);
             return Ok(BinaryLowering::Generic);
         }
-        // A monomorphic compile under `GenericWhenPolymorphic` makes the
-        // recv-class guard recompile on a miss, so the site flips to the
-        // generic path the moment the VM observes class variance rather than
-        // side-exiting forever.
-        let recompile_on_miss = policy == PolymorphicPolicy::Dispatch;
-        if recompile_on_miss {
-            state.flush_gp(ir);
-        }
+        // Still monomorphic: make the recv-class guard recompile on a miss, so
+        // the site flips to the treatment above the moment the VM observes
+        // class variance rather than side-exiting forever.
+        state.flush_gp(ir);
         Ok(BinaryLowering::Called(self.call_binary_method(
             state,
             ir,
@@ -664,7 +692,7 @@ impl<'a> JitContext<'a> {
             rhs_class,
             IdentId::from(binop),
             bc_pos,
-            recompile_on_miss,
+            true,
         )?))
     }
 
@@ -691,7 +719,6 @@ impl<'a> JitContext<'a> {
             polymorphic,
             bc_pos,
             BinaryInlineMode::Value,
-            PolymorphicPolicy::Ignore,
         )? {
             BinaryLowering::Emitted => Ok(CompileResult::Continue),
             BinaryLowering::Generic => {
@@ -728,7 +755,6 @@ impl<'a> JitContext<'a> {
             polymorphic,
             bc_pos,
             BinaryInlineMode::Value,
-            PolymorphicPolicy::Dispatch,
         )? {
             BinaryLowering::Emitted => Ok(CompileResult::Continue),
             BinaryLowering::Generic => {
@@ -767,7 +793,6 @@ impl<'a> JitContext<'a> {
             polymorphic,
             bc_pos,
             BinaryInlineMode::CmpBr { brkind, dest },
-            PolymorphicPolicy::Dispatch,
         )? {
             // The fused form guards + compares + branches without ever
             // materializing the flag. Side-branch bookkeeping stays here; the
@@ -892,9 +917,9 @@ mod tests {
     /// self-consistent still fails here.
     ///
     /// This also covers the arithmetic arms, which have no caller yet —
-    /// `PolymorphicPolicy::Ignore` keeps `+` off the generic path — so they
-    /// are checked from the moment they are written rather than from whenever
-    /// the flip lands.
+    /// arithmetic reaches the generic path only at a polymorphic site whose
+    /// arm is not float-valued, so the table is checked in full here rather
+    /// than only where a benchmark happens to exercise it.
     #[test]
     fn generic_fn_implements_the_operator_it_names() {
         let mut globals = Globals::new_test();
@@ -1104,12 +1129,11 @@ mod tests {
     }
 
     /// An arithmetic site the VM marks polymorphic. `TraceIr::BinOp` now
-    /// carries that bit, but `PolymorphicPolicy::Ignore` makes it inert — the
-    /// site keeps its receiver guard and deopts on a miss. Locks the result
-    /// down either way, so the eventual flip to `Dispatch` has to preserve
-    /// it: every operand pair here (Integer/Integer, Float/Integer,
-    /// Integer/Float, Float/Float, and a Bignum that overflows the fixnum
-    /// tag) must come out the same however the site is lowered.
+    /// carries that bit, and a site whose arm is not float-valued now
+    /// dispatches on it. Every operand pair here — Integer/Integer,
+    /// Float/Integer, Integer/Float, Float/Float, and a Bignum that overflows
+    /// the fixnum tag — must come out the same whichever way the site is
+    /// lowered, dispatched or guarded.
     #[test]
     fn binop_polymorphic_site_operand_matrix() {
         run_test(
@@ -1180,6 +1204,81 @@ mod tests {
              probe([false, false, true], 1),
              probe([false, false, false, true], 1),
              probe([true], nil)]
+            "#,
+        );
+    }
+
+    /// The arm the arithmetic dispatch newly makes live: a site whose
+    /// receiver alternates between `Integer` and a class with its own `+`.
+    /// The hot class inlines, and everything else takes `add_values`, which
+    /// re-dispatches the name — so the user method has to run, and raise
+    /// where it raises.
+    ///
+    /// This is the shape the dispatch is *for*. rubykon's arithmetic deopts
+    /// look similar in the profile but are not: its `Integer` guard failures
+    /// are a Bignum failing the fixnum-tag test, and the JIT does not compile
+    /// Bignum arithmetic — deopting there is the intended handling, and the
+    /// site is monomorphic anyway.
+    ///
+    /// A Bignum reaching a site that *does* dispatch is handled rather than
+    /// exited: it fails the arm's fixnum-tag guard and lands in the residual,
+    /// where `add_values` does the BigInt in C. Hence the `1 << 70` below.
+    #[test]
+    fn binop_dispatch_residual_runs_user_plus() {
+        run_test(
+            r#"
+            class W
+              def initialize(v) = (@v = v)
+              def +(o) = @v + o * 10
+            end
+            def probe(x) = x + 1
+            vals = [1, W.new(2), 3, W.new(4)]
+            res = []
+            600.times { |i| res << probe(vals[i % 4]) }
+            [res.uniq.sort_by(&:to_s), probe(1 << 70), probe(2.5)]
+            "#,
+        );
+    }
+
+    /// Two shapes the arithmetic dispatch declines, both of which still have
+    /// to answer correctly: a site whose arms disagree on the kind of result
+    /// (`Float` receiver, `Integer` argument — one arm answers a float, the
+    /// other a fixnum, so the merge could only box), and one whose argument
+    /// class varies (the arm's own argument guard would keep deopting however
+    /// the receiver is resolved).
+    #[test]
+    fn binop_float_site_keeps_its_guard() {
+        run_test(
+            r#"
+            def disagree(x) = x + 1
+            def unstable(x, y) = x + y
+            vals = [1, 2.5, 3, 4.5]
+            a = []
+            b = []
+            600.times do |i|
+              a << disagree(vals[i % 4])
+              b << unstable(vals[i % 4], vals[(i + 1) % 4])
+            end
+            [a.uniq.sort_by(&:to_s), b.uniq.sort_by(&:to_s),
+             disagree(1 << 70), unstable(2.5, 1 << 70)]
+            "#,
+        );
+    }
+
+    /// The shape the dispatch keeps: every arm answers a float, because the
+    /// argument is one, and the argument never varies. This is the case the
+    /// earlier "exclude anything involving Float" rule gave up on — it is
+    /// worth ~8% — and the receiver alternating is exactly what the dispatch
+    /// resolves.
+    #[test]
+    fn binop_float_arg_site_dispatches() {
+        run_test(
+            r#"
+            def probe(x) = x + 1.5
+            vals = [1, 2.5, 3, 4.5]
+            res = []
+            600.times { |i| res << probe(vals[i % 4]) }
+            [res.uniq.sort_by(&:to_s), probe(1 << 70), probe(-0.0)]
             "#,
         );
     }

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -22,6 +22,7 @@
 0142f6a78c90261818a919df5e34508a	true	define_method(:boom) { :bam }\n            Object.method_defined?(:b
 01443549f3178fa419efc8dfabeb3d03	[1, 4, 5]	class MyAry; def to_ary; [4,5]; end; end\nobj = MyAry.new\na = [1]; a.concat(obj);
 0157b6a817ac1fed2a62196ed525d722	["a.rb:1: Some runtime error (RuntimeError)\\n\\tfrom b.rb:2\\n", "Traceback (most recent call last):\\n\\t1: from b.rb:2\\na.rb:1: Some runtime error (RuntimeError)\\n", "a.rb:1: \\e[1mSome runtime error (\\e[1;4mRuntimeError\\e[m\\e[1m)\\e[m\\n\\tfrom b.rb:2\\n", "\\e[1mTraceback\\e[m (most recent call last):\\n\\t1: from b.rb:2\\na.rb:1: \\e[1mSome runtime error (\\e[1;4mRuntimeError\\e[m\\e[1m)\\e[m\\n"]	e = RuntimeError.new("Some runtime error")\n        e.set_backtrace(["a.
+015b75d45254c81989823601f22bc528	[[12, 14, 2, 4], 1180591620717411303425, 3.5]	class W\n              def initialize(v) = (@v = v)\n              de
 015d950e92f84266477f809be2d52ad7	"my_temp"	m = Module.new\n            m.set_temporary_name("my_temp")\n        
 0181411f6f14be38811bc49fd1ac2c8f	[false, true, true, false, false, false, false]	[!true, !false, !nil, !0, !"", ![], !:sym]\n        
 0198f55071323ce6b7b0f303a1e8dd25	"abc"	"abc\\n".chomp
@@ -156,6 +157,7 @@
 0ac4a1a595e5d45cfae6000f22e5b73a	:utterly_undefined_method_name	begin\n              Object.instance_method(:utterly_undefined_metho
 0adbd96399227bda6ca3f78bcce77b16	:ok	old_dep = Warning[:deprecated]\n            old_stderr = $stderr\n   
 0b006d8d0b7c3b6cbbde169c66a256f9	"hello\\n"	require "socket"\n            s = TCPServer.new("127.0.0.1", 0)\n    
+0b02d3e203d76b6ec36d970414527996	[[2.5, 4.0, 4.5, 6.0], 1.1805916207174113e+21, 1.5]	def probe(x) = x + 1.5\n            vals = [1, 2.5, 3, 4.5]\n        
 0b0604dcfa5aa2a90ccb9b55c158b24e	101	def get_binding\n              x = 100\n              binding\n       
 0b272bc1eee3862ebd5afe122f6530ac	[0, 50, "custom", true, false, false]	def check(x) = x.is_a?(Integer)\n            def fro(x) = x.frozen?\n
 0b360a7151ca4646f547e0ecffd6cf13	[true, true, true, true, true, ArgumentError, ArgumentError, TypeError, TypeError, Hash, false]	(ENV["MONO_T_ZZ"]="hi"; a=ENV["MONO_T_ZZ"].frozen?; b=ENV.method(:has_key?)==ENV
@@ -1883,6 +1885,7 @@ a2d359f2c679ed0c41cd0e8c0e78b3b5	"Xhello"	s = "hello"; s.bytesplice(0...-7, "X")
 a2d5fdfdd6933f6f7b5579a98d897e1d	["abc", "de", 1, :sys_neg_arg, :rnb_neg_arg, :sys_eof, :rnb_eof, nil]	require "stringio"\n\n            res = []\n            io = StringIO.new("abcdef")
 a2e679bc25d5bbcdcffa24d1390f7717	[true, 0, true, true, true, 0]	pid = fork { exit 0 }\n            Process.wait(pid)\n            s =
 a2fe58a4b8970857e7e6bc4daf663e90	[["UTF-8", "EUC-JP", 1, false], ["UTF-8", "EUC-JP", 1, false], ["UTF-8", "EUC-JP"], [true, "ASCII-8BIT", true], 1, [42, []]]	path = "/tmp/monoruby_test_iostate_#{Process.pid}_#{rand(100000)}"\n
+a315e27bdfdf0dfa963d5e510f6c345b	[[2, 3.5, 4, 5.5], [3.5, 5.5, 7.5], 1180591620717411303425, 1.1805916207174113e+21]	def disagree(x) = x + 1\n            def unstable(x, y) = x + y\n    
 a31930a9e915d99cf23e80f66584373b	["m0", 420, 21, "m0", 0, 4, 109, 30, 777, 5, 880, 24, "argerr", "NoMethodError", "m0", 70, 0]	class C\n          def m0; "m0"; end\n          def m1(a); a * 10; end\n  
 a32adc46f1bb4ed6ce92840c775bbf19	""	"".upcase
 a32db795d17419028fabd7b655b6becb	"bar"	class Foo\n              def bar; "bar"; end\n              alias :'b


### PR DESCRIPTION
Comparisons have taken the two-arm dispatch since #1128. Arithmetic could not, and turning it over wholesale is a regression — the two conditions that make it a win are both things only the PMC can answer.

## The two conditions

**The arms have to agree on the kind of result.** A numeric operator answers a float when either operand is one, and the arms differ only in the receiver — so they agree when the argument is a float (every arm answers a float) or when no observed receiver is one (every arm answers an integer). A site that mixes them can only merge as `S(Value)`: the float arm boxes a result the next float instruction has to decode again. That measured **+62% with the deopt count unchanged** — it had not removed a side exit at all, only moved which site took one.

**The argument class has to be stable.** The dispatch resolves the *receiver*; an arithmetic arm still guards its own argument internally (`Integer#+` takes a different path for an Integer rhs than a Float one), so at a site whose argument varies that inner guard keeps failing however the receiver is resolved. Dispatching there buys nothing and costs the extra branch: **+10% on a `Float + (Float | Integer)` site whose deopt count did not move**.

**The inline cache cannot answer either question.** It holds the last operand pair only, so a site the PMC records as `Float/Float x98 | Float/Integer x101` and one that is always `Float/Float` both report `rhs_class: Float`. The PMC keeps the distribution, so both tests read it.

## Measured

Five runs each, against master:

| site | dispatched | master | this PR |
|---|---|---|---|
| `x + 1.5` — receiver `Integer`/`Float`, argument always `Float` | yes | 87–89ms | **80–83ms** |
| `x + 1` — receiver `Integer`/`W#+`, all-integer | yes | 125–130ms | **104–107ms** |
| `t + (x + 1)` — argument alternating | no | 52–54ms | 52–53ms |

An earlier revision used "exclude anything involving `Float`". That kept the second row and gave up the first; the argument-stability test is what lets both through.

## `PolymorphicPolicy` goes with it

It existed to say that arithmetic ignored the VM's polymorphic bit while comparisons honoured it. With both honouring it the enum was a parameter that was always `Dispatch`, so it is gone and the two new tests live in `binary_dispatch`, next to the merge they are about. Comparisons need neither test: their generators answer any operand pair without an inner guard, and their result is a flag that costs nothing to merge.

## Why the benchmark set does not move

The four ruby-bench benchmarks and optcarrot are unchanged, and rubykon explains why. Its two big arithmetic deopt sites are:

- a `Float` receiver with an `Integer` argument — the arms disagree, so this PR declines it;
- an `Integer` receiver failing the **fixnum tag** test, i.e. a Bignum. The JIT does not compile Bignum arithmetic, so deopting there is the intended handling rather than something a dispatch was going to recover — and Fixnum and Bignum are one `ClassId` to the PMC, so the site never looks polymorphic at all.

Worth recording alongside that: the deopt count is a poor proxy for time in this JIT. An earlier experiment removed 458,370 of rubykon's 458,370+ arithmetic deopts and wall time did not move; #1128 removed 1.8M comparison deopts with the same result. The wins above come from the residual arm's C call being cheaper than a guard miss, not from the deopt count.

## Verification

- Full suite green, plain and with `--features stress-spill-pool`
- `cargo check --target aarch64-unknown-linux-gnu` clean
- Four ruby-bench benchmarks flat within noise, correct output
- New tests pin the two declined shapes (arms disagreeing, argument unstable) and the kept one, each including a Bignum operand

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_