### PR TITLE
JIT: chain deopt — convert a whole suspended chain to interpreter frames at once

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -486,7 +486,7 @@ Modes via `MONORUBY_TEST_ORACLE`:
 | `profile`           | Collect deopt/recompile statistics (implies `dump-bc`, `dump-traceir`) |
 | `perf`              | Emit perf-compatible symbol maps                                       |
 | `dump-require`      | Log `require`/`load` file resolution                                   |
-| `chain-deopt`       | Emit per-call-site chain-exit handlers and route on-stack (BOP) eviction through the chain-deopt walk instead of return-continuation patching — the validation switch for `doc/chain_deopt.md`'s mechanism |
+| `chain-deopt`       | Emit per-call-site chain-exit handlers and escalate every deopt / error side exit through the chain-deopt walk (BOP eviction converts by chain instead of patching too) — the validation switch for `doc/chain_deopt.md`'s mechanism |
 
 The JIT is always compiled in regardless of features; it is disabled at runtime
 with the `--no-jit` flag. The old `jit`/`jit_x86` build cfgs and the `no-jit`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -486,6 +486,7 @@ Modes via `MONORUBY_TEST_ORACLE`:
 | `profile`           | Collect deopt/recompile statistics (implies `dump-bc`, `dump-traceir`) |
 | `perf`              | Emit perf-compatible symbol maps                                       |
 | `dump-require`      | Log `require`/`load` file resolution                                   |
+| `chain-deopt`       | Emit per-call-site chain-exit handlers and route on-stack (BOP) eviction through the chain-deopt walk instead of return-continuation patching — the validation switch for `doc/chain_deopt.md`'s mechanism |
 
 The JIT is always compiled in regardless of features; it is disabled at runtime
 with the `--no-jit` flag. The old `jit`/`jit_x86` build cfgs and the `no-jit`

--- a/doc/README.md
+++ b/doc/README.md
@@ -44,7 +44,7 @@ Two things to know before reading:
 | [`polymorphic_call.md`](polymorphic_call.md) | JA | plan | Receiver-polymorphic call sites: why `x.nil?` / `x == nil` deopt on every nil receiver, the implemented nil-tolerant guard, and the design space (predicate generalization, PIC, page discipline) with measurements. |
 | [`bop_redefinition.md`](bop_redefinition.md) | JA | design record | What licenses inlining `1 + 2`, what happens when Ruby revokes it, and why the current all-or-nothing response is both too narrow (silently wrong answers) and too blunt (24× slower, permanently). Measured against CRuby. |
 | [`handoff_record_stream.md`](handoff_record_stream.md) | EN | plan / history | Handoff note for the record-driven lowering work; a summary of `regalloc_separation.md` §12–21 as of that branch. |
-| [`chain_deopt.md`](chain_deopt.md) | EN | plan | Dropping a whole suspended JIT chain back to the interpreter in one step, so a speculation broken deep inside can be undone. What the VM already provides, one attempt that fails and why, and the return-type inference the mechanism would buy back. |
+| [`chain_deopt.md`](chain_deopt.md) | EN | plan | Dropping a whole suspended JIT chain back to the interpreter in one step, so a speculation broken deep inside can be undone. What the VM already provides, one attempt that fails and why, and the return-type inference the mechanism would buy back. §8 records the implemented mechanism (and where it departs from the plan); the speculation itself is still unbuilt. |
 
 ## Runtime services
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -44,6 +44,7 @@ Two things to know before reading:
 | [`polymorphic_call.md`](polymorphic_call.md) | JA | plan | Receiver-polymorphic call sites: why `x.nil?` / `x == nil` deopt on every nil receiver, the implemented nil-tolerant guard, and the design space (predicate generalization, PIC, page discipline) with measurements. |
 | [`bop_redefinition.md`](bop_redefinition.md) | JA | design record | What licenses inlining `1 + 2`, what happens when Ruby revokes it, and why the current all-or-nothing response is both too narrow (silently wrong answers) and too blunt (24× slower, permanently). Measured against CRuby. |
 | [`handoff_record_stream.md`](handoff_record_stream.md) | EN | plan / history | Handoff note for the record-driven lowering work; a summary of `regalloc_separation.md` §12–21 as of that branch. |
+| [`chain_deopt.md`](chain_deopt.md) | EN | plan | Dropping a whole suspended JIT chain back to the interpreter in one step, so a speculation broken deep inside can be undone. What the VM already provides, one attempt that fails and why, and the return-type inference the mechanism would buy back. |
 
 ## Runtime services
 

--- a/doc/chain_deopt.md
+++ b/doc/chain_deopt.md
@@ -5,8 +5,15 @@ exercised end-to-end, and the **escalation half of step 4** — the per-frame
 switch that makes every interpreter-resuming side exit run the chain-deopt
 walk, plus the runtime entry it calls — is in place (§8.6). The speculation
 itself (the `Float` guard and the `locals_to_S` relaxation, §5 steps 4–5) and
-the return-state recovery (§6) are not. §8 records what was built, and the
-places the built thing deliberately differs from the design below.
+the return-state recovery (§6) are not. §8 records what was built.
+
+**⚠ Before starting §5 step 5, read §9.** The built mechanism writes the
+suspended frames back **lazily** (each frame converts as its `ret` reaches
+its chain-exit handler). That deviates from the intended design — the walk
+is supposed to write every frame back **eagerly**, at deopt time — and the
+deviation is masked only for as long as `locals_to_S` still boxes every
+local before a block call. The speculation removes exactly that masking, so
+the lazy form must be converted to eager *first*.
 
 ---
 
@@ -442,3 +449,70 @@ the two coexist in one chain.
 | Runtime table, the walks | `chain_deopt_table`, `register_chain_exit`, `chain_deopt`, `evict_suspended_frames` (`codegen.rs`) |
 | Escalation switch + runtime entry | `JitContext::escalate_side_exits` (`jitgen/context.rs`), `AsmIr::escalate_exits` (`jitgen/asmir.rs`), `runtime::chain_deopt` (`codegen/runtime.rs`) |
 | Return-address writer | `Cfp::set_return_addr` (`executor/frame.rs`) |
+
+## 9. The lazy write-back is a deviation — make it eager before step 5
+
+### 9.1 What the built mechanism actually does
+
+`Codegen::chain_deopt` (`codegen.rs`) rewrites each suspended frame's
+return-address slot to that site's chain-exit handler — **and nothing
+else**. The frame's write-back runs only when control returns to it: the
+innermost frame `ret`s, lands in the handler, the handler writes that one
+frame back and tails into the VM continuation; then the next frame out, and
+so on. Only the frame that *raised* the deopt is written back eagerly (by
+its own escalated side exit, before it calls `runtime::chain_deopt`).
+
+So immediately after a deopt in `A → B → C` at `C`:
+
+| frame | local slots |
+|---|---|
+| C | correct (its own side exit wrote them) |
+| B, A | **stale** — write-back deferred to their `ret`s |
+
+### 9.2 Why that is wrong, and why nothing catches it today
+
+The intended design (§2) is that the walk converts the whole chain at deopt
+time: **all** frames written back, return addresses pointed at the **VM's
+shared post-call continuation** — control never re-enters JIT code, and no
+per-site handler exists at all. (Note the tension in the built form: a
+per-site handler is only reachable *because* the return address points at
+it rather than at the VM — the lazy write-back and the per-site handlers
+are two faces of the same deviation.)
+
+The soundness gap: once `C` is running in the interpreter, anything that
+reads an outer frame's locals through `outer_lfp` — a block body touching
+`A`'s variables, `binding`, a backtrace with argument values — reads `A`'s
+**slots**, which still hold whatever was there before `A`'s floats were
+promoted to `LinkMode::F`. Today this cannot be observed solely because
+`locals_to_S` boxes every local into its slot before *every* block-passing
+call, so every frame on an `outer` chain happens to have correct slots.
+§5 step 5 removes exactly that guarantee; the lazy form breaks the moment
+it lands.
+
+The `chain-deopt` feature suite (3203/3203 green) is therefore a regression
+base for the *conversion machinery* — stack rewriting, `ret`-entry handler
+state, unwind interaction — not evidence that lazy write-back is sound.
+
+### 9.3 The conversion
+
+1. Extend the walk to replay each suspended frame's write-back **during**
+   `chain_deopt`, then point its return address at the shared VM entry
+   (§3.1 / §8.2's corrected form of it).
+2. The replay needs, per return address: the `WriteBack`, the frame's spill
+   `base`, and the site's `UsingFpr` save-area layout. §8.1 already
+   recorded the layout facts: pool registers live `rsp`-relative at the
+   call (`callee_rbp + 32 + 8i`, one slot per set bit of `UsingFpr`, bit
+   order); spilled `FPReg`s (`>= PHYS_FPR_POOL`) are `base`-relative.
+   `forward_rest` / `forward_kwrest` can call the existing `create_array` /
+   `correct_rest_kw` from Rust — GC-safe because every source value is in a
+   scanned frame slot.
+3. Remove the per-site chain-exit handlers and the `DestLabel` table —
+   `chain_deopt_table` maps `return_addr` to the replay data instead.
+   This also deletes the §8.2/§8.4 complexity (handler continuations, the
+   unwind-path interaction) that existed only to serve `ret`-entry.
+4. Re-run the `chain-deopt` feature suite; it must stay green through the
+   conversion.
+
+Ordering: this precedes §5 steps 4–5. The firing point (step 4's guard) can
+land together with it, but the `locals_to_S` relaxation must not land before
+it.

--- a/doc/chain_deopt.md
+++ b/doc/chain_deopt.md
@@ -1,7 +1,9 @@
 # Chain deopt — handoff note
 
-**Kind:** plan. **Status:** nothing implemented; this records what was
-verified, what was tried and rejected, and the order the work should go in.
+**Kind:** plan. **Status:** the *mechanism* (§5 steps 1–3) is implemented and
+exercised end-to-end; the speculation it exists for (§5 steps 4–5) and the
+return-state recovery (§6) are not. §8 records what was built, and the one
+place the built thing deliberately differs from the design below.
 
 ---
 
@@ -166,6 +168,9 @@ targeting the VM entry (§3.1), where `vm_store_rdi` does the store.
 
 ## 5. Order of work
 
+Steps 1–3 are done — see §8, and note that step 1 was built differently
+(and much more cheaply) than written here.
+
 1. **Runtime table** `return_addr -> (WriteBack, spill base)`, plus the Rust
    routine that replays one against a frame's `rbp`/`lfp`.
 2. **Expose the VM entry**: bind a label at `done:` and publish its address.
@@ -241,3 +246,124 @@ The constraints that force this:
   `binding` / `Binding#local_variable_get`, generic (non-specialized) block
   invocation, `move_frame_to_heap`, backtraces — and the interpreter itself
   once *the block* deopts and the VM runs the block's body.
+
+## 8. What is implemented (§5 steps 1–3)
+
+### 8.1 The write-back is replayed by emitted code, not from Rust
+
+Step 1 above asks for a runtime table `return_addr -> (WriteBack, spill
+base)` and a Rust routine that replays a `WriteBack` against a frame. That
+is **not** what was built, for two reasons found while building it.
+
+First, §3.3's premise is wrong in an important detail. It says `FprSave` has
+already spilled a suspended frame's live floats "into that frame's own spill
+area" — the `base`-relative region a Rust replay could read. It has not:
+`fpr_save_with_cont` saves the *pool-resident* registers to an `rsp`-relative
+area it allocates at the call (`[rsp + 16 + 8i]`, one slot per set bit of
+that site's `UsingFpr`, in bit order). Only the already-*spilled* `FPReg`s —
+ids `>= PHYS_FPR_POOL`, the minority — are `base`-relative. The values are
+still recoverable (the save area sits at `callee_rbp + 32 + 8i`, since
+`callee_rbp == rsp_after_FprSave - 16`), but a Rust replay would have to
+carry each site's `UsingFpr`, reproduce that layout, and do it again for
+aarch64's differently-shaped `d`-register area.
+
+Second, the replay is not a memory shuffle even after that: `forward_rest` /
+`forward_kwrest` (§3.3) mean re-implementing `create_array` /
+`correct_rest_kw` argument marshalling in Rust, against the same two frame
+layouts.
+
+So instead each call site gets a **chain-exit handler** on the cold page —
+`SideExit::ChainExit` / `LSideExitKind::ChainExit`, emitted by
+`gen_chain_exit_with_label` (x86) and `a64_gen_chain_exit` (aarch64), and the
+runtime table is `return_addr -> DestLabel` (`Codegen::chain_deopt_table`).
+The handler reuses `gen_write_back_for_deopt` verbatim, so there is one
+write-back implementation per arch rather than two, and no chance of the
+Rust copy drifting from the emitted one. The cost is cold code per call
+site, roughly doubling what the existing per-site `Evict` handler already
+costs — which is why emission is gated for now (§8.3).
+
+The handler is entered by `ret`, so it starts from the register state the
+normal return continuation would see — `rbp` restored, `rax` holding the
+callee's result, `r14` still the *callee's* LFP, `rsp` on the cont frame with
+the `FprSave` area above it. It therefore:
+
+1. runs the `pop_frame` the hijacked `ret` skipped — restoring
+   `Executor::cfp` and `r14`. This has to be **first**, not merely before the
+   VM hand-off: the write-back boxes floats and can materialize a deferred
+   rest `Array`, both of which allocate, and the GC marks from
+   `Executor::cfp`, which on entry still names the callee frame that has just
+   been torn down;
+2. reloads the FP pool from the save area **without** popping it
+   (`fpr_reload_cont`) — `rsp` has to stay on the cont frame;
+3. stashes `rax` in the callee's dead frame header (a 16-byte adjustment, so
+   the boxing calls in the write-back stay 16-byte aligned);
+4. runs `gen_write_back_for_deopt`;
+5. restores `rax` and jumps to the VM's post-call continuation (which repeats
+   the `pop_frame`; it is idempotent).
+
+### 8.2 The VM entry is one instruction earlier than §3.1 says
+
+§3.1 names `done:` as the entry to bind. `done:` sits *after*
+`vm_call`'s trailing `pop_frame`, and a hijacked `ret` skips the JIT frame's
+own `pop_frame` — so a frame resumed at `done:` would run with
+`Executor::cfp` and `r14` still pointing at the callee. The published address
+(`Codegen::vm_call_continuation`) is therefore the return address of
+`call_funcdata`'s `call`, one step earlier, so the VM's own `pop_frame` runs.
+Everything else in §3.1 holds: the sequence is entirely stack-driven, so the
+one address serves every send and yield site, on both arches
+(x86 `vm_send`, aarch64 `a64_op_send` just past its `blr`).
+
+### 8.3 How it is exercised without a firing point
+
+Steps 4–5 do not exist yet, so nothing in a normal build calls
+`Codegen::chain_deopt`. The `chain-deopt` cargo feature (default-off) routes
+`check_bop_redefine` through the walk instead of `immediate_eviction`. The
+two are observationally equivalent — both convert every suspended JIT frame
+into an interpreter frame — and `tests/redefine.rs` already covers exactly
+this shape: `redefine_bop_onstack_caller` fails with the stale inlined `+`
+(8 instead of 999) if the suspended caller resumes its compiled body, so the
+test passing under the feature is a positive signal that the conversion
+happened, not just that nothing crashed.
+
+What this validates: the walk, the return-address rewrite, the handler's
+frame/LFP/FP-pool restore, the write-back, and the hand-off to the VM
+continuation, across normal calls, generic yields, and specialized
+calls/yields. What it does **not** validate is the case chain deopt exists
+for — a frame whose local is *unboxed at the moment of conversion* — because
+under BOP eviction the innermost frame still deopts through its own handler
+first.
+
+The producers (`AbstractState::chain_exit`) are gated on the same feature, so
+a default build emits no chain-exit handlers at all and pays nothing. When
+step 4 lands, that gate becomes the per-site decision §6 argues for rather
+than a build-wide switch.
+
+### 8.4 A rewritten return-address slot is also on the unwind path
+
+Worth knowing before building step 4, because it is not obvious: an
+exception does **not** bypass the rewritten slot. `entry_raise` with no
+in-frame handler unwinds by running the frame's ordinary epilogue and
+`ret`ing with the error signal in `rax`/`x0` — so a propagating exception
+lands in the chain-exit handler too, and the handler's tail hands it to the
+VM continuation's `vm_handle_error`, which re-raises from the now-converted
+frame at the call site. Non-local exits (`MethodReturn`, `Break`) take the
+same route, including `method_return_specialized`, which lands in the
+handler belonging to the *outermost* inlined call — the one whose `dst` the
+value is destined for.
+
+This is what we want (the frame is converted before the VM inspects it for
+a `rescue`), and it means the handler must be correct for `rax == 0`, not
+only for a normal return. It is: the write-back does not read `rax`, and the
+stash/restore preserves the zero.
+
+### 8.5 Where the code is
+
+| Piece | Location |
+|---|---|
+| `AsmChain`, `SideExit::ChainExit`, `AsmInst::ChainExit`, `new_chain_exit` | `jitgen/asmir.rs` |
+| `LSideExitKind::ChainExit`, `LInst::ChainExit` | `jitgen/lir.rs` |
+| Producers (call / specialized call / yield / specialized yield) | `AbstractState::chain_exit`, `jitgen/compile/method_call.rs` |
+| Handler emission | `gen_chain_exit_with_label` (`jitgen.rs`), `a64_gen_chain_exit` (`arch/aarch64/compile/mod.rs`) |
+| FP-pool reload without popping | `fpr_reload_cont` / `a64_fpr_reload_cont` |
+| Runtime table, VM entry, the walk | `chain_deopt_table`, `vm_call_continuation`, `register_chain_exit`, `chain_deopt` (`codegen.rs`) |
+| Return-address writer | `Cfp::set_return_addr` (`executor/frame.rs`) |

--- a/doc/chain_deopt.md
+++ b/doc/chain_deopt.md
@@ -1,9 +1,12 @@
 # Chain deopt — handoff note
 
 **Kind:** plan. **Status:** the *mechanism* (§5 steps 1–3) is implemented and
-exercised end-to-end; the speculation it exists for (§5 steps 4–5) and the
-return-state recovery (§6) are not. §8 records what was built, and the one
-place the built thing deliberately differs from the design below.
+exercised end-to-end, and the **escalation half of step 4** — the per-frame
+switch that makes every interpreter-resuming side exit run the chain-deopt
+walk, plus the runtime entry it calls — is in place (§8.6). The speculation
+itself (the `Float` guard and the `locals_to_S` relaxation, §5 steps 4–5) and
+the return-state recovery (§6) are not. §8 records what was built, and the
+places the built thing deliberately differs from the design below.
 
 ---
 
@@ -301,41 +304,66 @@ the `FprSave` area above it. It therefore:
 5. restores `rax` and jumps to the VM's post-call continuation (which repeats
    the `pop_frame`; it is idempotent).
 
-### 8.2 The VM entry is one instruction earlier than §3.1 says
+### 8.2 The handler carries its own continuation — §3.1's shared VM entry was wrong
 
-§3.1 names `done:` as the entry to bind. `done:` sits *after*
-`vm_call`'s trailing `pop_frame`, and a hijacked `ret` skips the JIT frame's
-own `pop_frame` — so a frame resumed at `done:` would run with
-`Executor::cfp` and `r14` still pointing at the callee. The published address
-(`Codegen::vm_call_continuation`) is therefore the return address of
-`call_funcdata`'s `call`, one step earlier, so the VM's own `pop_frame` runs.
-Everything else in §3.1 holds: the sequence is entirely stack-driven, so the
-one address serves every send and yield site, on both arches
-(x86 `vm_send`, aarch64 `a64_op_send` just past its `blr`).
+§3.1 proposes tailing every handler into the VM's shared post-call
+continuation, on the grounds that the sequence is entirely stack-driven and
+carries no per-site state. That was **built first and then torn out**, for a
+reason §3.1 missed: the shared continuation re-derives the destination slot
+and the resume pc from the bytecode **assuming a 2-unit send instruction**
+(`movzxw rdi, [r13 + 4]`; `addq r13, 32`; on error `entry_raise`'s
+`r13 - 16` lands on the send's second unit, which the exception table still
+covers *for sends*). But operator call sites — `BinOp` / `Index` / …,
+**1-unit** bytecodes — dispatch through the same `send` emitter and get
+chain-exit handlers too. At such a site the shared continuation reads a
+garbage destination slot, resumes one whole instruction too far, and on a
+propagating exception looks up the exception table at the *following*
+instruction — which silently skips an `ensure` whose protected range ends at
+the operator (found by `Enumerator.new { |y| begin; y << 1; ensure; … }`
+with a raising consumer block, once every error exit escalated).
+
+So the handler now runs its **own per-site continuation** — it statically
+knows the call's `dst` slot and site pc: drop the cont frame, test the
+result; store into `dst` and resume the fetch loop at `pc.next()` (which is
+per-opcode-size correct), or on the error signal hand the *call-site* pc to
+`entry_raise` under each arch's convention (x86 `pc + 1` before the `-16`,
+aarch64 `pc` unchanged). The `Codegen::vm_call_continuation` publication has
+been removed. The cont-frame pc slot is still written at every site
+(`Kernel#caller` reads it) but the handler no longer consumes it.
+
+A hijacked `ret` still skips the JIT frame's own `pop_frame`, so the handler
+performs it first — before the write-back, whose boxing/materializing calls
+can GC, and the mark walk starts from `Executor::cfp`.
 
 ### 8.3 How it is exercised without a firing point
 
-Steps 4–5 do not exist yet, so nothing in a normal build calls
-`Codegen::chain_deopt`. The `chain-deopt` cargo feature (default-off) routes
-`check_bop_redefine` through the walk instead of `immediate_eviction`. The
-two are observationally equivalent — both convert every suspended JIT frame
-into an interpreter frame — and `tests/redefine.rs` already covers exactly
-this shape: `redefine_bop_onstack_caller` fails with the stale inlined `+`
-(8 instead of 999) if the suspended caller resumes its compiled body, so the
-test passing under the feature is a positive signal that the conversion
-happened, not just that nothing crashed.
+Steps 4–5's speculation does not exist yet, so nothing in a normal build
+calls `Codegen::chain_deopt`. Under the `chain-deopt` cargo feature
+(default-off) two things exercise it:
+
+* **BOP eviction** converts by chain instead of by patching: the walks are
+  observationally equivalent — both convert every suspended JIT frame into
+  an interpreter frame — and `tests/redefine.rs` already covers exactly this
+  shape: `redefine_bop_onstack_caller` fails with the stale inlined `+`
+  (8 instead of 999) if the suspended caller resumes its compiled body, so
+  the test passing under the feature is a positive signal that the
+  conversion happened, not just that nothing crashed.
+* **Every side exit escalates** (§8.6): each deopt / recompile-deopt / error
+  exit taken anywhere in the suite fires the walk from the deopting frame,
+  so the deopt → walk → handler-cascade path — the one the speculation will
+  actually take — is exercised at every deopt site the suite reaches, not
+  only at BOP redefinitions.
 
 What this validates: the walk, the return-address rewrite, the handler's
 frame/LFP/FP-pool restore, the write-back, and the hand-off to the VM
 continuation, across normal calls, generic yields, and specialized
 calls/yields. What it does **not** validate is the case chain deopt exists
 for — a frame whose local is *unboxed at the moment of conversion* — because
-under BOP eviction the innermost frame still deopts through its own handler
-first.
+without the `locals_to_S` relaxation no suspended frame ever holds one.
 
 The producers (`AbstractState::chain_exit`) are gated on the same feature, so
 a default build emits no chain-exit handlers at all and pays nothing. When
-step 4 lands, that gate becomes the per-site decision §6 argues for rather
+step 5 lands, that gate becomes the per-site decision §6 argues for rather
 than a build-wide switch.
 
 ### 8.4 A rewritten return-address slot is also on the unwind path
@@ -344,9 +372,10 @@ Worth knowing before building step 4, because it is not obvious: an
 exception does **not** bypass the rewritten slot. `entry_raise` with no
 in-frame handler unwinds by running the frame's ordinary epilogue and
 `ret`ing with the error signal in `rax`/`x0` — so a propagating exception
-lands in the chain-exit handler too, and the handler's tail hands it to the
-VM continuation's `vm_handle_error`, which re-raises from the now-converted
-frame at the call site. Non-local exits (`MethodReturn`, `Break`) take the
+lands in the chain-exit handler too, and the handler's error branch (§8.2)
+hands the call-site pc to `entry_raise`, which re-raises from the
+now-converted frame at the call site — running its `rescue`/`ensure` there
+or unwinding further. Non-local exits (`MethodReturn`, `Break`) take the
 same route, including `method_return_specialized`, which lands in the
 handler belonging to the *outermost* inlined call — the one whose `dst` the
 value is destined for.
@@ -356,7 +385,52 @@ a `rescue`), and it means the handler must be correct for `rax == 0`, not
 only for a normal return. It is: the write-back does not read `rax`, and the
 stash/restore preserves the zero.
 
-### 8.5 Where the code is
+### 8.5 Escalating side exits (§5 step 4's mechanism, §6's mechanical guarantee)
+
+A frame compiled under the speculation must convert its suspended callers on
+**every** path that resumes the interpreter in-frame, not just the `Float`
+guard on the offending store: once the interpreter runs any of the frame's
+bytecode it can reach an outer local through `Load/StoreDynVar`, a `binding`,
+or a capture, and would read the stale slot. §6 asks for a mechanical
+guarantee rather than review discipline, and this is it:
+
+* `JitContext::escalate_side_exits` is the single decision point. It is
+  stamped onto each `AsmIr` at construction, and **every** side-exit
+  constructor (`new_deopt` / `new_deopt_with_pc` / `deopt_from_point` /
+  `new_recompile_deopt` / `new_error`) reads it — an emitter cannot forget
+  to escalate because emitters do not choose. Today it returns
+  `cfg!(feature = "chain-deopt")`; the per-frame speculation flag ORs in
+  here when step 5 lands.
+* An escalated `Deoptimize` / `RecompileDeoptimize` / `Error` handler calls
+  `runtime::chain_deopt(vm)` **after** its write-back (the frame is fully
+  homed, and the walk itself allocates nothing) and before resuming the
+  fetch loop / entering `entry_raise`. The walk starts at the deopting
+  frame's own cfp, so its own return-address slot is rewritten too — that is
+  what converts its caller when the now-interpreted frame eventually
+  returns.
+* `Error` exits escalate because a raise can be rescued *in-frame* (an
+  interpreter resume like any deopt) or unwind through the suspended callers
+  — §8.4's path, which requires the slots to have been rewritten.
+* `Evict` handlers do **not** escalate: they are only entered through the
+  chain-wide eviction walk below, which has already converted (or patched)
+  every suspended frame in one pass.
+
+The walk stops converting where the table stops: an unregistered return
+address marks the boundary of the compilation region that speculated, and
+frames beyond it hold no unboxed cross-frame state, so they may resume their
+compiled bodies. (Under the validation feature every site registers, so the
+walk converts everything — strictly more conversion than needed, which is
+sound for the same reason BOP eviction is.)
+
+BOP eviction itself now goes through one unified walk
+(`Codegen::evict_suspended_frames`): per suspended frame it prefers the
+site's chain-exit handler (rewrite the return-address slot, leave the code
+untouched) and falls back to the recorded patch point (`jmp deopt` written
+into the code). A default build has no chain entries and degenerates to pure
+patching; the feature build is pure chain deopt; with per-site speculation
+the two coexist in one chain.
+
+### 8.6 Where the code is
 
 | Piece | Location |
 |---|---|
