### PR TITLE
JIT: key the PIC's arms by target, and fold away the class-independent generator

### DIFF
--- a/monoruby/src/builtins/arithmetic_sequence.rs
+++ b/monoruby/src/builtins/arithmetic_sequence.rs
@@ -122,7 +122,7 @@ fn as_begin_inline(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     inline_field_load(state, ir, store, callid, crate::rvalue::AS_BEGIN_OFFSET)
@@ -145,7 +145,7 @@ fn as_end_inline(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     inline_field_load(state, ir, store, callid, crate::rvalue::AS_END_OFFSET)
@@ -168,7 +168,7 @@ fn as_step_inline(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     inline_field_load(state, ir, store, callid, crate::rvalue::AS_STEP_OFFSET)
@@ -198,7 +198,7 @@ fn as_exclude_end_inline(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -375,7 +375,7 @@ fn array_size(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -414,9 +414,14 @@ fn array_clone(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    class_id: ClassId,
+    class_id: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
+    let Some(class_id) = class_id else {
+        // The call site could not prove the receiver's class (a multi-class
+        // dispatch arm / the class-set guard); this generator needs it.
+        return false;
+    };
     let callsite = &store[callid];
     if !callsite.is_simple() {
         return false;
@@ -457,9 +462,14 @@ fn array_dup_inline(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    class_id: ClassId,
+    class_id: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
+    let Some(class_id) = class_id else {
+        // The call site could not prove the receiver's class (a multi-class
+        // dispatch arm / the class-set guard); this generator needs it.
+        return false;
+    };
     let callsite = &store[callid];
     if !callsite.is_simple() {
         return false;
@@ -970,9 +980,14 @@ fn array_shl(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    recv_class: ClassId,
+    recv_class: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
+    let Some(recv_class) = recv_class else {
+        // The call site could not prove the receiver's class (a multi-class
+        // dispatch arm / the class-set guard); this generator needs it.
+        return false;
+    };
     let callsite = &store[callid];
     if !callsite.is_simple() {
         return false;
@@ -1020,9 +1035,14 @@ fn array_rotate_(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    recv_class: ClassId,
+    recv_class: Option<ClassId>,
     arg_class: Option<ClassId>,
 ) -> bool {
+    let Some(recv_class) = recv_class else {
+        // The call site could not prove the receiver's class (a multi-class
+        // dispatch arm / the class-set guard); this generator needs it.
+        return false;
+    };
     let callsite = &store[callid];
     if !callsite.is_simple() || callsite.pos_num > 1 {
         return false;
@@ -1292,7 +1312,7 @@ fn array_index(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     idx_class: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -1403,7 +1423,7 @@ fn array_index_assign(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     idx_class: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];

--- a/monoruby/src/builtins/class.rs
+++ b/monoruby/src/builtins/class.rs
@@ -24,9 +24,14 @@ pub(super) fn gen_class_allocate_inline(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    self_class: ClassId,
+    self_class: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
+    let Some(self_class) = self_class else {
+        // The call site could not prove the receiver's class (a multi-class
+        // dispatch arm / the class-set guard); this generator needs it.
+        return false;
+    };
     let callsite = &store[callid];
     if !callsite.is_simple() {
         return false;

--- a/monoruby/src/builtins/fiber.rs
+++ b/monoruby/src/builtins/fiber.rs
@@ -286,7 +286,7 @@ fn fiber_yield_inline(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];

--- a/monoruby/src/builtins/fiddle.rs
+++ b/monoruby/src/builtins/fiddle.rs
@@ -427,7 +427,7 @@ fn fiddle_read_inline(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -497,7 +497,7 @@ fn fiddle_write_inline(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -1006,7 +1006,7 @@ fn hash_default_assign(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -1049,9 +1049,14 @@ fn hash_index(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    recv_class: ClassId,
+    recv_class: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
+    let Some(recv_class) = recv_class else {
+        // The call site could not prove the receiver's class (a multi-class
+        // dispatch arm / the class-set guard); this generator needs it.
+        return false;
+    };
     let callsite = &store[callid];
     if !callsite.is_simple() {
         return false;
@@ -1084,9 +1089,14 @@ fn hash_get_or_key(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    recv_class: ClassId,
+    recv_class: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
+    let Some(recv_class) = recv_class else {
+        // The call site could not prove the receiver's class (a multi-class
+        // dispatch arm / the class-set guard); this generator needs it.
+        return false;
+    };
     let callsite = &store[callid];
     if !callsite.is_simple() || callsite.pos_num != 1 {
         return false;
@@ -1120,7 +1130,7 @@ fn hash_index_assign(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -1414,7 +1424,7 @@ fn hash_compare_by_identity(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let Some(callsite) = hash_accessor_callsite(store, callid) else {
@@ -1436,7 +1446,7 @@ fn hash_default_value(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     hash_default_inline(state, ir, store, callid, false)
@@ -1451,7 +1461,7 @@ fn hash_default_proc(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     hash_default_inline(state, ir, store, callid, true)
@@ -1483,7 +1493,7 @@ fn hash_size(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -1514,7 +1524,7 @@ fn hash_entry_count(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -1542,7 +1552,7 @@ fn hash_live_at(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     idx_class: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -1596,7 +1606,7 @@ fn hash_key_at(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     idx_class: Option<ClassId>,
 ) -> bool {
     hash_entry_at_inline(state, ir, store, callid, idx_class, true)
@@ -1608,7 +1618,7 @@ fn hash_value_at(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     idx_class: Option<ClassId>,
 ) -> bool {
     hash_entry_at_inline(state, ir, store, callid, idx_class, false)

--- a/monoruby/src/builtins/kernel.rs
+++ b/monoruby/src/builtins/kernel.rs
@@ -26,7 +26,7 @@ pub fn define_loop_mode_builtins(globals: &mut Globals) {
 pub(super) fn init(globals: &mut Globals) -> Module {
     let klass = globals.define_toplevel_module("Kernel");
     let kernel_class = klass.id();
-    globals.define_builtin_inline_func_class_independent(
+    globals.define_builtin_inline_func(
         kernel_class,
         "nil?",
         nil,
@@ -299,7 +299,7 @@ pub(super) fn init(globals: &mut Globals) -> Module {
         .set_default_copy_hooks(init_copy_fid, init_dup_fid, init_clone_fid);
     globals.define_builtin_funcs_rest(kernel_class, "enum_for", &["to_enum"], to_enum);
     globals.define_builtin_func_rest(kernel_class, "extend", extend);
-    globals.define_builtin_inline_func_class_independent(
+    globals.define_builtin_inline_func(
         kernel_class,
         "object_id",
         super::object::object_id,
@@ -413,7 +413,8 @@ fn nil(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
     Ok(Value::bool(lfp.self_val().is_nil()))
 }
 
-/// Class-independent (see `InlineGenClassIndependent`): a pure Value
+/// Reads only the receiver Value, so it keeps firing where the class is
+/// unproven: a pure Value
 /// comparison against `nil`, correct for any receiver.
 fn kernel_nil(
     state: &mut AbstractState,
@@ -421,6 +422,10 @@ fn kernel_nil(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
+    // The receiver Value is all this reads, so an unproven class
+    // (a multi-class dispatch arm / the class-set guard) is no obstacle.
+    _: Option<ClassId>,
+    _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
     if !callsite.is_simple() {
@@ -506,9 +511,14 @@ fn kernel_not_match(
     ctx: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    recv_class: ClassId,
+    recv_class: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
+    let Some(recv_class) = recv_class else {
+        // The call site could not prove the receiver's class (a multi-class
+        // dispatch arm / the class-set guard); this generator needs it.
+        return false;
+    };
     let callsite = &store[callid];
     if !callsite.is_simple() || callsite.pos_num != 1 {
         return false;
@@ -544,7 +554,7 @@ fn kernel_block_given(
     jitctx: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -4660,7 +4670,7 @@ pub fn object_send(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -4735,9 +4745,14 @@ fn kernel_is_a(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    recv_class: ClassId,
+    recv_class: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
+    let Some(recv_class) = recv_class else {
+        // The call site could not prove the receiver's class (a multi-class
+        // dispatch arm / the class-set guard); this generator needs it.
+        return false;
+    };
     let callsite = &store[callid];
     if !callsite.is_simple() {
         return false;
@@ -5289,9 +5304,14 @@ fn object_respond_to(
     ctx: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    recv_class: ClassId,
+    recv_class: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
+    let Some(recv_class) = recv_class else {
+        // The call site could not prove the receiver's class (a multi-class
+        // dispatch arm / the class-set guard); this generator needs it.
+        return false;
+    };
     let callsite = &store[callid];
     if !callsite.is_simple() {
         return false;
@@ -5490,9 +5510,14 @@ fn kernel_instance_of(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    recv_class: ClassId,
+    recv_class: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
+    let Some(recv_class) = recv_class else {
+        // The call site could not prove the receiver's class (a multi-class
+        // dispatch arm / the class-set guard); this generator needs it.
+        return false;
+    };
     let callsite = &store[callid];
     if !callsite.is_simple() {
         return false;

--- a/monoruby/src/builtins/math.rs
+++ b/monoruby/src/builtins/math.rs
@@ -689,7 +689,7 @@ fn math_sqrt(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];

--- a/monoruby/src/builtins/numeric/float.rs
+++ b/monoruby/src/builtins/numeric/float.rs
@@ -342,7 +342,7 @@ fn float_toi(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -435,7 +435,7 @@ fn integer_succ(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -474,7 +474,7 @@ fn integer_tof(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -768,7 +768,7 @@ fn integer_shr(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     rhs_class: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -846,7 +846,7 @@ fn integer_shl(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     rhs_class: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -921,7 +921,7 @@ fn integer_rem(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     rhs_class: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -1033,7 +1033,7 @@ fn integer_pow(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     rhs_class: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -1262,7 +1262,7 @@ fn integer_index(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     nth_class: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];

--- a/monoruby/src/builtins/object.rs
+++ b/monoruby/src/builtins/object.rs
@@ -12,7 +12,7 @@ pub(super) fn init(globals: &mut Globals) {
     // BasicObject methods
 
     globals.define_private_builtin_func(BASIC_OBJECT_CLASS, "initialize", bo_initialize, 0);
-    globals.define_builtin_inline_func_class_independent(
+    globals.define_builtin_inline_func(
         BASIC_OBJECT_CLASS,
         "__id__",
         object_id,
@@ -66,7 +66,7 @@ pub(super) fn init(globals: &mut Globals) {
         true,
     );
     globals.define_builtin_func(OBJECT_CLASS, "freeze", freeze, 0);
-    globals.define_builtin_inline_func_class_independent(
+    globals.define_builtin_inline_func(
         OBJECT_CLASS,
         "frozen?",
         frozen,
@@ -147,7 +147,8 @@ fn frozen(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result
     Ok(Value::bool(lfp.self_val().is_frozen()))
 }
 
-/// Class-independent (see `InlineGenClassIndependent`): the predicate reads
+/// Reads only the receiver Value, so it keeps firing where the class is
+/// unproven: the predicate reads
 /// the Value tag and the RValue header only — packed values are frozen,
 /// heap Numerics are frozen, everything else tests the header FROZEN bit
 /// (`emit_frozen_pred` mirrors `Value::is_frozen` exactly, chilled strings
@@ -158,6 +159,10 @@ pub(super) fn object_frozen(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
+    // The receiver Value is all this reads, so an unproven class
+    // (a multi-class dispatch arm / the class-set guard) is no obstacle.
+    _: Option<ClassId>,
+    _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
     if !callsite.is_simple() {
@@ -334,7 +339,7 @@ fn object_not(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -406,7 +411,8 @@ pub(super) fn object_id(
     Ok(Value::integer(lfp.self_val().id() as i64))
 }
 
-/// Class-independent (see `InlineGenClassIndependent`): `Value::id()` works
+/// Reads only the receiver Value, so it keeps firing where the class is
+/// unproven: `Value::id()` works
 /// on the raw Value bits, correct for any receiver.
 pub(super) fn object_object_id(
     state: &mut AbstractState,
@@ -414,6 +420,10 @@ pub(super) fn object_object_id(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
+    // The receiver Value is all this reads, so an unproven class
+    // (a multi-class dispatch arm / the class-set guard) is no obstacle.
+    _: Option<ClassId>,
+    _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
     if !callsite.is_simple() {

--- a/monoruby/src/builtins/range.rs
+++ b/monoruby/src/builtins/range.rs
@@ -93,7 +93,7 @@ fn range_begin(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -131,7 +131,7 @@ fn range_end(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -251,7 +251,7 @@ fn range_exclude_end(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -417,7 +417,7 @@ fn string_eq_gen(
     ctx: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     arg_class: Option<ClassId>,
 ) -> bool {
     string_cmp_const_gen(state, ir, ctx, store, callid, arg_class, false)
@@ -431,7 +431,7 @@ fn string_ne_gen(
     ctx: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     arg_class: Option<ClassId>,
 ) -> bool {
     string_cmp_const_gen(state, ir, ctx, store, callid, arg_class, true)
@@ -857,9 +857,14 @@ fn string_shl_gen(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    recv_class: ClassId,
+    recv_class: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
+    let Some(recv_class) = recv_class else {
+        // The call site could not prove the receiver's class (a multi-class
+        // dispatch arm / the class-set guard); this generator needs it.
+        return false;
+    };
     let callsite = &store[callid];
     if !callsite.is_simple() || callsite.pos_num != 1 {
         return false;
@@ -4060,7 +4065,7 @@ fn string_bytesize(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -4442,7 +4447,7 @@ fn string_getbyte(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];
@@ -4471,7 +4476,7 @@ fn string_setbyte(
     _: &JitContext,
     store: &Store,
     callid: CallSiteId,
-    _: ClassId,
+    _: Option<ClassId>,
     _: Option<ClassId>,
 ) -> bool {
     let callsite = &store[callid];

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -936,6 +936,29 @@ impl Codegen {
             // guard — each class's check falls through on match (branch to
             // ok) and moves to the next candidate on mismatch; the last
             // candidate's mismatch is the real deopt.
+            // Same membership chain as `GuardClassIn`, with the last
+            // candidate's miss going to the next arm instead of a side exit.
+            LInst::BrClassNotIn {
+                reg,
+                classes,
+                target,
+            } => {
+                let ok = self.jit.label();
+                let len = classes.len();
+                for (i, class) in classes.iter().enumerate() {
+                    if i + 1 < len {
+                        let next = self.jit.label();
+                        self.a64_guard_class(reg, *class, &next);
+                        monoasm_arm64!(&mut self.jit,
+                            b ok;
+                        );
+                        self.jit.bind_label(next);
+                    } else {
+                        self.a64_guard_class(reg, *class, &target);
+                    }
+                }
+                self.jit.bind_label(ok);
+            }
             LInst::GuardClassIn {
                 reg,
                 classes,

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -57,6 +57,7 @@ impl Codegen {
             | AsmInst::OptCase { .. }
             | AsmInst::GuardClass(..)
             | AsmInst::GuardClassIn(..)
+            | AsmInst::BrClassNotIn(..)
             | AsmInst::Deopt(..)
             | AsmInst::HandleError(..)
             | AsmInst::CheckStack { .. }
@@ -610,6 +611,29 @@ impl Codegen {
             }
             // Dispatch arm: the miss is the next arm, not a side exit.
             LInst::BrClassNe { reg, class, target } => self.guard_class(reg, class, &target),
+            // Same membership chain as `GuardClassIn`, with the last
+            // candidate's miss going to the next arm instead of a side exit.
+            LInst::BrClassNotIn {
+                reg,
+                classes,
+                target,
+            } => {
+                let ok = self.jit.label();
+                let len = classes.len();
+                for (i, class) in classes.iter().enumerate() {
+                    if i + 1 < len {
+                        let next = self.jit.label();
+                        self.guard_class(reg, *class, &next);
+                        monoasm!( &mut self.jit,
+                            jmp ok;
+                        );
+                        self.jit.bind_label(next);
+                    } else {
+                        self.guard_class(reg, *class, &target);
+                    }
+                }
+                self.jit.bind_label(ok);
+            }
             LInst::GuardClassIn {
                 reg,
                 classes,

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1428,6 +1428,16 @@ pub(super) enum AsmInst {
     /// business.
     ///
     BrClassNe(GP, ClassId, JitLabel),
+    ///
+    /// Dispatch arm over a *set* of classes: fall through when `GP`'s runtime
+    /// class is any of them, branch to the label otherwise.
+    ///
+    /// [`AsmInst::GuardClassIn`] with the miss sent to the next arm instead of
+    /// a side exit — the same relationship [`AsmInst::BrClassNe`] has to
+    /// `GuardClass`. A miss here is control flow, not a guard failure, so the
+    /// `profile` recorder must not book it as one.
+    ///
+    BrClassNotIn(GP, Box<[ClassId]>, JitLabel),
     CheckLocal(JitLabel),
     CheckKwRest(SlotId),
     OptCase {
@@ -2568,6 +2578,9 @@ impl AsmInst {
             Self::Br(label) => format!("br {:?}", label),
             Self::BrClassNe(gpr, class, label) => {
                 format!("br_class_ne {:?} {:?} {:?}", gpr, class, label)
+            }
+            Self::BrClassNotIn(gpr, classes, label) => {
+                format!("br_class_not_in {:?} {:?} {:?}", gpr, classes, label)
             }
             Self::CheckLocal(label) => format!("check_local {:?}", label),
             Self::OptCase {

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -140,6 +140,16 @@ impl Codegen {
                     deopt,
                 });
             }
+            // Dispatch arm over a class set: any listed class falls through,
+            // everything else goes to the next arm.
+            AsmInst::BrClassNotIn(r, classes, dest) => {
+                let target = frame.resolve_label(&mut self.jit, dest);
+                self.encode_linst(LInst::BrClassNotIn {
+                    reg: r,
+                    classes,
+                    target,
+                });
+            }
             // Class-set guard: any listed class passes, everything else
             // deopts.
             AsmInst::GuardClassIn(r, classes, deopt) => {

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -254,7 +254,7 @@ impl<'a> JitContext<'a> {
             // The plain generators (`Integer#% ** << >>`) have no fused
             // compare-and-branch form, so they only serve `Value` mode.
             InlineFuncInfo::InlineGen(f) if matches!(mode, BinaryInlineMode::Value) => {
-                if self.inline_asm(state, ir, f, callid, lhs_class, rhs_class) {
+                if self.inline_asm(state, ir, f, callid, Some(lhs_class), rhs_class) {
                     BinaryInlineOutcome::Done
                 } else {
                     BinaryInlineOutcome::Declined

--- a/monoruby/src/codegen/jitgen/compile/index.rs
+++ b/monoruby/src/codegen/jitgen/compile/index.rs
@@ -65,7 +65,7 @@ impl<'a> JitContext<'a> {
             state.load(ir, base, GP::Rdi);
             state.guard_class(ir, base, GP::Rdi, recv_class, deopt);
         }
-        if self.inline_asm(state, ir, f, callid, recv_class, idx_class) {
+        if self.inline_asm(state, ir, f, callid, Some(recv_class), idx_class) {
             self.record_bop_dep(recv_class, op);
             state.unset_side_effect_guard();
             true
@@ -195,7 +195,7 @@ impl<'a> JitContext<'a> {
         let Some(InlineFuncInfo::InlineGen(f)) = self.store.inline_info.get_inline(fid) else {
             unreachable!("index_inline_class only answers InlineGen targets")
         };
-        if !self.inline_asm(&mut fast, ir, f, callid, inline_class, idx_class) {
+        if !self.inline_asm(&mut fast, ir, f, callid, Some(inline_class), idx_class) {
             ir.restore(ir_save);
             *state = state_save;
             return Ok(false);

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -294,9 +294,8 @@ impl<'a> JitContext<'a> {
         //
         // When the class-set guard below is taken, the receiver's class is
         // NOT statically refined (it may be any member of the set), so the
-        // inline generators that assume a single `recv_class` receiver must
-        // be skipped for this compile — only the class-independent ones
-        // (`InlineGenClassIndependent`) may still fire.
+        // generator is handed `None` and decides for itself whether it can
+        // still emit.
         // A set-guarded dispatch arm has already emitted the membership test
         // that admitted this receiver, and every class it admits resolves to
         // `func_id`. Emitting a receiver guard here would be redundant at
@@ -364,19 +363,22 @@ impl<'a> JitContext<'a> {
             && let Some(info) = self.store.inline_info.get_inline(func_id)
         {
             match info {
-                // Class-independent generators read only the receiver Value
-                // (the type carries no ClassId to consult), so they are sound
-                // even behind the class-set guard, where the receiver's class
-                // is not statically refined.
-                InlineFuncInfo::InlineGenClassIndependent(f) => {
-                    if self.inline_asm_class_independent(state, ir, f, callid) {
+                // The generator is handed the receiver class only when the
+                // site proved one: behind the class-set guard (or a
+                // multi-class dispatch arm) it gets `None` and decides for
+                // itself, which is how `nil?` / `frozen?` / `__id__` /
+                // `object_id` keep firing there while a generator that needs
+                // the class declines to the ordinary call.
+                InlineFuncInfo::InlineGen(f) => {
+                    let proven = (!same_target_set_guarded).then_some(recv_class);
+                    if self.inline_asm(state, ir, f, callid, proven, arg_class) {
                         state.unset_side_effect_guard();
                         return Ok(CompileResult::Continue);
                     }
                 }
-                // Every other inliner assumes the single compile-time
-                // receiver class; behind the set guard it must fall through
-                // to the ordinary (set-guarded) builtin call.
+                // The operator generators still take a definite receiver
+                // class, so behind the set guard they fall through to the
+                // ordinary (set-guarded) builtin call.
                 _ if same_target_set_guarded => {}
                 // Explicit-send spelling of a numeric operator (`1.+(2)`,
                 // `a.==(b)`): fire the binary generator in Value mode. The
@@ -406,12 +408,6 @@ impl<'a> JitContext<'a> {
                         return Ok(CompileResult::Continue);
                     }
                     // Declined: fall through to the ordinary builtin call.
-                }
-                InlineFuncInfo::InlineGen(f) => {
-                    if self.inline_asm(state, ir, f, callid, recv_class, arg_class) {
-                        state.unset_side_effect_guard();
-                        return Ok(CompileResult::Continue);
-                    }
                 }
                 InlineFuncInfo::CFunc_F_F(f) => {
                     let CallSiteInfo { args, dst, .. } = *callsite;
@@ -1159,11 +1155,13 @@ impl<'a> JitContext<'a> {
             &JitContext,
             &Store,
             CallSiteId,
-            ClassId,
+            Option<ClassId>,
             Option<ClassId>,
         ) -> bool,
         callid: CallSiteId,
-        recv_class: ClassId,
+        // `None` when the call site could not prove the receiver's class —
+        // see `InlineGen`.
+        recv_class: Option<ClassId>,
         arg_class: Option<ClassId>,
     ) -> bool {
         // No GP flush here: a register-only inline keeps the residents live,
@@ -1230,27 +1228,6 @@ impl<'a> JitContext<'a> {
         let state_save = state.clone();
         let ir_save = ir.save();
         if f(state, ir, self, &self.store, callid, recv_class) {
-            true
-        } else {
-            *state = state_save;
-            ir.restore(ir_save);
-            false
-        }
-    }
-
-    /// [`inline_asm`](Self::inline_asm) for class-independent generators —
-    /// same save/restore protocol, minus the class arguments their type
-    /// doesn't have.
-    fn inline_asm_class_independent(
-        &mut self,
-        state: &mut AbstractState,
-        ir: &mut AsmIr,
-        f: impl Fn(&mut AbstractState, &mut AsmIr, &JitContext, &Store, CallSiteId) -> bool,
-        callid: CallSiteId,
-    ) -> bool {
-        let state_save = state.clone();
-        let ir_save = ir.save();
-        if f(state, ir, self, &self.store, callid) {
             true
         } else {
             *state = state_save;
@@ -2007,7 +1984,7 @@ mod tests {
         );
     }
 
-    /// Class-independent inline generators (`InlineGenClassIndependent`)
+    /// A generator that reads only the receiver Value
     /// keep firing behind the polymorphic class-set guard. Covers: `nil?` /
     /// `frozen?` / `object_id` at a 4-class site (set guard + inline, the
     /// receiver class statically unrefined), every representation arm of the
@@ -2019,7 +1996,7 @@ mod tests {
     /// `object_id` values differ from CRuby's, so only identity-stability
     /// (`oid(v) == v.object_id`) is compared, never the raw id.
     #[test]
-    fn polymorphic_class_independent_inline() {
+    fn polymorphic_classless_inline() {
         run_test(
             r#"
             def fro(x) = x.frozen?

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -297,8 +297,13 @@ impl<'a> JitContext<'a> {
         // inline generators that assume a single `recv_class` receiver must
         // be skipped for this compile — only the class-independent ones
         // (`InlineGenClassIndependent`) may still fire.
-        let mut same_target_set_guarded = false;
-        if state.class(recv) != Some(recv_class) {
+        // A set-guarded dispatch arm has already emitted the membership test
+        // that admitted this receiver, and every class it admits resolves to
+        // `func_id`. Emitting a receiver guard here would be redundant at
+        // best and — since only one of the arm's classes is `recv_class` —
+        // would deopt the rest at worst.
+        let mut same_target_set_guarded = self.in_set_guarded_arm();
+        if !same_target_set_guarded && state.class(recv) != Some(recv_class) {
             if !recompile_on_recv_miss
                 && let Some(classes) = self.pmc_same_target_classes(callid, recv_class, func_id)
             {

--- a/monoruby/src/codegen/jitgen/compile/pic.rs
+++ b/monoruby/src/codegen/jitgen/compile/pic.rs
@@ -59,12 +59,31 @@ use super::{method_call::PMC_SET_SHARE_DIVISOR, *};
 const PIC_WAYS: usize = PMC_WAYS;
 
 ///
-/// One dispatch arm: a receiver class and the target it resolves to.
+/// One dispatch arm: the target, and every observed receiver class that
+/// resolves to it.
 ///
-struct PicWay {
-    class: ClassId,
+/// Arms are keyed by `FuncId`, not by class. Classes that share a target
+/// share an arm, so a site like `Kernel#nil?` seen on four classes emits one
+/// call sequence behind a four-class membership test rather than four copies
+/// of the same sequence. It also means the arm cannot refine the receiver to
+/// a single class unless it holds exactly one — see `single_class`.
+///
+struct PicGroup {
     func_id: FuncId,
     visibility: Visibility,
+    classes: Vec<ClassId>,
+}
+
+impl PicGroup {
+    /// The class every receiver reaching this arm has, when there is only
+    /// one. `None` for a multi-class arm, which may not refine the state and
+    /// so may only fire class-independent inline generators.
+    fn single_class(&self) -> Option<ClassId> {
+        match self.classes.as_slice() {
+            [class] => Some(*class),
+            _ => None,
+        }
+    }
 }
 
 impl<'a> JitContext<'a> {
@@ -78,7 +97,7 @@ impl<'a> JitContext<'a> {
     /// unlike the class-set guard there is no single-instruction fallback to
     /// rewrite it as.
     ///
-    fn pic_ways(&mut self, callid: CallSiteId) -> Option<Vec<PicWay>> {
+    fn pic_groups(&mut self, callid: CallSiteId) -> Option<Vec<PicGroup>> {
         let callsite = &self.store[callid];
         let name = callsite.name?;
         // A block argument makes the callee able to capture the frame, and
@@ -95,9 +114,10 @@ impl<'a> JitContext<'a> {
             return None;
         }
         classes.sort_unstable_by_key(|(_, count)| std::cmp::Reverse(*count));
-        let mut ways: Vec<PicWay> = Vec::with_capacity(classes.len());
+        let mut groups: Vec<PicGroup> = Vec::with_capacity(classes.len());
+        let mut admitted = 0usize;
         for (class, count) in classes {
-            if ways.len() == PIC_WAYS {
+            if admitted == PIC_WAYS {
                 break;
             }
             // A rare tail is not worth an arm — the classes ahead of it pay
@@ -128,23 +148,30 @@ impl<'a> JitContext<'a> {
             {
                 continue;
             }
-            ways.push(PicWay {
-                class,
-                func_id,
-                visibility,
-            });
+            admitted += 1;
+            // Fold into the arm for this target if one is already open. The
+            // groups stay in first-seen order, which is most-observed-first,
+            // so the hottest target is tested first.
+            if let Some(g) = groups.iter_mut().find(|g| g.func_id == func_id) {
+                g.classes.push(class);
+            } else {
+                groups.push(PicGroup {
+                    func_id,
+                    visibility,
+                    classes: vec![class],
+                });
+            }
         }
-        if ways.len() < 2 {
+        if admitted < 2 {
             return None;
         }
-        // All arms sharing one target is the class-set guard's case, and one
-        // membership guard over the set beats a chain of compares around
-        // duplicate call sequences.
-        let first = ways[0].func_id;
-        if ways.iter().all(|w| w.func_id == first) {
+        // One target for every class is the class-set guard's case, and one
+        // membership guard over the set beats an arm that tests the same set
+        // and then falls into the only call sequence there is.
+        if groups.len() < 2 {
             return None;
         }
-        Some(ways)
+        Some(groups)
     }
 
     ///
@@ -159,7 +186,7 @@ impl<'a> JitContext<'a> {
         ir: &mut AsmIr,
         callid: CallSiteId,
     ) -> JitResult<bool> {
-        let Some(ways) = self.pic_ways(callid) else {
+        let Some(groups) = self.pic_groups(callid) else {
             return Ok(false);
         };
         let CallSiteInfo {
@@ -187,48 +214,64 @@ impl<'a> JitContext<'a> {
         probe.load(ir, recv, GP::Rdi);
         let entry = probe;
 
+        // The chain tests each arm's class set in turn and the *last* arm's
+        // test is the deopting one, so a receiver is compared against the
+        // union exactly once. Hoisting the deopt into a separate union guard
+        // ahead of the arms reads better but compares everything twice — it
+        // measured ~16% slower.
         let mut miss: Option<JitLabel> = None;
-        for (i, way) in ways.iter().enumerate() {
-            let last = i + 1 == ways.len();
+        for (i, group) in groups.iter().enumerate() {
+            let last = i + 1 == groups.len();
             if let Some(miss) = miss.take() {
                 ir.push(AsmInst::Label(miss));
             }
             let mut arm = entry.clone();
             if last {
-                // A miss on the last arm is a class the VM never observed
-                // here: deopt, exactly as the monomorphic guard did for every
-                // off-class receiver.
-                //
-                // `guard_class` emits nothing when the state already proves
-                // the class, which would leave the arm reachable by *any*
-                // receiver that missed the ones before it. The entry state
-                // cannot prove it (the site is only tried when the receiver's
-                // class is unknown), but the arm is a miscompile if that ever
-                // stops holding, so say so.
-                debug_assert_ne!(arm.class(recv), Some(way.class));
+                // Falling out of the last arm's set is a class the VM never
+                // observed here: deopt, exactly as the monomorphic guard did
+                // for every off-class receiver.
                 let deopt = ir.new_deopt(&arm);
-                arm.guard_class(ir, recv, GP::Rdi, way.class, deopt);
+                ir.push(AsmInst::GuardClassIn(
+                    GP::Rdi,
+                    group.classes.clone().into_boxed_slice(),
+                    deopt,
+                ));
             } else {
                 let next = self.label();
-                ir.push(AsmInst::BrClassNe(GP::Rdi, way.class, next));
+                ir.push(AsmInst::BrClassNotIn(
+                    GP::Rdi,
+                    group.classes.clone().into_boxed_slice(),
+                    next,
+                ));
                 miss = Some(next);
-                // Reaching this arm *is* the proof, so refine without a
-                // second guard — which is also what lets the arm's inline
-                // generators fire.
-                arm.guard_class_state(recv, way.class);
             }
+            // Reaching an arm proves the receiver's class only when the arm
+            // holds one. A multi-class arm leaves it unrefined, so
+            // `compile_method_call` sees an unproven receiver and restricts
+            // itself to class-independent inline generators — the same
+            // treatment the class-set guard gets, for the same reason.
+            let recv_class = match group.single_class() {
+                Some(class) => {
+                    // `guard_class_state` refines without emitting a guard,
+                    // which is also what lets the arm's inline generators
+                    // fire.
+                    arm.guard_class_state(recv, class);
+                    class
+                }
+                None => group.classes[0],
+            };
             // Specialization is suppressed inside an arm (see
             // `JitContext::in_dispatch_arm`), and every other way out of
-            // `compile_method_call` was hoisted into `pic_ways`, so the arm
+            // `compile_method_call` was hoisted into `pic_groups`, so the arm
             // always lands on the merge.
-            let outcome = self.with_dispatch_arm(|this| {
+            let outcome = self.with_arm(group.single_class().is_none(), |this| {
                 this.compile_method_call(
                     &mut arm,
                     ir,
-                    way.class,
+                    recv_class,
                     None,
-                    way.func_id,
-                    way.visibility,
+                    group.func_id,
+                    group.visibility,
                     callid,
                     false,
                 )

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -794,10 +794,6 @@ impl<'a> JitContext<'a> {
     ///
     /// Run *f* with the dispatch-arm flag set, restoring it afterwards.
     ///
-    pub(super) fn with_dispatch_arm<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
-        self.with_arm(false, f)
-    }
-
     ///
     /// Run *f* inside a dispatch arm, recording whether the arm's receiver
     /// class is proven (`set_guarded == false`) or merely known to be one of

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -659,6 +659,17 @@ pub(crate) struct JitContext<'a> {
     /// callee body into each of up to four arms is the opposite.
     ///
     in_dispatch_arm: bool,
+    ///
+    /// Inside a dispatch arm whose receiver class is *not* proven: the arm
+    /// covers several classes, all resolving to the arm's target, and the
+    /// membership test that admitted them has already been emitted.
+    ///
+    /// `compile_method_call` reads this to skip its own receiver guard (the
+    /// arm's test is the guard) and to restrict itself to class-independent
+    /// inline generators, which is the same treatment the class-set guard
+    /// gets, for the same reason.
+    ///
+    in_set_guarded_arm: bool,
 
     ///
     /// Class version at compile time.
@@ -733,6 +744,7 @@ impl<'a> JitContext<'a> {
             codegen_mode,
             fused_skip: None,
             in_dispatch_arm: false,
+            in_set_guarded_arm: false,
             class_version,
             const_version,
             refinements,
@@ -752,6 +764,7 @@ impl<'a> JitContext<'a> {
             codegen_mode: false,
             fused_skip: None,
             in_dispatch_arm: false,
+            in_set_guarded_arm: false,
             class_version: self.class_version,
             const_version: self.const_version,
             refinements: self.refinements,
@@ -774,13 +787,28 @@ impl<'a> JitContext<'a> {
         self.in_dispatch_arm
     }
 
+    pub(super) fn in_set_guarded_arm(&self) -> bool {
+        self.in_set_guarded_arm
+    }
+
     ///
     /// Run *f* with the dispatch-arm flag set, restoring it afterwards.
     ///
     pub(super) fn with_dispatch_arm<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        self.with_arm(false, f)
+    }
+
+    ///
+    /// Run *f* inside a dispatch arm, recording whether the arm's receiver
+    /// class is proven (`set_guarded == false`) or merely known to be one of
+    /// the arm's set.
+    ///
+    pub(super) fn with_arm<R>(&mut self, set_guarded: bool, f: impl FnOnce(&mut Self) -> R) -> R {
         let saved = std::mem::replace(&mut self.in_dispatch_arm, true);
+        let saved_set = std::mem::replace(&mut self.in_set_guarded_arm, set_guarded);
         let r = f(self);
         self.in_dispatch_arm = saved;
+        self.in_set_guarded_arm = saved_set;
         r
     }
 

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -440,6 +440,14 @@ pub(in crate::codegen) enum LInst {
         class: ClassId,
         target: DestLabel,
     },
+    /// Dispatch arm over a class set: fall through when `reg`'s runtime class
+    /// is any of `classes`, branch to `target` otherwise. The miss is control
+    /// flow (the next arm), not a side exit.
+    BrClassNotIn {
+        reg: GP,
+        classes: Box<[ClassId]>,
+        target: DestLabel,
+    },
     /// Class-set guard: pass when `reg`'s runtime class is any of `classes`,
     /// branch to `deopt` otherwise.
     GuardClassIn {

--- a/monoruby/src/executor/inline.rs
+++ b/monoruby/src/executor/inline.rs
@@ -3,12 +3,6 @@ use super::*;
 #[allow(non_camel_case_types)]
 pub(crate) enum InlineFuncInfo {
     InlineGen(Box<InlineGen>),
-    /// A generator whose emitted code never consults the receiver's (or an
-    /// argument's) class — the type has no `ClassId` parameters to consult.
-    /// The JIT fires these even behind a polymorphic class-set guard, where
-    /// the other variants must be skipped (their code assumes the single
-    /// compile-time receiver class).
-    InlineGenClassIndependent(Box<InlineGenClassIndependent>),
     /// A numeric binary operator / comparison generator, fired guard-free
     /// from the binop/cmp bytecode dispatchers under the basic-op license
     /// (and from `compile_method_call` for explicit sends). See
@@ -25,10 +19,6 @@ pub(crate) enum InlineFuncInfo {
 impl InlineFuncInfo {
     pub(crate) fn new_inline_gen(f: Box<InlineGen>) -> Self {
         InlineFuncInfo::InlineGen(f)
-    }
-
-    pub(crate) fn new_inline_gen_class_independent(f: Box<InlineGenClassIndependent>) -> Self {
-        InlineFuncInfo::InlineGenClassIndependent(f)
     }
 
     pub(crate) fn new_inline_gen_binary(f: Box<InlineGenBinary>) -> Self {

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -89,29 +89,41 @@ pub(crate) fn ruby_platform() -> &'static str {
         .unwrap_or(DEFAULT_PLATFORM)
 }
 
+/// Inline generator for an ordinary builtin.
+///
+/// # The caller's obligation
+///
+/// Firing a generator at all asserts that **whatever class the receiver turns
+/// out to have at run time, it resolves this call site's name to the method
+/// this generator implements**. That is the caller's to guarantee, and it does
+/// not depend on the parameter below: a class-set guard admits only classes it
+/// re-resolved to this method, and a dispatch arm is entered only by classes
+/// grouped under this target.
+///
+/// # What the parameter adds
+///
+/// `Some(class)` says the receiver's class is additionally *statically known*
+/// to be exactly `class`, so the generator may emit code specialized to it.
+///
+/// `None` says only that the site could not name it — a dispatch arm covering
+/// several classes, or the class-set guard. The resolution guarantee above
+/// still holds; what is missing is which class it is. A generator whose
+/// emitted code depends on that must decline (`return false`); one that reads
+/// only the receiver's Value representation (`nil?`, `frozen?`, `__id__`,
+/// `object_id`) ignores the parameter and keeps firing.
+///
+/// Keeping the receiver and argument classes on the same footing is what lets
+/// one generator shape serve both, so there is no separate
+/// "class-independent" registration to pick between — and no way to register
+/// a generator under the wrong one.
 pub(crate) type InlineGen = dyn Fn(
     &mut jitgen::AbstractState,
     &mut jitgen::asmir::AsmIr,
     &crate::jitgen::JitContext,
     &Store,
     CallSiteId,
-    ClassId,
     Option<ClassId>,
-) -> bool;
-
-/// Class-independent inline generator: the emitted code depends only on the
-/// receiver's Value representation, never on a statically known receiver (or
-/// argument) class, so the JIT may fire it even behind a polymorphic
-/// class-set guard (`GuardClassIn`), where the receiver's class is not
-/// refined at compile time. The narrower signature — no `ClassId`
-/// parameters at all — enforces that contract by type: a generator that
-/// needs a class cannot be registered through this shape.
-pub(crate) type InlineGenClassIndependent = dyn Fn(
-    &mut jitgen::AbstractState,
-    &mut jitgen::asmir::AsmIr,
-    &crate::jitgen::JitContext,
-    &Store,
-    CallSiteId,
+    Option<ClassId>,
 ) -> bool;
 
 /// Binary-operator inline generator: the JIT-inline implementation of a

--- a/monoruby/src/globals/method.rs
+++ b/monoruby/src/globals/method.rs
@@ -518,38 +518,6 @@ impl Globals {
         self.define_builtin_inline_funcs(class_id, name, &[], address, inline_gen, arg_num)
     }
 
-    /// Like [`define_builtin_inline_func`](Self::define_builtin_inline_func),
-    /// but registers a class-independent generator (see
-    /// [`InlineGenClassIndependent`]): its code reads only the receiver
-    /// Value, so the JIT also fires it behind a polymorphic class-set guard.
-    pub(crate) fn define_builtin_inline_func_class_independent(
-        &mut self,
-        class_id: ClassId,
-        name: &str,
-        address: BuiltinFn,
-        inline_gen: Box<InlineGenClassIndependent>,
-        arg_num: usize,
-    ) -> FuncId {
-        let fid = self.new_builtin_fn(
-            class_id,
-            name,
-            address,
-            Visibility::Public,
-            arg_num,
-            arg_num,
-            false,
-            &[],
-            false,
-        );
-        let info = inline::InlineFuncInfo::new_inline_gen_class_independent(inline_gen);
-        self.store.inline_info.add_inline(fid, info);
-        fid
-    }
-
-    /// [`define_basic_op`](Self::define_basic_op) plus a binary inline
-    /// generator (see [`InlineGenBinary`]): keeps the `is_basic_op` entry
-    /// flag and registers the generator the binop/cmp JIT dispatchers fire
-    /// guard-free under the basic-op license.
     pub(crate) fn define_basic_op_inline(
         &mut self,
         class_id: ClassId,


### PR DESCRIPTION
Two changes to how a polymorphic call site is dispatched. Neither is a speed-up — the second is explicitly a simplification, and the first did not measure. Please read the numbers before merging the first one.

## 1. The PIC's arms are keyed by target, not by class

`405b140e`

An arm was one receiver class. Classes that resolve the name to the *same* method therefore got one copy of the call sequence each, and the mechanism refused any site where all classes shared a target — that case belonged to the class-set guard, which is one membership test around one call sequence.

Arms are now keyed by `FuncId`: the classes that resolve to a target share its arm, admitted by a membership test over that group's set. A single group is still the class-set guard's case and still declines here, so the two mechanisms meet rather than overlap.

The chain tests each group's set in turn and the **last** group's test is the deopting one, so a receiver is compared against the union exactly once. Hoisting the deopt into a separate union guard ahead of the arms reads better and was the first thing I wrote; it compares everything twice and measured ~16% slower.

A multi-class arm cannot refine the receiver, so it tells `compile_method_call` so (`in_set_guarded_arm`) and gets the same treatment the class-set guard gets.

**This did not measure.** Five runs each, against master:

| site | master | this PR |
|---|---|---|
| 4 classes → 2 targets | 95–107ms | 97–102ms |
| 4 classes → 3 targets | 57–59ms | 58–61ms |
| megamorphic `nil?` (one group, path unchanged) | 258–321ms | 261–275ms |

The one real effect is code size, from the duplicate call sequences going away:

| site | master | this PR |
|---|---|---|
| 4 classes → 2 targets | 817 bytes | **501 bytes** |
| 4 classes → 3 targets | 213 bytes | 205 bytes |

That should help the instruction cache and my microbenchmarks are far too small to show it. If a 39% reduction in emitted code at such a site is not worth a change that cannot be shown to be faster, this commit is the one to drop — the second does not depend on the grouping, only on the `in_set_guarded_arm` plumbing it introduces.

Adds `BrClassNotIn` (branch when the class is *not* in a set) to the IR and both backends — `GuardClassIn`'s chain with the last miss going to the next arm instead of a side exit, which is the relationship `BrClassNe` already has to `GuardClass`.

## 2. The class-independent inline generator folds into the general one

`7d9eb3b8`

`InlineGenClassIndependent` was a second generator shape whose only difference was the absence of the `ClassId` parameters — the narrower signature enforced "never consults the receiver's class" by type. The cost was a parallel mechanism: its own type alias, `InlineFuncInfo` variant, `define_builtin_*` registration, `inline_asm_*` helper, and a special case in the dispatcher's inline switch that had to stay ahead of every other arm.

Making the receiver class `Option<ClassId>` collapses all of it. The argument class was already optional, so both now read the same way: the call site passes what it has.

**What the caller owes does not change with that parameter.** Firing a generator at all asserts that whatever class the receiver turns out to have at run time, it resolves this call site's name to the method this generator implements — the class-set guard admits only classes it re-resolved to this method, and a dispatch arm is entered only by classes grouped under this target. `Some(class)` adds that the class is also statically known; `None` says only that the site cannot name it, not that anything about resolution is weaker.

So the four former class-independent generators (`nil?`, `frozen?`, `__id__`, `object_id`) ignore the parameter and keep firing where the class is unproven, exactly as before. Of the 52 `InlineGen` generators, **40 never looked at the class in the first place** (`_: ClassId`) and 12 bind it and now decline on `None` — a fair measure of how much the distinction was carrying.

What this gives up is the type-level guarantee: a generator could now `unwrap()` the class where it must not, where before the parameter was not there to misuse. In exchange there is one shape to register through and no way to pick the wrong one.

Behaviour-preserving, and confirmed so: an experiment that instead removed the *gate* (letting every generator fire behind a set guard) fails `backtrace_set_backtrace_merged` and `hash_to_h_semantics`, which is what says the distinction was load-bearing and had to be preserved rather than deleted.

## Verification

- Full suite green
- `cargo check --target aarch64-unknown-linux-gnu` clean
- Timings unchanged on the megamorphic-`nil?`, shared-target and split-target microbenchmarks

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_