### PR TITLE
JIT: run the constructor idiom without a frame

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -2744,6 +2744,17 @@ impl Codegen {
             // the specialized body (rewriting its `SpecializedCall` `bl`) then
             // deopt. Mirrors x86 `guard_class_version_specialized` (no counter —
             // the recompile bakes in the new version, so it won't re-fire).
+            // `dst <- [caller_fp - rbp_local(slot)]`. The caller's frame
+            // pointer is the one saved at `[x29]` (the D1 gate guarantees
+            // exactly one level up); x11 is a free lowering temp, and
+            // `a64_frame_load` owns the offset-range handling through x10.
+            AsmInst::LoadCallerSlot { slot, dst } => {
+                let d = dst.a64().0;
+                monoasm_arm64!(&mut self.jit,
+                    ldr x11, [x29];
+                );
+                self.a64_frame_load(d, 11, rbp_local(slot) as u32);
+            }
             AsmInst::GuardClassVersionSpecialized { idx, deopt } => {
                 let global_idx = self.specialized_base + idx;
                 let deopt = labels[deopt].clone();

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -195,6 +195,18 @@ impl Codegen {
             | AsmInst::RestKw { .. } => {
                 unreachable!("handled by the shared compile_asmir dispatcher")
             }
+            // `dst <- [caller_rbp - rbp_local(slot)]`. This body established
+            // its own rbp (`init_func`), so the caller's is the value saved
+            // at `[rbp]`; the D1 gate guarantees the caller is exactly one
+            // level up. Same addressing as `jit_set_arguments_forwarded`.
+            AsmInst::LoadCallerSlot { slot, dst } => {
+                let r = dst as u64;
+                let ofs = rbp_local(slot);
+                monoasm! { &mut self.jit,
+                    movq R(r), [rbp];
+                    movq R(r), [R(r) - (ofs)];
+                }
+            }
             AsmInst::GuardClassVersionSpecialized { idx, deopt } => {
                 let deopt = &labels[deopt];
                 self.guard_class_version_specialized(

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -2189,6 +2189,27 @@ pub(super) enum AsmInst {
         dst: GP,
     },
     ///
+    /// Load the **caller** frame's slot *slot* into *dst*.
+    ///
+    /// The one place a compiled body legitimately reads outside its own
+    /// frame: D1 defers a `...` forward's rest `Array`, leaving the
+    /// forwarded positionals in the caller's slots (`DeferredForward::src`,
+    /// caller register numbering). `SetArgumentsForwarded` copies them into
+    /// a callee frame; this reads a single one directly, for consumers that
+    /// build no frame at all.
+    ///
+    /// Only valid where the deferral annotation is: inside a specialized
+    /// forwarding trampoline, whose caller is exactly one level up, so the
+    /// caller's frame pointer is the one saved at `[fp]`.
+    ///
+    /// #### out
+    /// - dst: Value
+    ///
+    LoadCallerSlot {
+        slot: SlotId,
+        dst: GP,
+    },
+    ///
     /// Store *src* in an instance var *ivarid* of the object *rdi*.
     ///
     /// #### in

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -7,6 +7,7 @@ mod dispatch;
 mod unary_op;
 #[cfg(feature = "emit-cfg")]
 mod dump_cfg;
+mod frameless;
 mod index;
 mod loop_analysis;
 mod method_call;

--- a/monoruby/src/codegen/jitgen/compile/frameless.rs
+++ b/monoruby/src/codegen/jitgen/compile/frameless.rs
@@ -1,0 +1,167 @@
+//! Frame-free expansion of the constructor idiom.
+//!
+//! `def initialize(a, b) = (@a = a; @b = b)` is the single most common
+//! method body in object-heavy Ruby, and today it costs a full method
+//! frame to run three `mov`s. This module recognises that body and lets
+//! [`compile_method_call`](JitContext::compile_method_call) emit the
+//! stores straight into the caller, with no frame pushed at all.
+//!
+//! # How this differs from the other two folds
+//!
+//! `ISeqHint::ConstReturn` / `SelfReturn` elide the call by *discarding*
+//! the body — nothing of the callee is emitted. Specialization
+//! (`specialized_iseq`) does the opposite: it emits the whole body, tuned
+//! for the call site, and still **calls** it. This sits between them: the
+//! body really runs, but as the caller's own instructions.
+//!
+//! # What makes the frame dispensable
+//!
+//! Not "the body cannot side-exit" — `attr_writer` already inlines behind
+//! a frozen guard, and a deopt is fine because it rebuilds from the
+//! *caller's* frame state, which is the one that exists. What the callee
+//! must not do is *need a frame of its own*: no call or `yield` (a
+//! callee's callee walks `cfp` and would find the caller's frame), nothing
+//! that can raise or appear in a backtrace, no `binding`, no `super`, no
+//! access to an `outer` frame.
+//!
+//! Restricting the body to `StoreIvar` from a parameter slot, plus the
+//! `Ret`, buys all of that at once: every instruction is a move between
+//! things the caller already holds. The frozen guard is the one side exit,
+//! and it is hoisted ahead of the stores so the expansion is all-or-nothing
+//! (see [`ivar_store_body`] for why that matters).
+
+use super::*;
+
+///
+/// Where a callee parameter's value lives, as seen from the frame being
+/// compiled.
+///
+#[derive(Clone, Copy)]
+pub(super) enum ArgSlot {
+    /// A slot of this frame — the ordinary case.
+    Own(SlotId),
+    ///
+    /// A slot of the **caller's** frame, reachable only through the saved
+    /// frame pointer.
+    ///
+    /// This is where a `...` forward's positionals stay when D1 defers the
+    /// rest `Array`: `Class#new`'s `o.__builtin_initialize__(...)` never
+    /// materializes them into its own slots, so the expansion reads them
+    /// where the caller left them (`AsmInst::LoadCallerSlot`). They are
+    /// live there for the whole call, and on the control-frame chain, so
+    /// this is as GC-safe as the rest-array materialization that would
+    /// otherwise read the same window.
+    ///
+    Caller(SlotId),
+}
+
+///
+/// The recognised shape of a frame-free constructor body.
+///
+/// Parameter indices are 0-based: index `i` is the callee's `SlotId(i + 1)`,
+/// and the call site maps it back to whichever caller slot supplies that
+/// argument.
+///
+pub(super) struct IvarStoreBody {
+    ///
+    /// `(ivar name, parameter index)` in body order. Order is preserved
+    /// because it is observable: it fixes the order the ivar slots are
+    /// created in, and hence `#instance_variables`.
+    ///
+    pub stores: Vec<(IdentId, u16)>,
+    ///
+    /// The parameter index whose value the body returns — the last
+    /// assignment's RHS. `initialize`'s result is discarded by `Class#new`,
+    /// so this is usually dead, but a direct `obj.send(:initialize, ...)`
+    /// can read it.
+    ///
+    pub ret: u16,
+}
+
+///
+/// The most ivar stores a body may contain and still be expanded.
+///
+/// Each store is one `mov` in the caller, so the only cost of a larger
+/// body is the caller's code size, multiplied by the number of sites that
+/// construct this class. Six is `OBJECT_INLINE_IVAR`, i.e. every store an
+/// object can take without spilling to the heap table — past that the
+/// expansion would be declined anyway.
+///
+const MAX_STORES: usize = 6;
+
+///
+/// Recognise `def initialize(a, b, ...) = (@x = a; @y = b; ...)`.
+///
+/// Returns `None` for anything else. The test is purely *static* — the
+/// shape of the body. The call site adds the conditions that depend on it
+/// (the argument shape binds without `ArgumentError`, the receiver class
+/// is known, its ivar slots exist and are inline); see
+/// [`JitContext::expand_ivar_stores`].
+///
+/// # Why a single basic block
+///
+/// A branch would be legal in principle (`CondBr` reads the Value itself,
+/// so it needs no operand class and no call), but a *conditional* store
+/// breaks the all-or-nothing property the hoisted frozen guard relies on:
+/// the guard would have to prove the object unfrozen even on the path that
+/// stores nothing, turning a legal call into a deopt. Straight-line bodies
+/// are what the target idiom is, so this stays the whole scope for now.
+///
+pub(super) fn ivar_store_body(store: &Store, iseq_id: ISeqId) -> Option<IvarStoreBody> {
+    let iseq = &store[iseq_id];
+    // An `outer` means the body reads locals through `outer_lfp` — exactly
+    // the frame it would not have.
+    if iseq.outer.is_some() {
+        return None;
+    }
+    let func = &store[iseq.func_id()];
+    // `is_simple` is the JIT's usual "plain positional parameters only"
+    // test: no optional, rest, post, keyword, block or forwarding
+    // parameter. Each of those needs the argument binding that frame setup
+    // performs; the caller already holds the plain ones in slots.
+    if !func.meta().is_simple() || iseq.block_param().is_some() {
+        return None;
+    }
+    let pos_num = func.params().total_positional_args();
+    if pos_num == 0 || pos_num > u16::MAX as usize {
+        return None;
+    }
+    if iseq.bb_info.len() != 1 {
+        return None;
+    }
+    let BasicBlockInfoEntry { begin, end, .. } = iseq.bb_info[BasicBlockId(0)];
+    // Parameters occupy `SlotId(1) ..= SlotId(pos_num)`; `SlotId(0)` is self.
+    let param_index = |slot: SlotId| -> Option<u16> {
+        let i = slot.0;
+        (i >= 1 && i as usize <= pos_num).then(|| i - 1)
+    };
+    let mut stores: Vec<(IdentId, u16)> = vec![];
+    let mut ret = None;
+    for idx in begin..=end {
+        match TraceIr::from_pc(iseq.get_pc(idx), store) {
+            // The prologue. Binding positional arguments the caller has.
+            TraceIr::InitMethod(..) => {}
+            TraceIr::StoreIvar(src, name, _) => {
+                if stores.len() >= MAX_STORES || ret.is_some() {
+                    return None;
+                }
+                stores.push((name, param_index(src)?));
+            }
+            TraceIr::Ret(slot) => {
+                if ret.is_some() {
+                    return None;
+                }
+                ret = Some(param_index(slot)?);
+            }
+            _ => return None,
+        }
+    }
+    if stores.is_empty() {
+        // A body with no store is `ISeqHint`'s business, not ours.
+        return None;
+    }
+    Some(IvarStoreBody {
+        stores,
+        ret: ret?,
+    })
+}

--- a/monoruby/src/codegen/jitgen/compile/frameless.rs
+++ b/monoruby/src/codegen/jitgen/compile/frameless.rs
@@ -142,17 +142,14 @@ pub(super) fn ivar_store_body(store: &Store, iseq_id: ISeqId) -> Option<IvarStor
             // The prologue. Binding positional arguments the caller has.
             TraceIr::InitMethod(..) => {}
             TraceIr::StoreIvar(src, name, _) => {
-                if stores.len() >= MAX_STORES || ret.is_some() {
+                if stores.len() >= MAX_STORES {
                     return None;
                 }
                 stores.push((name, param_index(src)?));
             }
-            TraceIr::Ret(slot) => {
-                if ret.is_some() {
-                    return None;
-                }
-                ret = Some(param_index(slot)?);
-            }
+            // A basic block ends at its terminator, so this runs at most
+            // once and always last.
+            TraceIr::Ret(slot) => ret = Some(param_index(slot)?),
             _ => return None,
         }
     }

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -569,6 +569,55 @@ impl<'a> JitContext<'a> {
                         }
                         return Ok(CompileResult::Continue);
                     }
+                    // Frame-free expansion of the constructor idiom
+                    // (`def initialize(a, b) = (@a = a; @b = b)`): emit the
+                    // stores as the caller's own instructions instead of
+                    // pushing a frame to run three `mov`s. Same gate as the
+                    // folds above, because it needs the same thing they do —
+                    // an argument shape that binds without `ArgumentError`.
+                    if let Some(body) = frameless::ivar_store_body(&self.store, iseq) {
+                        let callee_pos = self.store[func_id].params().total_positional_args();
+                        // Where each callee parameter lives in *this* frame.
+                        // Direct call sites hand them over contiguously from
+                        // `args`; a `...` forward splits them into the lead
+                        // positionals plus the D1-deferred rest range, which
+                        // is where `Class#new`'s `__builtin_initialize__(...)`
+                        // — the shape that actually matters — lands.
+                        let arg_slots: Option<Vec<frameless::ArgSlot>> = if simple_fold {
+                            (pos_num == callee_pos).then(|| {
+                                (0..callee_pos)
+                                    .map(|i| frameless::ArgSlot::Own(args + i))
+                                    .collect()
+                            })
+                        } else {
+                            let lead_num = pos_num - 1;
+                            state
+                                .deferred_rest_src(args + lead_num)
+                                .filter(|(_, len)| lead_num + *len as usize == callee_pos)
+                                .map(|(rest, len)| {
+                                    (0..lead_num)
+                                        .map(|i| frameless::ArgSlot::Own(args + i))
+                                        .chain(
+                                            (0..len as usize)
+                                                .map(|i| frameless::ArgSlot::Caller(rest + i)),
+                                        )
+                                        .collect()
+                                })
+                        };
+                        if let Some(arg_slots) = arg_slots
+                            && self.expand_ivar_stores(
+                                state, ir, recv_class, recv, dst, &body, &arg_slots,
+                            )
+                        {
+                            if forwarded_fold {
+                                // Same reasoning as the fold above: the
+                                // expansion *is* the forwarding consume, so
+                                // keep the caller-side `create_array` skip on.
+                                ir.set_deferred_rest();
+                            }
+                            return Ok(CompileResult::Continue);
+                        }
+                    }
                 }
                 // Use `is_C_immediate` here, not `is_C`: heap-resident
                 // `LinkMode::C` (e.g. class constants newly folded by
@@ -883,6 +932,98 @@ impl<'a> JitContext<'a> {
         state.def_rax2acc(ir, dst);
         state.unset_side_effect_guard();
         CompileResult::Continue
+    }
+
+    ///
+    /// Emit a recognised constructor body ([`frameless::ivar_store_body`])
+    /// as the caller's own instructions — no frame pushed, no call made.
+    ///
+    /// `arg_slots[i]` is the caller slot supplying the callee's parameter
+    /// `i`. Returns `false` when the receiver class cannot take the stores
+    /// this way, in which case nothing has been emitted and the caller
+    /// falls through to the ordinary call.
+    ///
+    /// # Why the frozen guard is hoisted
+    ///
+    /// Storing to a frozen object must raise `FrozenError`, and the raise
+    /// has to come from a real `initialize` frame with the right backtrace
+    /// — which is exactly the frame this path does not build. So the guard
+    /// runs **before any store**, and a frozen receiver deopts to the call
+    /// instruction: the VM then performs the whole call itself and raises
+    /// properly. That is only sound while no store has happened yet, which
+    /// is why the body must be straight-line (a conditional store would
+    /// leave the guard proving something about a path that never stores).
+    ///
+    fn expand_ivar_stores(
+        &mut self,
+        state: &mut AbstractState,
+        ir: &mut AsmIr,
+        recv_class: ClassId,
+        recv: SlotId,
+        dst: Option<SlotId>,
+        body: &frameless::IvarStoreBody,
+        arg_slots: &[frameless::ArgSlot],
+    ) -> bool {
+        // Only `RValue`s with the object layout have inline ivar slots at a
+        // fixed offset; anything else stores through the heap table, which
+        // needs `using_fpr` bookkeeping and a possible reallocation call.
+        if !self.store[recv_class].is_object_ty_instance() {
+            return false;
+        }
+        // Resolve every slot *before* emitting anything, so a body that is
+        // only partly expandable emits nothing at all.
+        let mut plan = Vec::with_capacity(body.stores.len());
+        for &(name, param) in &body.stores {
+            // The ivar id is created by the first execution of this store,
+            // and `initialize` has necessarily run in the interpreter to get
+            // the caller this hot — so a miss here means the class reaching
+            // this site is not the one the body writes (a subclass whose own
+            // `new` has never run). Decline rather than recompile: the
+            // ordinary call is correct and this is only an optimization.
+            let Some(ivarid) = self.store[recv_class].get_ivarid(name) else {
+                return false;
+            };
+            if !ivarid.is_inline() {
+                return false;
+            }
+            plan.push((ivarid, arg_slots[param as usize]));
+        }
+        state.load(ir, recv, GP::Rdi);
+        let deopt = ir.new_deopt(state);
+        ir.guard_frozen(deopt);
+        for (ivarid, src_slot) in plan {
+            let src = match src_slot {
+                frameless::ArgSlot::Own(slot) => state.load_or_reg(ir, slot, GP::Rax),
+                frameless::ArgSlot::Caller(slot) => {
+                    ir.push(AsmInst::LoadCallerSlot {
+                        slot,
+                        dst: GP::Rax,
+                    });
+                    GP::Rax
+                }
+            };
+            // Re-materialize the base: an argument living in an FP register
+            // is boxed on the way out, and boxing is a call.
+            state.load(ir, recv, GP::Rdi);
+            ir.push(AsmInst::StoreIVarInline { src, ivarid });
+        }
+        if let Some(dst) = dst {
+            // The body returns its last assignment's RHS.
+            match arg_slots[body.ret as usize] {
+                // Copying the slot (rather than reading it back) keeps an
+                // unboxed float unboxed.
+                frameless::ArgSlot::Own(slot) => state.copy_slot(ir, slot, dst),
+                frameless::ArgSlot::Caller(slot) => {
+                    ir.push(AsmInst::LoadCallerSlot {
+                        slot,
+                        dst: GP::Rax,
+                    });
+                    state.def_rax2acc(ir, Some(dst));
+                }
+            }
+        }
+        state.unset_side_effect_guard();
+        true
     }
 
     /// JIT inline a `Struct` member reader. Receiver class is already
@@ -2180,6 +2321,94 @@ mod tests {
             res << (begin; Fold.new(1, k: 2); rescue ArgumentError => e; e.class; end)
             res << Fold.new(1) { :blk }.class
             res << $effects.size
+            res
+            "#,
+        );
+    }
+
+    /// Frame-free expansion of `def initialize(a, b) = (@a = a; @b = b)`:
+    /// the stores must land in the right slots for a plain construction, a
+    /// subclass (whose ivar table is its own), a body reached through
+    /// `send` (where `initialize`'s return value — the last RHS — is
+    /// actually observable), and values of every representation the store
+    /// has to box on the way in (nil, unboxed float, Bignum).
+    #[test]
+    fn frameless_ivar_stores() {
+        run_test(
+            r#"
+            class V
+              def initialize(x, y, z); @x = x; @y = y; @z = z; end
+              attr_reader :x, :y, :z
+            end
+            class Sub < V; end
+            # A subclass that assigns its own ivars first, so its slot
+            # numbering diverges from the superclass's: the expansion must
+            # resolve names against the *receiver's* class, not the one the
+            # body was written in.
+            class Skew < V
+              def pre; @w = 0; @z = 0; @y = 0; @x = 0; end
+            end
+            Skew.allocate.pre
+            res = []
+            r = []; 100.times {|i| v = V.new(i, i * 2, i.to_f); r << [v.x, v.y, v.z] }
+            res << r.last
+            r = []; 100.times {|i| v = Sub.new(i, i, i); r << [v.class, v.x] }
+            res << r.last
+            r = []; 100.times {|i| v = Skew.new(i, i + 1, i + 2); r << [v.x, v.y, v.z] }
+            res << r.last
+            r = []; 100.times {|i| v = V.new(nil, 1.5, 2 ** 70); r << [v.x, v.y, v.z] }
+            res << r.last
+            # `initialize` returns its last assignment's RHS.
+            r = []; 100.times {|i| o = V.allocate; r << o.send(:initialize, i, 2, 3) }
+            res << r.last
+            res << V.new(1, 2, 3).instance_variables
+            res
+            "#,
+        );
+    }
+
+    /// What the expansion must NOT swallow. The frozen guard is hoisted
+    /// ahead of every store, so a frozen receiver has to raise
+    /// `FrozenError` with **nothing written** — the deopt hands the whole
+    /// call back to the interpreter. Arity still raises, a redefinition
+    /// still takes effect, and a body just past the inline-slot budget
+    /// (more than `OBJECT_INLINE_IVAR` ivars) still runs correctly through
+    /// the ordinary call.
+    #[test]
+    fn frameless_ivar_stores_declines() {
+        run_test(
+            r#"
+            class V
+              def initialize(x, y); @x = x; @y = y; end
+              attr_reader :x, :y
+            end
+            class Wide
+              def initialize(a, b, c, d, e, f, g, h)
+                @a = a; @b = b; @c = c; @d = d; @e = e; @f = f; @g = g; @h = h
+              end
+              def all = [@a, @b, @c, @d, @e, @f, @g, @h]
+            end
+            res = []
+            r = nil
+            100.times do
+              o = V.allocate.freeze
+              begin
+                o.send(:initialize, 1, 2)
+              rescue => e
+                r = [e.class, o.instance_variables]
+              end
+            end
+            res << r
+            r = []; 100.times {|i| r << Wide.new(1, 2, 3, 4, 5, 6, 7, i).all }
+            res << r.last
+            res << (begin; V.new(1); rescue ArgumentError => e; e.class; end)
+            res << (begin; V.new(1, 2, 3); rescue ArgumentError => e; e.class; end)
+            100.times { V.new(1, 2) }
+            class V
+              def initialize(x, y); @x = x + 100; @y = y; end
+            end
+            r = []; 100.times { r << V.new(1, 2).x }
+            res << r.uniq
             res
             "#,
         );

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -2414,6 +2414,62 @@ mod tests {
         );
     }
 
+    /// The expansion is not about `initialize`: **any** method whose body
+    /// is just ivar stores qualifies, and on a direct call site the
+    /// arguments are the caller's own slots rather than a `...` forward's
+    /// deferred window. That also makes the return value — the last
+    /// assignment's RHS — routinely observable, which `Class#new` discards.
+    ///
+    /// Alongside those, the four shapes that must fall through to the
+    /// ordinary call: a receiver whose layout has no inline ivar slots
+    /// (`Struct`), a body whose ivars land past the inline budget, a body
+    /// with a branch (the hoisted frozen guard needs every path to store),
+    /// and a body with no store at all.
+    #[test]
+    fn frameless_ivar_stores_direct_call() {
+        run_test(
+            r#"
+            class C
+              def set2(a, b); @a = a; @b = b; end
+              def set1(x); @x = x; end
+              def echo(x) = x
+              def call_set(...) = set2(...)
+              def maybe(a, b); @a = a if a; @b = b; end
+              def pair = [@a, @b]
+              attr_reader :x
+            end
+            # Six ivars already claim every inline slot, so this class's
+            # `@a` / `@b` live in the heap table.
+            class Heapy
+              def pre; @p0 = 0; @p1 = 0; @p2 = 0; @p3 = 0; @p4 = 0; @p5 = 0; end
+              def set2(a, b); @a = a; @b = b; end
+              def pair = [@a, @b]
+            end
+            Heapy.new.pre
+            S = Struct.new(:q) do
+              def set2(a, b); @a = a; @b = b; end
+              def pair = [@a, @b]
+            end
+            res = []
+            c = C.new
+            r = []; 100.times {|i| r << c.set2(i, i + 1) }; res << [r.last, c.pair]
+            r = []; 100.times {|i| r << c.set1(i.to_f) };   res << [r.last, c.x]
+            r = []; 100.times {|i| r << c.echo(i) };        res << r.last
+            # Through a `...` trampoline, where the result *is* read.
+            r = []; 100.times {|i| r << c.call_set(i, i * 2) }; res << [r.last, c.pair]
+            h = Heapy.new
+            r = []; 100.times {|i| r << h.set2(i, i + 1) }; res << [r.last, h.pair]
+            s = S.new(0)
+            r = []; 100.times {|i| r << s.set2(i, i + 1) }; res << [r.last, s.pair]
+            r = []; 100.times {|i| r << c.maybe(nil, i) }; res << [r.last, c.pair]
+            r = []; 100.times {|i| r << c.maybe(i, i) };   res << [r.last, c.pair]
+            d = C.new.freeze
+            res << (begin; d.set2(1, 2); rescue => e; [e.class, d.pair]; end)
+            res
+            "#,
+        );
+    }
+
     /// The same fold on a plain `def f(...) = g(...)` trampoline (not just
     /// the `Class#new` shape), and the invalidation path: once a folded
     /// callee is redefined with a body that has a side effect, the compiled

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -1971,6 +1971,7 @@ a966ff673f0471a0f7996609730def4c	"missing keyword: :x"	def msg; yield; "no error
 a96f44dffe64892feff990050d690d94	[150, false, true, false, false]	class Tail1; end\n            class Tail2; end\n            class Tai
 a98bef4ea7d42ca9b3589602d2392195	[[5, 6], [0, 0], [5, 6], [1, 1], [5, 6], [2, 2], [5, 6], [3, 3], [5, 6], [4, 4], [5, 6], [5, 5], [5, 6], [6, 6], [5, 6], [7, 7], [5, 6], [8, 8], [5, 6], [9, 9], [5, 6], [10, 10], [5, 6], [11, 11], [5, 6], [12, 12], [5, 6], [13, 13], [5, 6], [14, 14], [5, 6], [15, 15], [5, 6], [16, 16], [5, 6], [17, 17], [5, 6], [18, 18], [5, 6], [19, 19], [5, 6], [20, 20], [5, 6], [21, 21], [5, 6], [22, 22], [5, 6], [23, 23], [5, 6], [24, 24], [5, 6], [25, 25], [5, 6], [26, 26], [5, 6], [27, 27], [5, 6], [28, 28], [5, 6], [29, 29]]	class N\n          attr_reader :v\n          def initialize(a: 0, b: 1) =
 a9a64f0fa64e4bb1ec264c4f7c86df8b	:OVERRIDDEN	class Integer; def *(o); :OVERRIDDEN; end; end; 3 * 4
+a9ae3e391f88203fe65c9135f9075c2e	[[100, [99, 100]], [99.0, 99.0], 99, [198, [99, 198]], [100, [99, 100]], [100, [99, 100]], [99, [99, 99]], [99, [99, 99]], [FrozenError, [nil, nil]]]	class C\n              def set2(a, b); @a = a; @b = b; end\n         
 a9b082961457f87dd5dd3df08a2bc22e	"CAFÉ"	"Café".upcase
 a9cceae0d32dce8d89f28a34f27a49e1	[RuntimeError, "boom"]	o = Object.new\n            def o.each; raise "boom"; end\n          
 a9d059f319ef4e98b5696e426ac2c89b	TypeError	(Regexp.new("x").send(:initialize, "y"); nil) rescue $!.class

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -1825,6 +1825,7 @@
 9dbc194b1b0f6de59813ff04a2e9663a	[20, 20, 100, 2, 2]	Bar = 100\n            class Foo\n              autoload :Bar, "./c"\n
 9dbef04511724f84642f3b1be7361af9	[:get_raised, :set_raised]	class D\n              def initialize() @a = {k: 1} end\n            
 9dc570781d3034551d04772d71561543	:OVERRIDDEN	class Float; def ==(o); :OVERRIDDEN; end; end; 3.0 == 4.0
+9e03dfa339ff319e0498759ad4a0f1b2	[[99, 198, 99.0], [Sub, 99], [nil, 1.5, 1180591620717411303424], 3, [:@x, :@y, :@z]]	class V\n              def initialize(x, y, z); @x = x; @y = y; @z =
 9e349938558e7f648ad2c96a5fab61e1	:NOPE	class CGetMissingNameErr; end\n            begin\n              CGetM
 9e41b878cb2cd158c0051841526faf43	:OVERRIDDEN	class Integer; def !; :OVERRIDDEN; end; end; !(3)
 9e717e788200f4da9792d264e6819b02	[[], [1], [1, 2], [nil], [[1, 2]], nil, 1, [1, 2], nil, [1, 2]]	p = []\n        o = Object.new\n        def o.each\n          yield\n      
@@ -2192,6 +2193,7 @@ bb5498e7dcf365fa231082e385a52382	[42, 7, :nme]	class NestOuter\n              de
 bb7dc7125b3d11eacda38a33f25683d7	["global-variable", "global-variable", "global-variable", "global-variable", "global-variable"]	[defined?($/), defined?($\\), defined?($,), defined?($;), defined?($.)]
 bb7e42a0efd2830d60846fb262b25aba	:OVERRIDDEN	class FalseClass; def ===(o); :OVERRIDDEN; end; end; false === false
 bb9bac558eea3d2782caab01dd00745b	12.1	def f(a,b)\n          a + b\n        end\n        f(5.1, 7)\n        
+bb9fe807d5884dd09dd75a4832ce674c	[[FrozenError, []], [1, 2, 3, 4, 5, 6, 7, 99], ArgumentError, ArgumentError, [101]]	class V\n              def initialize(x, y); @x = x; @y = y; end\n   
 bba413775b9fdc4e5a5520013caecba6	true	Process.getpriority(Process::PRIO_USER, 0).is_a?(Integer)
 bbb536d6446e4acae479f2a76bbc22b8	[false, true, "payload"]	base = "/tmp/monoruby_test_rename_#{Process.pid}_#{rand(100000)}"\n 
 bbf39b957f63dc57cf6be6b238e3322a	"HELLO world"	s = "hello world"; s.bytesplice(0..4, "HELLO WORLD", 0..-7); s
@@ -2315,6 +2317,7 @@ c4bd1413a0e0e43d5ccb56e00501ef61	[[[:a, 1], [:b, 2]], [[:a, 1], [:b, 2]], [[:a, 
 c520fc850e949eb2bf64f11afc5f2940	"Foo"	module Foo; end\n        Foo.to_s\n        
 c5374e944984f6dd8304adbe5f87f4d5	[10, 20]	fiber1 = Fiber.new { true }\n            fiber2 = Fiber.new { fiber1
 c53a4d5b6fe802b427b290829cb4dc35	[5, [:a, :b, :c, :d, :e], 0, 3, false, 5, [:a, :b, :c, :d, :e], 1, 3, false, 5, [:a, :b, :c, :d, :e], 2, 3, false, 5, [:a, :b, :c, :d, :e], 3, 3, false, 5, [:a, :b, :c, :d, :e], 4, 3, false, 5, [:a, :b, :c, :d, :e], 5, 3, false, 5, [:a, :b, :c, :d, :e], 6, 3, false, 5, [:a, :b, :c, :d, :e], 7, 3, false, 5, [:a, :b, :c, :d, :e], 8, 3, false, 5, [:a, :b, :c, :d, :e], 9, 3, false, 5, [:a, :b, :c, :d, :e], 10, 3, false, 5, [:a, :b, :c, :d, :e], 11, 3, false, 5, [:a, :b, :c, :d, :e], 12, 3, false, 5, [:a, :b, :c, :d, :e], 13, 3, false, 5, [:a, :b, :c, :d, :e], 14, 3, false, 5, [:a, :b, :c, :d, :e], 15, 3, false, 5, [:a, :b, :c, :d, :e], 16, 3, false, 5, [:a, :b, :c, :d, :e], 17, 3, false, 5, [:a, :b, :c, :d, :e], 18, 3, false, 5, [:a, :b, :c, :d, :e], 19, 3, false]	def m(i) = {a: i, b: 2, c: 3}\n        r = []\n        20.times do |i|\n  
+c541a3e07294eab4a4d213c945171c7a	[[99, 198, 99.0], [Sub, 99], [99, 100, 101], [nil, 1.5, 1180591620717411303424], 3, [:@x, :@y, :@z]]	class V\n              def initialize(x, y, z); @x = x; @y = y; @z =
 c55e6248eb41c6e540c40b61f2e992ed	420	class C\n          def f\n            x = 0\n            10.times { x += y
 c56c19f790a407710bd65fa095a58592	[3, 3]	from = 1\n        to = 2\n        [(from..to ? 3 : 4), (from...to ? 3 : 4
 c57f3073a34696e272a4c621e59717cf	false	"a".index(/a/); $~.nil?


### PR DESCRIPTION
`def initialize(a, b) = (@a = a; @b = b)` is the most common method body in object-heavy Ruby, and today it costs a full method frame to run two `mov`s. When the callee's body is nothing but ivar stores from its parameters, this emits those stores as the **caller's own instructions**: no frame pushed, no call made, no argument binding.

## Where this sits

This is a third thing next to the two folds already at that site:

| | body | frame |
|---|---|---|
| `ISeqHint::ConstReturn` / `SelfReturn` | discarded | none |
| specialization (`specialized_iseq`) | emitted, call-site-tuned | **pushed** |
| **this** | emitted as the caller's | **none** |

## Why the frame is dispensable

Not "the body cannot side-exit" — a deopt is fine, it rebuilds from the *caller's* frame, which is the one that exists. It is that the body needs no frame **of its own**: no call or `yield` whose callee would walk `cfp` and find the caller's frame where it expects the inlined one's, nothing that can raise or appear in a backtrace, no `binding`, no `super`, no `outer`.

Restricting the body to `StoreIvar` from a parameter slot plus the `Ret` buys all of that at once — every instruction becomes a move between things the caller already holds.

## The frozen guard

Storing to a frozen object must raise `FrozenError`, and the raise has to come from a real `initialize` frame with the right backtrace — exactly the frame this path does not build. So the guard runs **before any store**, and a frozen receiver deopts to the call instruction; the interpreter then performs the whole call and raises properly.

That is sound only while no store has happened yet, which is why the body must be straight-line. A conditional store would leave the guard proving something about a path that stores nothing.

## Reaching the arguments

The shape that matters arrives through `Class#new`'s `o.__builtin_initialize__(...)`, whose positionals stay in the **caller's** slots because D1 defers the `...` rest `Array`. `AsmInst::LoadCallerSlot` reads one of them directly, with the same `[caller_fp - rbp_local(slot)]` addressing `SetArgumentsForwarded` already uses. Lowered on both backends.

## Restrictions (deliberate, for this first step)

- inline ivar slots only (`OBJECT_INLINE_IVAR`), on object-layout receivers;
- ivar ids must already exist. `initialize` has necessarily run in the interpreter to get the caller this hot, so a miss means the receiver is not the class the body writes (a subclass whose own `new` has never run).

Every decline falls through to the ordinary call, so no path gets worse.

## Measurements

20M constructions of `V3.new(a, b, c)` with three ivar stores, matched allocation baseline:

| | time |
|---|---|
| `E.new` (alloc + empty `initialize` frame) | 385ms |
| `F.new` + 3 inlined `attr_writer` calls | 432ms |
| `V3.new(a,b,c)` **before** | 530ms |
| `V3.new(a,b,c)` **after** | **397ms** |

25% off the whole construction, allocation included — and below the frame-free `attr_writer` route, since the three call sites go too.

A/B, interleaved, median of 3:

| benchmark | base | head | |
|---|---|---|---|
| **app_aobench** | 7.567s | **7.152s** | **−5.5%** |
| lee | 18.689s | 18.036s | −3.5% |
| erubi | 13.130s | 12.951s | −1.4% |
| chunky-png | 23.924s | 23.715s | −0.9% |
| rubykon | 15.284s | 15.182s | −0.7% |
| so_nbody, binarytrees, so_mandelbrot, app_fib, blurhash, plb2 | | | unchanged |

aobench is the workload for this: 60,717,936 `Vec#initialize` plus 9,373,120 `Ray#initialize` calls, all of exactly this shape. The unchanged benchmarks do not run the shape on a hot path — `so_nbody`'s `Planet#initialize` runs five times, and its hot `move_from_i` calls only `attr_reader`s, which already inline. `so_nbody` and `app_fib` were re-measured over 7 runs each; the distributions overlap completely.

## Verification

- `cargo nextest run --features stress-spill-pool` — **3201 tests run, 3201 passed, 0 failed**
- `cargo check --target aarch64-unknown-linux-gnu` clean
- aobench with `srand(0)` restored: output **byte-identical** to both the base build and CRuby (196623 bytes)

Two new tests. `frameless_ivar_stores` covers a plain construction, a subclass, **a subclass whose ivar slot numbering diverges from the superclass's** (the expansion must resolve names against the receiver's class), values of every representation the store has to box (nil, unboxed float, Bignum), `initialize`'s return value through `send`, and `instance_variables`.

`frameless_ivar_stores_declines` covers what it must not swallow: a frozen receiver raising `FrozenError` **with nothing written**, both arity errors, a body one ivar past the inline budget, and a redefinition taking effect after the site is compiled.

## Next

aobench's largest call is `Vec#vdot` at 84,357,568 calls — `@x * b.x + @y * b.y + @z * b.z`, whose only calls are `attr_reader`s that themselves inline to nothing. The allow-list rejects any `MethodCall` outright, so it falls out. Relaxing that to "no call that *needs a frame*" would take the reach from 70M to ~155M calls here, and would additionally let a `Float` result stay in an FP register instead of round-tripping through a boxed return. Left for a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_