@@ -365,5 +439,6 @@ stash/restore preserves the zero.
 | Producers (call / specialized call / yield / specialized yield) | `AbstractState::chain_exit`, `jitgen/compile/method_call.rs` |
 | Handler emission | `gen_chain_exit_with_label` (`jitgen.rs`), `a64_gen_chain_exit` (`arch/aarch64/compile/mod.rs`) |
 | FP-pool reload without popping | `fpr_reload_cont` / `a64_fpr_reload_cont` |
-| Runtime table, VM entry, the walk | `chain_deopt_table`, `vm_call_continuation`, `register_chain_exit`, `chain_deopt` (`codegen.rs`) |
+| Runtime table, the walks | `chain_deopt_table`, `register_chain_exit`, `chain_deopt`, `evict_suspended_frames` (`codegen.rs`) |
+| Escalation switch + runtime entry | `JitContext::escalate_side_exits` (`jitgen/context.rs`), `AsmIr::escalate_exits` (`jitgen/asmir.rs`), `runtime::chain_deopt` (`codegen/runtime.rs`) |
 | Return-address writer | `Cfp::set_return_addr` (`executor/frame.rs`) |

--- a/doc/chain_deopt.md
+++ b/doc/chain_deopt.md
@@ -1,19 +1,15 @@
 # Chain deopt — handoff note
 
 **Kind:** plan. **Status:** the *mechanism* (§5 steps 1–3) is implemented and
-exercised end-to-end, and the **escalation half of step 4** — the per-frame
-switch that makes every interpreter-resuming side exit run the chain-deopt
-walk, plus the runtime entry it calls — is in place (§8.6). The speculation
-itself (the `Float` guard and the `locals_to_S` relaxation, §5 steps 4–5) and
-the return-state recovery (§6) are not. §8 records what was built.
-
-**⚠ Before starting §5 step 5, read §9.** The built mechanism writes the
-suspended frames back **lazily** (each frame converts as its `ret` reaches
-its chain-exit handler). That deviates from the intended design — the walk
-is supposed to write every frame back **eagerly**, at deopt time — and the
-deviation is masked only for as long as `locals_to_S` still boxes every
-local before a block call. The speculation removes exactly that masking, so
-the lazy form must be converted to eager *first*.
+exercised end-to-end **in its eager form** — the walk replays every suspended
+frame's write-back at deopt time and points its return-address slot at one
+shared VM continuation stub (§9.3's conversion has landed; §8 describes the
+implementation). The **escalation half of step 4** — the per-frame switch
+that makes every interpreter-resuming side exit run the chain-deopt walk,
+plus the runtime entry it calls — is in place (§8.6). The speculation itself
+(the `Float` guard and the `locals_to_S` relaxation, §5 steps 4–5) and the
+return-state recovery (§6) are not. §9 stays as the record of why the
+original lazy build was wrong.
 
 ---
 
@@ -178,8 +174,8 @@ targeting the VM entry (§3.1), where `vm_store_rdi` does the store.
 
 ## 5. Order of work
 
-Steps 1–3 are done — see §8, and note that step 1 was built differently
-(and much more cheaply) than written here.
+Steps 1–3 are done, essentially as written (after a detour through a lazy
+per-site-handler form — §9) — see §8.
 
 1. **Runtime table** `return_addr -> (WriteBack, spill base)`, plus the Rust
    routine that replays one against a frame's `rbp`/`lfp`.
@@ -257,90 +253,106 @@ The constraints that force this:
   invocation, `move_frame_to_heap`, backtraces — and the interpreter itself
   once *the block* deopts and the VM runs the block's body.
 
-## 8. What is implemented (§5 steps 1–3)
+## 8. What is implemented (§5 steps 1–3, eager form)
 
-### 8.1 The write-back is replayed by emitted code, not from Rust
+### 8.1 The write-back is replayed from Rust, at deopt time
 
-Step 1 above asks for a runtime table `return_addr -> (WriteBack, spill
-base)` and a Rust routine that replays a `WriteBack` against a frame. That
-is **not** what was built, for two reasons found while building it.
+Step 1's runtime table exists as designed: `Codegen::chain_deopt_table` maps
+a call's return address to a `ChainReplay` (`jitgen.rs`) carrying the site's
+`WriteBack`, the frame's spill `base`, the site's `UsingFpr`, the call's
+`dst` slot, and the call-site pc. The walk clones the entry and
+`ChainReplay::replay` writes the suspended caller frame back **during the
+walk**, in Rust.
 
-First, §3.3's premise is wrong in an important detail. It says `FprSave` has
-already spilled a suspended frame's live floats "into that frame's own spill
-area" — the `base`-relative region a Rust replay could read. It has not:
-`fpr_save_with_cont` saves the *pool-resident* registers to an `rsp`-relative
-area it allocates at the call (`[rsp + 16 + 8i]`, one slot per set bit of
-that site's `UsingFpr`, in bit order). Only the already-*spilled* `FPReg`s —
-ids `>= PHYS_FPR_POOL`, the minority — are `base`-relative. The values are
-still recoverable (the save area sits at `callee_rbp + 32 + 8i`, since
-`callee_rbp == rsp_after_FprSave - 16`), but a Rust replay would have to
-carry each site's `UsingFpr`, reproduce that layout, and do it again for
-aarch64's differently-shaped `d`-register area.
+Layout facts the replay depends on (each re-verified against the emission
+code; they are load-bearing now):
 
-Second, the replay is not a memory shuffle even after that: `forward_rest` /
-`forward_kwrest` (§3.3) mean re-implementing `create_array` /
-`correct_rest_kw` argument marshalling in Rust, against the same two frame
-layouts.
+* Every frame — VM, JIT, native wrapper — establishes `bp == cfp + BP_CFP`
+  in its prologue (`Cfp::frame_bp`), so `callee_rbp = callee_cfp + 8` and
+  the caller's saved bp is `[callee_rbp]`.
+* §3.3's premise was wrong in one detail: `FprSave` does **not** spill the
+  pool-resident floats into the frame's `base`-relative spill area. The
+  cont-mode save (`fpr_save_with_cont` / `emit_fpr_save`) puts them in an
+  `rsp`-relative area allocated at the call — one 8-byte slot per set bit of
+  the site's `UsingFpr`, in bit order, at `[rsp + 16 + 8i]` — which after
+  the call/prologue sits at **`callee_rbp + 32 + 8i`** (since
+  `callee_rbp == rsp_after_FprSave - 16`). The formula is byte-identical on
+  aarch64 (`emit_fpr_save` mirrors the x86 shape; `stp x29, x30` is the same
+  16-byte adjustment as `call` + `pushq rbp`), so one arch-neutral replay
+  serves both.
+* Spilled `FPReg`s (ids `>= PHYS_FPR_POOL`) live `base`-relative in the
+  caller frame: `[caller_rbp - (base - 24 + 8n)]` (`PhysMap::resolve`,
+  shared by both arches).
+* The caller's LFP is read through `caller_cfp.lfp()` — the cfp slot is
+  redirected when a frame is promoted to the heap, exactly like the `r14`
+  the emitted deopt write-back uses.
 
-So instead each call site gets a **chain-exit handler** on the cold page —
-`SideExit::ChainExit` / `LSideExitKind::ChainExit`, emitted by
-`gen_chain_exit_with_label` (x86) and `a64_gen_chain_exit` (aarch64), and the
-runtime table is `return_addr -> DestLabel` (`Codegen::chain_deopt_table`).
-The handler reuses `gen_write_back_for_deopt` verbatim, so there is one
-write-back implementation per arch rather than two, and no chance of the
-Rust copy drifting from the emitted one. The cost is cold code per call
-site, roughly doubling what the existing per-site `Evict` handler already
-costs — which is why emission is gated for now (§8.3).
+`forward_rest` / `forward_kwrest` call `runtime::create_array` /
+`runtime::kwrest_hash` (the `correct_rest_kw` equivalent) from Rust, against
+the dynamic caller's frame reached through the saved bp — the same
+addressing the emitted `gen_forward_rest_materialize` /
+`gen_forward_kwrest_materialize` use. They run after the fpr/literal/void
+stores, so every deferred `dst` slot already holds its `nil` and the frame
+stays GC-consistent across the allocating helper calls. GC safety overall:
+slots always hold whole, valid (possibly stale) `Value`s, and the GC scans
+them as such, so the replay may allocate at any point.
 
-The handler is entered by `ret`, so it starts from the register state the
-normal return continuation would see — `rbp` restored, `rax` holding the
-callee's result, `r14` still the *callee's* LFP, `rsp` on the cont frame with
-the `FprSave` area above it. It therefore:
+Because the replay allocates, it must not run under the `CODEGEN` borrow:
+the walks (`Codegen::chain_deopt`, `Codegen::evict_suspended_frames`) only
+**collect** a `Vec<ChainConversion>` plan; the callers
+(`runtime::chain_deopt`, `Codegen::check_bop_redefine`) apply it after the
+borrow is released. Write-back order within one frame is fixed (deferred
+materialization last); frames are applied in walk order, which is sound
+because the replays touch disjoint frames (rest/kwrest sources are raw
+slots, valid regardless of conversion order).
 
-1. runs the `pop_frame` the hijacked `ret` skipped — restoring
-   `Executor::cfp` and `r14`. This has to be **first**, not merely before the
-   VM hand-off: the write-back boxes floats and can materialize a deferred
-   rest `Array`, both of which allocate, and the GC marks from
-   `Executor::cfp`, which on entry still names the callee frame that has just
-   been torn down;
-2. reloads the FP pool from the save area **without** popping it
-   (`fpr_reload_cont`) — `rsp` has to stay on the cont frame;
-3. stashes `rax` in the callee's dead frame header (a 16-byte adjustment, so
-   the boxing calls in the write-back stay 16-byte aligned);
-4. runs `gen_write_back_for_deopt`;
-5. restores `rax` and jumps to the VM's post-call continuation (which repeats
-   the `pop_frame`; it is idempotent).
+### 8.2 One shared continuation stub — §3.1's raw VM entry is still wrong, the pad slot fixes it
 
-### 8.2 The handler carries its own continuation — §3.1's shared VM entry was wrong
-
-§3.1 proposes tailing every handler into the VM's shared post-call
-continuation, on the grounds that the sequence is entirely stack-driven and
-carries no per-site state. That was **built first and then torn out**, for a
-reason §3.1 missed: the shared continuation re-derives the destination slot
-and the resume pc from the bytecode **assuming a 2-unit send instruction**
+§3.1 proposes pointing every rewritten return-address slot at the VM's
+shared post-call continuation, on the grounds that the sequence is entirely
+stack-driven and carries no per-site state. That is wrong for a reason §3.1
+missed: the shared continuation re-derives the destination slot and the
+resume pc from the bytecode **assuming a 2-unit send instruction**
 (`movzxw rdi, [r13 + 4]`; `addq r13, 32`; on error `entry_raise`'s
 `r13 - 16` lands on the send's second unit, which the exception table still
 covers *for sends*). But operator call sites — `BinOp` / `Index` / …,
-**1-unit** bytecodes — dispatch through the same `send` emitter and get
-chain-exit handlers too. At such a site the shared continuation reads a
-garbage destination slot, resumes one whole instruction too far, and on a
+**1-unit** bytecodes — dispatch through the same `send` emitter and register
+for chain deopt too. At such a site the raw VM continuation reads a garbage
+destination slot, resumes one whole instruction too far, and on a
 propagating exception looks up the exception table at the *following*
 instruction — which silently skips an `ensure` whose protected range ends at
 the operator (found by `Enumerator.new { |y| begin; y << 1; ensure; … }`
 with a raising consumer block, once every error exit escalated).
 
-So the handler now runs its **own per-site continuation** — it statically
-knows the call's `dst` slot and site pc: drop the cont frame, test the
-result; store into `dst` and resume the fetch loop at `pc.next()` (which is
-per-opcode-size correct), or on the error signal hand the *call-site* pc to
-`entry_raise` under each arch's convention (x86 `pc + 1` before the `-16`,
-aarch64 `pc` unchanged). The `Codegen::vm_call_continuation` publication has
-been removed. The cont-frame pc slot is still written at every site
-(`Kernel#caller` reads it) but the handler no longer consumes it.
+The fix keeps §3.1's "one address serves every site" without decoding
+bytecode: **one** stub per arch (`gen_chain_cont_stub`, emitted with the VM
+handlers), plus a per-site continuation word the walk stores into the
+callee's **cont-frame pad slot** (`Cfp::set_cont_frame_data`, CFP+32 — the
+second half of the 16-byte cont frame, reserved by every caller and read by
+nothing on the normal return path). The word packs `conv(dst)` (0 = none)
+in the high 32 bits and the byte advance to the next instruction
+(`pc.next() - pc`, per-opcode-size correct: 16 or 32) in the low 32 bits.
 
-A hijacked `ret` still skips the JIT frame's own `pop_frame`, so the handler
-performs it first — before the write-back, whose boxing/materializing calls
-can GC, and the mark walk starts from `Executor::cfp`.
+Entered by `ret` — the frame's write-back already replayed at deopt time —
+the stub only has to:
+
+1. run the `pop_frame` the hijacked `ret` skipped (`rbp`/`x29`-derived, so
+   correct whatever the callee left in the global registers): restore
+   `Executor::cfp` and the LFP register;
+2. read the call-site pc from the cont frame's pc slot (`ContFramePc` wrote
+   it at every JIT site; `Kernel#caller` reads the same slot) and the
+   continuation word from the pad, then drop the cont frame;
+3. on the error signal (result 0), hand the call-site pc to `entry_raise`
+   under each arch's convention (x86 `pc + 1` before the `-16`, aarch64 `pc`
+   unchanged);
+4. otherwise store the result into `dst` (if any) and resume the fetch loop
+   at `pc + advance`.
+
+The stub never allocates, so no GC concern; the dead `FprSave` area above
+the cont frame is simply left below the frame, as every side exit leaves
+it. There are no per-site handlers, no `SideExit::ChainExit`, and no
+`fpr_reload_cont` — the pool registers are dead at the stub (the replay
+consumed the save area).
 
 ### 8.3 How it is exercised without a firing point
 
@@ -357,19 +369,19 @@ calls `Codegen::chain_deopt`. Under the `chain-deopt` cargo feature
   conversion happened, not just that nothing crashed.
 * **Every side exit escalates** (§8.6): each deopt / recompile-deopt / error
   exit taken anywhere in the suite fires the walk from the deopting frame,
-  so the deopt → walk → handler-cascade path — the one the speculation will
+  so the deopt → replay → stub-return path — the one the speculation will
   actually take — is exercised at every deopt site the suite reaches, not
   only at BOP redefinitions.
 
-What this validates: the walk, the return-address rewrite, the handler's
-frame/LFP/FP-pool restore, the write-back, and the hand-off to the VM
-continuation, across normal calls, generic yields, and specialized
-calls/yields. What it does **not** validate is the case chain deopt exists
-for — a frame whose local is *unboxed at the moment of conversion* — because
-without the `locals_to_S` relaxation no suspended frame ever holds one.
+What this validates: the walk, the eager replay, the return-address rewrite,
+the stub's frame/LFP restore and result/raise hand-off, across normal calls,
+generic yields, and specialized calls/yields. What it does **not** validate
+is the case chain deopt exists for — a frame whose local is *unboxed at the
+moment of conversion* — because without the `locals_to_S` relaxation no
+suspended frame ever holds one.
 
 The producers (`AbstractState::chain_exit`) are gated on the same feature, so
-a default build emits no chain-exit handlers at all and pays nothing. When
+a default build registers no chain entries at all and pays nothing. When
 step 5 lands, that gate becomes the per-site decision §6 argues for rather
 than a build-wide switch.
 
@@ -379,18 +391,18 @@ Worth knowing before building step 4, because it is not obvious: an
 exception does **not** bypass the rewritten slot. `entry_raise` with no
 in-frame handler unwinds by running the frame's ordinary epilogue and
 `ret`ing with the error signal in `rax`/`x0` — so a propagating exception
-lands in the chain-exit handler too, and the handler's error branch (§8.2)
+lands in the continuation stub too, and the stub's error branch (§8.2)
 hands the call-site pc to `entry_raise`, which re-raises from the
 now-converted frame at the call site — running its `rescue`/`ensure` there
 or unwinding further. Non-local exits (`MethodReturn`, `Break`) take the
-same route, including `method_return_specialized`, which lands in the
-handler belonging to the *outermost* inlined call — the one whose `dst` the
-value is destined for.
+same route, including `method_return_specialized`, whose `ret` lands in the
+stub via the slot belonging to the *outermost* inlined call — the one whose
+`dst` the value is destined for.
 
 This is what we want (the frame is converted before the VM inspects it for
-a `rescue`), and it means the handler must be correct for `rax == 0`, not
-only for a normal return. It is: the write-back does not read `rax`, and the
-stash/restore preserves the zero.
+a `rescue`), and it means the stub must be correct for `rax == 0`, not only
+for a normal return. It is: the error branch touches neither `dst` nor the
+advance, and the frame's write-back already ran at deopt time.
 
 ### 8.5 Escalating side exits (§5 step 4's mechanism, §6's mechanical guarantee)
 
@@ -410,11 +422,12 @@ guarantee rather than review discipline, and this is it:
   here when step 5 lands.
 * An escalated `Deoptimize` / `RecompileDeoptimize` / `Error` handler calls
   `runtime::chain_deopt(vm)` **after** its write-back (the frame is fully
-  homed, and the walk itself allocates nothing) and before resuming the
-  fetch loop / entering `entry_raise`. The walk starts at the deopting
-  frame's own cfp, so its own return-address slot is rewritten too — that is
-  what converts its caller when the now-interpreted frame eventually
-  returns.
+  homed) and before resuming the fetch loop / entering `entry_raise`. The
+  runtime entry collects the plan under the `CODEGEN` borrow and applies it
+  (replay + slot rewrite) after releasing it — the replay allocates (§8.1).
+  The walk starts at the deopting frame's own cfp, so its own
+  return-address slot is rewritten too — that is what converts its caller
+  when the now-interpreted frame eventually returns.
 * `Error` exits escalate because a raise can be rescued *in-frame* (an
   interpreter resume like any deopt) or unwind through the suspended callers
   — §8.4's path, which requires the slots to have been rewritten.
@@ -427,11 +440,15 @@ address marks the boundary of the compilation region that speculated, and
 frames beyond it hold no unboxed cross-frame state, so they may resume their
 compiled bodies. (Under the validation feature every site registers, so the
 walk converts everything — strictly more conversion than needed, which is
-sound for the same reason BOP eviction is.)
+sound for the same reason BOP eviction is.) A frame converted by an earlier
+walk is skipped the same way a VM frame is — its rewritten return address
+*is* a VM address (the stub) — which is load-bearing: interpreted inner
+frames may have updated its slots through `outer_lfp` since, and a second
+replay would clobber them with stale floats.
 
 BOP eviction itself now goes through one unified walk
 (`Codegen::evict_suspended_frames`): per suspended frame it prefers the
-site's chain-exit handler (rewrite the return-address slot, leave the code
+chain conversion (replay + return-address rewrite, leaving the code
 untouched) and falls back to the recorded patch point (`jmp deopt` written
 into the code). A default build has no chain entries and degenerates to pure
 patching; the feature build is pure chain deopt; with per-site speculation
@@ -441,16 +458,22 @@ the two coexist in one chain.
 
 | Piece | Location |
 |---|---|
-| `AsmChain`, `SideExit::ChainExit`, `AsmInst::ChainExit`, `new_chain_exit` | `jitgen/asmir.rs` |
-| `LSideExitKind::ChainExit`, `LInst::ChainExit` | `jitgen/lir.rs` |
+| `ChainExitSpec` (compile-time), `ChainReplay` + the Rust replay, `ChainConversion` | `jitgen.rs` |
+| `AsmInst::ChainExit` (registration, no code emitted) | `jitgen/asmir.rs`; lowered in `jitgen/asmir/compile_shared.rs` |
+| `LInst::ChainExit` | `jitgen/lir.rs` |
 | Producers (call / specialized call / yield / specialized yield) | `AbstractState::chain_exit`, `jitgen/compile/method_call.rs` |
-| Handler emission | `gen_chain_exit_with_label` (`jitgen.rs`), `a64_gen_chain_exit` (`arch/aarch64/compile/mod.rs`) |
-| FP-pool reload without popping | `fpr_reload_cont` / `a64_fpr_reload_cont` |
+| Shared continuation stub | `gen_chain_cont_stub` (`arch/x86_64/vmgen.rs`, `arch/aarch64/vmgen.rs`), address in `Codegen::chain_cont_stub` |
+| `kwrest_hash` (the `correct_rest_kw` equivalent for the replay) | `codegen/runtime.rs` |
 | Runtime table, the walks | `chain_deopt_table`, `register_chain_exit`, `chain_deopt`, `evict_suspended_frames` (`codegen.rs`) |
 | Escalation switch + runtime entry | `JitContext::escalate_side_exits` (`jitgen/context.rs`), `AsmIr::escalate_exits` (`jitgen/asmir.rs`), `runtime::chain_deopt` (`codegen/runtime.rs`) |
-| Return-address writer | `Cfp::set_return_addr` (`executor/frame.rs`) |
+| Frame writers/readers | `Cfp::set_return_addr`, `Cfp::set_cont_frame_data`, `Cfp::frame_bp` (`executor/frame.rs`) |
 
-## 9. The lazy write-back is a deviation — make it eager before step 5
+## 9. The lazy write-back was a deviation — record of the eager conversion
+
+**Resolved.** The mechanism was first built in a lazy, per-site-handler
+form; this section records what that form did, why it was unsound to build
+the speculation on, and the conversion plan — which has since landed (§8
+describes the eager implementation). §9.1–9.2 describe the *former* build.
 
 ### 9.1 What the built mechanism actually does
 
@@ -489,30 +512,34 @@ call, so every frame on an `outer` chain happens to have correct slots.
 §5 step 5 removes exactly that guarantee; the lazy form breaks the moment
 it lands.
 
-The `chain-deopt` feature suite (3203/3203 green) is therefore a regression
+The `chain-deopt` feature suite (3203/3203 green) was therefore a regression
 base for the *conversion machinery* — stack rewriting, `ret`-entry handler
-state, unwind interaction — not evidence that lazy write-back is sound.
+state, unwind interaction — not evidence that lazy write-back was sound.
 
-### 9.3 The conversion
+### 9.3 The conversion — landed
 
-1. Extend the walk to replay each suspended frame's write-back **during**
-   `chain_deopt`, then point its return address at the shared VM entry
-   (§3.1 / §8.2's corrected form of it).
-2. The replay needs, per return address: the `WriteBack`, the frame's spill
-   `base`, and the site's `UsingFpr` save-area layout. §8.1 already
-   recorded the layout facts: pool registers live `rsp`-relative at the
-   call (`callee_rbp + 32 + 8i`, one slot per set bit of `UsingFpr`, bit
-   order); spilled `FPReg`s (`>= PHYS_FPR_POOL`) are `base`-relative.
-   `forward_rest` / `forward_kwrest` can call the existing `create_array` /
-   `correct_rest_kw` from Rust — GC-safe because every source value is in a
-   scanned frame slot.
-3. Remove the per-site chain-exit handlers and the `DestLabel` table —
-   `chain_deopt_table` maps `return_addr` to the replay data instead.
-   This also deletes the §8.2/§8.4 complexity (handler continuations, the
-   unwind-path interaction) that existed only to serve `ret`-entry.
-4. Re-run the `chain-deopt` feature suite; it must stay green through the
-   conversion.
+1. ~~Extend the walk to replay each suspended frame's write-back **during**
+   `chain_deopt`, then point its return address at the shared VM entry.~~
+   Done — with §8.2's correction: the raw VM send continuation is wrong for
+   1-unit operator sites, so the rewritten slots point at one shared stub
+   (`gen_chain_cont_stub`) that reads the per-site `dst`/advance word the
+   walk stored in the cont-frame pad slot.
+2. ~~The replay needs, per return address: the `WriteBack`, the frame's
+   spill `base`, and the site's `UsingFpr` save-area layout.~~ Done —
+   `ChainReplay` carries exactly that (plus `dst` and the site pc for the
+   stub's continuation word); the layout facts are restated, verified, in
+   §8.1. `forward_rest` / `forward_kwrest` call `runtime::create_array` /
+   `runtime::kwrest_hash` from Rust — GC-safe because every source value is
+   in a scanned frame slot.
+3. ~~Remove the per-site chain-exit handlers and the `DestLabel` table —
+   `chain_deopt_table` maps `return_addr` to the replay data instead.~~
+   Done — `SideExit::ChainExit` / `LSideExitKind::ChainExit`,
+   `gen_chain_exit_with_label` / `a64_gen_chain_exit`, and
+   `fpr_reload_cont` / `a64_fpr_reload_cont` are deleted; §8.4's unwind
+   path now terminates in the stub's error branch.
+4. ~~Re-run the `chain-deopt` feature suite; it must stay green through the
+   conversion.~~ Done — 3203/3203 green in the eager form (and the default
+   suite unchanged).
 
-Ordering: this precedes §5 steps 4–5. The firing point (step 4's guard) can
-land together with it, but the `locals_to_S` relaxation must not land before
-it.
+Ordering: this preceded §5 steps 4–5, as required. The `locals_to_S`
+relaxation is now unblocked.

--- a/doc/chain_deopt.md
+++ b/doc/chain_deopt.md
@@ -1,0 +1,243 @@
+# Chain deopt — handoff note
+
+**Kind:** plan. **Status:** nothing implemented; this records what was
+verified, what was tried and rejected, and the order the work should go in.
+
+---
+
+## 1. What this is for
+
+The optimization we want is **speculative unboxed `Float` locals across a
+block call**.
+
+Today a method call that passes a block demotes every local to
+`LinkMode::S` before the call:
+
+```rust
+// compile/method_call.rs
+// We must write back all local vars to the stack and set the state to
+// LinkMode::S when they are possibly accessed or captured from inner blocks.
+if callsite.block_fid.is_some() {
+    state.locals_to_S(ir);
+}
+```
+
+so a `Float` local is boxed on every block call, because the inner block
+might read or write it. The speculation is to **stop demoting**: keep the
+local unboxed in the frame's FP spill area and let the (specialized,
+non-capturable) block read and write it there. If the block ever stores a
+non-`Float` into such a local the speculation is dead — the outer frame's
+compiled code assumes an `f64` at a spill offset that no longer holds one —
+and the whole suspended chain has to fall back to the interpreter at once.
+
+The motivating shape is real and hot. `benchmark/app_aobench.rb`:
+
+```ruby
+occlusion = 0.0
+nphi.times do |j|
+  ntheta.times do |i|
+    ...
+    occlusion += 1.0     # outer Float local, mutated from two blocks deep
+  end
+end
+```
+
+**Chain deopt is the enabling mechanism, not the optimization.** It also
+pays for itself a second time — see §6.
+
+## 2. The mechanism
+
+On a deep deopt, leave every frame where it is and convert the whole
+suspended chain from JIT frames into interpreter frames:
+
+1. for every JIT frame on the stack, write its spilled xmm/d registers back
+   into its local slots (boxing the floats);
+2. rewrite each frame's **return-address slot on the stack** to the VM's
+   post-call continuation;
+3. the continuation reads the suspended pc off the stack, so that slot has
+   to be right (it is — see §3.2).
+
+Control then never re-enters JIT code: each `ret` lands in the interpreter.
+
+This is **not** what `Codegen::immediate_eviction` does. That one writes a
+`jmp deopt` into the *code* at the call's return continuation, so control
+returns into JIT code and deopts one instruction later. Chain deopt does not
+touch code and does not return into JIT code at all.
+
+## 3. What was verified in the source
+
+### 3.1 The VM entry already exists and is shared
+
+`arch/x86_64/vmgen/method_call.rs:81`, the send opcode's post-call sequence:
+
+```asm
+done:
+  pop_cont_frame     ; popq r13 (suspended pc); addq rsp, 8
+                     ; movzxw rdi, [r13 + RET_REG_FROM_CALLSITE]  <- dst slot, from the bytecode
+                     ; addq r13, 32                               <- past the 2-unit send
+  vm_handle_error
+  vm_store_rdi(rax)  ; store the return value into dst
+  fetch_and_dispatch
+```
+
+It is **entirely stack-driven and carries no per-site state**: it recovers
+the pc from the stack, re-derives the destination slot from the bytecode at
+that pc, stores `rax`, and resumes. So a *single* address serves every call
+site. Bind a label there and expose its address.
+
+### 3.2 The suspended pc is already correct — no prerequisite work
+
+`AsmInst::ContFramePc { call_site_pc }` (`asmir.rs:1678`) stores the
+call-site pc into the outgoing cont-frame slot — documented as "the slot
+`Kernel#caller` reads". Its producers cover every JIT call/yield emitter:
+
+| `compile/method_call.rs` | emitter | path |
+|---|---|---|
+| 822 | `compile_yield_specialized` | specialized yield |
+| 1419 | `send` | ordinary call |
+| 1484 | `send_specialized` | specialized call |
+| 1520 | `compile_yield` | generic yield |
+
+`Cfp::caller_pc_slot`'s "not every dispatch path writes it" caveat is about
+non-JIT paths (the invoker's zero sentinel). Filling the pc lazily during
+the walk remains available as belt-and-braces, but is not needed to start.
+
+### 3.3 The write-back is heavier than a memcpy
+
+`WriteBack` (`jitgen.rs:175`) has six kinds of entry:
+
+```rust
+fpr: Vec<(FPReg, Vec<SlotId>)>,                            // float -> one or more slots
+literal: Vec<(Value, SlotId)>,
+void: Vec<SlotId>,
+gp: Vec<(GP, SlotId)>,                                     // empty in shipping builds
+forward_rest: Vec<(SlotId, SlotId, u16)>,                  // D1: build the rest Array
+forward_kwrest: Vec<(SlotId, Box<[(IdentId, SlotId)]>)>,   // K1: build the kwrest Hash
+```
+
+To replay one from Rust the walker needs the `WriteBack` **and the frame's
+spill base** (`base`, today only a compile-time argument to
+`gen_write_back_for_deopt`). `forward_rest` / `forward_kwrest` additionally
+need `create_array` / `correct_rest_kw` calls, so this is not a pure memory
+shuffle.
+
+Why replaying from Rust is possible at all: xmm is caller-saved, so
+`FprSave` has already spilled every live float of a **suspended** frame into
+that frame's own spill area. Only the innermost frame still has live values
+in registers, and that one deopts through its compiled handler as it does
+today.
+
+### 3.4 The registration key already exists
+
+`return_addr_table` (`codegen.rs`) maps a suspended call's return address to
+its side exit, filled by `set_deopt_with_return_addr` from all four emitters
+above. The runtime table wants the same key.
+
+## 4. A rejected attempt — do not repeat it
+
+Rewriting the stack's return address to point at that frame's **`Evict`
+handler** looks like it should work. It does not, and it fails loudly
+(`caller_lines_survive_specialized_frame_eviction`, SIGABRT inside
+`pmc_record_binary`).
+
+The instruction order at a specialized call is:
+
+```
+call callee            <- the return address points here
+<result-store code emitted by def_rax2acc_return>
+patch_point            <- where immediate_eviction writes its jmp
+```
+
+and `compile/method_call.rs:835` fixes the contract:
+
+```rust
+let res = state.def_rax2acc_return(ir, dst, return_state);  // emits the result store
+state.immediate_evict(ir, evict);                            // records patch_point + write_back
+```
+
+The `Evict` write-back is captured **after** the result store is modelled,
+so the handler assumes that store has already run. Entering it directly by
+`ret` skips the store, the callee's return value never reaches its slot, and
+garbage propagates.
+
+`immediate_eviction` patches at `patch_point` — *after* the result store —
+precisely for this reason. Chain deopt sidesteps the whole issue by
+targeting the VM entry (§3.1), where `vm_store_rdi` does the store.
+
+## 5. Order of work
+
+1. **Runtime table** `return_addr -> (WriteBack, spill base)`, plus the Rust
+   routine that replays one against a frame's `rbp`/`lfp`.
+2. **Expose the VM entry**: bind a label at `done:` and publish its address.
+3. **The walk**: `Cfp::set_return_addr` (a writer next to the existing
+   `return_addr()` at `frame.rs:76`), then walk the CFP chain applying 1 and
+   2. Model the loop on `immediate_eviction`, which already skips VM frames
+   via `check_vm_address` and handles recursion by visiting every frame.
+4. **Firing point**: the `Float` guard on a block's `StoreDynVar` into an
+   outer unboxed local. Write back *before* performing the offending store,
+   or the write-back overwrites it.
+5. **Relax `locals_to_S`** for qualifying block calls, and point the block's
+   `Load/StoreDynVar` at the outer frame's spill area.
+6. **Recover the return-state narrowing** — see §6.
+
+## 6. The second payoff: `frame_had_deopt`
+
+`compile/method_call.rs:1243` currently gives up all return-type inference
+for any callee that *could* deopt:
+
+```rust
+if self.store[iseq_id].has_exception_handler() || frame_had_deopt {
+    s.taint_for_unmodeled_rescue();     // ret -> ReturnValue::Value
+}
+```
+
+and propagates the fact one level out (`current_frame_mut().had_deopt = true`),
+so one deopt-able site anywhere in an inlined subtree flattens every
+enclosing return state to `Value`. This is PR #505's fix for a real
+unsoundness: a deopted callee resumes in the interpreter and can return a
+value outside the class the abstract interpreter predicted.
+
+Chain deopt licenses removing the `frame_had_deopt` half:
+
+* callee completes in JIT — the inference was derived from exactly those
+  compiled paths, so it holds;
+* callee deopts — the caller is converted too, its compiled code never
+  resumes, and the `Guarded::Class(..)` tag is never acted on.
+
+Two conditions on that argument:
+
+* **Every deopt below a site that consumed a narrowed return state must
+  escalate to chain deopt.** Blanket escalation would make today's cheap
+  per-frame deopts pay a chain walk and throw away the caller's compiled
+  execution, so gate it per site. Specialization compiles the callee body
+  *per call site*, so the flag can be baked in at compile time. This is the
+  quietest thing in the design to get wrong — a missed escalation shows up
+  only as a wrong class tag — so it wants a mechanical guarantee (a frame
+  flag every side-exit emitter in that frame consults), not review
+  discipline.
+* **`has_exception_handler` stays.** An exception raised and rescued *inside*
+  the callee returns normally with no deopt at all, so chain deopt never
+  fires and the happy-path-only inference is still wrong (issue #405).
+
+Note also that `taint_for_unmodeled_rescue` (`state.rs:598`) bundles the
+`ret` downgrade with clearing `invariants.side_effect_guard`; splitting the
+deopt reason from the rescue reason means deciding both, and the
+`side_effect_guard` half needs its own written argument.
+
+## 7. Gating for the speculation itself (§5.4–5.5)
+
+Agreed scope: **specialized `iseq_block` only, and only where the frame
+cannot be captured** (`possibly_capture_without_block` / `has_block_arg`
+false). Generic block invocation is out of scope for now.
+
+The constraints that force this:
+
+* **GC.** `Lfp::mark` (`frame.rs:284`) walks `meta.regs()` and marks every
+  slot as a `Value`. A raw `f64` in a local slot would be scanned as a heap
+  pointer, so unboxed values must stay in the FP spill area and the block
+  must be pointed *there*, not at `[outer_lfp - slot]`.
+* **Escape paths.** Anything that reads `[outer_lfp - slot]` expecting a
+  boxed `Value` breaks the speculation: a captured `Proc` called later,
+  `binding` / `Binding#local_variable_get`, generic (non-specialized) block
+  invocation, `move_frame_to_heap`, backtraces — and the interpreter itself
+  once *the block* deopts and the VM runs the block's body.

--- a/monoruby/Cargo.toml
+++ b/monoruby/Cargo.toml
@@ -66,6 +66,14 @@ phys-table = []
 phys-loop-aware = []
 emit-cfg = ["dump-bc", "dump-traceir"]
 dump-require = []
+# doc/chain_deopt.md: route on-stack eviction through the chain-deopt walk
+# (rewrite each suspended frame's return-address slot to its chain-exit
+# handler) instead of `immediate_eviction`'s return-continuation code patch.
+# The two are observationally equivalent — both convert every suspended JIT
+# frame into an interpreter frame — so this is how the chain-deopt mechanism
+# is exercised end-to-end before the speculation that will fire it (§5 steps
+# 4-5) exists. Default-off; a validation switch, not a shipping path.
+chain-deopt = []
 
 [dependencies]
 clap = { version = "4.6.1", features = ["derive"] }

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -671,17 +671,6 @@ pub struct Codegen {
     /// at the recorded continuation, this one is written *into the stack* so
     /// control leaves JIT code on `ret`.
     chain_deopt_table: HashMap<CodePtr, DestLabel>,
-    /// The VM's shared post-call continuation, i.e. the address a chain-exit
-    /// handler tails into (`doc/chain_deopt.md` §3.1). It carries no
-    /// per-site state: it recovers the suspended pc from the cont-frame slot
-    /// on the stack, re-derives the destination slot from the bytecode there,
-    /// stores the callee's result and resumes the fetch loop — so one address
-    /// serves every call and yield site.
-    ///
-    /// This is the position *just past* the VM send's `call`, before its
-    /// `pop_frame`; the handler performs the `pop_frame` itself, since the
-    /// hijacked `ret` skips the JIT frame's own.
-    vm_call_continuation: Option<CodePtr>,
     pub(crate) specialized_info: Vec<(ISeqId, ClassId, DestLabel)>,
     pub(crate) specialized_base: usize,
     vm_code_position: (Option<CodePtr>, usize, Option<CodePtr>, usize),
@@ -1055,7 +1044,6 @@ impl Codegen {
             return_addr_table: HashMap::default(),
             asm_return_addr_table: HashMap::default(),
             chain_deopt_table: HashMap::default(),
-            vm_call_continuation: None,
             specialized_info: Vec::new(),
             specialized_base: 0,
             vm_entry: entry_panic.clone(),
@@ -1466,11 +1454,7 @@ impl Codegen {
         CODEGEN.with(|codegen| {
             let mut codegen = codegen.borrow_mut();
             if std::mem::replace(&mut codegen.bop_eviction_pending, false) {
-                if cfg!(feature = "chain-deopt") {
-                    codegen.chain_deopt(cfp);
-                } else {
-                    codegen.immediate_eviction(cfp);
-                }
+                codegen.evict_suspended_frames(cfp);
             }
         });
     }
@@ -1486,12 +1470,41 @@ impl Codegen {
         unsafe { *addr }
     }
 
-    fn immediate_eviction(&mut self, mut cfp: Cfp) {
+    ///
+    /// Convert (or arrange to deopt) every suspended JIT frame in *cfp*'s
+    /// control-frame chain, after a basic-op redefinition made their compiled
+    /// continuations stale. Per-frame, the mechanism is chosen by what the
+    /// call site registered:
+    ///
+    /// * a **chain-exit handler** (`chain_deopt_table`) — rewrite the frame's
+    ///   return-address slot so its `ret` lands in the handler and the frame
+    ///   becomes an interpreter frame, leaving the compiled body untouched
+    ///   (`doc/chain_deopt.md` §2);
+    /// * otherwise a **patch point** (`return_addr_table`) — overwrite the
+    ///   call's return continuation in the *code* with a `jmp deopt`
+    ///   (immediate eviction).
+    ///
+    /// A default build emits no chain-exit handlers, so this degenerates to
+    /// pure immediate eviction; under the `chain-deopt` feature every site
+    /// registers one and the walk is pure chain deopt. When the unboxed-
+    /// locals speculation (§5 step 5) lands, speculative call sites emit
+    /// chain exits per-site and the two mechanisms coexist in one chain.
+    ///
+    fn evict_suspended_frames(&mut self, mut cfp: Cfp) {
         let mut return_addr = unsafe { cfp.return_addr() };
         while let Some(prev_cfp) = cfp.prev() {
-            let ret = return_addr.unwrap();
-            if !self.check_vm_address(ret) {
-                if let Some((patch_point, deopt)) = self.get_deopt_with_return_addr(ret) {
+            if let Some(ret) = return_addr
+                && !self.check_vm_address(ret)
+            {
+                if let Some(chain) = self.chain_deopt_table.get(&ret).cloned() {
+                    let handler = self.jit.get_label_address(&chain);
+                    #[cfg(any(feature = "deopt", feature = "profile"))]
+                    eprintln!("### bop eviction: frame return {ret:?} -> chain exit {handler:?}");
+                    // SAFETY: as in `chain_deopt` — `cfp` is a live control
+                    // frame of the current thread's stack, and `handler` was
+                    // emitted for exactly this call site.
+                    unsafe { cfp.set_return_addr(handler) };
+                } else if let Some((patch_point, deopt)) = self.get_deopt_with_return_addr(ret) {
                     let patch_point = patch_point.unwrap();
                     self.patch_return_to_deopt(patch_point, &deopt);
                 }
@@ -1545,24 +1558,6 @@ impl Codegen {
         self.return_addr_table.get(&return_addr).cloned()
     }
 
-    /// The address of the VM's shared post-call continuation
-    /// (`vm_call_continuation`). Panics if the VM has not been constructed —
-    /// a chain-exit handler can only be emitted after `construct_vm`, which
-    /// happens in `Codegen::new`, so a `None` here is a construction-order
-    /// bug, not a runtime condition.
-    pub(in crate::codegen) fn vm_call_continuation(&self) -> CodePtr {
-        self.vm_call_continuation
-            .expect("vm_call_continuation: VM code has not been generated yet")
-    }
-
-    /// Record the VM's post-call continuation. Called once per VM
-    /// construction, from the first `send` handler generated: every call and
-    /// yield handler shares the same stack-driven sequence, so the first one
-    /// is as good as any (`doc/chain_deopt.md` §3.1).
-    pub(in crate::codegen) fn set_vm_call_continuation(&mut self, addr: CodePtr) {
-        self.vm_call_continuation.get_or_insert(addr);
-    }
-
     /// `LInst::ChainExit`: map this call's return address (recorded moments
     /// ago by `set_deopt_with_return_addr` under the same `evict` id) to its
     /// chain-exit handler.
@@ -1588,15 +1583,19 @@ impl Codegen {
     /// writes the frame's unboxed values back into its local slots and tails
     /// into the VM's post-call continuation.
     ///
-    /// Unlike [`Self::immediate_eviction`] this touches no machine code, so a
-    /// compiled body that is still valid for *future* invocations survives.
+    /// Unlike [`Self::evict_suspended_frames`]' return-address patching this
+    /// touches no machine code, so a compiled body that is still valid for
+    /// *future* invocations survives.
     ///
     /// Frames whose return address is in VM code or an invoker are already
     /// interpreted (or are a foreign entry) and are skipped, but the walk
     /// continues past them: a chain may alternate VM and JIT frames. A JIT
-    /// return address with no table entry is likewise skipped — the dispatch
-    /// paths that do not register one (the invokers) cannot be resumed
-    /// through the VM's send continuation anyway.
+    /// return address with no table entry is likewise skipped: for BOP
+    /// eviction the patching walk covers those sites, and for an escalated
+    /// side exit (`runtime::chain_deopt`) an unregistered site marks the
+    /// boundary of the compilation region that speculated — frames beyond it
+    /// hold no unboxed cross-frame state and may resume their compiled
+    /// bodies.
     ///
     pub(crate) fn chain_deopt(&mut self, mut cfp: Cfp) {
         let mut return_addr = unsafe { cfp.return_addr() };

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -663,6 +663,25 @@ pub struct Codegen {
     /// return_addr => (patch_point, deopt)
     return_addr_table: HashMap<CodePtr, (Option<CodePtr>, DestLabel)>,
     asm_return_addr_table: HashMap<AsmEvict, CodePtr>,
+    /// `doc/chain_deopt.md` §5 step 1: a suspended call's return address =>
+    /// that call site's chain-exit handler. Keyed identically to
+    /// `return_addr_table` (§3.4), because both are looked up from a
+    /// suspended frame's return-address slot; the two differ only in what
+    /// they do with the hit — `return_addr_table` patches the frame's *code*
+    /// at the recorded continuation, this one is written *into the stack* so
+    /// control leaves JIT code on `ret`.
+    chain_deopt_table: HashMap<CodePtr, DestLabel>,
+    /// The VM's shared post-call continuation, i.e. the address a chain-exit
+    /// handler tails into (`doc/chain_deopt.md` §3.1). It carries no
+    /// per-site state: it recovers the suspended pc from the cont-frame slot
+    /// on the stack, re-derives the destination slot from the bytecode there,
+    /// stores the callee's result and resumes the fetch loop — so one address
+    /// serves every call and yield site.
+    ///
+    /// This is the position *just past* the VM send's `call`, before its
+    /// `pop_frame`; the handler performs the `pop_frame` itself, since the
+    /// hijacked `ret` skips the JIT frame's own.
+    vm_call_continuation: Option<CodePtr>,
     pub(crate) specialized_info: Vec<(ISeqId, ClassId, DestLabel)>,
     pub(crate) specialized_base: usize,
     vm_code_position: (Option<CodePtr>, usize, Option<CodePtr>, usize),
@@ -1035,6 +1054,8 @@ impl Codegen {
             compilation_unit: Vec::new(),
             return_addr_table: HashMap::default(),
             asm_return_addr_table: HashMap::default(),
+            chain_deopt_table: HashMap::default(),
+            vm_call_continuation: None,
             specialized_info: Vec::new(),
             specialized_base: 0,
             vm_entry: entry_panic.clone(),
@@ -1445,7 +1466,11 @@ impl Codegen {
         CODEGEN.with(|codegen| {
             let mut codegen = codegen.borrow_mut();
             if std::mem::replace(&mut codegen.bop_eviction_pending, false) {
-                codegen.immediate_eviction(cfp);
+                if cfg!(feature = "chain-deopt") {
+                    codegen.chain_deopt(cfp);
+                } else {
+                    codegen.immediate_eviction(cfp);
+                }
             }
         });
     }
@@ -1518,6 +1543,83 @@ impl Codegen {
         return_addr: CodePtr,
     ) -> Option<(Option<CodePtr>, DestLabel)> {
         self.return_addr_table.get(&return_addr).cloned()
+    }
+
+    /// The address of the VM's shared post-call continuation
+    /// (`vm_call_continuation`). Panics if the VM has not been constructed —
+    /// a chain-exit handler can only be emitted after `construct_vm`, which
+    /// happens in `Codegen::new`, so a `None` here is a construction-order
+    /// bug, not a runtime condition.
+    pub(in crate::codegen) fn vm_call_continuation(&self) -> CodePtr {
+        self.vm_call_continuation
+            .expect("vm_call_continuation: VM code has not been generated yet")
+    }
+
+    /// Record the VM's post-call continuation. Called once per VM
+    /// construction, from the first `send` handler generated: every call and
+    /// yield handler shares the same stack-driven sequence, so the first one
+    /// is as good as any (`doc/chain_deopt.md` §3.1).
+    pub(in crate::codegen) fn set_vm_call_continuation(&mut self, addr: CodePtr) {
+        self.vm_call_continuation.get_or_insert(addr);
+    }
+
+    /// `LInst::ChainExit`: map this call's return address (recorded moments
+    /// ago by `set_deopt_with_return_addr` under the same `evict` id) to its
+    /// chain-exit handler.
+    ///
+    /// The `unwrap` is load-bearing for the same reason as
+    /// `emit_immediate_evict`'s: `AsmEvict` ids restart per block while
+    /// `asm_return_addr_table` is never cleared, so a producer that forgot to
+    /// register its return address would silently pick up a stale same-id
+    /// entry and give an unrelated live call site the wrong handler.
+    pub(in crate::codegen) fn register_chain_exit(&mut self, evict: AsmEvict, chain: DestLabel) {
+        let return_addr = *self.asm_return_addr_table.get(&evict).unwrap();
+        self.chain_deopt_table.insert(return_addr, chain);
+    }
+
+    ///
+    /// Convert every suspended JIT frame in *cfp*'s control-frame chain into
+    /// an interpreter frame (`doc/chain_deopt.md` §2).
+    ///
+    /// Each frame is left exactly where it is; only its **return-address
+    /// slot** is rewritten, to that call site's chain-exit handler. Control
+    /// therefore never re-enters a compiled body: as the innermost frame (and
+    /// then each frame in turn) returns, the `ret` lands in the handler, which
+    /// writes the frame's unboxed values back into its local slots and tails
+    /// into the VM's post-call continuation.
+    ///
+    /// Unlike [`Self::immediate_eviction`] this touches no machine code, so a
+    /// compiled body that is still valid for *future* invocations survives.
+    ///
+    /// Frames whose return address is in VM code or an invoker are already
+    /// interpreted (or are a foreign entry) and are skipped, but the walk
+    /// continues past them: a chain may alternate VM and JIT frames. A JIT
+    /// return address with no table entry is likewise skipped — the dispatch
+    /// paths that do not register one (the invokers) cannot be resumed
+    /// through the VM's send continuation anyway.
+    ///
+    pub(crate) fn chain_deopt(&mut self, mut cfp: Cfp) {
+        let mut return_addr = unsafe { cfp.return_addr() };
+        while let Some(prev_cfp) = cfp.prev() {
+            if let Some(ret) = return_addr
+                && !self.check_vm_address(ret)
+                && let Some(chain) = self.chain_deopt_table.get(&ret).cloned()
+            {
+                let handler = self.jit.get_label_address(&chain);
+                #[cfg(any(feature = "deopt", feature = "profile"))]
+                eprintln!("### chain deopt: frame return {ret:?} -> chain exit {handler:?}");
+                // SAFETY: `cfp` is a live control frame of the current
+                // thread's stack (we reached it by walking `prev()` from the
+                // executor's cfp), and `handler` is a finalized code address
+                // in this JitModule. The slot we overwrite is the frame's
+                // return address, which is only read by the `ret` that ends
+                // the frame below it — and that has not run yet, or we would
+                // not have found this frame suspended.
+                unsafe { cfp.set_return_addr(handler) };
+            }
+            cfp = prev_cfp;
+            return_addr = unsafe { cfp.return_addr() };
+        }
     }
 
     /// aarch64 specialized recompile: overwrite the single 4-byte `bl entry`

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -25,6 +25,7 @@ pub(crate) mod signal_table;
 mod arch;
 
 use self::jitgen::asmir::AsmEvict;
+use self::jitgen::{ChainConversion, ChainReplay};
 
 use super::*;
 use crate::bytecodegen::inst::*;
@@ -663,14 +664,22 @@ pub struct Codegen {
     /// return_addr => (patch_point, deopt)
     return_addr_table: HashMap<CodePtr, (Option<CodePtr>, DestLabel)>,
     asm_return_addr_table: HashMap<AsmEvict, CodePtr>,
-    /// `doc/chain_deopt.md` §5 step 1: a suspended call's return address =>
-    /// that call site's chain-exit handler. Keyed identically to
-    /// `return_addr_table` (§3.4), because both are looked up from a
-    /// suspended frame's return-address slot; the two differ only in what
-    /// they do with the hit — `return_addr_table` patches the frame's *code*
-    /// at the recorded continuation, this one is written *into the stack* so
+    /// `doc/chain_deopt.md` §5 step 1 / §9.3: a suspended call's return
+    /// address => the data needed to convert the suspended caller frame
+    /// eagerly (replay its write-back from Rust, hand the shared VM
+    /// continuation stub its per-site `dst`/resume data). Keyed identically
+    /// to `return_addr_table` (§3.4), because both are looked up from a
+    /// suspended frame's return-address slot; the two differ in what they do
+    /// with the hit — `return_addr_table` patches the frame's *code* at the
+    /// recorded continuation, this one drives a stack-only conversion so
     /// control leaves JIT code on `ret`.
-    chain_deopt_table: HashMap<CodePtr, DestLabel>,
+    chain_deopt_table: HashMap<CodePtr, ChainReplay>,
+    /// The shared chain-deopt post-call continuation stub
+    /// (`gen_chain_cont_stub`): the single address every converted frame's
+    /// return-address slot is pointed at. Emitted with the VM handlers, so
+    /// `check_vm_address` covers it — which is what makes an
+    /// already-converted frame skippable on a later walk.
+    chain_cont_stub: DestLabel,
     pub(crate) specialized_info: Vec<(ISeqId, ClassId, DestLabel)>,
     pub(crate) specialized_base: usize,
     vm_code_position: (Option<CodePtr>, usize, Option<CodePtr>, usize),
@@ -893,6 +902,12 @@ impl Codegen {
     ///
     pub(in crate::codegen) fn construct_vm(&mut self) {
         let h = self.gen_vm_handlers();
+        // Emitted here, inside the VM code span `vm_code_position` records, so
+        // `check_vm_address` returns true for the stub — a converted frame's
+        // rewritten return address then reads as "already interpreted" and a
+        // later walk skips it instead of replaying a stale write-back over
+        // slots the interpreter may have updated since.
+        self.gen_chain_cont_stub();
         self.dispatch[1] = h.singleton_method_def;
         self.dispatch[2] = h.method_def;
         self.dispatch[3] = h.br_inst;
@@ -1044,6 +1059,7 @@ impl Codegen {
             return_addr_table: HashMap::default(),
             asm_return_addr_table: HashMap::default(),
             chain_deopt_table: HashMap::default(),
+            chain_cont_stub: entry_panic.clone(),
             specialized_info: Vec::new(),
             specialized_base: 0,
             vm_entry: entry_panic.clone(),
@@ -1451,12 +1467,22 @@ impl Codegen {
     /// when the definition just executed actually redefined a basic op —
     /// `set_bop_redefine` arms the flag and this consumes it.
     pub fn check_bop_redefine(cfp: Cfp) {
-        CODEGEN.with(|codegen| {
+        let plan = CODEGEN.with(|codegen| {
             let mut codegen = codegen.borrow_mut();
             if std::mem::replace(&mut codegen.bop_eviction_pending, false) {
-                codegen.evict_suspended_frames(cfp);
+                codegen.evict_suspended_frames(cfp)
+            } else {
+                Vec::new()
             }
         });
+        // Applied outside the CODEGEN borrow: the replay half allocates and
+        // can run a GC (see `runtime::chain_deopt`).
+        for conversion in plan {
+            // SAFETY: every planned frame was found suspended on the current
+            // thread's control-frame chain moments ago, and nothing has run
+            // since — no frame has returned.
+            unsafe { conversion.apply() };
+        }
     }
 
     /// The basic-op version: bumped by every redefinition, baked into
@@ -1476,34 +1502,35 @@ impl Codegen {
     /// continuations stale. Per-frame, the mechanism is chosen by what the
     /// call site registered:
     ///
-    /// * a **chain-exit handler** (`chain_deopt_table`) — rewrite the frame's
-    ///   return-address slot so its `ret` lands in the handler and the frame
-    ///   becomes an interpreter frame, leaving the compiled body untouched
-    ///   (`doc/chain_deopt.md` §2);
+    /// * a **chain conversion** (`chain_deopt_table`) — plan the eager
+    ///   conversion (`doc/chain_deopt.md` §2/§9.3): replay the suspended
+    ///   caller's write-back and rewrite the frame's return-address slot to
+    ///   the shared VM continuation stub, leaving the compiled body
+    ///   untouched. Returned to the caller for application outside the
+    ///   `CODEGEN` borrow (the replay allocates);
     /// * otherwise a **patch point** (`return_addr_table`) — overwrite the
     ///   call's return continuation in the *code* with a `jmp deopt`
-    ///   (immediate eviction).
+    ///   (immediate eviction), done in place.
     ///
-    /// A default build emits no chain-exit handlers, so this degenerates to
+    /// A default build registers no chain entries, so this degenerates to
     /// pure immediate eviction; under the `chain-deopt` feature every site
-    /// registers one and the walk is pure chain deopt. When the unboxed-
-    /// locals speculation (§5 step 5) lands, speculative call sites emit
-    /// chain exits per-site and the two mechanisms coexist in one chain.
+    /// registers and the walk is pure chain deopt. When the unboxed-locals
+    /// speculation (§5 step 5) lands, speculative call sites register
+    /// per-site and the two mechanisms coexist in one chain.
     ///
-    fn evict_suspended_frames(&mut self, mut cfp: Cfp) {
+    #[must_use]
+    fn evict_suspended_frames(&mut self, mut cfp: Cfp) -> Vec<ChainConversion> {
+        let stub = self.jit.get_label_address(&self.chain_cont_stub);
+        let mut plan = Vec::new();
         let mut return_addr = unsafe { cfp.return_addr() };
         while let Some(prev_cfp) = cfp.prev() {
             if let Some(ret) = return_addr
                 && !self.check_vm_address(ret)
             {
-                if let Some(chain) = self.chain_deopt_table.get(&ret).cloned() {
-                    let handler = self.jit.get_label_address(&chain);
+                if let Some(replay) = self.chain_deopt_table.get(&ret).cloned() {
                     #[cfg(any(feature = "deopt", feature = "profile"))]
-                    eprintln!("### bop eviction: frame return {ret:?} -> chain exit {handler:?}");
-                    // SAFETY: as in `chain_deopt` — `cfp` is a live control
-                    // frame of the current thread's stack, and `handler` was
-                    // emitted for exactly this call site.
-                    unsafe { cfp.set_return_addr(handler) };
+                    eprintln!("### bop eviction: frame return {ret:?} -> chain conversion");
+                    plan.push(ChainConversion::new(cfp, prev_cfp, replay, stub));
                 } else if let Some((patch_point, deopt)) = self.get_deopt_with_return_addr(ret) {
                     let patch_point = patch_point.unwrap();
                     self.patch_return_to_deopt(patch_point, &deopt);
@@ -1512,6 +1539,7 @@ impl Codegen {
             cfp = prev_cfp;
             return_addr = unsafe { cfp.return_addr() };
         }
+        plan
     }
 
     /// Overwrite the instruction(s) at a specialized call's return continuation
@@ -1560,28 +1588,33 @@ impl Codegen {
 
     /// `LInst::ChainExit`: map this call's return address (recorded moments
     /// ago by `set_deopt_with_return_addr` under the same `evict` id) to its
-    /// chain-exit handler.
+    /// replay data.
     ///
     /// The `unwrap` is load-bearing for the same reason as
     /// `emit_immediate_evict`'s: `AsmEvict` ids restart per block while
     /// `asm_return_addr_table` is never cleared, so a producer that forgot to
     /// register its return address would silently pick up a stale same-id
-    /// entry and give an unrelated live call site the wrong handler.
-    pub(in crate::codegen) fn register_chain_exit(&mut self, evict: AsmEvict, chain: DestLabel) {
+    /// entry and give an unrelated live call site the wrong replay data.
+    pub(in crate::codegen) fn register_chain_exit(&mut self, evict: AsmEvict, replay: ChainReplay) {
         let return_addr = *self.asm_return_addr_table.get(&evict).unwrap();
-        self.chain_deopt_table.insert(return_addr, chain);
+        self.chain_deopt_table.insert(return_addr, replay);
     }
 
     ///
-    /// Convert every suspended JIT frame in *cfp*'s control-frame chain into
-    /// an interpreter frame (`doc/chain_deopt.md` §2).
+    /// Plan the conversion of every suspended JIT frame in *cfp*'s
+    /// control-frame chain into an interpreter frame (`doc/chain_deopt.md`
+    /// §2, eager form §9.3).
     ///
-    /// Each frame is left exactly where it is; only its **return-address
-    /// slot** is rewritten, to that call site's chain-exit handler. Control
-    /// therefore never re-enters a compiled body: as the innermost frame (and
-    /// then each frame in turn) returns, the `ret` lands in the handler, which
-    /// writes the frame's unboxed values back into its local slots and tails
-    /// into the VM's post-call continuation.
+    /// Each frame is left exactly where it is. Applying a planned
+    /// [`ChainConversion`] replays the suspended caller's write-back (boxing
+    /// its unboxed floats into its local slots) and rewrites the callee's
+    /// **return-address slot** to the shared VM post-call continuation stub,
+    /// with the site's `dst`/resume word in the cont-frame pad slot. Control
+    /// therefore never re-enters a compiled body: as the innermost frame
+    /// (and then each frame in turn) returns, the `ret` lands in the stub,
+    /// which stores the result and resumes the fetch loop. The plan is
+    /// returned instead of applied because the replay allocates and this
+    /// runs under the `CODEGEN` borrow (see `runtime::chain_deopt`).
     ///
     /// Unlike [`Self::evict_suspended_frames`]' return-address patching this
     /// touches no machine code, so a compiled body that is still valid for
@@ -1589,36 +1622,36 @@ impl Codegen {
     ///
     /// Frames whose return address is in VM code or an invoker are already
     /// interpreted (or are a foreign entry) and are skipped, but the walk
-    /// continues past them: a chain may alternate VM and JIT frames. A JIT
-    /// return address with no table entry is likewise skipped: for BOP
-    /// eviction the patching walk covers those sites, and for an escalated
-    /// side exit (`runtime::chain_deopt`) an unregistered site marks the
-    /// boundary of the compilation region that speculated — frames beyond it
-    /// hold no unboxed cross-frame state and may resume their compiled
-    /// bodies.
+    /// continues past them: a chain may alternate VM and JIT frames. A frame
+    /// converted by an earlier walk is skipped the same way — its rewritten
+    /// return address is the stub, a VM address — which is load-bearing: its
+    /// slots may since have been updated through `outer_lfp` by interpreted
+    /// inner frames, and a second replay would clobber them with stale
+    /// floats. A JIT return address with no table entry is likewise skipped:
+    /// for BOP eviction the patching walk covers those sites, and for an
+    /// escalated side exit (`runtime::chain_deopt`) an unregistered site
+    /// marks the boundary of the compilation region that speculated — frames
+    /// beyond it hold no unboxed cross-frame state and may resume their
+    /// compiled bodies.
     ///
-    pub(crate) fn chain_deopt(&mut self, mut cfp: Cfp) {
+    #[must_use]
+    pub(crate) fn chain_deopt(&mut self, mut cfp: Cfp) -> Vec<ChainConversion> {
+        let stub = self.jit.get_label_address(&self.chain_cont_stub);
+        let mut plan = Vec::new();
         let mut return_addr = unsafe { cfp.return_addr() };
         while let Some(prev_cfp) = cfp.prev() {
             if let Some(ret) = return_addr
                 && !self.check_vm_address(ret)
-                && let Some(chain) = self.chain_deopt_table.get(&ret).cloned()
+                && let Some(replay) = self.chain_deopt_table.get(&ret).cloned()
             {
-                let handler = self.jit.get_label_address(&chain);
                 #[cfg(any(feature = "deopt", feature = "profile"))]
-                eprintln!("### chain deopt: frame return {ret:?} -> chain exit {handler:?}");
-                // SAFETY: `cfp` is a live control frame of the current
-                // thread's stack (we reached it by walking `prev()` from the
-                // executor's cfp), and `handler` is a finalized code address
-                // in this JitModule. The slot we overwrite is the frame's
-                // return address, which is only read by the `ret` that ends
-                // the frame below it — and that has not run yet, or we would
-                // not have found this frame suspended.
-                unsafe { cfp.set_return_addr(handler) };
+                eprintln!("### chain deopt: frame return {ret:?} -> chain conversion");
+                plan.push(ChainConversion::new(cfp, prev_cfp, replay, stub));
             }
             cfp = prev_cfp;
             return_addr = unsafe { cfp.return_addr() };
         }
+        plan
     }
 
     /// aarch64 specialized recompile: overwrite the single 4-byte `bl entry`

--- a/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
@@ -952,7 +952,7 @@ impl Codegen {
     /// Mirrors x86 `do_specialized_call`: set_lfp + push_frame, optionally bind
     /// the deopt re-entry `patch_point`, `bl entry`, then pop_frame. Returns the
     /// post-`bl` address (the return continuation); the caller records it via
-    /// `set_deopt_with_return_addr` so `immediate_eviction` can later overwrite
+    /// `set_deopt_with_return_addr` so the eviction walk (`evict_suspended_frames`) can later overwrite
     /// the continuation with a `B deopt` on BOP redefinition.
     pub(in crate::codegen::jitgen::asmir) fn do_specialized_call(
         &mut self,
@@ -1223,7 +1223,7 @@ impl Codegen {
     /// eviction: when a basic op is redefined *inside* the callee, the caller's
     /// own compiled body (inline integer arithmetic, folds) is stale the moment
     /// the callee returns, and the callee's entry guards cannot protect the
-    /// *caller*. `immediate_eviction` finds this frame's return address in
+    /// *caller*. `evict_suspended_frames` finds this frame's return address in
     /// `return_addr_table` and overwrites the recorded patch point (bound by
     /// the following `ImmediateEvict`, after the result store) with a `B evict`
     /// so the frame deopts instead of resuming stale code.

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -252,18 +252,6 @@ impl Codegen {
                     });
                     label
                 }
-                SideExit::ChainExit(pc, wb, using_fpr, dst) => {
-                    let label = self.jit.label();
-                    lir.push(LInst::SideExit {
-                        kind: LSideExitKind::ChainExit { using_fpr, dst },
-                        pc,
-                        wb,
-                        entry: label.clone(),
-                        loop_jit_spill_bytes: bump,
-                        base: frame.base_stack_offset,
-                    });
-                    label
-                }
                 // Evict(None) is a placeholder always overwritten with
                 // Evict(Some(..)) before codegen (mirrors x86 gen_asm's
                 // `_ => unreachable!()`).
@@ -391,107 +379,6 @@ impl Codegen {
             mov x21, (pc0);
             b raise;
         );
-    }
-
-    /// Chain-exit handler (`doc/chain_deopt.md` §2) — twin of x86
-    /// `gen_chain_exit_with_label`.
-    ///
-    /// Reached by `ret`, not by a branch from this frame's body: the
-    /// chain-deopt walk wrote this handler's address into the callee frame's
-    /// return-address slot (`[x29 + 8]`, the `stp x29, x30` LR save). On entry
-    /// `x29` is this frame's frame pointer again (the callee's epilogue did
-    /// that), `x0` holds the callee's return value, `x22` (LFP) still holds
-    /// the *callee's* LFP, and `sp` points at the cont frame with the
-    /// `emit_fpr_save` area just above it.
-    ///
-    /// So: restore this frame as the current one (the pop_frame the hijacked
-    /// `ret` skipped), reload the caller-saved FP pool out of the save area,
-    /// write back, and run the handler's own post-call continuation: store
-    /// `x0` into the call's destination slot and resume the fetch loop at the
-    /// site's next instruction, or on the error signal (`x0 == 0`) hand the
-    /// site pc to `entry_raise`. Per-site rather than the VM's shared send
-    /// continuation because that one assumes a 2-unit send bytecode — wrong
-    /// for the 1-unit operator sites that also dispatch through `send` (see
-    /// the x86 twin `gen_chain_exit_with_label`).
-    ///
-    /// The pop_frame has to come **first**, before the write-back: boxing a
-    /// float or materializing a deferred rest `Array` allocates, so a GC can
-    /// run inside the write-back, and the mark walk starts from
-    /// `Executor::cfp` — which on entry still names the callee frame that has
-    /// just been torn down.
-    ///
-    /// `x0` is stashed across the write-back (which clobbers it) in the
-    /// callee's dead frame header, keeping `sp` 16-byte aligned.
-    fn a64_gen_chain_exit(
-        &mut self,
-        wb: &WriteBack,
-        entry: DestLabel,
-        base: usize,
-        using_fpr: UsingFpr,
-        pc: BytecodePtr,
-        dst: Option<SlotId>,
-    ) {
-        let fetch = self.vm_fetch();
-        let raise = self.entry_raise();
-        let error = self.jit.label();
-        self.jit.bind_label(entry);
-        // pop_frame: EXEC.cfp + LFP from x29, exactly as `a64_do_call`'s
-        // return continuation would have done.
-        let lfp = GP::R14.a64().0;
-        monoasm_arm64!(&mut self.jit,
-            sub x10, x29, #(BP_CFP as u32);
-            str x10, [x19, #(EXECUTOR_CFP as u32)];
-            ldur x(lfp), [x29, #(-((BP_CFP + CFP_LFP) as i32))];
-        );
-        // Reload the FP pool from the save area the call left in place.
-        self.a64_fpr_reload_cont(using_fpr);
-        monoasm_arm64!(&mut self.jit,
-            sub sp, sp, #(16);
-            str x0, [sp, #(8)];
-        );
-        self.a64_gen_write_back_for_deopt(wb, base);
-        monoasm_arm64!(&mut self.jit,
-            ldr x0, [sp, #(8)];
-            // Drop the stash and the cont frame in one go — the resume pc is
-            // baked in below, so the slot is no longer needed.
-            add sp, sp, #(32);
-            cbz x0, error;
-        );
-        // Normal return: store the result and resume interpreting at the
-        // next instruction.
-        if let Some(dst) = dst {
-            self.a64_frame_store(0, lfp, conv(dst) as u32);
-        }
-        let next_pc = pc.next().as_ptr() as u64;
-        monoasm_arm64!(&mut self.jit,
-            mov x21, (next_pc);
-            b fetch;
-        );
-        // Error / non-local-exit signal: aarch64's `entry_raise` passes x21
-        // through unchanged, so hand it the call-site pc itself — the same
-        // convention as `a64_gen_handle_error`.
-        let pc0 = pc.as_ptr() as u64;
-        monoasm_arm64!(&mut self.jit,
-        error:
-            mov x21, (pc0);
-            b raise;
-        );
-    }
-
-    /// Reload the live FP pool registers from a cont-mode `emit_fpr_save` area
-    /// **without** popping it, leaving sp on the continuation frame. The
-    /// chain-exit handler's counterpart to `emit_fpr_restore`.
-    fn a64_fpr_reload_cont(&mut self, using_fpr: UsingFpr) {
-        let pad = CONTINUATION_FRAME_SIZE as u32;
-        let mut i = 0u32;
-        for (xi, b) in using_fpr.iter().enumerate() {
-            if *b {
-                let pr = xi as u32 + 2;
-                let ofs = pad + 8 * i;
-                monoasm_arm64!(&mut self.jit, ldr d(pr), [sp, #(ofs)];);
-                i += 1;
-            }
-        }
     }
 
     /// Write back live values to LFP slots for a side exit, r14(x22)-relative
@@ -1465,9 +1352,6 @@ impl Codegen {
                 }
                 LSideExitKind::Error { chain } => {
                     self.a64_gen_handle_error(pc, &wb, entry, loop_jit_spill_bytes, base, chain)
-                }
-                LSideExitKind::ChainExit { using_fpr, dst } => {
-                    self.a64_gen_chain_exit(&wb, entry, base, using_fpr, pc, dst)
                 }
             },
             // Macro-ops (irreducible runtime-call shapes) are delegated to the

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -143,11 +143,18 @@ impl Codegen {
         if entry.is_none()
             && exit.is_none()
             && let Some((bb, deopt)) = ir.as_pure_deopt()
-            && let Some((pc, wb)) = ir.pure_deopt_target(deopt)
+            && let Some((pc, wb, chain)) = ir.pure_deopt_target(deopt)
         {
             let wb = wb.clone();
             let bb_label = frame.resolve_label(&mut self.jit, bb);
-            self.a64_gen_deopt(pc, &wb, bb_label, frame.loop_jit_spill_bytes, frame.base_stack_offset);
+            self.a64_gen_deopt(
+                pc,
+                &wb,
+                bb_label,
+                frame.loop_jit_spill_bytes,
+                frame.base_stack_offset,
+                chain,
+            );
             return;
         }
 
@@ -169,7 +176,7 @@ impl Codegen {
         {
             monoasm_arm64!(&mut self.jit, b skip;);
         }
-        let mut deopt_table: std::collections::HashMap<(BytecodePtr, WriteBack), DestLabel> =
+        let mut deopt_table: std::collections::HashMap<(BytecodePtr, WriteBack, bool), DestLabel> =
             std::collections::HashMap::new();
         // Loop-JIT entry sp-bump to undo before any exit resumes the VM.
         let bump = frame.loop_jit_spill_bytes;
@@ -196,14 +203,14 @@ impl Codegen {
                     });
                     label
                 }
-                SideExit::Deoptimize(pc, wb) => {
-                    let key = (pc, wb);
+                SideExit::Deoptimize(pc, wb, chain) => {
+                    let key = (pc, wb, chain);
                     if let Some(label) = deopt_table.get(&key) {
                         label.clone()
                     } else {
                         let label = self.jit.label();
                         lir.push(LInst::SideExit {
-                            kind: LSideExitKind::Deopt,
+                            kind: LSideExitKind::Deopt { chain: key.2 },
                             pc: key.0,
                             wb: key.1.clone(),
                             entry: label.clone(),
@@ -217,10 +224,14 @@ impl Codegen {
                 // Treat recompile-deopt as a plain deopt for now: fall back to
                 // the interpreter without the counter-gated recompile (still
                 // correct, just not yet self-optimizing).
-                SideExit::RecompileDeoptimize(pc, wb, reason, position) => {
+                SideExit::RecompileDeoptimize(pc, wb, reason, position, chain) => {
                     let label = self.jit.label();
                     lir.push(LInst::SideExit {
-                        kind: LSideExitKind::RecompileDeopt { reason, position },
+                        kind: LSideExitKind::RecompileDeopt {
+                            reason,
+                            position,
+                            chain,
+                        },
                         pc,
                         wb,
                         entry: label.clone(),
@@ -229,10 +240,10 @@ impl Codegen {
                     });
                     label
                 }
-                SideExit::Error(pc, wb) => {
+                SideExit::Error(pc, wb, chain) => {
                     let label = self.jit.label();
                     lir.push(LInst::SideExit {
-                        kind: LSideExitKind::Error,
+                        kind: LSideExitKind::Error { chain },
                         pc,
                         wb,
                         entry: label.clone(),
@@ -241,10 +252,10 @@ impl Codegen {
                     });
                     label
                 }
-                SideExit::ChainExit(pc, wb, using_fpr) => {
+                SideExit::ChainExit(pc, wb, using_fpr, dst) => {
                     let label = self.jit.label();
                     lir.push(LInst::SideExit {
-                        kind: LSideExitKind::ChainExit { using_fpr },
+                        kind: LSideExitKind::ChainExit { using_fpr, dst },
                         pc,
                         wb,
                         entry: label.clone(),
@@ -303,6 +314,7 @@ impl Codegen {
         entry: DestLabel,
         loop_jit_spill_bytes: usize,
         base: usize,
+        chain: bool,
     ) {
         self.jit.bind_label(entry);
         // Write back FIRST, while the loop sp-bump still keeps sp below the
@@ -312,12 +324,33 @@ impl Codegen {
         // `side_exit_with_label` and doc/regalloc_separation.md §39).
         self.a64_gen_write_back_for_deopt(wb, base);
         self.a64_undo_loop_rsp_bump(loop_jit_spill_bytes);
+        // Chain escalation (`doc/chain_deopt.md` §5 step 4): convert every
+        // suspended JIT frame in the caller chain before this frame resumes
+        // in the interpreter. After the write-back, so the frame is fully
+        // homed in the LFP for the walk.
+        if chain {
+            self.a64_call_chain_deopt();
+        }
         let pc_ptr = pc.as_ptr() as u64;
         let fetch = self.vm_fetch();
         // PC == x21.
         monoasm_arm64!(&mut self.jit,
             mov x21, (pc_ptr);
             b fetch;
+        );
+    }
+
+    /// `runtime::chain_deopt(vm)` — the escalated-side-exit walk. x19 holds
+    /// `&mut Executor`; LR is saved around the `blr` like every other runtime
+    /// call emitted into a JIT body.
+    fn a64_call_chain_deopt(&mut self) {
+        let f = runtime::chain_deopt as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x19;
+            str x30, [sp, #-16]!;              // save LR (16-aligned)
+            mov x9, (f);
+            blr x9;
+            ldr x30, [sp], #16;                // restore LR
         );
     }
 
@@ -338,12 +371,20 @@ impl Codegen {
         entry: DestLabel,
         loop_jit_spill_bytes: usize,
         base: usize,
+        chain: bool,
     ) {
         self.jit.bind_label(entry);
         // Write back before undoing the bump — same spill-clobber reason as
         // `a64_gen_deopt` / the x86 `side_exit_with_label` (§39).
         self.a64_gen_write_back_for_deopt(wb, base);
         self.a64_undo_loop_rsp_bump(loop_jit_spill_bytes);
+        // Chain escalation: the raise may be rescued *inside* this frame
+        // (resuming it in the interpreter) or unwind through the suspended
+        // callers — either way they must be converted first
+        // (`doc/chain_deopt.md` §5 step 4 / §8.4).
+        if chain {
+            self.a64_call_chain_deopt();
+        }
         let pc0 = pc.as_ptr() as u64;
         let raise = self.entry_raise();
         monoasm_arm64!(&mut self.jit,
@@ -365,16 +406,19 @@ impl Codegen {
     ///
     /// So: restore this frame as the current one (the pop_frame the hijacked
     /// `ret` skipped), reload the caller-saved FP pool out of the save area,
-    /// write back, and branch to the VM's post-call continuation — which pops
-    /// the cont frame for the resume pc, stores `x0` into the call's
-    /// destination slot and resumes the fetch loop.
+    /// write back, and run the handler's own post-call continuation: store
+    /// `x0` into the call's destination slot and resume the fetch loop at the
+    /// site's next instruction, or on the error signal (`x0 == 0`) hand the
+    /// site pc to `entry_raise`. Per-site rather than the VM's shared send
+    /// continuation because that one assumes a 2-unit send bytecode — wrong
+    /// for the 1-unit operator sites that also dispatch through `send` (see
+    /// the x86 twin `gen_chain_exit_with_label`).
     ///
     /// The pop_frame has to come **first**, before the write-back: boxing a
     /// float or materializing a deferred rest `Array` allocates, so a GC can
     /// run inside the write-back, and the mark walk starts from
     /// `Executor::cfp` — which on entry still names the callee frame that has
-    /// just been torn down. (The VM continuation repeats it; it is
-    /// idempotent.)
+    /// just been torn down.
     ///
     /// `x0` is stashed across the write-back (which clobbers it) in the
     /// callee's dead frame header, keeping `sp` 16-byte aligned.
@@ -384,8 +428,12 @@ impl Codegen {
         entry: DestLabel,
         base: usize,
         using_fpr: UsingFpr,
+        pc: BytecodePtr,
+        dst: Option<SlotId>,
     ) {
-        let cont = self.vm_call_continuation().as_ptr() as u64;
+        let fetch = self.vm_fetch();
+        let raise = self.entry_raise();
+        let error = self.jit.label();
         self.jit.bind_label(entry);
         // pop_frame: EXEC.cfp + LFP from x29, exactly as `a64_do_call`'s
         // return continuation would have done.
@@ -395,9 +443,7 @@ impl Codegen {
             str x10, [x19, #(EXECUTOR_CFP as u32)];
             ldur x(lfp), [x29, #(-((BP_CFP + CFP_LFP) as i32))];
         );
-        // Reload the FP pool from the save area the call left in place. Loads
-        // only — sp must stay on the cont frame for the VM continuation's
-        // `ldr PC, [sp]`.
+        // Reload the FP pool from the save area the call left in place.
         self.a64_fpr_reload_cont(using_fpr);
         monoasm_arm64!(&mut self.jit,
             sub sp, sp, #(16);
@@ -406,9 +452,29 @@ impl Codegen {
         self.a64_gen_write_back_for_deopt(wb, base);
         monoasm_arm64!(&mut self.jit,
             ldr x0, [sp, #(8)];
-            add sp, sp, #(16);
-            mov x9, (cont);
-            br x9;
+            // Drop the stash and the cont frame in one go — the resume pc is
+            // baked in below, so the slot is no longer needed.
+            add sp, sp, #(32);
+            cbz x0, error;
+        );
+        // Normal return: store the result and resume interpreting at the
+        // next instruction.
+        if let Some(dst) = dst {
+            self.a64_frame_store(0, lfp, conv(dst) as u32);
+        }
+        let next_pc = pc.next().as_ptr() as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x21, (next_pc);
+            b fetch;
+        );
+        // Error / non-local-exit signal: aarch64's `entry_raise` passes x21
+        // through unchanged, so hand it the call-site pc itself — the same
+        // convention as `a64_gen_handle_error`.
+        let pc0 = pc.as_ptr() as u64;
+        monoasm_arm64!(&mut self.jit,
+        error:
+            mov x21, (pc0);
+            b raise;
         );
     }
 
@@ -1369,8 +1435,11 @@ impl Codegen {
                 loop_jit_spill_bytes,
                 base,
             } => match kind {
-                LSideExitKind::Deopt | LSideExitKind::Evict => {
-                    self.a64_gen_deopt(pc, &wb, entry, loop_jit_spill_bytes, base)
+                LSideExitKind::Deopt { chain } => {
+                    self.a64_gen_deopt(pc, &wb, entry, loop_jit_spill_bytes, base, chain)
+                }
+                LSideExitKind::Evict => {
+                    self.a64_gen_deopt(pc, &wb, entry, loop_jit_spill_bytes, base, false)
                 }
                 // A monomorphically-compiled site (e.g. a `BinCmp`) whose
                 // receiver-class guard missed because it went polymorphic.
@@ -1382,22 +1451,23 @@ impl Codegen {
                 // falls straight through while the counter is unexhausted),
                 // branching to `deopt_body` to resume in the interpreter, or to
                 // `error_body` if the recompile itself raised a FatalError.
-                LSideExitKind::RecompileDeopt { reason, position } => {
+                LSideExitKind::RecompileDeopt {
+                    reason,
+                    position,
+                    chain,
+                } => {
                     let deopt_body = self.jit.label();
                     let error_body = self.jit.label();
                     self.jit.bind_label(entry);
                     self.emit_recompile_deopt(position, &deopt_body, Some(&error_body), reason);
-                    self.a64_gen_deopt(pc, &wb, deopt_body, loop_jit_spill_bytes, base);
-                    self.a64_gen_handle_error(pc, &wb, error_body, loop_jit_spill_bytes, base);
+                    self.a64_gen_deopt(pc, &wb, deopt_body, loop_jit_spill_bytes, base, chain);
+                    self.a64_gen_handle_error(pc, &wb, error_body, loop_jit_spill_bytes, base, chain);
                 }
-                LSideExitKind::Error => {
-                    self.a64_gen_handle_error(pc, &wb, entry, loop_jit_spill_bytes, base)
+                LSideExitKind::Error { chain } => {
+                    self.a64_gen_handle_error(pc, &wb, entry, loop_jit_spill_bytes, base, chain)
                 }
-                // The chain exit needs no `pc`: it tails into the VM's
-                // post-call continuation, which reads the resume pc off the
-                // stack (`doc/chain_deopt.md` §3.1).
-                LSideExitKind::ChainExit { using_fpr } => {
-                    self.a64_gen_chain_exit(&wb, entry, base, using_fpr)
+                LSideExitKind::ChainExit { using_fpr, dst } => {
+                    self.a64_gen_chain_exit(&wb, entry, base, using_fpr, pc, dst)
                 }
             },
             // Macro-ops (irreducible runtime-call shapes) are delegated to the
@@ -2276,7 +2346,7 @@ impl Codegen {
 
     /// Record this position (the return continuation of a call, after the
     /// result store) as the return-address patch point for `evict`. On BOP
-    /// redefinition, `Codegen::immediate_eviction` overwrites the instruction
+    /// redefinition, `Codegen::evict_suspended_frames` overwrites the instruction
     /// here with a `B deopt` so the stale frame deopts on return instead of
     /// resuming its compiled body (whose inline integer arithmetic / folds
     /// assume the builtin op). Mirrors x86.
@@ -2296,7 +2366,7 @@ impl Codegen {
             .and_modify(|e| e.0 = Some(patch_point));
     }
 
-    /// Register a specialized call's return address so `immediate_eviction` can
+    /// Register a specialized call's return address so the eviction walk can
     /// find and patch it. Identical to the x86 helper (the tables are arch-
     /// neutral fields on `Codegen`).
     /// Store the call-site pc into the outgoing cont-frame slot

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -241,6 +241,18 @@ impl Codegen {
                     });
                     label
                 }
+                SideExit::ChainExit(pc, wb, using_fpr) => {
+                    let label = self.jit.label();
+                    lir.push(LInst::SideExit {
+                        kind: LSideExitKind::ChainExit { using_fpr },
+                        pc,
+                        wb,
+                        entry: label.clone(),
+                        loop_jit_spill_bytes: bump,
+                        base: frame.base_stack_offset,
+                    });
+                    label
+                }
                 // Evict(None) is a placeholder always overwritten with
                 // Evict(Some(..)) before codegen (mirrors x86 gen_asm's
                 // `_ => unreachable!()`).
@@ -338,6 +350,82 @@ impl Codegen {
             mov x21, (pc0);
             b raise;
         );
+    }
+
+    /// Chain-exit handler (`doc/chain_deopt.md` §2) — twin of x86
+    /// `gen_chain_exit_with_label`.
+    ///
+    /// Reached by `ret`, not by a branch from this frame's body: the
+    /// chain-deopt walk wrote this handler's address into the callee frame's
+    /// return-address slot (`[x29 + 8]`, the `stp x29, x30` LR save). On entry
+    /// `x29` is this frame's frame pointer again (the callee's epilogue did
+    /// that), `x0` holds the callee's return value, `x22` (LFP) still holds
+    /// the *callee's* LFP, and `sp` points at the cont frame with the
+    /// `emit_fpr_save` area just above it.
+    ///
+    /// So: restore this frame as the current one (the pop_frame the hijacked
+    /// `ret` skipped), reload the caller-saved FP pool out of the save area,
+    /// write back, and branch to the VM's post-call continuation — which pops
+    /// the cont frame for the resume pc, stores `x0` into the call's
+    /// destination slot and resumes the fetch loop.
+    ///
+    /// The pop_frame has to come **first**, before the write-back: boxing a
+    /// float or materializing a deferred rest `Array` allocates, so a GC can
+    /// run inside the write-back, and the mark walk starts from
+    /// `Executor::cfp` — which on entry still names the callee frame that has
+    /// just been torn down. (The VM continuation repeats it; it is
+    /// idempotent.)
+    ///
+    /// `x0` is stashed across the write-back (which clobbers it) in the
+    /// callee's dead frame header, keeping `sp` 16-byte aligned.
+    fn a64_gen_chain_exit(
+        &mut self,
+        wb: &WriteBack,
+        entry: DestLabel,
+        base: usize,
+        using_fpr: UsingFpr,
+    ) {
+        let cont = self.vm_call_continuation().as_ptr() as u64;
+        self.jit.bind_label(entry);
+        // pop_frame: EXEC.cfp + LFP from x29, exactly as `a64_do_call`'s
+        // return continuation would have done.
+        let lfp = GP::R14.a64().0;
+        monoasm_arm64!(&mut self.jit,
+            sub x10, x29, #(BP_CFP as u32);
+            str x10, [x19, #(EXECUTOR_CFP as u32)];
+            ldur x(lfp), [x29, #(-((BP_CFP + CFP_LFP) as i32))];
+        );
+        // Reload the FP pool from the save area the call left in place. Loads
+        // only — sp must stay on the cont frame for the VM continuation's
+        // `ldr PC, [sp]`.
+        self.a64_fpr_reload_cont(using_fpr);
+        monoasm_arm64!(&mut self.jit,
+            sub sp, sp, #(16);
+            str x0, [sp, #(8)];
+        );
+        self.a64_gen_write_back_for_deopt(wb, base);
+        monoasm_arm64!(&mut self.jit,
+            ldr x0, [sp, #(8)];
+            add sp, sp, #(16);
+            mov x9, (cont);
+            br x9;
+        );
+    }
+
+    /// Reload the live FP pool registers from a cont-mode `emit_fpr_save` area
+    /// **without** popping it, leaving sp on the continuation frame. The
+    /// chain-exit handler's counterpart to `emit_fpr_restore`.
+    fn a64_fpr_reload_cont(&mut self, using_fpr: UsingFpr) {
+        let pad = CONTINUATION_FRAME_SIZE as u32;
+        let mut i = 0u32;
+        for (xi, b) in using_fpr.iter().enumerate() {
+            if *b {
+                let pr = xi as u32 + 2;
+                let ofs = pad + 8 * i;
+                monoasm_arm64!(&mut self.jit, ldr d(pr), [sp, #(ofs)];);
+                i += 1;
+            }
+        }
     }
 
     /// Write back live values to LFP slots for a side exit, r14(x22)-relative
@@ -1304,6 +1392,12 @@ impl Codegen {
                 }
                 LSideExitKind::Error => {
                     self.a64_gen_handle_error(pc, &wb, entry, loop_jit_spill_bytes, base)
+                }
+                // The chain exit needs no `pc`: it tails into the VM's
+                // post-call continuation, which reads the resume pc off the
+                // stack (`doc/chain_deopt.md` §3.1).
+                LSideExitKind::ChainExit { using_fpr } => {
+                    self.a64_gen_chain_exit(&wb, entry, base, using_fpr)
                 }
             },
             // Macro-ops (irreducible runtime-call shapes) are delegated to the

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -14,6 +14,48 @@ mod variables;
 
 
 impl Codegen {
+    /// Emit the shared chain-deopt post-call continuation stub — twin of the
+    /// x86 `gen_chain_cont_stub` (see its doc for the contract). Entered by
+    /// `ret` from a converted frame's callee: `x29` is this frame's frame
+    /// pointer again, `x0` holds the result (0 = error signal), `sp` points
+    /// at the cont frame (`[sp]` call-site pc, `[sp + 8]` the walk's
+    /// per-site continuation word). aarch64's `entry_raise` takes the pc
+    /// unchanged in x21, so the error branch needs no `+1` adjustment.
+    pub(in crate::codegen) fn gen_chain_cont_stub(&mut self) {
+        let label = self.jit.label();
+        let fetch = self.vm_fetch();
+        let raise = self.entry_raise();
+        let error = self.jit.label();
+        let no_store = self.jit.label();
+        self.jit.bind_label(label.clone());
+        monoasm_arm64!(&mut self.jit,
+            // pop_frame: EXEC.cfp + LFP from x29 (x29-derived, so correct
+            // regardless of what the callee left in the global registers).
+            sub x10, x29, #(BP_CFP as u32);
+            str x10, [x(EXEC.0), #(EXECUTOR_CFP as u32)];
+            ldur x(LFP.0), [x29, #(-((BP_CFP + CFP_LFP) as i32))];
+            ldr x9, [sp, #(8)];
+            ldr x(PC.0), [sp];
+            add sp, sp, #(16);
+            cbz x0, error;
+            // Resume pc: call-site pc + per-opcode-size advance (low 32 bits
+            // of the continuation word).
+            lsl x10, x9, #(32);
+            lsr x10, x10, #(32);
+            add x(PC.0), x(PC.0), x10;
+            // conv(dst) (0 = no destination slot).
+            lsr x9, x9, #(32);
+            cbz x9, no_store;
+            sub x10, x(LFP.0), x9;
+            str x0, [x10];
+        no_store:
+            b fetch;
+        error:
+            b raise;
+        );
+        self.chain_cont_stub = label;
+    }
+
     pub(in crate::codegen) fn gen_vm_handlers(&mut self) -> VmHandlers {
         self.a64_gen_entry_raise();
         self.a64_gen_stack_overflow();

--- a/monoruby/src/codegen/arch/aarch64/vmgen/method_call.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen/method_call.rs
@@ -166,6 +166,16 @@ impl Codegen {
             ldr x(PC.0), [x15, #(FUNCDATA_PC as u32)];
             ldr x10, [x15, #(FUNCDATA_CODEPTR as u32)];
             blr x10;
+        );
+        // Chain deopt tails into the frame-restoring continuation that starts
+        // here (`doc/chain_deopt.md` §3.1): the address just past the `blr`,
+        // *before* the pop_frame below — a hijacked `ret` skips the JIT
+        // frame's own pop_frame, so the sequence a converted frame resumes
+        // through has to contain one. Carries no per-site state, so this one
+        // address serves every send and yield site.
+        let call_return_addr = self.jit.get_current_address();
+        self.set_vm_call_continuation(call_return_addr);
+        monoasm_arm64!(&mut self.jit,
         // pop_frame: EXEC.cfp = (X29 - BP_CFP). Mirrors x86 `lea r14,[rbp-8]`
         // — set EXEC.cfp to the *address* of this frame's CFP descriptor (set
         // up by the caller's push_frame before our vm_entry). We must NOT

--- a/monoruby/src/codegen/arch/aarch64/vmgen/method_call.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen/method_call.rs
@@ -167,14 +167,6 @@ impl Codegen {
             ldr x10, [x15, #(FUNCDATA_CODEPTR as u32)];
             blr x10;
         );
-        // Chain deopt tails into the frame-restoring continuation that starts
-        // here (`doc/chain_deopt.md` §3.1): the address just past the `blr`,
-        // *before* the pop_frame below — a hijacked `ret` skips the JIT
-        // frame's own pop_frame, so the sequence a converted frame resumes
-        // through has to contain one. Carries no per-site state, so this one
-        // address serves every send and yield site.
-        let call_return_addr = self.jit.get_current_address();
-        self.set_vm_call_continuation(call_return_addr);
         monoasm_arm64!(&mut self.jit,
         // pop_frame: EXEC.cfp = (X29 - BP_CFP). Mirrors x86 `lea r14,[rbp-8]`
         // — set EXEC.cfp to the *address* of this frame's CFP descriptor (set

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -973,28 +973,29 @@ impl Codegen {
                 loop_jit_spill_bytes,
                 base,
             } => match kind {
-                LSideExitKind::Deopt => {
-                    self.gen_deopt_with_label(pc, &wb, entry, loop_jit_spill_bytes, base)
+                LSideExitKind::Deopt { chain } => {
+                    self.gen_deopt_with_label(pc, &wb, entry, loop_jit_spill_bytes, base, chain)
                 }
                 LSideExitKind::Evict => {
                     self.gen_evict_with_label(pc, &wb, entry, loop_jit_spill_bytes, base)
                 }
-                LSideExitKind::RecompileDeopt { reason, position } => self
-                    .gen_recompile_deopt_with_label(
-                        pc,
-                        &wb,
-                        reason,
-                        position,
-                        entry,
-                        loop_jit_spill_bytes,
-                        base,
-                    ),
-                LSideExitKind::Error => self.gen_handle_error(pc, wb, entry, base),
-                // The chain exit needs no `pc`: it tails into the VM's
-                // post-call continuation, which reads the resume pc off the
-                // stack (`doc/chain_deopt.md` §3.1).
-                LSideExitKind::ChainExit { using_fpr } => {
-                    self.gen_chain_exit_with_label(&wb, entry, base, using_fpr)
+                LSideExitKind::RecompileDeopt {
+                    reason,
+                    position,
+                    chain,
+                } => self.gen_recompile_deopt_with_label(
+                    pc,
+                    &wb,
+                    reason,
+                    position,
+                    entry,
+                    loop_jit_spill_bytes,
+                    base,
+                    chain,
+                ),
+                LSideExitKind::Error { chain } => self.gen_handle_error(pc, wb, entry, base, chain),
+                LSideExitKind::ChainExit { using_fpr, dst } => {
+                    self.gen_chain_exit_with_label(&wb, entry, base, using_fpr, pc, dst)
                 }
             },
             // Macro-ops (irreducible runtime-call shapes) are delegated to the

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -104,6 +104,7 @@ impl Codegen {
             | AsmInst::MethodRet(..)
             | AsmInst::BlockBreak(..)
             | AsmInst::ImmediateEvict { .. }
+            | AsmInst::ChainExit { .. }
             | AsmInst::GuardClassVersion { .. }
             | AsmInst::ContFramePc { .. }
             | AsmInst::SetupMethodFrame { .. }
@@ -989,6 +990,12 @@ impl Codegen {
                         base,
                     ),
                 LSideExitKind::Error => self.gen_handle_error(pc, wb, entry, base),
+                // The chain exit needs no `pc`: it tails into the VM's
+                // post-call continuation, which reads the resume pc off the
+                // stack (`doc/chain_deopt.md` §3.1).
+                LSideExitKind::ChainExit { using_fpr } => {
+                    self.gen_chain_exit_with_label(&wb, entry, base, using_fpr)
+                }
             },
             // Macro-ops (irreducible runtime-call shapes) are delegated to the
             // arch-neutral fallback, which dispatches to the per-arch `emit_*`.

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -994,9 +994,6 @@ impl Codegen {
                     chain,
                 ),
                 LSideExitKind::Error { chain } => self.gen_handle_error(pc, wb, entry, base, chain),
-                LSideExitKind::ChainExit { using_fpr, dst } => {
-                    self.gen_chain_exit_with_label(&wb, entry, base, using_fpr, pc, dst)
-                }
             },
             // Macro-ops (irreducible runtime-call shapes) are delegated to the
             // arch-neutral fallback, which dispatches to the per-arch `emit_*`.

--- a/monoruby/src/codegen/arch/x86_64/vmgen.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen.rs
@@ -86,6 +86,72 @@ impl Codegen {
     }
 
     ///
+    /// Emit the shared chain-deopt post-call continuation stub
+    /// (`doc/chain_deopt.md` §9.3) — the single address every converted
+    /// frame's return-address slot points at.
+    ///
+    /// Entered by `ret` from the frame's callee: `rbp` is this frame's frame
+    /// pointer again (the callee's `leave` did that), `rax` holds the
+    /// callee's result (0 = error signal), and `rsp` points at the cont
+    /// frame — `[rsp]` the call-site pc (`ContFramePc`), `[rsp + 8]` the
+    /// per-site continuation word the chain-deopt walk stored
+    /// (`ChainReplay::cont_data`: high 32 bits `conv(dst)` or 0, low 32 bits
+    /// the byte advance to the next instruction). The frame's write-back was
+    /// already replayed at deopt time, so all that is left of the post-call
+    /// continuation is: restore the frame registers, store the result, and
+    /// resume the fetch loop — or hand the call-site pc to `entry_raise` on
+    /// the error signal (a raise or non-local exit unwinds through this stub
+    /// too, since unwinding `ret`s through the rewritten slot with 0 in
+    /// `rax`).
+    ///
+    /// The VM's own send continuation cannot serve here: it re-derives `dst`
+    /// and the resume pc from the bytecode assuming a 2-unit send, which is
+    /// wrong for the 1-unit operator sites (`BinOp` / `Index` / …) that also
+    /// dispatch through the `send` emitter — hence the pad-slot word.
+    ///
+    /// `pop_frame` (rbp-derived, so correct regardless of what the callee
+    /// left in the global registers) restores `Executor::cfp` and `r14`
+    /// before anything else; the stub itself never allocates. The `FprSave`
+    /// area above the cont frame is dead (the replay consumed it) and is
+    /// simply left below the frame, like every side exit does.
+    ///
+    pub(in crate::codegen) fn gen_chain_cont_stub(&mut self) {
+        let label = self.jit.label();
+        let fetch = self.vm_fetch();
+        let raise = self.entry_raise();
+        let error = self.jit.label();
+        let no_store = self.jit.label();
+        self.jit.bind_label(label.clone());
+        self.pop_frame();
+        monoasm! { &mut self.jit,
+            movq rdi, [rsp + 8];
+            movq r13, [rsp];
+            addq rsp, 16;
+            testq rax, rax;
+            jeq  error;
+            // Resume pc: call-site pc + per-opcode-size advance (low 32 bits;
+            // `movl` zero-extends).
+            movl rcx, rdi;
+            addq r13, rcx;
+            // conv(dst) (0 = no destination slot).
+            shrq rdi, 32;
+            testq rdi, rdi;
+            jeq  no_store;
+            negq rdi;
+            movq [r14 + rdi], rax;
+        no_store:
+            jmp  fetch;
+        // Error / non-local-exit signal: `entry_raise` subtracts one unit
+        // from r13, so hand it the call-site pc + 1 unit — the same
+        // convention as `gen_handle_error`.
+        error:
+            addq r13, 16;
+            jmp  raise;
+        };
+        self.chain_cont_stub = label;
+    }
+
+    ///
     /// Emit the VM entry and every bytecode-opcode handler, returning their
     /// entry points. The arch-neutral [`Codegen::construct_vm`] lays the
     /// returned [`VmHandlers`] into the `dispatch` table.

--- a/monoruby/src/codegen/arch/x86_64/vmgen/method_call.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen/method_call.rs
@@ -77,7 +77,13 @@ impl Codegen {
         };
         self.get_func_data();
         self.set_method_outer();
-        self.vm_call(is_simple);
+        let call_return_addr = self.vm_call(is_simple);
+        // Chain deopt tails into this frame-restoring continuation
+        // (`doc/chain_deopt.md` §3.1). It is the address just past the
+        // `call`, *before* `vm_call`'s trailing `pop_frame` — a hijacked
+        // `ret` skips the JIT frame's own `pop_frame`, so the sequence a
+        // converted frame resumes through has to contain one.
+        self.set_vm_call_continuation(call_return_addr);
         monoasm! { &mut self.jit,
         done:
         };
@@ -190,11 +196,15 @@ impl Codegen {
     /// - r13: pc
     /// - r15: &FuncData
     ///
+    /// Returns the call's return address — the position of the trailing
+    /// `pop_frame`, which chain deopt publishes as the VM's post-call
+    /// continuation (`doc/chain_deopt.md` §3.1).
+    ///
     fn vm_call(
         &mut self,
         // The call site has no keyword arguments, no splat arguments, no hash splat arguments, and no block argument.
         is_simple: bool,
-    ) {
+    ) -> CodePtr {
         monoasm! { &mut self.jit,
             // set meta
             movq rax, [r15 + (FUNCDATA_META)];
@@ -255,7 +265,7 @@ impl Codegen {
             self.generic_handle_arguments(runtime::vm_handle_arguments);
             self.vm_handle_error();
         }
-        self.call_funcdata();
+        self.call_funcdata()
     }
 
     ///

--- a/monoruby/src/codegen/arch/x86_64/vmgen/method_call.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen/method_call.rs
@@ -77,13 +77,7 @@ impl Codegen {
         };
         self.get_func_data();
         self.set_method_outer();
-        let call_return_addr = self.vm_call(is_simple);
-        // Chain deopt tails into this frame-restoring continuation
-        // (`doc/chain_deopt.md` §3.1). It is the address just past the
-        // `call`, *before* `vm_call`'s trailing `pop_frame` — a hijacked
-        // `ret` skips the JIT frame's own `pop_frame`, so the sequence a
-        // converted frame resumes through has to contain one.
-        self.set_vm_call_continuation(call_return_addr);
+        self.vm_call(is_simple);
         monoasm! { &mut self.jit,
         done:
         };
@@ -196,15 +190,11 @@ impl Codegen {
     /// - r13: pc
     /// - r15: &FuncData
     ///
-    /// Returns the call's return address — the position of the trailing
-    /// `pop_frame`, which chain deopt publishes as the VM's post-call
-    /// continuation (`doc/chain_deopt.md` §3.1).
-    ///
     fn vm_call(
         &mut self,
         // The call site has no keyword arguments, no splat arguments, no hash splat arguments, and no block argument.
         is_simple: bool,
-    ) -> CodePtr {
+    ) {
         monoasm! { &mut self.jit,
             // set meta
             movq rax, [r15 + (FUNCDATA_META)];
@@ -265,7 +255,7 @@ impl Codegen {
             self.generic_handle_arguments(runtime::vm_handle_arguments);
             self.vm_handle_error();
         }
-        self.call_funcdata()
+        self.call_funcdata();
     }
 
     ///

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -1076,6 +1076,7 @@ impl Codegen {
         wb: WriteBack,
         entry: DestLabel,
         base: usize,
+        chain: bool,
     ) {
         let raise = self.entry_raise();
         assert_eq!(0, self.jit.get_page());
@@ -1084,6 +1085,18 @@ impl Codegen {
         entry:
         );
         self.gen_write_back_for_deopt(&wb, base);
+        // Chain escalation (`doc/chain_deopt.md` §5 step 4): the raise may be
+        // rescued *inside* this frame (resuming it in the interpreter) or
+        // unwind through the suspended callers — either way every suspended
+        // JIT frame above must be converted first. The write-back has run, so
+        // the frame is fully homed for the walk.
+        if chain {
+            monoasm!( &mut self.jit,
+                movq rdi, rbx;
+                movq rax, (runtime::chain_deopt);
+                call rax;
+            );
+        }
         monoasm!( &mut self.jit,
             movq r13, ((pc + 1).as_ptr());
             jmp  raise;
@@ -1104,8 +1117,9 @@ impl Codegen {
         entry: DestLabel,
         loop_jit_spill_bytes: usize,
         base: usize,
+        chain: bool,
     ) {
-        self.side_exit_with_label(pc, wb, entry, false, None, loop_jit_spill_bytes, base)
+        self.side_exit_with_label(pc, wb, entry, false, None, loop_jit_spill_bytes, base, chain)
     }
 
     ///
@@ -1126,6 +1140,7 @@ impl Codegen {
         entry: DestLabel,
         loop_jit_spill_bytes: usize,
         base: usize,
+        chain: bool,
     ) {
         self.side_exit_with_label(
             pc,
@@ -1135,6 +1150,7 @@ impl Codegen {
             Some((reason, position)),
             loop_jit_spill_bytes,
             base,
+            chain,
         )
     }
 
@@ -1154,10 +1170,22 @@ impl Codegen {
     ///
     /// So the handler restores the frame (`pop_frame`: `Executor::cfp` and
     /// `r14`), reloads the caller-saved FP pool out of the save area, writes
-    /// every live value back into this frame's local slots, and jumps to the
-    /// VM's post-call continuation — which pops the cont frame to recover the
-    /// resume pc, stores `rax` into the call's destination slot, and resumes
-    /// the fetch loop. From there this frame is an ordinary interpreter frame.
+    /// every live value back into this frame's local slots, and then runs its
+    /// own post-call continuation: drop the cont frame, and either store
+    /// `rax` into the call's destination slot and resume the fetch loop at
+    /// the site's next instruction, or — when `rax` carries the error signal
+    /// (an exception or non-local exit propagating out of the callee) — hand
+    /// the site pc to `entry_raise`, which runs this frame's `rescue` /
+    /// `ensure` or keeps unwinding.
+    ///
+    /// The continuation is per-site rather than the VM's shared send
+    /// continuation deliberately: that continuation re-derives the
+    /// destination slot and the resume pc from the bytecode **assuming a
+    /// 2-unit send instruction**, but operator call sites (`BinOp` / `Index`
+    /// / …, 1-unit bytecodes) dispatch through the same `send` emitter — at
+    /// such a site the shared continuation would read a garbage destination
+    /// slot, skip the following instruction on resume, and miss the
+    /// exception table on a raise (the `y << 1`-inside-`ensure` shape).
     ///
     /// The `pop_frame` has to come **first**, before the write-back: boxing a
     /// float or materializing a deferred rest `Array` allocates, so a GC can
@@ -1176,8 +1204,12 @@ impl Codegen {
         entry: DestLabel,
         base: usize,
         using_fpr: UsingFpr,
+        pc: BytecodePtr,
+        dst: Option<SlotId>,
     ) {
-        let cont = self.vm_call_continuation();
+        let fetch = self.vm_fetch();
+        let raise = self.entry_raise();
+        let error = self.jit.label();
         assert_eq!(0, self.jit.get_page());
         self.jit.select_page(1);
         self.jit.bind_label(entry);
@@ -1185,9 +1217,7 @@ impl Codegen {
         // destinations are r14-relative, and any GC it triggers marks from
         // `Executor::cfp`.
         self.pop_frame();
-        // Reload the FP pool from the save area the call left in place. Loads
-        // only — rsp must stay on the cont frame for the VM continuation's
-        // `popq r13`.
+        // Reload the FP pool from the save area the call left in place.
         self.fpr_reload_cont(using_fpr);
         monoasm!( &mut self.jit,
             subq rsp, 16;
@@ -1196,9 +1226,31 @@ impl Codegen {
         self.gen_write_back_for_deopt(wb, base);
         monoasm!( &mut self.jit,
             movq rax, [rsp + 8];
-            addq rsp, 16;
-            movq rdi, (cont.as_ptr() as u64);
-            jmp  rdi;
+            // Drop the stash and the cont frame ([pc][pad]) in one go — the
+            // resume pc is baked in below, so the slot is no longer needed.
+            addq rsp, 32;
+            testq rax, rax;
+            jeq  error;
+        );
+        // Normal return: store the result and resume interpreting at the
+        // next instruction (`next` skips the 2-unit sends' cache word and
+        // leaves 1-unit operator sites at exactly the following op).
+        if let Some(dst) = dst {
+            monoasm!( &mut self.jit,
+                movq [r14 - (conv(dst))], rax;
+            );
+        }
+        monoasm!( &mut self.jit,
+            movq r13, (pc.next().as_ptr());
+            jmp  fetch;
+        );
+        // Error / non-local-exit signal: `entry_raise` subtracts one unit
+        // from r13, so hand it `pc + 1` to deliver the call-site pc — the
+        // same convention as `gen_handle_error`.
+        monoasm!( &mut self.jit,
+        error:
+            movq r13, ((pc + 1).as_ptr());
+            jmp  raise;
         );
         self.jit.select_page(0);
     }
@@ -1214,7 +1266,10 @@ impl Codegen {
         loop_jit_spill_bytes: usize,
         base: usize,
     ) {
-        self.side_exit_with_label(pc, wb, entry, true, None, loop_jit_spill_bytes, base)
+        // Evict handlers are only entered through a chain-wide eviction walk,
+        // which converts (or patches) every suspended frame in one pass — no
+        // per-handler escalation needed.
+        self.side_exit_with_label(pc, wb, entry, true, None, loop_jit_spill_bytes, base, false)
     }
 
     ///
@@ -1232,6 +1287,7 @@ impl Codegen {
         recompile: Option<(RecompileReason, Option<BytecodePtr>)>,
         loop_jit_spill_bytes: usize,
         base: usize,
+        chain: bool,
     ) {
         assert_eq!(0, self.jit.get_page());
         self.jit.select_page(1);
@@ -1277,6 +1333,17 @@ impl Codegen {
                 movq rsi, r12;
                 movq rdx, r13;
                 movq rax, (crate::globals::log_deoptimize);
+                call rax;
+            );
+        }
+        // Chain escalation (`doc/chain_deopt.md` §5 step 4): convert every
+        // suspended JIT frame in the caller chain before this frame resumes
+        // in the interpreter. Runs after the write-back (the frame is fully
+        // homed in the LFP) and before the recompile hook / fetch.
+        if chain {
+            monoasm!( &mut self.jit,
+                movq rdi, rbx;
+                movq rax, (runtime::chain_deopt);
                 call rax;
             );
         }

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -727,6 +727,27 @@ impl JitModule {
     }
 
     ///
+    /// Reload the live FP pool registers from a cont-mode save area
+    /// **without** popping it, leaving rsp on the continuation frame.
+    ///
+    /// Used by the chain-exit handler (`gen_chain_exit_with_label`), which
+    /// needs the pool registers back to write them out but must leave the
+    /// cont frame in place for the VM continuation's `popq r13`.
+    ///
+    pub(crate) fn fpr_reload_cont(&mut self, using_fpr: UsingFpr) {
+        let pad = CONTINUATION_FRAME_SIZE as i32;
+        let mut i = 0;
+        for (x, b) in using_fpr.iter().enumerate() {
+            if *b {
+                monoasm!( &mut self.jit,
+                    movq xmm(x as u64 + 2), [rsp + (pad + 8 * i)];
+                );
+                i += 1;
+            }
+        }
+    }
+
+    ///
     /// Restore floating point registers in use.
     ///
     fn fpr_restore_with_cont(&mut self, using_fpr: UsingFpr, cont: bool) {
@@ -1115,6 +1136,71 @@ impl Codegen {
             loop_jit_spill_bytes,
             base,
         )
+    }
+
+    ///
+    /// Emit this call site's **chain-exit** handler (`doc/chain_deopt.md` §2).
+    ///
+    /// Entered by `ret`, not by a branch from this frame's body: the
+    /// chain-deopt walk has written this handler's address into the callee
+    /// frame's return-address slot. On entry, therefore,
+    ///
+    /// - `rbp` is this frame's frame pointer again (the callee's `leave` did
+    ///   that), but `r14` still holds the *callee's* LFP,
+    /// - `rax` holds the callee's return value,
+    /// - `rsp` is where the call left it: pointing at the cont frame, with the
+    ///   `FprSave` area (`using_fpr`) just above it, exactly as the normal
+    ///   return continuation would find it.
+    ///
+    /// So the handler restores the frame (`pop_frame`: `Executor::cfp` and
+    /// `r14`), reloads the caller-saved FP pool out of the save area, writes
+    /// every live value back into this frame's local slots, and jumps to the
+    /// VM's post-call continuation — which pops the cont frame to recover the
+    /// resume pc, stores `rax` into the call's destination slot, and resumes
+    /// the fetch loop. From there this frame is an ordinary interpreter frame.
+    ///
+    /// The `pop_frame` has to come **first**, before the write-back: boxing a
+    /// float or materializing a deferred rest `Array` allocates, so a GC can
+    /// run inside the write-back, and the mark walk starts from
+    /// `Executor::cfp` — which on entry still names the callee frame that has
+    /// just been torn down. (The VM continuation repeats the `pop_frame`;
+    /// it is idempotent.)
+    ///
+    /// `rax` is stashed across the write-back (which destroys it) in the
+    /// callee's dead frame header, keeping `rsp` 16-byte aligned for the
+    /// boxing calls the write-back makes.
+    ///
+    pub(in crate::codegen) fn gen_chain_exit_with_label(
+        &mut self,
+        wb: &WriteBack,
+        entry: DestLabel,
+        base: usize,
+        using_fpr: UsingFpr,
+    ) {
+        let cont = self.vm_call_continuation();
+        assert_eq!(0, self.jit.get_page());
+        self.jit.select_page(1);
+        self.jit.bind_label(entry);
+        // Restore this frame as the current one: the write-back's
+        // destinations are r14-relative, and any GC it triggers marks from
+        // `Executor::cfp`.
+        self.pop_frame();
+        // Reload the FP pool from the save area the call left in place. Loads
+        // only — rsp must stay on the cont frame for the VM continuation's
+        // `popq r13`.
+        self.fpr_reload_cont(using_fpr);
+        monoasm!( &mut self.jit,
+            subq rsp, 16;
+            movq [rsp + 8], rax;
+        );
+        self.gen_write_back_for_deopt(wb, base);
+        monoasm!( &mut self.jit,
+            movq rax, [rsp + 8];
+            addq rsp, 16;
+            movq rdi, (cont.as_ptr() as u64);
+            jmp  rdi;
+        );
+        self.jit.select_page(0);
     }
 
     ///

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -325,6 +325,237 @@ impl UsingFpr {
     }
 }
 
+///
+/// Compile-time half of a call site's chain-deopt registration
+/// (`doc/chain_deopt.md` §2/§9.3): everything the eager replay needs that is
+/// known while building `AsmIr`. The frame's spill `base` is attached at
+/// lowering time (`AsmInst::ChainExit` → [`ChainReplay`]), where
+/// `base_stack_offset` is available.
+///
+#[derive(Debug, Clone)]
+pub(crate) struct ChainExitSpec {
+    wb: WriteBack,
+    using_fpr: UsingFpr,
+    dst: Option<SlotId>,
+    pc: BytecodePtr,
+}
+
+impl ChainExitSpec {
+    ///
+    /// Capture this call site's replay data. Must be called at the point
+    /// where the outgoing frame is fully set up and `dst` has already been
+    /// discarded — i.e. next to `new_error` — so the write-back describes the
+    /// frame exactly as the post-call continuation expects to find it: every
+    /// live value homed in the LFP, `dst` still untouched (the continuation
+    /// stores it from the callee's return value).
+    ///
+    /// `using_fpr` is the call's `FprSave` set, which fixes the layout of the
+    /// save area the replay reads the pool-resident floats out of.
+    ///
+    pub(crate) fn new(
+        state: &AbstractFrame,
+        using_fpr: UsingFpr,
+        dst: Option<SlotId>,
+    ) -> Self {
+        Self {
+            wb: state.get_write_back(),
+            using_fpr,
+            dst,
+            pc: state.pc(),
+        }
+    }
+
+    pub(in crate::codegen) fn into_replay(self, base: usize) -> ChainReplay {
+        ChainReplay {
+            wb: self.wb,
+            base,
+            using_fpr: self.using_fpr,
+            dst: self.dst,
+            pc: self.pc,
+        }
+    }
+}
+
+///
+/// Runtime half of a call site's chain-deopt registration: the value of
+/// `Codegen::chain_deopt_table`, keyed by the call's return address. Carries
+/// what the eager walk needs to (a) replay the suspended caller frame's
+/// write-back from Rust and (b) hand the shared VM continuation stub its
+/// per-site post-call data (`dst`, resume-pc advance) through the cont-frame
+/// pad slot.
+///
+#[derive(Debug, Clone)]
+pub(crate) struct ChainReplay {
+    wb: WriteBack,
+    /// The caller frame's spill `base` (`base_stack_offset`), which fixes the
+    /// `[rbp/x29 - (base - 24 + 8n)]` addresses of its spilled `FPReg`s.
+    base: usize,
+    using_fpr: UsingFpr,
+    dst: Option<SlotId>,
+    /// The call-site pc.
+    pc: BytecodePtr,
+}
+
+impl ChainReplay {
+    ///
+    /// The word the walk stores into the callee frame's cont-frame pad slot
+    /// for the shared continuation stub: high 32 bits = `conv(dst)` (`0` =
+    /// no destination slot; `conv` is never 0 since `conv(SlotId(0)) ==
+    /// LFP_SELF`), low 32 bits = the byte advance from the call-site pc to
+    /// the next instruction (16 or 32 — `BytecodePtr::next` is
+    /// per-opcode-size aware, which is what makes one shared stub correct
+    /// for both 2-unit sends and 1-unit operator sites).
+    ///
+    fn cont_data(&self) -> u64 {
+        let dst = match self.dst {
+            Some(dst) => conv(dst) as u64,
+            None => 0,
+        };
+        let advance = (self.pc.next().as_ptr() as u64) - (self.pc.as_ptr() as u64);
+        (dst << 32) | advance
+    }
+
+    ///
+    /// Replay this suspended caller frame's write-back from Rust
+    /// (`doc/chain_deopt.md` §9.3): box its live floats into its local slots
+    /// and materialize any deferred rest `Array` / kwrest `Hash`, so the
+    /// frame is fully homed before the interpreter (or anything reading it
+    /// through `outer_lfp`) can see it.
+    ///
+    /// Frame layout facts this relies on (see §8 of the doc): every JIT/VM
+    /// frame has `rbp == cfp + BP_CFP`; the call's `FprSave` area lives at
+    /// `callee_rbp + 32 + 8i` (one slot per set bit of `using_fpr`, in bit
+    /// order); spilled `FPReg`s live at `caller_rbp - (base - 24 + 8n)`.
+    ///
+    /// GC safety: each slot store is a whole boxed `Value`, and every slot
+    /// holds a valid (possibly stale) `Value` throughout, so the allocations
+    /// here (boxing, `create_array`, the kwrest `Hash`) can trigger a
+    /// collection at any point.
+    ///
+    /// ### safety
+    /// `callee_cfp` must be a live control frame of the current thread's
+    /// stack whose return address is the call site this replay was
+    /// registered for, and `caller_cfp` its `prev()`.
+    ///
+    unsafe fn replay(&self, callee_cfp: Cfp, caller_cfp: Cfp) {
+        let callee_bp = callee_cfp.frame_bp();
+        let caller_bp = caller_cfp.frame_bp();
+        // The caller frame may have been moved to the heap by the callee;
+        // the cfp's LFP slot is redirected at promotion, so this reads the
+        // live copy (the emitted deopt write-back's r14 does the same).
+        let mut caller_lfp = caller_cfp.lfp();
+        for (fpr, slots) in &self.wb.fpr {
+            let f = if fpr.0 < PHYS_FPR_POOL {
+                // Pool-resident: the call's `FprSave` spilled it to the save
+                // area above the cont frame, one slot per set bit in bit
+                // order.
+                debug_assert!(self.using_fpr[fpr.0]);
+                let i = self.using_fpr[..fpr.0].count_ones();
+                // SAFETY: per the layout facts above, the save area occupies
+                // `callee_bp + 32 ..` and slot `i` belongs to `fpr`.
+                unsafe { *((callee_bp as usize + 32 + 8 * i) as *const f64) }
+            } else {
+                let off = (self.base as i64) - 24 + 8 * ((fpr.0 - PHYS_FPR_POOL) as i64);
+                // SAFETY: the caller frame is suspended on the stack, so its
+                // spill slot still holds the unboxed f64.
+                unsafe { *(((caller_bp as usize as i64) - off) as usize as *const f64) }
+            };
+            let v = Value::float(f);
+            for slot in slots {
+                // SAFETY: `slot` is a register slot of the caller frame.
+                unsafe { caller_lfp.set_register(*slot, Some(v)) };
+            }
+        }
+        for (v, slot) in &self.wb.literal {
+            // SAFETY: as above.
+            unsafe { caller_lfp.set_register(*slot, Some(*v)) };
+        }
+        for slot in &self.wb.void {
+            // SAFETY: as above.
+            unsafe { caller_lfp.set_register(*slot, Some(Value::nil())) };
+        }
+        // GP-pool residents exist only under the (unfinished) GP allocator;
+        // shipping builds never record any.
+        debug_assert!(self.wb.gp.is_empty());
+        // D1/K1 run last, so the literal loop above has already written each
+        // deferred `dst` slot (mode `C(nil)`) and the frame stays
+        // GC-consistent across the allocating helper calls. The source slots
+        // live in the frame's *dynamic caller* (the outermost,
+        // non-specialized frame), reached through the rbp the trampoline
+        // frame saved — exactly as the emitted write-back addresses them.
+        for (dst, src, len) in &self.wb.forward_rest {
+            // SAFETY: `caller_bp` is the suspended trampoline frame's rbp;
+            // `[caller_bp]` is the rbp it saved in its prologue.
+            let grand_bp = unsafe { *(caller_bp as *const u64) };
+            let src = ((grand_bp as i64 - rbp_local(*src) as i64) as usize) as *mut Value;
+            let v = runtime::create_array(src, *len as usize);
+            // SAFETY: `dst` is the trampoline frame's rest local.
+            unsafe { caller_lfp.set_register(*dst, Some(v)) };
+        }
+        for (dst, table) in &self.wb.forward_kwrest {
+            // SAFETY: as for `forward_rest`.
+            let grand_bp = unsafe { *(caller_bp as *const u64) };
+            // SAFETY: `lfp == rbp - RBP_LOCAL_FRAME` in every JIT frame.
+            let grand_lfp =
+                unsafe { Lfp::from_ptr((grand_bp as usize - RBP_LOCAL_FRAME as usize) as *mut u8) };
+            let v = runtime::kwrest_hash(table, grand_lfp);
+            // SAFETY: `dst` is the trampoline frame's kwrest local.
+            unsafe { caller_lfp.set_register(*dst, Some(v)) };
+        }
+    }
+}
+
+///
+/// One frame's worth of eager chain-deopt conversion, produced by the walks
+/// (`Codegen::chain_deopt` / `Codegen::evict_suspended_frames`) and applied
+/// by their callers *after* the `CODEGEN` borrow is released — the replay
+/// allocates (boxing, rest-`Array`/kwrest-`Hash` materialization) and so can
+/// run a GC, which must not happen while the thread-local is held.
+///
+pub(crate) struct ChainConversion {
+    callee_cfp: Cfp,
+    caller_cfp: Cfp,
+    replay: ChainReplay,
+    /// The shared VM post-call continuation stub (`gen_chain_cont_stub`).
+    stub: CodePtr,
+}
+
+impl ChainConversion {
+    pub(crate) fn new(callee_cfp: Cfp, caller_cfp: Cfp, replay: ChainReplay, stub: CodePtr) -> Self {
+        Self {
+            callee_cfp,
+            caller_cfp,
+            replay,
+            stub,
+        }
+    }
+
+    ///
+    /// Convert the suspended caller frame: replay its write-back, then hand
+    /// the callee's cont frame the per-site continuation word and point the
+    /// callee's return-address slot at the shared VM continuation stub. From
+    /// here on control never re-enters the caller's compiled body.
+    ///
+    /// ### safety
+    /// As for [`ChainReplay::replay`]; additionally the callee's `ret` must
+    /// not have run yet (it has not — the walk found the frame suspended).
+    ///
+    pub(crate) unsafe fn apply(self) {
+        let Self {
+            mut callee_cfp,
+            caller_cfp,
+            replay,
+            stub,
+        } = self;
+        // SAFETY: guaranteed by the caller.
+        unsafe {
+            replay.replay(callee_cfp, caller_cfp);
+            callee_cfp.set_cont_frame_data(replay.cont_data());
+            callee_cfp.set_return_addr(stub);
+        }
+    }
+}
+
 #[allow(dead_code)]
 #[derive(Debug)]
 pub(super) struct SpecializedCodeInfo {
@@ -724,27 +955,6 @@ impl JitModule {
 
     pub(crate) fn fpr_restore(&mut self, using_fpr: UsingFpr) {
         self.fpr_restore_with_cont(using_fpr, false);
-    }
-
-    ///
-    /// Reload the live FP pool registers from a cont-mode save area
-    /// **without** popping it, leaving rsp on the continuation frame.
-    ///
-    /// Used by the chain-exit handler (`gen_chain_exit_with_label`), which
-    /// needs the pool registers back to write them out but must leave the
-    /// cont frame in place for the VM continuation's `popq r13`.
-    ///
-    pub(crate) fn fpr_reload_cont(&mut self, using_fpr: UsingFpr) {
-        let pad = CONTINUATION_FRAME_SIZE as i32;
-        let mut i = 0;
-        for (x, b) in using_fpr.iter().enumerate() {
-            if *b {
-                monoasm!( &mut self.jit,
-                    movq xmm(x as u64 + 2), [rsp + (pad + 8 * i)];
-                );
-                i += 1;
-            }
-        }
     }
 
     ///
@@ -1152,107 +1362,6 @@ impl Codegen {
             base,
             chain,
         )
-    }
-
-    ///
-    /// Emit this call site's **chain-exit** handler (`doc/chain_deopt.md` §2).
-    ///
-    /// Entered by `ret`, not by a branch from this frame's body: the
-    /// chain-deopt walk has written this handler's address into the callee
-    /// frame's return-address slot. On entry, therefore,
-    ///
-    /// - `rbp` is this frame's frame pointer again (the callee's `leave` did
-    ///   that), but `r14` still holds the *callee's* LFP,
-    /// - `rax` holds the callee's return value,
-    /// - `rsp` is where the call left it: pointing at the cont frame, with the
-    ///   `FprSave` area (`using_fpr`) just above it, exactly as the normal
-    ///   return continuation would find it.
-    ///
-    /// So the handler restores the frame (`pop_frame`: `Executor::cfp` and
-    /// `r14`), reloads the caller-saved FP pool out of the save area, writes
-    /// every live value back into this frame's local slots, and then runs its
-    /// own post-call continuation: drop the cont frame, and either store
-    /// `rax` into the call's destination slot and resume the fetch loop at
-    /// the site's next instruction, or — when `rax` carries the error signal
-    /// (an exception or non-local exit propagating out of the callee) — hand
-    /// the site pc to `entry_raise`, which runs this frame's `rescue` /
-    /// `ensure` or keeps unwinding.
-    ///
-    /// The continuation is per-site rather than the VM's shared send
-    /// continuation deliberately: that continuation re-derives the
-    /// destination slot and the resume pc from the bytecode **assuming a
-    /// 2-unit send instruction**, but operator call sites (`BinOp` / `Index`
-    /// / …, 1-unit bytecodes) dispatch through the same `send` emitter — at
-    /// such a site the shared continuation would read a garbage destination
-    /// slot, skip the following instruction on resume, and miss the
-    /// exception table on a raise (the `y << 1`-inside-`ensure` shape).
-    ///
-    /// The `pop_frame` has to come **first**, before the write-back: boxing a
-    /// float or materializing a deferred rest `Array` allocates, so a GC can
-    /// run inside the write-back, and the mark walk starts from
-    /// `Executor::cfp` — which on entry still names the callee frame that has
-    /// just been torn down. (The VM continuation repeats the `pop_frame`;
-    /// it is idempotent.)
-    ///
-    /// `rax` is stashed across the write-back (which destroys it) in the
-    /// callee's dead frame header, keeping `rsp` 16-byte aligned for the
-    /// boxing calls the write-back makes.
-    ///
-    pub(in crate::codegen) fn gen_chain_exit_with_label(
-        &mut self,
-        wb: &WriteBack,
-        entry: DestLabel,
-        base: usize,
-        using_fpr: UsingFpr,
-        pc: BytecodePtr,
-        dst: Option<SlotId>,
-    ) {
-        let fetch = self.vm_fetch();
-        let raise = self.entry_raise();
-        let error = self.jit.label();
-        assert_eq!(0, self.jit.get_page());
-        self.jit.select_page(1);
-        self.jit.bind_label(entry);
-        // Restore this frame as the current one: the write-back's
-        // destinations are r14-relative, and any GC it triggers marks from
-        // `Executor::cfp`.
-        self.pop_frame();
-        // Reload the FP pool from the save area the call left in place.
-        self.fpr_reload_cont(using_fpr);
-        monoasm!( &mut self.jit,
-            subq rsp, 16;
-            movq [rsp + 8], rax;
-        );
-        self.gen_write_back_for_deopt(wb, base);
-        monoasm!( &mut self.jit,
-            movq rax, [rsp + 8];
-            // Drop the stash and the cont frame ([pc][pad]) in one go — the
-            // resume pc is baked in below, so the slot is no longer needed.
-            addq rsp, 32;
-            testq rax, rax;
-            jeq  error;
-        );
-        // Normal return: store the result and resume interpreting at the
-        // next instruction (`next` skips the 2-unit sends' cache word and
-        // leaves 1-unit operator sites at exactly the following op).
-        if let Some(dst) = dst {
-            monoasm!( &mut self.jit,
-                movq [r14 - (conv(dst))], rax;
-            );
-        }
-        monoasm!( &mut self.jit,
-            movq r13, (pc.next().as_ptr());
-            jmp  fetch;
-        );
-        // Error / non-local-exit signal: `entry_raise` subtracts one unit
-        // from r13, so hand it `pc + 1` to deliver the call-site pc — the
-        // same convention as `gen_handle_error`.
-        monoasm!( &mut self.jit,
-        error:
-            movq r13, ((pc + 1).as_ptr());
-            jmp  raise;
-        );
-        self.jit.select_page(0);
     }
 
     ///

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -61,6 +61,21 @@ pub(crate) enum ArrayIndexKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct AsmEvict(usize);
 
+///
+/// A **chain-exit** side exit: the handler a suspended JIT frame is made to
+/// `ret` into when the whole control-frame chain has to be converted from
+/// JIT frames into interpreter frames at once (`doc/chain_deopt.md`).
+///
+/// Distinct from [`AsmEvict`], which is reached by *patching the call's
+/// return continuation* and therefore runs **after** the site's result
+/// store; a chain exit is reached by *rewriting the return-address slot*
+/// and so runs **before** it — the VM's post-call continuation performs the
+/// store instead. That is why it carries its own write-back, captured at
+/// the call (post-`discard(dst)`, pre-`def`) rather than at `next_pc`.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct AsmChain(usize);
+
 pub(crate) struct SideExitLabels(Vec<DestLabel>);
 
 impl SideExitLabels {
@@ -93,6 +108,14 @@ impl std::ops::Index<AsmEvict> for SideExitLabels {
     type Output = DestLabel;
 
     fn index(&self, index: AsmEvict) -> &Self::Output {
+        &self.0[index.0]
+    }
+}
+
+impl std::ops::Index<AsmChain> for SideExitLabels {
+    type Output = DestLabel;
+
+    fn index(&self, index: AsmChain) -> &Self::Output {
         &self.0[index.0]
     }
 }
@@ -322,6 +345,33 @@ impl AsmIr {
     pub(crate) fn new_evict(&mut self) -> AsmEvict {
         let i = self.new_label(SideExit::Evict(None));
         AsmEvict(i)
+    }
+
+    ///
+    /// Allocate this call site's chain-exit handler (`doc/chain_deopt.md` §2).
+    ///
+    /// Must be called at the point where the outgoing frame is fully set up
+    /// and `dst` has already been discarded — i.e. next to `new_error` — so
+    /// the captured write-back describes the frame exactly as the VM's
+    /// post-call continuation expects to find it: every live value homed in
+    /// the LFP, `dst` still untouched (the continuation's `vm_store_rdi`
+    /// writes it from the callee's return value).
+    ///
+    /// `using_fpr` is the call's `FprSave` set, which the handler needs to
+    /// reload the caller-saved FP pool registers out of the save area the
+    /// call left behind before it can write them back.
+    ///
+    pub(crate) fn new_chain_exit(
+        &mut self,
+        state: &AbstractFrame,
+        using_fpr: UsingFpr,
+    ) -> AsmChain {
+        let i = self.new_label(SideExit::ChainExit(
+            state.pc(),
+            state.get_write_back(),
+            using_fpr,
+        ));
+        AsmChain(i)
     }
 
     pub(crate) fn new_deopt_with_pc(&mut self, state: &AbstractFrame, pc: BytecodePtr) -> AsmDeopt {
@@ -1868,6 +1918,20 @@ pub(super) enum AsmInst {
     ImmediateEvict {
         evict: AsmEvict,
     },
+    ///
+    /// Register this call site's chain-exit handler in the runtime table
+    /// (`doc/chain_deopt.md` §5 step 1). Emits no machine code: it looks the
+    /// call's return address up by `evict` (recorded moments earlier by
+    /// `set_deopt_with_return_addr`) and maps it to `chain`'s handler, so the
+    /// chain-deopt walk can find the handler from a suspended frame's
+    /// return-address slot alone.
+    ///
+    /// Must be emitted after the call instruction it belongs to.
+    ///
+    ChainExit {
+        evict: AsmEvict,
+        chain: AsmChain,
+    },
     CheckBOP {
         deopt: AsmDeopt,
     },
@@ -2648,6 +2712,13 @@ pub enum SideExit {
     ///
     RecompileDeoptimize(BytecodePtr, WriteBack, RecompileReason, Option<BytecodePtr>),
     Error(BytecodePtr, WriteBack),
+    ///
+    /// Chain-exit handler for a suspended call (`doc/chain_deopt.md`). The
+    /// `pc` is the *call-site* pc and is carried for diagnostics only — the
+    /// handler tails into the VM's post-call continuation, which recovers the
+    /// resume pc from the cont-frame slot on the stack.
+    ///
+    ChainExit(BytecodePtr, WriteBack, UsingFpr),
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -2728,6 +2799,18 @@ impl Codegen {
                     let label = self.jit.label();
                     lir.push(LInst::SideExit {
                         kind: LSideExitKind::Error,
+                        pc,
+                        wb,
+                        entry: label.clone(),
+                        loop_jit_spill_bytes,
+                        base,
+                    });
+                    label
+                }
+                SideExit::ChainExit(pc, wb, using_fpr) => {
+                    let label = self.jit.label();
+                    lir.push(LInst::SideExit {
+                        kind: LSideExitKind::ChainExit { using_fpr },
                         pc,
                         wb,
                         entry: label.clone(),

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -139,6 +139,13 @@ pub(crate) struct AsmIr {
     /// generic / native callee). Producer skips `create_array` only
     /// when `deferred_rest && !needs_rest_array`.
     needs_rest_array: bool,
+    /// Every interpreter-resuming side exit built through this IR escalates
+    /// to chain deopt (`doc/chain_deopt.md` §5 step 4 / §6): the handler runs
+    /// the chain-deopt walk after its write-back, converting every suspended
+    /// JIT frame in the caller chain before the interpreter resumes. Stamped
+    /// once from [`JitContext::escalate_side_exits`] so the side-exit
+    /// constructors are the single consultation point.
+    escalate_exits: bool,
 }
 
 impl std::ops::Index<AsmEvict> for AsmIr {
@@ -174,6 +181,7 @@ impl AsmIr {
             had_deopt: false,
             deferred_rest: false,
             needs_rest_array: false,
+            escalate_exits: ctx.escalate_side_exits(),
         }
     }
 
@@ -302,11 +310,14 @@ impl AsmIr {
     /// ordinary cold-handler path. aarch64-only (see [`Self::as_pure_deopt`]).
     ///
     #[cfg(target_arch = "aarch64")]
-    pub(super) fn pure_deopt_target(&self, deopt: AsmDeopt) -> Option<(BytecodePtr, &WriteBack)> {
+    pub(super) fn pure_deopt_target(
+        &self,
+        deopt: AsmDeopt,
+    ) -> Option<(BytecodePtr, &WriteBack, bool)> {
         if self.side_exit.len() == 1
-            && let SideExit::Deoptimize(pc, wb) = &self.side_exit[deopt.0]
+            && let SideExit::Deoptimize(pc, wb, chain) = &self.side_exit[deopt.0]
         {
-            Some((*pc, wb))
+            Some((*pc, wb, *chain))
         } else {
             None
         }
@@ -365,17 +376,23 @@ impl AsmIr {
         &mut self,
         state: &AbstractFrame,
         using_fpr: UsingFpr,
+        dst: Option<SlotId>,
     ) -> AsmChain {
         let i = self.new_label(SideExit::ChainExit(
             state.pc(),
             state.get_write_back(),
             using_fpr,
+            dst,
         ));
         AsmChain(i)
     }
 
     pub(crate) fn new_deopt_with_pc(&mut self, state: &AbstractFrame, pc: BytecodePtr) -> AsmDeopt {
-        let i = self.new_label(SideExit::Deoptimize(pc, state.get_write_back()));
+        let i = self.new_label(SideExit::Deoptimize(
+            pc,
+            state.get_write_back(),
+            self.escalate_exits,
+        ));
         self.had_deopt = true;
         AsmDeopt(i)
     }
@@ -413,7 +430,11 @@ impl AsmIr {
     /// reading the live `AbstractFrame`.
     ///
     pub(super) fn deopt_from_point(&mut self, point: &DeoptPoint) -> AsmDeopt {
-        let i = self.new_label(SideExit::Deoptimize(point.pc(), point.write_back().clone()));
+        let i = self.new_label(SideExit::Deoptimize(
+            point.pc(),
+            point.write_back().clone(),
+            self.escalate_exits,
+        ));
         self.had_deopt = true;
         AsmDeopt(i)
     }
@@ -440,13 +461,18 @@ impl AsmIr {
             state.get_write_back(),
             reason,
             position,
+            self.escalate_exits,
         ));
         self.had_deopt = true;
         AsmDeopt(i)
     }
 
     pub(crate) fn new_error_with_pc(&mut self, state: &AbstractFrame, pc: BytecodePtr) -> AsmError {
-        let i = self.new_label(SideExit::Error(pc, state.get_write_back()));
+        let i = self.new_label(SideExit::Error(
+            pc,
+            state.get_write_back(),
+            self.escalate_exits,
+        ));
         AsmError(i)
     }
 
@@ -2701,7 +2727,13 @@ impl AsmInst {
 #[derive(Debug)]
 pub enum SideExit {
     Evict(Option<(BytecodePtr, WriteBack)>),
-    Deoptimize(BytecodePtr, WriteBack),
+    /// The trailing `bool` is the **chain-escalation** flag
+    /// (`doc/chain_deopt.md` §5 step 4 / §6), on `Deoptimize` /
+    /// `RecompileDeoptimize` / `Error` alike: the handler calls
+    /// `runtime::chain_deopt` after its write-back, so every suspended JIT
+    /// frame in the caller chain is converted into an interpreter frame
+    /// before this frame resumes in the interpreter (or starts unwinding).
+    Deoptimize(BytecodePtr, WriteBack, bool),
     ///
     /// A deopt that, after a small number of misses, recompiles the
     /// whole method/loop with the given reason instead of falling
@@ -2710,15 +2742,25 @@ pub enum SideExit {
     /// BinCmp sites so they flip to the non-deopting polymorphic
     /// path once the VM has observed class variance (Part B).
     ///
-    RecompileDeoptimize(BytecodePtr, WriteBack, RecompileReason, Option<BytecodePtr>),
-    Error(BytecodePtr, WriteBack),
+    RecompileDeoptimize(
+        BytecodePtr,
+        WriteBack,
+        RecompileReason,
+        Option<BytecodePtr>,
+        bool,
+    ),
+    Error(BytecodePtr, WriteBack, bool),
     ///
     /// Chain-exit handler for a suspended call (`doc/chain_deopt.md`). The
-    /// `pc` is the *call-site* pc and is carried for diagnostics only — the
-    /// handler tails into the VM's post-call continuation, which recovers the
-    /// resume pc from the cont-frame slot on the stack.
+    /// `pc` is the *call-site* pc and `dst` the call's destination slot: the
+    /// handler carries its own post-call continuation (store the callee's
+    /// result into `dst`, resume the fetch loop at `pc.next()`, or on an
+    /// error/non-local-exit signal hand `pc` to `entry_raise`) because the
+    /// VM's shared send continuation assumes a 2-unit send bytecode — wrong
+    /// for the 1-unit operator sites (`BinOp` / `Index` / …) that also
+    /// dispatch through `send`.
     ///
-    ChainExit(BytecodePtr, WriteBack, UsingFpr),
+    ChainExit(BytecodePtr, WriteBack, UsingFpr, Option<SlotId>),
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -2741,7 +2783,8 @@ impl Codegen {
         _fallthrough_in: bool,
     ) {
         let mut side_exits = SideExitLabels::new();
-        let mut deopt_table: HashMap<(BytecodePtr, WriteBack), DestLabel> = HashMap::default();
+        let mut deopt_table: HashMap<(BytecodePtr, WriteBack, bool), DestLabel> =
+            HashMap::default();
         let loop_jit_spill_bytes = frame.loop_jit_spill_bytes;
         let base = frame.base_stack_offset;
         // §9 (9a, first brick): reify the isolated side-exit handler block into a
@@ -2765,14 +2808,14 @@ impl Codegen {
                     });
                     label
                 }
-                SideExit::Deoptimize(pc, wb) => {
-                    let t = (pc, wb);
+                SideExit::Deoptimize(pc, wb, chain) => {
+                    let t = (pc, wb, chain);
                     if let Some(label) = deopt_table.get(&t) {
                         label.clone()
                     } else {
                         let label = self.jit.label();
                         lir.push(LInst::SideExit {
-                            kind: LSideExitKind::Deopt,
+                            kind: LSideExitKind::Deopt { chain: t.2 },
                             pc: t.0,
                             wb: t.1.clone(),
                             entry: label.clone(),
@@ -2783,10 +2826,14 @@ impl Codegen {
                         label
                     }
                 }
-                SideExit::RecompileDeoptimize(pc, wb, reason, position) => {
+                SideExit::RecompileDeoptimize(pc, wb, reason, position, chain) => {
                     let label = self.jit.label();
                     lir.push(LInst::SideExit {
-                        kind: LSideExitKind::RecompileDeopt { reason, position },
+                        kind: LSideExitKind::RecompileDeopt {
+                            reason,
+                            position,
+                            chain,
+                        },
                         pc,
                         wb,
                         entry: label.clone(),
@@ -2795,10 +2842,10 @@ impl Codegen {
                     });
                     label
                 }
-                SideExit::Error(pc, wb) => {
+                SideExit::Error(pc, wb, chain) => {
                     let label = self.jit.label();
                     lir.push(LInst::SideExit {
-                        kind: LSideExitKind::Error,
+                        kind: LSideExitKind::Error { chain },
                         pc,
                         wb,
                         entry: label.clone(),
@@ -2807,10 +2854,10 @@ impl Codegen {
                     });
                     label
                 }
-                SideExit::ChainExit(pc, wb, using_fpr) => {
+                SideExit::ChainExit(pc, wb, using_fpr, dst) => {
                     let label = self.jit.label();
                     lir.push(LInst::SideExit {
-                        kind: LSideExitKind::ChainExit { using_fpr },
+                        kind: LSideExitKind::ChainExit { using_fpr, dst },
                         pc,
                         wb,
                         entry: label.clone(),

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -61,21 +61,6 @@ pub(crate) enum ArrayIndexKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct AsmEvict(usize);
 
-///
-/// A **chain-exit** side exit: the handler a suspended JIT frame is made to
-/// `ret` into when the whole control-frame chain has to be converted from
-/// JIT frames into interpreter frames at once (`doc/chain_deopt.md`).
-///
-/// Distinct from [`AsmEvict`], which is reached by *patching the call's
-/// return continuation* and therefore runs **after** the site's result
-/// store; a chain exit is reached by *rewriting the return-address slot*
-/// and so runs **before** it — the VM's post-call continuation performs the
-/// store instead. That is why it carries its own write-back, captured at
-/// the call (post-`discard(dst)`, pre-`def`) rather than at `next_pc`.
-///
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) struct AsmChain(usize);
-
 pub(crate) struct SideExitLabels(Vec<DestLabel>);
 
 impl SideExitLabels {
@@ -108,14 +93,6 @@ impl std::ops::Index<AsmEvict> for SideExitLabels {
     type Output = DestLabel;
 
     fn index(&self, index: AsmEvict) -> &Self::Output {
-        &self.0[index.0]
-    }
-}
-
-impl std::ops::Index<AsmChain> for SideExitLabels {
-    type Output = DestLabel;
-
-    fn index(&self, index: AsmChain) -> &Self::Output {
         &self.0[index.0]
     }
 }
@@ -356,35 +333,6 @@ impl AsmIr {
     pub(crate) fn new_evict(&mut self) -> AsmEvict {
         let i = self.new_label(SideExit::Evict(None));
         AsmEvict(i)
-    }
-
-    ///
-    /// Allocate this call site's chain-exit handler (`doc/chain_deopt.md` §2).
-    ///
-    /// Must be called at the point where the outgoing frame is fully set up
-    /// and `dst` has already been discarded — i.e. next to `new_error` — so
-    /// the captured write-back describes the frame exactly as the VM's
-    /// post-call continuation expects to find it: every live value homed in
-    /// the LFP, `dst` still untouched (the continuation's `vm_store_rdi`
-    /// writes it from the callee's return value).
-    ///
-    /// `using_fpr` is the call's `FprSave` set, which the handler needs to
-    /// reload the caller-saved FP pool registers out of the save area the
-    /// call left behind before it can write them back.
-    ///
-    pub(crate) fn new_chain_exit(
-        &mut self,
-        state: &AbstractFrame,
-        using_fpr: UsingFpr,
-        dst: Option<SlotId>,
-    ) -> AsmChain {
-        let i = self.new_label(SideExit::ChainExit(
-            state.pc(),
-            state.get_write_back(),
-            using_fpr,
-            dst,
-        ));
-        AsmChain(i)
     }
 
     pub(crate) fn new_deopt_with_pc(&mut self, state: &AbstractFrame, pc: BytecodePtr) -> AsmDeopt {
@@ -1945,18 +1893,19 @@ pub(super) enum AsmInst {
         evict: AsmEvict,
     },
     ///
-    /// Register this call site's chain-exit handler in the runtime table
-    /// (`doc/chain_deopt.md` §5 step 1). Emits no machine code: it looks the
-    /// call's return address up by `evict` (recorded moments earlier by
-    /// `set_deopt_with_return_addr`) and maps it to `chain`'s handler, so the
-    /// chain-deopt walk can find the handler from a suspended frame's
+    /// Register this call site's replay data in the runtime table
+    /// (`doc/chain_deopt.md` §5 step 1 / §9.3). Emits no machine code: it
+    /// looks the call's return address up by `evict` (recorded moments
+    /// earlier by `set_deopt_with_return_addr`) and maps it to `spec`
+    /// (completed with the frame's spill `base` at lowering), so the
+    /// chain-deopt walk can replay the suspended frame's write-back from a
     /// return-address slot alone.
     ///
     /// Must be emitted after the call instruction it belongs to.
     ///
     ChainExit {
         evict: AsmEvict,
-        chain: AsmChain,
+        spec: Box<ChainExitSpec>,
     },
     CheckBOP {
         deopt: AsmDeopt,
@@ -2750,17 +2699,6 @@ pub enum SideExit {
         bool,
     ),
     Error(BytecodePtr, WriteBack, bool),
-    ///
-    /// Chain-exit handler for a suspended call (`doc/chain_deopt.md`). The
-    /// `pc` is the *call-site* pc and `dst` the call's destination slot: the
-    /// handler carries its own post-call continuation (store the callee's
-    /// result into `dst`, resume the fetch loop at `pc.next()`, or on an
-    /// error/non-local-exit signal hand `pc` to `entry_raise`) because the
-    /// VM's shared send continuation assumes a 2-unit send bytecode — wrong
-    /// for the 1-unit operator sites (`BinOp` / `Index` / …) that also
-    /// dispatch through `send`.
-    ///
-    ChainExit(BytecodePtr, WriteBack, UsingFpr, Option<SlotId>),
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -2846,18 +2784,6 @@ impl Codegen {
                     let label = self.jit.label();
                     lir.push(LInst::SideExit {
                         kind: LSideExitKind::Error { chain },
-                        pc,
-                        wb,
-                        entry: label.clone(),
-                        loop_jit_spill_bytes,
-                        base,
-                    });
-                    label
-                }
-                SideExit::ChainExit(pc, wb, using_fpr, dst) => {
-                    let label = self.jit.label();
-                    lir.push(LInst::SideExit {
-                        kind: LSideExitKind::ChainExit { using_fpr, dst },
                         pc,
                         wb,
                         entry: label.clone(),

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -509,12 +509,14 @@ impl Codegen {
             AsmInst::MethodRet(pc) => self.encode_linst(LInst::MethodRet { pc }),
             AsmInst::BlockBreak(pc) => self.encode_linst(LInst::BlockBreak { pc }),
             AsmInst::ImmediateEvict { evict } => self.encode_linst(LInst::ImmediateEvict { evict }),
-            // Emits nothing; registers this call's return address -> chain-exit
-            // handler so `Codegen::chain_deopt` can find the handler from a
-            // suspended frame's return-address slot (`doc/chain_deopt.md` §3.4).
-            AsmInst::ChainExit { evict, chain } => {
-                let chain = labels[chain].clone();
-                self.encode_linst(LInst::ChainExit { evict, chain });
+            // Emits nothing; registers this call's return address -> replay
+            // data so `Codegen::chain_deopt` can convert a frame suspended
+            // here from its return-address slot alone (`doc/chain_deopt.md`
+            // §3.4 / §9.3). The frame's spill `base` completes the spec here,
+            // where it is known.
+            AsmInst::ChainExit { evict, spec } => {
+                let replay = spec.into_replay(frame.base_stack_offset);
+                self.encode_linst(LInst::ChainExit { evict, replay });
             }
             // Method-call prologue: class-version guard, callee frame fields,
             // argument massage. (aarch64 SetArguments bails on a not-yet-ported
@@ -1519,8 +1521,8 @@ impl Codegen {
             LInst::ImmediateEvict { evict } => {
                 self.emit_immediate_evict(evict);
             }
-            LInst::ChainExit { evict, chain } => {
-                self.register_chain_exit(evict, chain);
+            LInst::ChainExit { evict, replay } => {
+                self.register_chain_exit(evict, replay);
             }
             LInst::Init { info, prologue_offset } => {
                 self.emit_init(info, prologue_offset);

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -509,6 +509,13 @@ impl Codegen {
             AsmInst::MethodRet(pc) => self.encode_linst(LInst::MethodRet { pc }),
             AsmInst::BlockBreak(pc) => self.encode_linst(LInst::BlockBreak { pc }),
             AsmInst::ImmediateEvict { evict } => self.encode_linst(LInst::ImmediateEvict { evict }),
+            // Emits nothing; registers this call's return address -> chain-exit
+            // handler so `Codegen::chain_deopt` can find the handler from a
+            // suspended frame's return-address slot (`doc/chain_deopt.md` §3.4).
+            AsmInst::ChainExit { evict, chain } => {
+                let chain = labels[chain].clone();
+                self.encode_linst(LInst::ChainExit { evict, chain });
+            }
             // Method-call prologue: class-version guard, callee frame fields,
             // argument massage. (aarch64 SetArguments bails on a not-yet-ported
             // argument shape, hence the bool result; the guard ignores the x86
@@ -1511,6 +1518,9 @@ impl Codegen {
             }
             LInst::ImmediateEvict { evict } => {
                 self.emit_immediate_evict(evict);
+            }
+            LInst::ChainExit { evict, chain } => {
+                self.register_chain_exit(evict, chain);
             }
             LInst::Init { info, prologue_offset } => {
                 self.emit_init(info, prologue_offset);

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -648,7 +648,7 @@ impl<'a> JitContext<'a> {
         // aarch64 dispatch-slot zeroing in `invalidate_jit_code`), the VM's
         // `loop_start` handler is swapped for the no-opt one so stale OSR
         // loop bodies are never re-entered, and on-stack frames deopt on
-        // return via `immediate_eviction`'s return-address patching (see
+        // return via the eviction walk's return-address patching (see
         // `emit_call`). A `def` executed *inside* JIT code is caught by the
         // `check_bop` after `MethodDef`/`SingletonMethodDef`.
         match self.fire_binary_inline(

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -1557,25 +1557,25 @@ impl AbstractState {
     }
 
     ///
-    /// Give this call site a chain-exit handler (`doc/chain_deopt.md` §2), so
-    /// a chain deopt can convert a frame suspended here into an interpreter
-    /// frame by rewriting the callee's return-address slot.
+    /// Register this call site for chain deopt (`doc/chain_deopt.md` §2/§9.3),
+    /// so the walk can convert a frame suspended here into an interpreter
+    /// frame: replay its write-back from Rust and rewrite the callee's
+    /// return-address slot to the shared VM continuation stub.
     ///
     /// Call this immediately after the site's call instruction: the write-back
     /// is read off the live state, which must still be the post-`discard(dst)`
-    /// state the VM's post-call continuation expects (it stores the result
-    /// into `dst` itself).
+    /// state the post-call continuation expects (it stores the result into
+    /// `dst` itself).
     ///
-    /// Emitting the handler costs cold code roughly the size of the site's
-    /// `Evict` handler, and nothing fires the walk in a default build yet
-    /// (§5 steps 4-5 are unimplemented), so it is compiled in only under the
+    /// Nothing fires the walk in a default build yet (§5 steps 4-5 are
+    /// unimplemented), so registration is compiled in only under the
     /// `chain-deopt` feature. When the speculation lands, this becomes the
     /// per-site decision §6 argues for rather than a build-wide switch.
     ///
     fn chain_exit(&self, ir: &mut AsmIr, evict: AsmEvict, using_fpr: UsingFpr, dst: Option<SlotId>) {
         if cfg!(feature = "chain-deopt") {
-            let chain = ir.new_chain_exit(self, using_fpr, dst);
-            ir.push(AsmInst::ChainExit { evict, chain });
+            let spec = Box::new(ChainExitSpec::new(self, using_fpr, dst));
+            ir.push(AsmInst::ChainExit { evict, spec });
         }
     }
 

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -830,6 +830,7 @@ impl<'a> JitContext<'a> {
         let meta = self.store[callee_fid].meta();
         ir.push(AsmInst::SetupYieldFrame { meta, outer });
         ir.push(AsmInst::SpecializedYield { entry, evict });
+        state.chain_exit(ir, evict, using_fpr);
         ir.fpr_restore_cont(using_fpr);
         ir.handle_error(error);
         let res = state.def_rax2acc_return(ir, dst, return_state);
@@ -1435,6 +1436,7 @@ impl AbstractState {
             evict,
             pc: self.pc(),
         });
+        self.chain_exit(ir, evict, using_fpr);
         ir.fpr_restore_cont(using_fpr);
         ir.handle_error(error);
         // When a capture guard follows (the callee may `move_frame_to_heap`,
@@ -1499,6 +1501,7 @@ impl AbstractState {
             patch_point,
             evict,
         });
+        self.chain_exit(ir, evict, using_fpr);
         ir.fpr_restore_cont(using_fpr);
         ir.handle_error(error);
         self.unset_side_effect_guard();
@@ -1536,6 +1539,7 @@ impl AbstractState {
             error,
             evict,
         });
+        self.chain_exit(ir, evict, using_fpr);
         ir.fpr_restore_cont(using_fpr);
         ir.handle_error(error);
         // A yielded block can capture this frame; home the result via the LFP
@@ -1550,6 +1554,29 @@ impl AbstractState {
         self.unset_class_version_guard();
         self.unset_const_version_guard();
         self.unset_side_effect_guard();
+    }
+
+    ///
+    /// Give this call site a chain-exit handler (`doc/chain_deopt.md` §2), so
+    /// a chain deopt can convert a frame suspended here into an interpreter
+    /// frame by rewriting the callee's return-address slot.
+    ///
+    /// Call this immediately after the site's call instruction: the write-back
+    /// is read off the live state, which must still be the post-`discard(dst)`
+    /// state the VM's post-call continuation expects (it stores the result
+    /// into `dst` itself).
+    ///
+    /// Emitting the handler costs cold code roughly the size of the site's
+    /// `Evict` handler, and nothing fires the walk in a default build yet
+    /// (§5 steps 4-5 are unimplemented), so it is compiled in only under the
+    /// `chain-deopt` feature. When the speculation lands, this becomes the
+    /// per-site decision §6 argues for rather than a build-wide switch.
+    ///
+    fn chain_exit(&self, ir: &mut AsmIr, evict: AsmEvict, using_fpr: UsingFpr) {
+        if cfg!(feature = "chain-deopt") {
+            let chain = ir.new_chain_exit(self, using_fpr);
+            ir.push(AsmInst::ChainExit { evict, chain });
+        }
     }
 
     fn immediate_evict(&mut self, ir: &mut AsmIr, evict: AsmEvict) {

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -830,7 +830,7 @@ impl<'a> JitContext<'a> {
         let meta = self.store[callee_fid].meta();
         ir.push(AsmInst::SetupYieldFrame { meta, outer });
         ir.push(AsmInst::SpecializedYield { entry, evict });
-        state.chain_exit(ir, evict, using_fpr);
+        state.chain_exit(ir, evict, using_fpr, dst);
         ir.fpr_restore_cont(using_fpr);
         ir.handle_error(error);
         let res = state.def_rax2acc_return(ir, dst, return_state);
@@ -1436,7 +1436,7 @@ impl AbstractState {
             evict,
             pc: self.pc(),
         });
-        self.chain_exit(ir, evict, using_fpr);
+        self.chain_exit(ir, evict, using_fpr, dst);
         ir.fpr_restore_cont(using_fpr);
         ir.handle_error(error);
         // When a capture guard follows (the callee may `move_frame_to_heap`,
@@ -1501,7 +1501,7 @@ impl AbstractState {
             patch_point,
             evict,
         });
-        self.chain_exit(ir, evict, using_fpr);
+        self.chain_exit(ir, evict, using_fpr, store[callid].dst);
         ir.fpr_restore_cont(using_fpr);
         ir.handle_error(error);
         self.unset_side_effect_guard();
@@ -1539,7 +1539,7 @@ impl AbstractState {
             error,
             evict,
         });
-        self.chain_exit(ir, evict, using_fpr);
+        self.chain_exit(ir, evict, using_fpr, dst);
         ir.fpr_restore_cont(using_fpr);
         ir.handle_error(error);
         // A yielded block can capture this frame; home the result via the LFP
@@ -1572,9 +1572,9 @@ impl AbstractState {
     /// `chain-deopt` feature. When the speculation lands, this becomes the
     /// per-site decision §6 argues for rather than a build-wide switch.
     ///
-    fn chain_exit(&self, ir: &mut AsmIr, evict: AsmEvict, using_fpr: UsingFpr) {
+    fn chain_exit(&self, ir: &mut AsmIr, evict: AsmEvict, using_fpr: UsingFpr, dst: Option<SlotId>) {
         if cfg!(feature = "chain-deopt") {
-            let chain = ir.new_chain_exit(self, using_fpr);
+            let chain = ir.new_chain_exit(self, using_fpr, dst);
             ir.push(AsmInst::ChainExit { evict, chain });
         }
     }

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -783,6 +783,28 @@ impl<'a> JitContext<'a> {
         self.codegen_mode
     }
 
+    ///
+    /// Whether every interpreter-resuming side exit emitted for the frame
+    /// currently being compiled must **escalate to chain deopt** — i.e. run
+    /// the chain-deopt walk (converting every suspended JIT frame in the
+    /// caller chain into an interpreter frame) before falling back to the
+    /// interpreter (`doc/chain_deopt.md` §5 step 4 / §6).
+    ///
+    /// This is the "mechanical guarantee" §6 asks for: the flag is consulted
+    /// in exactly one place — [`AsmIr::new`], which stamps it onto the IR so
+    /// every side-exit constructor (`new_deopt` / `new_recompile_deopt` /
+    /// `new_error` / `deopt_from_point`) picks it up — rather than relying on
+    /// each emitter to remember.
+    ///
+    /// Today it is driven by the `chain-deopt` validation feature (escalate
+    /// everywhere, so the whole test suite exercises the deopt → walk →
+    /// chain-exit-handler cascade). When the unboxed-locals speculation (§5
+    /// step 5) lands, the per-frame speculation flag is OR'd in here.
+    ///
+    pub(super) fn escalate_side_exits(&self) -> bool {
+        cfg!(feature = "chain-deopt")
+    }
+
     pub(super) fn in_dispatch_arm(&self) -> bool {
         self.in_dispatch_arm
     }

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -305,20 +305,6 @@ pub(in crate::codegen::jitgen) enum LSideExitKind {
     Error {
         chain: bool,
     },
-    /// Chain-exit handler (`doc/chain_deopt.md`): entered by `ret` — not by a
-    /// branch from the frame's own body — after the chain-deopt walk has
-    /// rewritten this call's return-address slot. It restores the caller's
-    /// frame registers (the `pop_frame` the hijacked continuation skipped),
-    /// reloads the FP pool out of the call's `FprSave` area (`using_fpr`),
-    /// writes back, and runs its own post-call continuation: store the
-    /// callee's result into `dst` and resume the fetch loop at the site's
-    /// next instruction, or on an error signal hand the site pc to
-    /// `entry_raise`. (Per-site, because the VM's shared send continuation
-    /// assumes a 2-unit send bytecode — wrong for 1-unit operator sites.)
-    ChainExit {
-        using_fpr: UsingFpr,
-        dst: Option<SlotId>,
-    },
 }
 
 /// Branch targets carry a *resolved* monoasm `DestLabel` (not the front-end
@@ -934,10 +920,10 @@ pub(in crate::codegen) enum LInst {
         evict: AsmEvict,
     },
     /// Register `evict`'s already-recorded call return address as the key for
-    /// `chain`'s chain-exit handler. Emits no machine code.
+    /// `replay` in the runtime chain-deopt table. Emits no machine code.
     ChainExit {
         evict: AsmEvict,
-        chain: DestLabel,
+        replay: ChainReplay,
     },
     Init {
         info: FnInitInfo,

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -290,6 +290,16 @@ pub(in crate::codegen::jitgen) enum LSideExitKind {
     },
     /// Error handler: write back then jump to the raise/`handle_error` path.
     Error,
+    /// Chain-exit handler (`doc/chain_deopt.md`): entered by `ret` — not by a
+    /// branch from the frame's own body — after the chain-deopt walk has
+    /// rewritten this call's return-address slot. It restores the caller's
+    /// frame registers (the `pop_frame` the hijacked continuation skipped),
+    /// reloads the FP pool out of the call's `FprSave` area (`using_fpr`),
+    /// writes back, and tails into the VM's post-call continuation, which
+    /// stores the callee's result and resumes interpreting this frame.
+    ChainExit {
+        using_fpr: UsingFpr,
+    },
 }
 
 /// Branch targets carry a *resolved* monoasm `DestLabel` (not the front-end
@@ -903,6 +913,12 @@ pub(in crate::codegen) enum LInst {
     },
     ImmediateEvict {
         evict: AsmEvict,
+    },
+    /// Register `evict`'s already-recorded call return address as the key for
+    /// `chain`'s chain-exit handler. Emits no machine code.
+    ChainExit {
+        evict: AsmEvict,
+        chain: DestLabel,
     },
     Init {
         info: FnInitInfo,

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -277,28 +277,47 @@ impl LAluOp {
 /// `SideExit` cases the JIT records while building `AsmIr`.
 #[derive(Debug, Clone)]
 pub(in crate::codegen::jitgen) enum LSideExitKind {
-    /// Plain deoptimization back to the VM fetch loop.
-    Deopt,
+    /// Plain deoptimization back to the VM fetch loop. `chain` escalates the
+    /// exit to chain deopt (`doc/chain_deopt.md` §5 step 4 / §6): after the
+    /// write-back the handler calls `runtime::chain_deopt`, converting every
+    /// suspended JIT frame in the caller chain into an interpreter frame
+    /// before this frame resumes in the interpreter.
+    Deopt {
+        chain: bool,
+    },
     /// Immediate eviction (BOP redefinition) — same shape as `Deopt`, with a
-    /// distinct `cfg(deopt/profile)` log reason.
+    /// distinct `cfg(deopt/profile)` log reason. Never chain-escalated: the
+    /// handler is only entered through a chain-wide eviction walk, which has
+    /// already converted (or patched) every suspended frame in one pass.
     Evict,
     /// Deopt that, once a miss counter is exhausted, recompiles the method/loop
-    /// (x86 only; aarch64 treats it as a plain `Deopt`).
+    /// (x86 only; aarch64 treats it as a plain `Deopt`). `chain` as on `Deopt`.
     RecompileDeopt {
         reason: RecompileReason,
         position: Option<BytecodePtr>,
+        chain: bool,
     },
     /// Error handler: write back then jump to the raise/`handle_error` path.
-    Error,
+    /// `chain` as on `Deopt` — an in-frame `rescue` resumes this frame in the
+    /// interpreter, and an unwinding raise `ret`s through the (now rewritten)
+    /// return-address slots of the suspended callers (`doc/chain_deopt.md`
+    /// §8.4), so the walk must have run either way.
+    Error {
+        chain: bool,
+    },
     /// Chain-exit handler (`doc/chain_deopt.md`): entered by `ret` — not by a
     /// branch from the frame's own body — after the chain-deopt walk has
     /// rewritten this call's return-address slot. It restores the caller's
     /// frame registers (the `pop_frame` the hijacked continuation skipped),
     /// reloads the FP pool out of the call's `FprSave` area (`using_fpr`),
-    /// writes back, and tails into the VM's post-call continuation, which
-    /// stores the callee's result and resumes interpreting this frame.
+    /// writes back, and runs its own post-call continuation: store the
+    /// callee's result into `dst` and resume the fetch loop at the site's
+    /// next instruction, or on an error signal hand the site pc to
+    /// `entry_raise`. (Per-site, because the VM's shared send continuation
+    /// assumes a 2-unit send bytecode — wrong for 1-unit operator sites.)
     ChainExit {
         using_fpr: UsingFpr,
+        dst: Option<SlotId>,
     },
 }
 

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -10,6 +10,24 @@ pub const PROCDATA_FUNCID: i64 = std::mem::offset_of!(ProcData, func_id) as _;
 // Runtime functions.
 //
 
+/// Escalated side exit (`doc/chain_deopt.md` §5 step 4 / §6): run the
+/// chain-deopt walk from a deopting frame, converting every suspended JIT
+/// frame in the caller chain into an interpreter frame before this frame
+/// falls back to the interpreter (or starts unwinding a raise).
+///
+/// Called from a chain-escalated side-exit handler **after** its deopt
+/// write-back, so the current frame is fully homed in the LFP; the walk
+/// itself only rewrites return-address slots on the stack (no allocation),
+/// so no GC can run inside it. The deopting frame's *own* return-address
+/// slot is rewritten too — that is what converts its caller once the
+/// now-interpreted frame eventually returns.
+pub(super) extern "C" fn chain_deopt(vm: &mut Executor) {
+    let cfp = vm.cfp();
+    #[cfg(any(feature = "deopt", feature = "profile"))]
+    eprintln!("### chain deopt: escalated from {:?}", cfp.lfp().func_id());
+    CODEGEN.with(|codegen| codegen.borrow_mut().chain_deopt(cfp));
+}
+
 /// Resolve the method for a call-site inline-cache miss.
 ///
 /// Returns the resolved `FuncId` in the **low 32 bits** (0 = not found /

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -16,16 +16,38 @@ pub const PROCDATA_FUNCID: i64 = std::mem::offset_of!(ProcData, func_id) as _;
 /// falls back to the interpreter (or starts unwinding a raise).
 ///
 /// Called from a chain-escalated side-exit handler **after** its deopt
-/// write-back, so the current frame is fully homed in the LFP; the walk
-/// itself only rewrites return-address slots on the stack (no allocation),
-/// so no GC can run inside it. The deopting frame's *own* return-address
-/// slot is rewritten too — that is what converts its caller once the
-/// now-interpreted frame eventually returns.
+/// write-back, so the current frame is fully homed in the LFP. The walk
+/// itself (under the `CODEGEN` borrow) only collects the conversion plan;
+/// applying it — each suspended frame's write-back replay plus the
+/// return-address rewrite — happens after the borrow is released, because
+/// the replay allocates (boxing floats, materializing deferred rest
+/// arrays/kwrest hashes) and so can run a GC. The deopting frame's *own*
+/// return-address slot is rewritten too — that is what converts its caller
+/// once the now-interpreted frame eventually returns.
 pub(super) extern "C" fn chain_deopt(vm: &mut Executor) {
     let cfp = vm.cfp();
     #[cfg(any(feature = "deopt", feature = "profile"))]
     eprintln!("### chain deopt: escalated from {:?}", cfp.lfp().func_id());
-    CODEGEN.with(|codegen| codegen.borrow_mut().chain_deopt(cfp));
+    let plan = CODEGEN.with(|codegen| codegen.borrow_mut().chain_deopt(cfp));
+    for conversion in plan {
+        // SAFETY: every planned frame was found suspended on the current
+        // thread's control-frame chain moments ago, and nothing has run
+        // since — no frame has returned.
+        unsafe { conversion.apply() };
+    }
+}
+
+/// The `correct_rest_kw` equivalent for the chain-deopt replay
+/// (`doc/chain_deopt.md` §9.3): rebuild a deferred `**kwrest` Hash from the
+/// caller's kw slots. GC-safe because every source value sits in a scanned
+/// frame slot.
+pub(in crate::codegen) fn kwrest_hash(table: &[(IdentId, SlotId)], lfp: Lfp) -> Value {
+    let mut map = RubyMap::default();
+    for (name, slot) in table {
+        let v = lfp.register(*slot).unwrap();
+        map.insert_sym(RubySymbol::new(*name), v);
+    }
+    Value::hash(map)
 }
 
 /// Resolve the method for a call-site inline-cache miss.

--- a/monoruby/src/executor/frame.rs
+++ b/monoruby/src/executor/frame.rs
@@ -78,6 +78,26 @@ impl Cfp {
     }
 
     ///
+    /// Overwrite the machine return address this frame will `ret` to.
+    ///
+    /// The writer half of [`Self::return_addr`], used by chain deopt
+    /// (`doc/chain_deopt.md` §5 step 3) to redirect a suspended JIT frame's
+    /// return into a chain-exit handler instead of its caller's compiled body.
+    ///
+    /// ### safety
+    /// *self* must be a live control frame of the current thread's stack, and
+    /// *addr* an address that is valid to return to with this frame's
+    /// register/stack state — in practice only a chain-exit handler emitted
+    /// for exactly this call site.
+    ///
+    pub(crate) unsafe fn set_return_addr(&mut self, addr: monoasm::CodePtr) {
+        unsafe {
+            *(self.as_ptr() as *mut Option<monoasm::CodePtr>).add(1 + BP_CFP as usize / 8) =
+                Some(addr)
+        };
+    }
+
+    ///
     /// The caller's suspended *pc*, read from the cont-frame slot the
     /// caller wrote just before calling into this frame (CFP+24: the
     /// VM's `push_cont_frame` `pushq r13`, the JIT's equivalent store,

--- a/monoruby/src/executor/frame.rs
+++ b/monoruby/src/executor/frame.rs
@@ -82,19 +82,46 @@ impl Cfp {
     ///
     /// The writer half of [`Self::return_addr`], used by chain deopt
     /// (`doc/chain_deopt.md` §5 step 3) to redirect a suspended JIT frame's
-    /// return into a chain-exit handler instead of its caller's compiled body.
+    /// return into the VM's shared post-call continuation stub instead of its
+    /// caller's compiled body.
     ///
     /// ### safety
     /// *self* must be a live control frame of the current thread's stack, and
     /// *addr* an address that is valid to return to with this frame's
-    /// register/stack state — in practice only a chain-exit handler emitted
-    /// for exactly this call site.
+    /// register/stack state — in practice only the chain-deopt continuation
+    /// stub, paired with a [`Self::set_cont_frame_data`] write.
     ///
     pub(crate) unsafe fn set_return_addr(&mut self, addr: monoasm::CodePtr) {
         unsafe {
             *(self.as_ptr() as *mut Option<monoasm::CodePtr>).add(1 + BP_CFP as usize / 8) =
                 Some(addr)
         };
+    }
+
+    ///
+    /// The machine frame pointer (`rbp`/`x29`) of the frame owning this CFP:
+    /// every frame — VM, JIT, or native wrapper — establishes
+    /// `bp == cfp + BP_CFP` in its prologue, so the address itself is the
+    /// register's value and `[bp]` is the saved caller bp.
+    ///
+    pub(crate) fn frame_bp(&self) -> *mut u64 {
+        unsafe { (self.as_ptr() as *mut u64).add(BP_CFP as usize / 8) }
+    }
+
+    ///
+    /// Write the cont-frame *pad* slot (CFP+32, the second half of the
+    /// 16-byte continuation frame whose first half is the pc slot read by
+    /// [`Self::caller_pc_slot`]). The pad is reserved by every caller
+    /// (`push_cont_frame` / the JIT's cont-mode `FprSave`) and read by
+    /// nothing on the normal return path; chain deopt stores the converted
+    /// call's per-site continuation word here for the shared stub to read
+    /// after this frame's `ret` (`doc/chain_deopt.md` §9.3).
+    ///
+    /// ### safety
+    /// *self* must be a live control frame of the current thread's stack.
+    ///
+    pub(crate) unsafe fn set_cont_frame_data(&mut self, data: u64) {
+        unsafe { *(self.as_ptr() as *mut u64).add(4) = data };
     }
 
     ///
@@ -340,6 +367,18 @@ impl Lfp {
     ///
     unsafe fn new(ptr: *mut u8) -> Self {
         Self(std::ptr::NonNull::new(ptr).unwrap())
+    }
+
+    ///
+    /// Create LFP from a raw pointer for callers outside this module (the
+    /// chain-deopt replay derives a suspended frame's LFP from its saved
+    /// frame pointer, `lfp == bp - RBP_LOCAL_FRAME`).
+    ///
+    /// ### safety
+    /// *ptr* must point at a valid local frame.
+    ///
+    pub(crate) unsafe fn from_ptr(ptr: *mut u8) -> Self {
+        unsafe { Self::new(ptr) }
     }
 
     ///

--- a/monoruby/tests/redefine.rs
+++ b/monoruby/tests/redefine.rs
@@ -292,6 +292,43 @@ fn redefine_bop_onstack_caller() {
     );
 }
 
+// The on-stack caller case with an unboxed `Float` local live across the call.
+// `acc` stays FPR-resident through `maybe_redefine` (no block at the call site,
+// so nothing demotes it), so converting the suspended frame has to box it out
+// of its FP home and into the local slot before the interpreter resumes —
+// exercising the float half of the eviction write-back, which the integer-only
+// cases above never reach. The trailing `3 + 4` is constant-folded by the JIT,
+// so it also checks the frame really stopped running its compiled body: a
+// resumed fold answers 7, an interpreter answers 999.
+//
+// Both on-stack mechanisms go through this: `immediate_eviction`'s
+// return-continuation patch and, under the `chain-deopt` feature, the
+// chain-exit handler's FP-pool reload (`doc/chain_deopt.md` §8).
+#[test]
+fn redefine_bop_onstack_caller_float_local() {
+    run_test(
+        r##"
+        $flag = false
+        def maybe_redefine
+          if $flag
+            Integer.class_eval("def +(o); 999; end")
+          end
+          nil
+        end
+        def float_carrier(a)
+          acc = 0.0
+          acc = acc + a * 1.5
+          maybe_redefine
+          acc = acc + 0.25
+          [acc, 3 + 4]
+        end
+        100.times { float_carrier(2.0) }
+        $flag = true
+        float_carrier(2.0)
+        "##,
+    );
+}
+
 // Same on-stack scenario reached through a GENERIC `yield` instead of a method
 // call: the yielded block redefines the basic op, and the yielding frame must
 // deopt on resume instead of running its stale compiled continuation. On

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -1862,6 +1862,7 @@ a0d8a60091bf358a78984cd54491c359	[true, 12, true, false, false]	t = Thread.new {
 a0ed7fceb0bb6c6c16a0106636e9eb4a	"あ"	s = "hello"; s.bytesplice(0..4, "あいう", 0..2); s
 a119cef46ae9c1190d2bbd29791572a2	true	def `(cmd); cmd.frozen?; end\n        def m; `ab`; end\n        m\n       
 a11ed1527c89aa21a332303e09009bd7	true	M = Data.define(:amount, :unit)\nM.new(1, "m").with(amount: 9).frozen?
+a13a2072b2f3375c306f9f28ca558183	[3.25, 999]	$flag = false\n        def maybe_redefine\n          if $flag\n           
 a143f6cff1e98f1d5b4da11574acdd7a	true	r = nil; 3.times { r = __ENCODING__ }; r.equal?(Encoding::UTF_8)
 a145f94943dc0794a58051ca1c98752f	[false, [1, 2]]	arr = [1, 2]\n        def arr.to_a; $flag = true; super; end\n        $fl
 a14e904cc31582d611449d8caacf0884	true	"abc".force_encoding("ISO-8859-1").encoding == Encoding::ISO_8859_1


### PR DESCRIPTION
Builds the mechanism a speculation needs in order to be undoable: when something breaks deep inside a specialized call chain, drop **every** frame on that chain back to the interpreter in one step, instead of one frame at a time.

This is the mechanism only — steps 1–4's escalation half of `doc/chain_deopt.md` §5. The optimization it exists for (§5 steps 4–5) and the return-state recovery (§6) are not in this PR.

## Why

The target optimization is **keeping a `Float` local unboxed across a block call**. Today any call that passes a block demotes every local first:

```rust
// We must write back all local vars to the stack and set the state to LinkMode::S
// when they are possibly accessed or captured from inner blocks.
if callsite.block_fid.is_some() {
    state.locals_to_S(ir);
}
```

so `occlusion` in aobench's `ambient_occlusion` is boxed on every one of the 64 inner iterations:

```ruby
occlusion = 0.0
nphi.times do |j|
  ntheta.times do |i|
    ...
    occlusion += 1.0     # outer Float local, mutated two blocks deep
  end
end
```

Removing the demotion means the block writes through to the outer frame's FP spill area. If it ever stores a non-`Float` there the outer frame's compiled code is holding an `f64` at an offset that no longer has one — which is only recoverable if the whole suspended chain can be undone at that moment.

There is a second payoff already identified but not taken here: `compile/method_call.rs`'s `frame_had_deopt` taint currently flattens *any* deopt-able callee's inferred return type to `Value` (PR #505). Once the caller is torn down along with the callee, that inference holds. See §6 of the doc.

## How

`Codegen::chain_deopt` walks the CFP chain and, for each suspended JIT frame:

- **replays its write-back from Rust** — boxing the pool-resident and spilled floats out of their FP homes into the frame's local slots, materializing a deferred rest `Array` / kwrest `Hash` if the site had one;
- **points its return-address slot at one shared VM continuation stub.**

No machine code is patched, so a compiled body that is still valid for future invocations survives — unlike `immediate_eviction`, which writes a `jmp deopt` into the call's return continuation and thereby deoptimizes that site for everyone, permanently.

Three things make one shared stub sufficient:

- the VM's post-call sequence is already entirely stack-driven — it recovers the suspended pc from the cont frame, re-derives the destination slot from the bytecode there, stores `rax`, and dispatches;
- the suspended pc is already correct for JIT frames: `AsmInst::ContFramePc` writes it at all four call/yield emitters (it is the slot `Kernel#caller` reads);
- anything genuinely per-site is passed as **data, not code** — the walk stores a word (dst register high, pc byte-advance low) in the cont frame's pad slot at CFP+32, which every caller reserves and nothing reads on the normal return path.

The stub is emitted inside the VM address span, so `check_vm_address` covers it. That is load-bearing rather than cosmetic: a converted frame then reads as already-interpreted, and a later walk skips it — a second replay would clobber slots an interpreted inner frame has since updated through `outer_lfp`.

The walk returns a conversion plan that is applied only after the `CODEGEN` borrow is released, because the replay allocates and can therefore run a GC.

## Eager, not lazy

The first working version converted each frame **lazily** — the walk only rewrote return addresses, and each frame wrote itself back when its own `ret` reached a per-call-site chain-exit handler. That is unsound for the thing chain deopt exists for, and the last commit replaces it.

Once the deopted frame is running in the interpreter, anything reading an outer frame's locals through `outer_lfp` — a block body touching the enclosing method's variables, `binding`, a backtrace with argument values — reads slots that have not been written back yet. Nothing observes it *today* only because `locals_to_S` still boxes every local before every block-passing call, which is exactly the guarantee the speculation removes.

Removing the per-site handlers also removed the machinery that existed only to serve `ret`-entry into them (their own continuations, and their interaction with the unwind path), and their cold-code cost at every call and yield site.

One earlier attempt is recorded in the doc as a dead end: redirecting a return address at that frame's existing `Evict` handler. The `Evict` write-back is captured *after* `def_rax2acc_return` emits the result store, so entering it by `ret` skips that store and the callee's return value never lands. This is why `immediate_eviction` patches after the store rather than at the return address.

## Verification

`chain-deopt` is a new **verification feature**, not a shipping one. It routes every interpreter-resuming side exit in specialized code — deopt, recompile-deopt, and error — through the chain-deopt walk, and converts BOP eviction by chain instead of by patching. With it on, the ordinary test suite's very large number of deopts all become chain-deopt executions:

| run | result |
|---|---|
| `cargo nextest run --features stress-spill-pool` | 3203 / 3203 passed |
| `cargo nextest run --features stress-spill-pool,chain-deopt` | 3203 / 3203 passed |
| `cargo check --target aarch64-unknown-linux-gnu` (± the feature) | clean |

Both backends implement the mechanism; nothing is x86-only.

`redefine_bop_onstack_caller_float_local` (`tests/redefine.rs`) is new and targets the float half specifically: an unboxed `Float` accumulator is live across a call that redefines `Integer#+`, so converting the suspended frame has to box it out of its FP home before the interpreter resumes — which the pre-existing integer-only on-stack cases never reach. Its trailing `3 + 4` is JIT-constant-folded, so the assertion also proves the frame really stopped running its compiled body (a resumed fold answers `7`; an interpreter answers `999`).

## Follow-ups

`doc/chain_deopt.md` is the design record and carries the remaining plan: the `Float` guard on a block's `StoreDynVar` (§5 step 4), relaxing `locals_to_S` (step 5), and the return-state recovery with its per-site escalation obligation (§6).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_