### PR TITLE
JIT: retire immediate eviction — chain deopt is the only way off a stale frame

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -44,7 +44,7 @@ Two things to know before reading:
 | [`polymorphic_call.md`](polymorphic_call.md) | JA | plan | Receiver-polymorphic call sites: why `x.nil?` / `x == nil` deopt on every nil receiver, the implemented nil-tolerant guard, and the design space (predicate generalization, PIC, page discipline) with measurements. |
 | [`bop_redefinition.md`](bop_redefinition.md) | JA | design record | What licenses inlining `1 + 2`, what happens when Ruby revokes it, and why the current all-or-nothing response is both too narrow (silently wrong answers) and too blunt (24× slower, permanently). Measured against CRuby. |
 | [`handoff_record_stream.md`](handoff_record_stream.md) | EN | plan / history | Handoff note for the record-driven lowering work; a summary of `regalloc_separation.md` §12–21 as of that branch. |
-| [`chain_deopt.md`](chain_deopt.md) | EN | plan | Dropping a whole suspended JIT chain back to the interpreter in one step, so a speculation broken deep inside can be undone. What the VM already provides, one attempt that fails and why, and the return-type inference the mechanism would buy back. §8 records the implemented mechanism (and where it departs from the plan); the speculation itself is still unbuilt. |
+| [`chain_deopt.md`](chain_deopt.md) | EN | plan | Dropping a whole suspended JIT chain back to the interpreter in one step, so a speculation broken deep inside can be undone. What the VM already provides, one attempt that fails and why, and the return-type inference the mechanism would buy back. §8 records the implemented mechanism (and where it departs from the plan); §10 records the retirement of immediate eviction, which it replaced. The speculation itself is still unbuilt. |
 
 ## Runtime services
 

--- a/doc/arch_difference.md
+++ b/doc/arch_difference.md
@@ -19,8 +19,8 @@ aarch64 port (`#704`) and the chunked-literal frame-size fix (`#709`).
 > could not lower, and catalogued ~two dozen bail sites. **That is no longer
 > true.** As of `#704` aarch64 lowers every `AsmInst` and every side exit, so it
 > never bails out of JIT compilation. The sections below describe the current,
-> bail-free state; §4 covers the asymmetries that *do* remain (recompilation
-> strategy and eviction patching — not coverage).
+> bail-free state; §4 covers the asymmetry that *does* remain (recompilation
+> strategy — not coverage).
 
 ---
 
@@ -138,14 +138,15 @@ aarch64 lowers what used to bail". The remaining *non-bail* asymmetries are in
 
 ---
 
-## 4. Remaining asymmetry: recompilation & eviction patching (not coverage)
+## 4. Remaining asymmetry: recompilation strategy (not coverage)
 
-Two mechanisms still differ, both centered on **patching / recompiling
-already-emitted code**, and both scoped to **non-specialized** frames. Neither
-is a coverage gap: where x86 patches or recompiles in place, aarch64 deopts to
-the VM, which then re-JITs through the normal warm-up counters. Correctness is
-identical; only the recompile *strategy* (and thus steady-state performance
-after a class-version change or BOP redefinition) differs.
+One mechanism still differs — **recompiling already-emitted code** on a
+class-version miss, and only for **non-specialized** frames. It is not a
+coverage gap: where x86 recompiles in place, aarch64 deopts to the VM, which
+then re-JITs through the normal warm-up counters. Correctness is identical;
+only the recompile *strategy* (and thus steady-state performance after a
+class-version change) differs. §4.2 records an eviction asymmetry that no
+longer exists.
 
 ### 4.1 Class-version-miss recompilation
 
@@ -173,32 +174,20 @@ after a class-version change or BOP redefinition) differs.
 So the gap is specifically the **non-specialized method/loop class-version
 guard**: x86 recompiles, aarch64 deopts.
 
-### 4.2 Eviction via return-address patching (BOP redefinition)
+### 4.2 On-stack eviction (BOP redefinition) — no longer asymmetric
 
-- **x86-64:** the regular `Call` / `Yield` records, per call site, the return
-  address plus a patch point (`emit_call` → `set_deopt_with_return_addr`,
-  [x86_64/compile/mod.rs:1285](../monoruby/src/codegen/arch/x86_64/compile/mod.rs#L1285)).
-  On **BOP (basic-op) redefinition** it rewrites the live return path to
-  redirect into a deopt handler — *without* recompiling.
-- **aarch64:** `a64_do_call`
-  ([aarch64/compile.rs:825](../monoruby/src/codegen/arch/aarch64/compile.rs#L825))
-  **skips** the return-address patching for the regular `Call`/`Yield` —
-  *"The eviction-on-return patching (`set_deopt_with_return_addr`) is x86-only
-  (runtime branch patching), so it is skipped — class-version changes are
-  caught by `GuardClassVersion` deopts instead."*
-- **Specialized calls/yields are symmetric:** aarch64 *does* implement
-  return-address patching for the specialized inlined-frame path —
-  `do_specialized_call`
-  ([aarch64/compile.rs:1068](../monoruby/src/codegen/arch/aarch64/compile.rs#L1068))
-  records the return address via `set_deopt_with_return_addr`
-  ([aarch64/compile.rs:2433](../monoruby/src/codegen/arch/aarch64/compile.rs#L2433)),
-  and `emit_immediate_evict`
-  ([aarch64/compile.rs:2416](../monoruby/src/codegen/arch/aarch64/compile.rs#L2416))
-  overwrites the recorded instruction on eviction.
+This section used to record an asymmetry: x86 recorded a return-address patch
+point at every call site and, on **BOP (basic-op) redefinition**, wrote a `jmp`
+into the live return path so the suspended frame deopted; aarch64 did that for
+specialized calls only, and relied on the inline class-version deopt for the
+rest.
 
-So the gap is specifically the **non-specialized `Call`/`Yield`**: x86 patches
-the return path for BOP eviction, aarch64 relies on the inline class-version
-deopt.
+Both halves are gone. Every call/yield site on both arches now records its
+return address (`set_deopt_with_return_addr`) purely as a *key*, and BOP
+redefinition runs the arch-neutral chain-deopt walk (`Codegen::chain_deopt`),
+which converts each suspended JIT frame into an interpreter frame from the
+stack alone — no code is patched, on either arch. See `doc/chain_deopt.md`
+§10.
 
 ---
 
@@ -213,7 +202,7 @@ deopt.
 | `guard_capture`               | yes (`branch_if_captured`)                                       | yes                                                                    |
 | `float_to_f64` unbox          | yes (flonum / heap-Float, 0.0 sign-bit trick)                    | yes (mirrored)                                                         |
 | class-version guard           | inline check **+ recompile + recovery** (page split, §4.1)       | inline check, **deopt only** for non-specialized; recompile for specialized frames (§4.1) |
-| eviction on BOP redefinition  | return-address patching for regular & specialized calls (§4.2)  | return-address patching for **specialized** calls only; regular calls rely on class-version deopt (§4.2) |
+| eviction on BOP redefinition  | arch-neutral chain-deopt walk, no code patching (§4.2)          | identical (§4.2)                                                        |
 
 Both `a64_guard_class` and `a64_guard_rvalue` always emit (they return a `bool`
 for symmetry with x86, but never return `false` — every `ClassId` is handled,
@@ -278,7 +267,7 @@ identically to `Slot`.
 > x86-64 and aarch64 now share the entire AsmIR front-end *and* full AsmInst
 > coverage — aarch64 lowers everything (large immediates via scratch
 > registers), so the `bool` bail return is vestigial. The only remaining
-> asymmetries are non-coverage: x86 recompiles-in-place / patches live return
-> addresses for **non-specialized** class-version misses and BOP eviction,
-> where aarch64 deopts to the VM and re-JITs (specialized frames are symmetric);
-> plus the x86-only `guard_class2` BigNum-routing helper.
+> asymmetries are non-coverage: x86 recompiles-in-place on a **non-specialized**
+> class-version miss where aarch64 deopts to the VM and re-JITs (specialized
+> frames are symmetric); plus the x86-only `guard_class2` BigNum-routing
+> helper. BOP eviction is now the same arch-neutral chain-deopt walk on both.

--- a/doc/bop_redefinition.md
+++ b/doc/bop_redefinition.md
@@ -83,8 +83,12 @@ fn insert_method(&mut self, class_id: ClassId, name: IdentId, entry: MethodTable
 呼び出し元の `Executor::{add_method, add_method_with_original,
 alias_method_for_class}` が担う。メソッド表を書き換えた**後**・`method_added`
 フックを呼ぶ**前**に `Codegen::check_bop_redefine(cfp)` を通し、フラグが非 0 なら
-`immediate_eviction` が CFP 鎖を遡って各フレームの return address を deopt に
-パッチする（`patch_return_to_deopt`）。戻ってきた時点で VM に落ちる。
+`Codegen::chain_deopt` が CFP 鎖を遡って各サスペンド中フレームを
+インタプリタフレームへ**変換**する（write-back の replay ＋ return address を
+共有 VM continuation stub に書き換え。`doc/chain_deopt.md` §10 を参照）。
+戻ってきた時点で VM に落ちる。かつてはコードそのものに `jmp deopt` を
+書き込む `immediate_eviction` がこれを担っていたが、chain deopt が完全に
+置き換えたので自己書き換えコードは無くなった。
 `method_added` は任意の Ruby を走らせるので、その前に片付けておく必要がある。
 
 この配置には 2 つ性質がある。
@@ -92,7 +96,7 @@ alias_method_for_class}` が担う。メソッド表を書き換えた**後**・
 - **レベルトリガであってエッジトリガではない。** `check_bop_redefine` は
   「今回の定義が basic op を潰したか」ではなく「フラグが立っているか」を見る。
   フラグは一度立つとクリアされないので、**以後プロセス内のあらゆるメソッド定義が
-  毎回 CFP 鎖の全走査と return address パッチを行う**。実測では他の要因
+  毎回 CFP 鎖の全走査とフレーム変換を行う**。実測では他の要因
   (JIT が止まることで再コンパイル churn も消える)に埋もれて有意差は出なかったが、
   構造としては無駄が残り続ける。
 - **経路が 3 つの funnel に限られる。** `remove_method` はここを通らない
@@ -555,8 +559,8 @@ Step 2b の時点では、stale な本体が 1 つでも出ると `dispatch[14]`
 `jit_invalidated` のグローバル一方向ラッチをやめ、「この iseq がどの
 (op, class) invariant に依存したか」を記録して該当分だけ無効化する。
 `InlineCacheEntry` と class-version ラベルという前例がある。あわせて
-`dispatch[14]`（`loop_start`）の no-opt 化と `immediate_eviction` の
-レベルトリガ（§1.3）もここで直す。
+`dispatch[14]`（`loop_start`）の no-opt 化とオンスタック始末
+（現 `chain_deopt`）のレベルトリガ（§1.3）もここで直す。
 
 ### Step 2 — 粒度を (演算子, クラス) へ（性能）
 
@@ -569,8 +573,8 @@ Step 2b の時点では、stale な本体が 1 つでも出ると `dispatch[14]`
 - **JIT**: `jit_invalidated` のグローバル一方向ラッチをやめ、「この iseq が
   どの (op, class) invariant に依存したか」を記録して該当分だけ無効化する。
   `InlineCacheEntry` と class-version ラベルという前例がある。
-- **`immediate_eviction` は残す** — オンスタックのフレームを片付ける手段は
-  粒度に関係なく必要である。ただし §1.3 の 2 性質を直す: 「フラグが非 0 か」の
+- **オンスタック始末（現 `chain_deopt`）は残す** — オンスタックのフレームを
+  片付ける手段は粒度に関係なく必要である。ただし §1.3 の 2 性質を直す: 「フラグが非 0 か」の
   レベルトリガをやめて**マスクのビットが 0→1 に遷移したときだけ**走らせ
   （エッジトリガ）、走査対象もその (op, class) に依存したフレームに絞る。
 - 効果: 「無関係な `Float#+` の再定義で fib が 24 倍遅くなる」が消える。

--- a/doc/chain_deopt.md
+++ b/doc/chain_deopt.md
@@ -4,12 +4,15 @@
 exercised end-to-end **in its eager form** — the walk replays every suspended
 frame's write-back at deopt time and points its return-address slot at one
 shared VM continuation stub (§9.3's conversion has landed; §8 describes the
-implementation). The **escalation half of step 4** — the per-frame switch
-that makes every interpreter-resuming side exit run the chain-deopt walk,
-plus the runtime entry it calls — is in place (§8.6). The speculation itself
-(the `Float` guard and the `locals_to_S` relaxation, §5 steps 4–5) and the
-return-state recovery (§6) are not. §9 stays as the record of why the
-original lazy build was wrong.
+implementation). Registration is unconditional in every build, and chain
+conversion is now the **only** way an on-stack JIT frame is dropped to the
+interpreter: immediate eviction — the code-patching mechanism this document
+was written against — is gone (§10). The **escalation half of step 4** — the
+per-frame switch that makes every interpreter-resuming side exit run the
+chain-deopt walk, plus the runtime entry it calls — is in place (§8.6). The
+speculation itself (the `Float` guard and the `locals_to_S` relaxation, §5
+steps 4–5) and the return-state recovery (§6) are not. §9 stays as the record
+of why the original lazy build was wrong.
 
 ---
 
@@ -67,10 +70,11 @@ suspended chain from JIT frames into interpreter frames:
 
 Control then never re-enters JIT code: each `ret` lands in the interpreter.
 
-This is **not** what `Codegen::immediate_eviction` does. That one writes a
+This is **not** what `Codegen::immediate_eviction` did. That one wrote a
 `jmp deopt` into the *code* at the call's return continuation, so control
-returns into JIT code and deopts one instruction later. Chain deopt does not
-touch code and does not return into JIT code at all.
+returned into JIT code and deopted one instruction later. Chain deopt does not
+touch code and does not return into JIT code at all — which is why it could
+replace immediate eviction outright rather than sit beside it (§10).
 
 ## 3. What was verified in the source
 
@@ -153,10 +157,10 @@ The instruction order at a specialized call is:
 ```
 call callee            <- the return address points here
 <result-store code emitted by def_rax2acc_return>
-patch_point            <- where immediate_eviction writes its jmp
+patch_point            <- where immediate_eviction wrote its jmp
 ```
 
-and `compile/method_call.rs:835` fixes the contract:
+and `compile/method_call.rs:835` fixed the contract:
 
 ```rust
 let res = state.def_rax2acc_return(ir, dst, return_state);  // emits the result store
@@ -168,9 +172,12 @@ so the handler assumes that store has already run. Entering it directly by
 `ret` skips the store, the callee's return value never reaches its slot, and
 garbage propagates.
 
-`immediate_eviction` patches at `patch_point` — *after* the result store —
+`immediate_eviction` patched at `patch_point` — *after* the result store —
 precisely for this reason. Chain deopt sidesteps the whole issue by
-targeting the VM entry (§3.1), where `vm_store_rdi` does the store.
+targeting the VM entry (§3.1), where `vm_store_rdi` does the store. (The
+argument is preserved because it is the reason the *stub*, not the frame's
+own `Evict` handler, is the conversion target; the patching mechanism it
+describes no longer exists — §10.)
 
 ## 5. Order of work
 
@@ -184,6 +191,7 @@ per-site-handler form — §9) — see §8.
    `return_addr()` at `frame.rs:76`), then walk the CFP chain applying 1 and
    2. Model the loop on `immediate_eviction`, which already skips VM frames
    via `check_vm_address` and handles recursion by visiting every frame.
+   (The chain walk has since *become* that loop — §10.)
 4. **Firing point**: the `Float` guard on a block's `StoreDynVar` into an
    outer unboxed local. Write back *before* performing the offending store,
    or the write-back overwrites it.
@@ -298,10 +306,9 @@ slots always hold whole, valid (possibly stale) `Value`s, and the GC scans
 them as such, so the replay may allocate at any point.
 
 Because the replay allocates, it must not run under the `CODEGEN` borrow:
-the walks (`Codegen::chain_deopt`, `Codegen::evict_suspended_frames`) only
-**collect** a `Vec<ChainConversion>` plan; the callers
-(`runtime::chain_deopt`, `Codegen::check_bop_redefine`) apply it after the
-borrow is released. Write-back order within one frame is fixed (deferred
+the walk (`Codegen::chain_deopt`) only **collects** a `Vec<ChainConversion>`
+plan; the callers (`runtime::chain_deopt`, `Codegen::check_bop_redefine`)
+apply it after the borrow is released. Write-back order within one frame is fixed (deferred
 materialization last); frames are applied in walk order, which is sound
 because the replays touch disjoint frames (rest/kwrest sources are raw
 slots, valid regardless of conversion order).
@@ -356,22 +363,21 @@ consumed the save area).
 
 ### 8.3 How it is exercised without a firing point
 
-Steps 4–5's speculation does not exist yet, so nothing in a normal build
-calls `Codegen::chain_deopt`. Under the `chain-deopt` cargo feature
-(default-off) two things exercise it:
+Steps 4–5's speculation does not exist yet, so the `Float` guard that will
+fire the walk does not either. Two things exercise it meanwhile:
 
-* **BOP eviction** converts by chain instead of by patching: the walks are
-  observationally equivalent — both convert every suspended JIT frame into
-  an interpreter frame — and `tests/redefine.rs` already covers exactly this
-  shape: `redefine_bop_onstack_caller` fails with the stale inlined `+`
-  (8 instead of 999) if the suspended caller resumes its compiled body, so
-  the test passing under the feature is a positive signal that the
-  conversion happened, not just that nothing crashed.
-* **Every side exit escalates** (§8.6): each deopt / recompile-deopt / error
-  exit taken anywhere in the suite fires the walk from the deopting frame,
-  so the deopt → replay → stub-return path — the one the speculation will
-  actually take — is exercised at every deopt site the suite reaches, not
-  only at BOP redefinitions.
+* **BOP eviction**, in *every* build: it is now the walk's only production
+  caller, so `tests/redefine.rs` covers the mechanism unconditionally.
+  `redefine_bop_onstack_caller` fails with the stale inlined `+` (8 instead
+  of 999) if the suspended caller resumes its compiled body, so the test
+  passing is a positive signal that the conversion happened, not just that
+  nothing crashed.
+* **Every side exit escalates** (§8.6), under the `chain-deopt` cargo
+  feature (default-off): each deopt / recompile-deopt / error exit taken
+  anywhere in the suite fires the walk from the deopting frame, so the
+  deopt → replay → stub-return path — the one the speculation will actually
+  take — is exercised at every deopt site the suite reaches, not only at BOP
+  redefinitions.
 
 What this validates: the walk, the eager replay, the return-address rewrite,
 the stub's frame/LFP restore and result/raise hand-off, across normal calls,
@@ -380,10 +386,11 @@ is the case chain deopt exists for — a frame whose local is *unboxed at the
 moment of conversion* — because without the `locals_to_S` relaxation no
 suspended frame ever holds one.
 
-The producers (`AbstractState::chain_exit`) are gated on the same feature, so
-a default build registers no chain entries at all and pays nothing. When
-step 5 lands, that gate becomes the per-site decision §6 argues for rather
-than a build-wide switch.
+The producers (`AbstractState::chain_exit`) are **not** gated: every call and
+yield site registers in every build, because with immediate eviction gone a
+site the table does not know is a site BOP eviction cannot convert (§10).
+The metadata cost is accepted. When step 5 lands, the per-site decision §6
+argues for rides on top of unconditional registration, not instead of it.
 
 ### 8.4 A rewritten return-address slot is also on the unwind path
 
@@ -431,28 +438,21 @@ guarantee rather than review discipline, and this is it:
 * `Error` exits escalate because a raise can be rescued *in-frame* (an
   interpreter resume like any deopt) or unwind through the suspended callers
   — §8.4's path, which requires the slots to have been rewritten.
-* `Evict` handlers do **not** escalate: they are only entered through the
-  chain-wide eviction walk below, which has already converted (or patched)
-  every suspended frame in one pass.
+* `Evict` handlers do **not** escalate — and are in fact no longer entered
+  at all: immediate eviction was their only entry (§10). The side-exit slot
+  survives because `AsmEvict` is the id under which a call site's return
+  address is recorded for `chain_exit`.
 
-The walk stops converting where the table stops: an unregistered return
-address marks the boundary of the compilation region that speculated, and
-frames beyond it hold no unboxed cross-frame state, so they may resume their
-compiled bodies. (Under the validation feature every site registers, so the
-walk converts everything — strictly more conversion than needed, which is
-sound for the same reason BOP eviction is.) A frame converted by an earlier
-walk is skipped the same way a VM frame is — its rewritten return address
-*is* a VM address (the stub) — which is load-bearing: interpreted inner
-frames may have updated its slots through `outer_lfp` since, and a second
-replay would clobber them with stale floats.
+Every JIT call/yield site registers, so the walk converts every suspended
+JIT frame it reaches — strictly more conversion than the speculation will
+need, which is sound for the same reason BOP eviction is. A frame converted
+by an earlier walk is skipped the same way a VM frame is — its rewritten
+return address *is* a VM address (the stub) — which is load-bearing:
+interpreted inner frames may have updated its slots through `outer_lfp`
+since, and a second replay would clobber them with stale floats.
 
-BOP eviction itself now goes through one unified walk
-(`Codegen::evict_suspended_frames`): per suspended frame it prefers the
-chain conversion (replay + return-address rewrite, leaving the code
-untouched) and falls back to the recorded patch point (`jmp deopt` written
-into the code). A default build has no chain entries and degenerates to pure
-patching; the feature build is pure chain deopt; with per-site speculation
-the two coexist in one chain.
+BOP eviction goes through the same walk (`Codegen::chain_deopt`) as an
+escalated side exit; there is one CFP walk and one conversion mechanism.
 
 ### 8.6 Where the code is
 
@@ -464,7 +464,7 @@ the two coexist in one chain.
 | Producers (call / specialized call / yield / specialized yield) | `AbstractState::chain_exit`, `jitgen/compile/method_call.rs` |
 | Shared continuation stub | `gen_chain_cont_stub` (`arch/x86_64/vmgen.rs`, `arch/aarch64/vmgen.rs`), address in `Codegen::chain_cont_stub` |
 | `kwrest_hash` (the `correct_rest_kw` equivalent for the replay) | `codegen/runtime.rs` |
-| Runtime table, the walks | `chain_deopt_table`, `register_chain_exit`, `chain_deopt`, `evict_suspended_frames` (`codegen.rs`) |
+| Runtime table, the walk | `chain_deopt_table`, `register_chain_exit`, `chain_deopt` (`codegen.rs`) |
 | Escalation switch + runtime entry | `JitContext::escalate_side_exits` (`jitgen/context.rs`), `AsmIr::escalate_exits` (`jitgen/asmir.rs`), `runtime::chain_deopt` (`codegen/runtime.rs`) |
 | Frame writers/readers | `Cfp::set_return_addr`, `Cfp::set_cont_frame_data`, `Cfp::frame_bp` (`executor/frame.rs`) |
 
@@ -475,9 +475,9 @@ form; this section records what that form did, why it was unsound to build
 the speculation on, and the conversion plan — which has since landed (§8
 describes the eager implementation). §9.1–9.2 describe the *former* build.
 
-### 9.1 What the built mechanism actually does
+### 9.1 What the built mechanism actually did
 
-`Codegen::chain_deopt` (`codegen.rs`) rewrites each suspended frame's
+`Codegen::chain_deopt` (`codegen.rs`) rewrote each suspended frame's
 return-address slot to that site's chain-exit handler — **and nothing
 else**. The frame's write-back runs only when control returns to it: the
 innermost frame `ret`s, lands in the handler, the handler writes that one
@@ -543,3 +543,48 @@ state, unwind interaction — not evidence that lazy write-back was sound.
 
 Ordering: this preceded §5 steps 4–5, as required. The `locals_to_S`
 relaxation is now unblocked.
+
+## 10. Immediate eviction is gone
+
+**Landed.** Chain conversion is the only mechanism that drops an on-stack JIT
+frame to the interpreter.
+
+Immediate eviction existed because a basic-op redefinition inside a callee
+makes the *caller's* already-compiled continuation stale — its inlined integer
+arithmetic and constant folds assume the builtin op — and the callee's entry
+guards cannot protect a frame that is already suspended. With no way to
+convert a suspended frame, the only lever was the code itself: record each
+call's return continuation as a patch point and, on redefinition, overwrite it
+with a `jmp`/`B` to that site's `Evict` handler, so the frame deopted one
+instruction after it resumed.
+
+Chain conversion subsumes that completely — it drops the same frames to the
+interpreter, from the stack rather than from the code — with three things the
+patching form could not offer:
+
+* a compiled body still valid for *future* invocations survives, because no
+  machine code is rewritten;
+* on aarch64 it removes a self-modifying-code path, with its
+  writable/I-cache-invalidate dance around every patched word (the remaining
+  SMC users are `patch_call_to_entry` and the recompilation patch points, which
+  are unrelated);
+* it is the mechanism the unboxed-locals speculation needs anyway, so there is
+  one walk to reason about instead of two that must agree.
+
+The single precondition was that **every** call and yield site register a
+`chain_deopt_table` entry, since an unregistered site is one the walk leaves
+running its stale body. §8.3's feature gate on `AbstractState::chain_exit` was
+therefore removed; every build pays the metadata.
+
+Removed with it: `Codegen::patch_return_to_deopt` (both arches),
+`get_deopt_with_return_addr` and the `return_addr_table` it read,
+`emit_immediate_evict` (both arches), and `AsmInst::ImmediateEvict` /
+`LInst::ImmediateEvict` with their dispatch arms. `asm_return_addr_table`
+stays — it is how `AsmInst::ChainExit`, pushed after the call when the return
+address is no longer at hand, names the site it belongs to. `AsmEvict` and
+`SideExit::Evict` stay for the same reason, though nothing branches to an
+`Evict` handler any more; retiring that emission is a separate cleanup.
+
+`Codegen::evict_suspended_frames` and `Codegen::chain_deopt` were the same CFP
+walk once the patch fallback was gone, and are now one function
+(`chain_deopt`), used by both `check_bop_redefine` and `runtime::chain_deopt`.

--- a/doc/lir.md
+++ b/doc/lir.md
@@ -112,7 +112,7 @@ benefit. The `lir.rs` unit test uses `matches!` instead of `==`.
 | Dispatch helpers (macro-op) | `GenericBinOp`, `OptEqCmp`, `ArrayTEq`, `CheckKwRest`, `RestKw` |
 | Definition (macro-op) | `MethodDef`, `SingletonMethodDef`, `ClassDef`, `SingletonClassDef`, `AliasMethod`, `UndefMethod` |
 | Method-prologue guards (macro-op) | `GuardClassVersion`, `RecompileDeopt`, `CheckStack`, `ExecGc`, `Init`, `LoopJitRspBump` |
-| Control flow / exceptions (macro-op) | `Ret`, `MethodRet`, `BlockBreak`, `Raise`, `Retry`, `Redo`, `EnsureEnd`, `Yield`, `BlockArgProxy`, `BlockArg`, `ImmediateEvict`, `Deopt`, `HandleError`, `Unreachable` |
+| Control flow / exceptions (macro-op) | `Ret`, `MethodRet`, `BlockBreak`, `Raise`, `Retry`, `Redo`, `EnsureEnd`, `Yield`, `BlockArgProxy`, `BlockArg`, `ChainExit`, `Deopt`, `HandleError`, `Unreachable` |
 
 `Lir` is a thin `Vec<LInst>` builder used where a multi-instruction sequence is
 convenient.
@@ -346,12 +346,13 @@ The remaining things handled **directly** (not through `encode_linst`):
   `send`, `fiddle`, the remaining integer shift/division guards, `object_id`
   (a runtime call). Several would still benefit from a couple of generic
   FP/branch/call LIR primitives.
-- **Pure patch / recompile *bookkeeping*** — the x86/aarch64 *non-coverage*
-  asymmetry of `doc/arch_difference.md` §4. The deopt *handler emission* now
-  goes through LIR (above); what stays out is the part that **emits no bytes**:
-  `ImmediateEvict` records a `return_addr_table` patch point (zero bytes), and
-  the actual return-address overwrite happens at BOP-redefinition time, not at
-  compile time. The clean invariant is therefore:
+- **Pure registration / recompile *bookkeeping*** — the x86/aarch64
+  *non-coverage* asymmetry of `doc/arch_difference.md` §4. The deopt *handler
+  emission* now goes through LIR (above); what stays out is the part that
+  **emits no bytes**: `ChainExit` records a call site's replay data in
+  `chain_deopt_table` (zero bytes), and the actual frame conversion happens at
+  BOP-redefinition / deopt time, not at compile time. The clean invariant is
+  therefore:
 
 > `encode_linst` is the single seam for byte **emission**; zero-byte
 > code-position metadata / runtime patch bookkeeping is *not* emission and stays

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -661,18 +661,17 @@ pub struct Codegen {
 
     compilation_unit: Vec<CompilationUnitInfo>,
 
-    /// return_addr => (patch_point, deopt)
-    return_addr_table: HashMap<CodePtr, (Option<CodePtr>, DestLabel)>,
+    /// A call site's `AsmEvict` id => the return address of its call
+    /// instruction, recorded by `set_deopt_with_return_addr` at emission.
+    /// The id is how `AsmInst::ChainExit` — pushed after the call, when the
+    /// address itself is no longer at hand — names the site it belongs to.
     asm_return_addr_table: HashMap<AsmEvict, CodePtr>,
     /// `doc/chain_deopt.md` §5 step 1 / §9.3: a suspended call's return
     /// address => the data needed to convert the suspended caller frame
     /// eagerly (replay its write-back from Rust, hand the shared VM
-    /// continuation stub its per-site `dst`/resume data). Keyed identically
-    /// to `return_addr_table` (§3.4), because both are looked up from a
-    /// suspended frame's return-address slot; the two differ in what they do
-    /// with the hit — `return_addr_table` patches the frame's *code* at the
-    /// recorded continuation, this one drives a stack-only conversion so
-    /// control leaves JIT code on `ret`.
+    /// continuation stub its per-site `dst`/resume data). Keyed by the
+    /// return-address slot of a suspended frame (§3.4), which is all the
+    /// walk has to go on.
     chain_deopt_table: HashMap<CodePtr, ChainReplay>,
     /// The shared chain-deopt post-call continuation stub
     /// (`gen_chain_cont_stub`): the single address every converted frame's
@@ -1056,7 +1055,6 @@ impl Codegen {
             alloc_used_addr: std::ptr::null_mut(),
             alloc_page_addr: std::ptr::null_mut(),
             compilation_unit: Vec::new(),
-            return_addr_table: HashMap::default(),
             asm_return_addr_table: HashMap::default(),
             chain_deopt_table: HashMap::default(),
             chain_cont_stub: entry_panic.clone(),
@@ -1470,7 +1468,7 @@ impl Codegen {
         let plan = CODEGEN.with(|codegen| {
             let mut codegen = codegen.borrow_mut();
             if std::mem::replace(&mut codegen.bop_eviction_pending, false) {
-                codegen.evict_suspended_frames(cfp)
+                codegen.chain_deopt(cfp)
             } else {
                 Vec::new()
             }
@@ -1496,102 +1494,11 @@ impl Codegen {
         unsafe { *addr }
     }
 
-    ///
-    /// Convert (or arrange to deopt) every suspended JIT frame in *cfp*'s
-    /// control-frame chain, after a basic-op redefinition made their compiled
-    /// continuations stale. Per-frame, the mechanism is chosen by what the
-    /// call site registered:
-    ///
-    /// * a **chain conversion** (`chain_deopt_table`) — plan the eager
-    ///   conversion (`doc/chain_deopt.md` §2/§9.3): replay the suspended
-    ///   caller's write-back and rewrite the frame's return-address slot to
-    ///   the shared VM continuation stub, leaving the compiled body
-    ///   untouched. Returned to the caller for application outside the
-    ///   `CODEGEN` borrow (the replay allocates);
-    /// * otherwise a **patch point** (`return_addr_table`) — overwrite the
-    ///   call's return continuation in the *code* with a `jmp deopt`
-    ///   (immediate eviction), done in place.
-    ///
-    /// A default build registers no chain entries, so this degenerates to
-    /// pure immediate eviction; under the `chain-deopt` feature every site
-    /// registers and the walk is pure chain deopt. When the unboxed-locals
-    /// speculation (§5 step 5) lands, speculative call sites register
-    /// per-site and the two mechanisms coexist in one chain.
-    ///
-    #[must_use]
-    fn evict_suspended_frames(&mut self, mut cfp: Cfp) -> Vec<ChainConversion> {
-        let stub = self.jit.get_label_address(&self.chain_cont_stub);
-        let mut plan = Vec::new();
-        let mut return_addr = unsafe { cfp.return_addr() };
-        while let Some(prev_cfp) = cfp.prev() {
-            if let Some(ret) = return_addr
-                && !self.check_vm_address(ret)
-            {
-                if let Some(replay) = self.chain_deopt_table.get(&ret).cloned() {
-                    #[cfg(any(feature = "deopt", feature = "profile"))]
-                    eprintln!("### bop eviction: frame return {ret:?} -> chain conversion");
-                    plan.push(ChainConversion::new(cfp, prev_cfp, replay, stub));
-                } else if let Some((patch_point, deopt)) = self.get_deopt_with_return_addr(ret) {
-                    let patch_point = patch_point.unwrap();
-                    self.patch_return_to_deopt(patch_point, &deopt);
-                }
-            }
-            cfp = prev_cfp;
-            return_addr = unsafe { cfp.return_addr() };
-        }
-        plan
-    }
-
-    /// Overwrite the instruction(s) at a specialized call's return continuation
-    /// (`patch_point`) so the now-stale frame deopts when control returns to it.
-    /// x86 has a coherent I-cache and RWX pages, so it just writes the
-    /// `jmp deopt` in place.
-    #[cfg(target_arch = "x86_64")]
-    fn patch_return_to_deopt(&mut self, patch_point: CodePtr, deopt: &DestLabel) {
-        self.jit.apply_jmp_patch_address(patch_point, deopt);
-        unsafe { patch_point.as_ptr().write(0xe9) };
-    }
-
-    /// aarch64 twin: overwrite the single 4-byte instruction at `patch_point`
-    /// with an unconditional `B deopt` (`0x14000000 | imm26`). Unlike x86 this
-    /// must (a) make the page writable and (b) synchronize the I-cache, since
-    /// AArch64 does not keep I/D caches coherent across self-modifying code —
-    /// `set_writable`/`set_executable` handle both (the latter invalidates the
-    /// I-cache; both are no-ops on Linux's RWX pages except that invalidation).
-    #[cfg(target_arch = "aarch64")]
-    fn patch_return_to_deopt(&mut self, patch_point: CodePtr, deopt: &DestLabel) {
-        self.jit.set_writable();
-        let dest = self.jit.get_label_address(deopt);
-        // Byte displacement from the patch point to the deopt handler; both are
-        // 4-byte aligned, so imm26 = disp / 4 (B's range is ±128 MiB). In the
-        // intended use the evict handler sits in the same compilation unit as
-        // the call site, so the distance is tiny — assert the range so an
-        // out-of-range pair (a table-corruption symptom) panics instead of
-        // silently branching to a masked wrong target.
-        let disp = dest - patch_point;
-        debug_assert!(
-            (-(1i64 << 27)..(1i64 << 27)).contains(&(disp as i64)),
-            "patch_return_to_deopt: B displacement out of imm26 range: {disp:#x}"
-        );
-        let imm26 = ((disp >> 2) as u32) & 0x03ff_ffff;
-        let word = 0x1400_0000u32 | imm26;
-        unsafe { (patch_point.as_ptr() as *mut u32).write(word) };
-        self.jit.set_executable();
-    }
-
-    fn get_deopt_with_return_addr(
-        &self,
-        return_addr: CodePtr,
-    ) -> Option<(Option<CodePtr>, DestLabel)> {
-        self.return_addr_table.get(&return_addr).cloned()
-    }
-
     /// `LInst::ChainExit`: map this call's return address (recorded moments
     /// ago by `set_deopt_with_return_addr` under the same `evict` id) to its
     /// replay data.
     ///
-    /// The `unwrap` is load-bearing for the same reason as
-    /// `emit_immediate_evict`'s: `AsmEvict` ids restart per block while
+    /// The `unwrap` is load-bearing: `AsmEvict` ids restart per block while
     /// `asm_return_addr_table` is never cleared, so a producer that forgot to
     /// register its return address would silently pick up a stale same-id
     /// entry and give an unrelated live call site the wrong replay data.
@@ -1605,6 +1512,16 @@ impl Codegen {
     /// control-frame chain into an interpreter frame (`doc/chain_deopt.md`
     /// §2, eager form §9.3).
     ///
+    /// This is the **only** way an on-stack JIT frame is dropped to the
+    /// interpreter, and it serves both callers: an escalated side exit
+    /// (`runtime::chain_deopt`), and a basic-op redefinition that made every
+    /// suspended compiled continuation stale (`Self::check_bop_redefine`).
+    /// The two used to differ — BOP eviction additionally patched a `jmp
+    /// deopt` into the *code* at the call's return continuation for sites
+    /// with no chain entry — but registration is now unconditional, so that
+    /// fallback covered nothing the walk does not, and self-modifying code
+    /// has left the picture entirely.
+    ///
     /// Each frame is left exactly where it is. Applying a planned
     /// [`ChainConversion`] replays the suspended caller's write-back (boxing
     /// its unboxed floats into its local slots) and rewrites the callee's
@@ -1612,13 +1529,11 @@ impl Codegen {
     /// with the site's `dst`/resume word in the cont-frame pad slot. Control
     /// therefore never re-enters a compiled body: as the innermost frame
     /// (and then each frame in turn) returns, the `ret` lands in the stub,
-    /// which stores the result and resumes the fetch loop. The plan is
-    /// returned instead of applied because the replay allocates and this
-    /// runs under the `CODEGEN` borrow (see `runtime::chain_deopt`).
-    ///
-    /// Unlike [`Self::evict_suspended_frames`]' return-address patching this
-    /// touches no machine code, so a compiled body that is still valid for
-    /// *future* invocations survives.
+    /// which stores the result and resumes the fetch loop. Because no machine
+    /// code is touched, a compiled body that is still valid for *future*
+    /// invocations survives. The plan is returned instead of applied because
+    /// the replay allocates and this runs under the `CODEGEN` borrow (see
+    /// `runtime::chain_deopt`).
     ///
     /// Frames whose return address is in VM code or an invoker are already
     /// interpreted (or are a foreign entry) and are skipped, but the walk
@@ -1628,11 +1543,9 @@ impl Codegen {
     /// slots may since have been updated through `outer_lfp` by interpreted
     /// inner frames, and a second replay would clobber them with stale
     /// floats. A JIT return address with no table entry is likewise skipped:
-    /// for BOP eviction the patching walk covers those sites, and for an
-    /// escalated side exit (`runtime::chain_deopt`) an unregistered site
-    /// marks the boundary of the compilation region that speculated — frames
-    /// beyond it hold no unboxed cross-frame state and may resume their
-    /// compiled bodies.
+    /// every JIT call/yield site registers, so what remains is a frame
+    /// entered by something that is not a compiled call site, and it holds
+    /// no cross-frame state this walk is responsible for.
     ///
     #[must_use]
     pub(crate) fn chain_deopt(&mut self, mut cfp: Cfp) -> Vec<ChainConversion> {
@@ -1640,8 +1553,14 @@ impl Codegen {
         let mut plan = Vec::new();
         let mut return_addr = unsafe { cfp.return_addr() };
         while let Some(prev_cfp) = cfp.prev() {
-            if let Some(ret) = return_addr
-                && !self.check_vm_address(ret)
+            // A frame with a previous control frame was entered by a
+            // `call`/`bl`, so its return-address slot holds a real address.
+            // `None` means the CFP chain or the frame layout is corrupt;
+            // skipping the frame would silently leave it running a compiled
+            // body this walk has just decided must not run, so abort loudly
+            // instead (as the pre-chain-deopt eviction walk always did).
+            let ret = return_addr.expect("suspended control frame has a null return address");
+            if !self.check_vm_address(ret)
                 && let Some(replay) = self.chain_deopt_table.get(&ret).cloned()
             {
                 #[cfg(any(feature = "deopt", feature = "profile"))]
@@ -1657,11 +1576,10 @@ impl Codegen {
     /// aarch64 specialized recompile: overwrite the single 4-byte `bl entry`
     /// instruction at `patch_point` (the `SpecializedCall` site, bound just
     /// before the `bl` in `do_specialized_call`) so it now branches into
-    /// the freshly compiled body at `entry`. The twin of
-    /// [`Self::patch_return_to_deopt`] but writing a `BL` (`0x9400_0000 |
-    /// imm26`) instead of a `B`: same ±128 MiB range and the same
-    /// writable / I-cache-synchronize dance (AArch64 has no I/D coherence for
-    /// self-modifying code). The new `bl` keeps the same return continuation
+    /// the freshly compiled body at `entry`. Writes a `BL` (`0x9400_0000 |
+    /// imm26`) with a ±128 MiB range, under the writable / I-cache-synchronize
+    /// dance AArch64 requires for self-modifying code (it keeps no I/D
+    /// coherence). The new `bl` keeps the same return continuation
     /// (the next instruction), so the post-call frame teardown is unchanged.
     #[cfg(target_arch = "aarch64")]
     fn patch_call_to_entry(&mut self, patch_point: CodePtr, entry: &DestLabel) {

--- a/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
@@ -950,10 +950,11 @@ impl Codegen {
     /// `SpecializedCall` / `SpecializedYield`: a direct branch-with-link into
     /// an inlined method/block entry already emitted in this code buffer.
     /// Mirrors x86 `do_specialized_call`: set_lfp + push_frame, optionally bind
-    /// the deopt re-entry `patch_point`, `bl entry`, then pop_frame. Returns the
-    /// post-`bl` address (the return continuation); the caller records it via
-    /// `set_deopt_with_return_addr` so the eviction walk (`evict_suspended_frames`) can later overwrite
-    /// the continuation with a `B deopt` on BOP redefinition.
+    /// the recompile re-entry `patch_point`, `bl entry`, then pop_frame. Returns
+    /// the post-`bl` address (the return continuation); the caller records it via
+    /// `set_deopt_with_return_addr` so the chain-deopt walk (`Codegen::chain_deopt`)
+    /// can find this site's replay data from a suspended frame's return-address
+    /// slot.
     pub(in crate::codegen::jitgen::asmir) fn do_specialized_call(
         &mut self,
         entry: DestLabel,
@@ -1084,15 +1085,15 @@ impl Codegen {
         );
     }
 
+    /// Record `return_addr` — the address the callee will `ret` to — under
+    /// this call site's `evict` id, so the `AsmInst::ChainExit` pushed just
+    /// after the call can key its replay data by it (`register_chain_exit`).
     pub(in crate::codegen::jitgen::asmir) fn set_deopt_with_return_addr(
         &mut self,
         return_addr: CodePtr,
         evict: AsmEvict,
-        evict_label: &DestLabel,
     ) {
         self.asm_return_addr_table.insert(evict, return_addr);
-        self.return_addr_table
-            .insert(return_addr, (None, evict_label.clone()));
     }
 
     /// Write the callee frame's meta/outer/block fields before a call.
@@ -1219,14 +1220,13 @@ impl Codegen {
     /// re-guard (see `a64_do_call`); otherwise it calls the wrapper `codeptr`
     /// as before.
     ///
-    /// Like x86, the call's return address is registered for BOP-redefinition
-    /// eviction: when a basic op is redefined *inside* the callee, the caller's
-    /// own compiled body (inline integer arithmetic, folds) is stale the moment
-    /// the callee returns, and the callee's entry guards cannot protect the
-    /// *caller*. `evict_suspended_frames` finds this frame's return address in
-    /// `return_addr_table` and overwrites the recorded patch point (bound by
-    /// the following `ImmediateEvict`, after the result store) with a `B evict`
-    /// so the frame deopts instead of resuming stale code.
+    /// Like x86, the call's return address is recorded under `evict` for the
+    /// following `ChainExit`: when a basic op is redefined *inside* the callee,
+    /// the caller's own compiled body (inline integer arithmetic, folds) is
+    /// stale the moment the callee returns, and the callee's entry guards
+    /// cannot protect the *caller*. `Codegen::chain_deopt` finds this frame's
+    /// return address in `chain_deopt_table` and converts the frame to an
+    /// interpreter frame instead of letting it resume stale code.
     pub(in crate::codegen::jitgen) fn emit_call(
         &mut self,
         codeptr: CodePtr,
@@ -1236,11 +1236,10 @@ impl Codegen {
         _jit_entry: Option<DestLabel>,
         jit_slot: Option<u64>,
         evict: AsmEvict,
-        evict_label: &DestLabel,
     ) {
         let return_addr =
             self.a64_do_call(codeptr, is_iseq, callee_pc, call_site_bc_ptr, jit_slot);
-        self.set_deopt_with_return_addr(return_addr, evict, evict_label);
+        self.set_deopt_with_return_addr(return_addr, evict);
     }
 
     /// Keyword-rest fixup: if the `slot` is nil, replace it with a fresh empty
@@ -1274,23 +1273,23 @@ impl Codegen {
     /// via `get_yield_data`). Mirrors x86 `gen_yield`: fetch the block's
     /// ProcData, build the callee block frame, massage arguments, then call the
     /// block's funcdata indirectly. Like every other machine-level call, the
-    /// block call's return address is registered for BOP-redefinition eviction
-    /// (see `emit_call`) — a yielded block can redefine a basic op, and the
-    /// yielding frame must then deopt on resume instead of running its stale
-    /// compiled continuation. Registering here also keeps the
-    /// `emit_immediate_evict` invariant that every `ImmediateEvict`'s evict id
-    /// was registered by its own site in the same block (AsmEvict ids restart
-    /// per block, so an unregistered producer would read a stale same-id entry
-    /// from `asm_return_addr_table` and hijack an unrelated site's patch
-    /// point). `error` catches a missing block, an argument error, or a callee
-    /// raise. Bails on an out-of-range callee-frame offset.
+    /// block call's return address is recorded under `evict` for the following
+    /// `ChainExit` (see `emit_call`) — a yielded block can redefine a basic op,
+    /// and the yielding frame must then be converted to an interpreter frame
+    /// instead of resuming its stale compiled continuation. Registering here
+    /// also keeps the `register_chain_exit` invariant that every `ChainExit`'s
+    /// evict id was registered by its own site in the same block (AsmEvict ids
+    /// restart per block, so an unregistered producer would read a stale
+    /// same-id entry from `asm_return_addr_table` and give an unrelated live
+    /// call site the wrong replay data). `error` catches a missing block, an
+    /// argument error, or a callee raise. Bails on an out-of-range
+    /// callee-frame offset.
     pub(in crate::codegen::jitgen) fn emit_yield(
         &mut self,
         callid: CallSiteId,
         simple: bool,
         error: &DestLabel,
         evict: AsmEvict,
-        evict_label: &DestLabel,
     ) -> bool {
         // Closely mirrors the proven VM `a64_op_yield`. x25/x26 are callee-saved
         // and used by neither the JIT global set (x19-x23) nor JIT'd code, so
@@ -1382,7 +1381,7 @@ impl Codegen {
             sub x10, x29, #((BP_CFP + CFP_LFP) as u32);
             ldr x22, [x10];
         );
-        self.set_deopt_with_return_addr(return_addr, evict, evict_label);
+        self.set_deopt_with_return_addr(return_addr, evict);
         true
     }
 

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -397,9 +397,10 @@ impl Codegen {
         for (v, slot) in &wb.literal {
             self.a64_store_imm_to_slot(v.id(), *slot, lfp);
         }
-        for slot in &wb.void {
-            self.a64_store_imm_to_slot(NIL_VALUE as u64, *slot, lfp);
-        }
+        // No `void` (nil-fill) loop — see x86 `gen_write_back_for_deopt`: only
+        // the GC write-back populates that field, and it never reaches a side
+        // exit.
+        debug_assert!(wb.void.is_empty());
         for (reg, slot) in &wb.gp {
             let off = slot.0 as u32 * 8 + LFP_SELF as u32;
             self.a64_frame_store(reg.a64().0, lfp, off);
@@ -2228,31 +2229,6 @@ impl Codegen {
         self.a64_block_break(pc);
     }
 
-    /// Record this position (the return continuation of a call, after the
-    /// result store) as the return-address patch point for `evict`. On BOP
-    /// redefinition, `Codegen::evict_suspended_frames` overwrites the instruction
-    /// here with a `B deopt` so the stale frame deopts on return instead of
-    /// resuming its compiled body (whose inline integer arithmetic / folds
-    /// assume the builtin op). Mirrors x86.
-    pub(in crate::codegen::jitgen) fn emit_immediate_evict(&mut self, evict: AsmEvict) {
-        // Every `ImmediateEvict` producer (normal call, generic yield,
-        // specialized call/yield) registers its own return address in the same
-        // block, so the id ALWAYS resolves to the fresh same-block entry.
-        // `unwrap` (x86 parity) is load-bearing: AsmEvict ids restart per
-        // block and `asm_return_addr_table` is never cleared, so a producer
-        // that forgot to register would otherwise silently read a stale
-        // same-id entry from an earlier block and repoint an unrelated live
-        // call site's patch point — a miscompile. Panic loudly instead.
-        let return_addr = *self.asm_return_addr_table.get(&evict).unwrap();
-        let patch_point = self.jit.get_current_address();
-        self.return_addr_table
-            .entry(return_addr)
-            .and_modify(|e| e.0 = Some(patch_point));
-    }
-
-    /// Register a specialized call's return address so the eviction walk can
-    /// find and patch it. Identical to the x86 helper (the tables are arch-
-    /// neutral fields on `Codegen`).
     /// Store the call-site pc into the outgoing cont-frame slot
     /// (`[sp]` = the callee frame's CFP+24). The 16-byte region was
     /// reserved by the preceding cont-mode `FprSave`, whose fp saves

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -397,10 +397,9 @@ impl Codegen {
         for (v, slot) in &wb.literal {
             self.a64_store_imm_to_slot(v.id(), *slot, lfp);
         }
-        // No `void` (nil-fill) loop — see x86 `gen_write_back_for_deopt`: only
-        // the GC write-back populates that field, and it never reaches a side
-        // exit.
-        debug_assert!(wb.void.is_empty());
+        for slot in &wb.void {
+            self.a64_store_imm_to_slot(NIL_VALUE as u64, *slot, lfp);
+        }
         for (reg, slot) in &wb.gp {
             let off = slot.0 as u32 * 8 + LFP_SELF as u32;
             self.a64_frame_store(reg.a64().0, lfp, off);

--- a/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/method_call.rs
@@ -293,8 +293,9 @@ impl Codegen {
         };
     }
 
-    /// The call itself: enter the callee and record a return-address deopt
-    /// patch point for `evict`. Store/frame-dependent target info is pre-resolved
+    /// The call itself: enter the callee and record the return address under
+    /// `evict`, so the following `ChainExit` can register this site for chain
+    /// deopt. Store/frame-dependent target info is pre-resolved
     /// by the dispatcher (codeptr / is_iseq / pcs / JIT entry), so this is
     /// store-free.
     pub(in crate::codegen::jitgen) fn emit_call(
@@ -307,7 +308,6 @@ impl Codegen {
         // aarch64 guard-free dispatch slot; x86 dispatches via `jit_entry`.
         _jit_slot: Option<u64>,
         evict: AsmEvict,
-        evict_label: &DestLabel,
     ) {
         self.set_lfp();
         self.push_frame();
@@ -338,7 +338,7 @@ impl Codegen {
         let return_addr = self.jit.get_current_address();
 
         self.pop_frame();
-        self.set_deopt_with_return_addr(return_addr, evict, evict_label);
+        self.set_deopt_with_return_addr(return_addr, evict);
     }
 
     pub(in crate::codegen::jitgen) fn do_specialized_call(

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -103,7 +103,6 @@ impl Codegen {
             | AsmInst::Ret
             | AsmInst::MethodRet(..)
             | AsmInst::BlockBreak(..)
-            | AsmInst::ImmediateEvict { .. }
             | AsmInst::ChainExit { .. }
             | AsmInst::GuardClassVersion { .. }
             | AsmInst::ContFramePc { .. }
@@ -1523,15 +1522,11 @@ impl Codegen {
         }
     }
 
-    pub(super) fn set_deopt_with_return_addr(
-        &mut self,
-        return_addr: CodePtr,
-        evict: AsmEvict,
-        evict_label: &DestLabel,
-    ) {
+    /// Record `return_addr` — the address the callee will `ret` to — under
+    /// this call site's `evict` id, so the `AsmInst::ChainExit` pushed just
+    /// after the call can key its replay data by it (`register_chain_exit`).
+    pub(super) fn set_deopt_with_return_addr(&mut self, return_addr: CodePtr, evict: AsmEvict) {
         self.asm_return_addr_table.insert(evict, return_addr);
-        self.return_addr_table
-            .insert(return_addr, (None, evict_label.clone()));
     }
 
     ///
@@ -1950,15 +1945,6 @@ impl Codegen {
             lea  rax, [rip + jump_table];
             jmp  [rax + rdi * 8];
         };
-    }
-
-    /// Record this position as the return-address patch point for `evict`.
-    pub(in crate::codegen::jitgen) fn emit_immediate_evict(&mut self, evict: AsmEvict) {
-        let patch_point = self.jit.get_current_address();
-        let return_addr = self.asm_return_addr_table.get(&evict).unwrap();
-        self.return_addr_table
-            .entry(*return_addr)
-            .and_modify(|e| e.0 = Some(patch_point));
     }
 
     /// Inline-cache class-version guard: deopt if the global class version moved
@@ -2512,10 +2498,9 @@ impl Codegen {
         simple: bool,
         error: &DestLabel,
         evict: AsmEvict,
-        evict_label: &DestLabel,
     ) -> bool {
         let return_addr = self.gen_yield(callid, simple, error);
-        self.set_deopt_with_return_addr(return_addr, evict, evict_label);
+        self.set_deopt_with_return_addr(return_addr, evict);
         true
     }
 

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -470,10 +470,13 @@ impl ChainReplay {
             // SAFETY: as above.
             unsafe { caller_lfp.set_register(*slot, Some(*v)) };
         }
-        for slot in &self.wb.void {
-            // SAFETY: as above.
-            unsafe { caller_lfp.set_register(*slot, Some(Value::nil())) };
-        }
+        // `void` (nil-fill of `LinkMode::V` slots) is never populated here:
+        // `WriteBack` has exactly two constructors, and only the GC-safepoint
+        // one (`get_gc_write_back`) fills `void` — `get_write_back`, which
+        // every side exit and every `ChainExitSpec` uses, hard-codes it empty.
+        // A GC write-back never reaches a chain replay, so there is nothing to
+        // nil-fill.
+        debug_assert!(self.wb.void.is_empty());
         // GP-pool residents exist only under the (unfinished) GP allocator;
         // shipping builds never record any.
         debug_assert!(self.wb.gp.is_empty());
@@ -506,9 +509,9 @@ impl ChainReplay {
 }
 
 ///
-/// One frame's worth of eager chain-deopt conversion, produced by the walks
-/// (`Codegen::chain_deopt` / `Codegen::evict_suspended_frames`) and applied
-/// by their callers *after* the `CODEGEN` borrow is released — the replay
+/// One frame's worth of eager chain-deopt conversion, produced by the walk
+/// (`Codegen::chain_deopt`) and applied by its callers *after* the
+/// `CODEGEN` borrow is released — the replay
 /// allocates (boxing, rest-`Array`/kwrest-`Hash` materialization) and so can
 /// run a GC, which must not happen while the thread-local is held.
 ///
@@ -1204,9 +1207,12 @@ impl JitModule {
         for (v, slot) in &wb.literal {
             self.literal_to_stack2(*slot, *v);
         }
-        for slot in &wb.void {
-            self.literal_to_stack2(*slot, Value::nil());
-        }
+        // No `void` (nil-fill) loop: only `get_gc_write_back` ever populates
+        // that field, and a GC write-back goes through `gen_write_back`, never
+        // here — every side exit's write-back comes from `get_write_back`,
+        // which hard-codes `void` empty. Same for the chain-deopt replay
+        // (`ChainReplay::replay`).
+        debug_assert!(wb.void.is_empty());
         for (reg, slot) in &wb.gp {
             monoasm! { &mut *self,
                 movq [r14 - (conv(*slot))], R(*reg as _);

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -470,13 +470,16 @@ impl ChainReplay {
             // SAFETY: as above.
             unsafe { caller_lfp.set_register(*slot, Some(*v)) };
         }
-        // `void` (nil-fill of `LinkMode::V` slots) is never populated here:
-        // `WriteBack` has exactly two constructors, and only the GC-safepoint
-        // one (`get_gc_write_back`) fills `void` — `get_write_back`, which
-        // every side exit and every `ChainExitSpec` uses, hard-codes it empty.
-        // A GC write-back never reaches a chain replay, so there is nothing to
-        // nil-fill.
-        debug_assert!(self.wb.void.is_empty());
+        // `void` nil-fills `LinkMode::V` slots. `get_write_back` — the
+        // constructor every `ChainExitSpec` goes through — hard-codes it
+        // empty, so this is expected to be a no-op; it is replayed anyway
+        // rather than asserted, because the identical "only the GC write-back
+        // populates `void`" argument turned out to be false for
+        // `gen_write_back_for_deopt`, which does receive populated ones.
+        for slot in &self.wb.void {
+            // SAFETY: as above.
+            unsafe { caller_lfp.set_register(*slot, Some(Value::nil())) };
+        }
         // GP-pool residents exist only under the (unfinished) GP allocator;
         // shipping builds never record any.
         debug_assert!(self.wb.gp.is_empty());
@@ -1207,12 +1210,9 @@ impl JitModule {
         for (v, slot) in &wb.literal {
             self.literal_to_stack2(*slot, *v);
         }
-        // No `void` (nil-fill) loop: only `get_gc_write_back` ever populates
-        // that field, and a GC write-back goes through `gen_write_back`, never
-        // here — every side exit's write-back comes from `get_write_back`,
-        // which hard-codes `void` empty. Same for the chain-deopt replay
-        // (`ChainReplay::replay`).
-        debug_assert!(wb.void.is_empty());
+        for slot in &wb.void {
+            self.literal_to_stack2(*slot, Value::nil());
+        }
         for (reg, slot) in &wb.gp {
             monoasm! { &mut *self,
                 movq [r14 - (conv(*slot))], R(*reg as _);

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1885,14 +1885,6 @@ pub(super) enum AsmInst {
         using_fpr: UsingFpr,
     },
     ///
-    /// Imnmediate eviction.
-    ///
-    /// When BOPs are re-defined, this palce will be overwritten by the code causes deoptimization.
-    ///
-    ImmediateEvict {
-        evict: AsmEvict,
-    },
-    ///
     /// Register this call site's replay data in the runtime table
     /// (`doc/chain_deopt.md` §5 step 1 / §9.3). Emits no machine code: it
     /// looks the call's return address up by `evict` (recorded moments

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -499,16 +499,13 @@ impl Codegen {
                     base: frame.base_stack_offset,
                 });
             }
-            // Method return / eviction family. `Ret` tears down the frame and
-            // returns; `MethodRet` sets the resume PC then returns through the
+            // Method return family. `Ret` tears down the frame and returns;
+            // `MethodRet` sets the resume PC then returns through the
             // method-return path; `BlockBreak` does the same through the
-            // block-break path (a non-local `break` out of a block);
-            // `ImmediateEvict` records a return-address patch point on x86 (a
-            // no-op on aarch64, which can't patch them).
+            // block-break path (a non-local `break` out of a block).
             AsmInst::Ret => self.encode_linst(LInst::Ret),
             AsmInst::MethodRet(pc) => self.encode_linst(LInst::MethodRet { pc }),
             AsmInst::BlockBreak(pc) => self.encode_linst(LInst::BlockBreak { pc }),
-            AsmInst::ImmediateEvict { evict } => self.encode_linst(LInst::ImmediateEvict { evict }),
             // Emits nothing; registers this call's return address -> replay
             // data so `Codegen::chain_deopt` can convert a frame suspended
             // here from its return-address slot alone (`doc/chain_deopt.md`
@@ -592,7 +589,6 @@ impl Codegen {
                 evict,
                 pc,
             } => {
-                let evict_label = labels[evict].clone();
                 let callee = &store[callee_fid];
                 let is_iseq = callee.is_iseq();
                 let (_, codeptr, callee_pc) = callee.get_data();
@@ -618,7 +614,6 @@ impl Codegen {
                     jit_entry,
                     jit_slot,
                     evict,
-                    evict_label,
                 });
             }
             // Method prologue: establish fp/lr, reserve the local frame, nil-fill
@@ -1008,17 +1003,16 @@ impl Codegen {
                 loop_jit_spill_bytes: frame.loop_jit_spill_bytes,
             }),
             // Generic `yield` (block target resolved at runtime). aarch64 builds
-            // the block frame and calls the funcdata indirectly; the x86-only
-            // return-address eviction patch is applied by the x86 emit_yield.
+            // the block frame and calls the funcdata indirectly; both arches
+            // record the block call's return address under `evict` for the
+            // following `ChainExit`.
             AsmInst::Yield { callid, simple, error, evict } => {
-                let evict_label = labels[evict].clone();
                 let error = labels[error].clone();
                 self.encode_linst(LInst::Yield {
                     callid,
                     simple,
                     error,
                     evict,
-                    evict_label,
                 });
             }
             // ---- Specialized inlined-frame family ------------------------------
@@ -1046,10 +1040,11 @@ impl Codegen {
                     cg.store_dyn_var_specialized(off, dst, src);
                 });
             }
-            // Direct call into an inlined method entry; the return-address patch
-            // point is recorded for BOP-redefinition eviction. Labels are
-            // resolved now (frame); the call + patch run at drain time, where
-            // `do_specialized_call`'s return address is the correct position.
+            // Direct call into an inlined method entry; the return address is
+            // recorded under `evict` so the following `ChainExit` can register
+            // this site. Labels are resolved now (frame); the call runs at drain
+            // time, where `do_specialized_call`'s return address is the correct
+            // position.
             AsmInst::SpecializedCall {
                 entry,
                 patch_point,
@@ -1058,9 +1053,9 @@ impl Codegen {
                 let patch_point =
                     patch_point.map(|label| frame.resolve_label(&mut self.jit, label));
                 let entry_label = frame.resolve_label(&mut self.jit, entry);
-                self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, labels, _| {
+                self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, _, _| {
                     let return_addr = cg.do_specialized_call(entry_label, patch_point);
-                    cg.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
+                    cg.set_deopt_with_return_addr(return_addr, evict);
                 });
             }
             // Specialized `yield`: build the block frame, then branch into the
@@ -1082,9 +1077,9 @@ impl Codegen {
             }
             AsmInst::SpecializedYield { entry, evict } => {
                 let entry_label = frame.resolve_label(&mut self.jit, entry);
-                self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, labels, _| {
+                self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, _, _| {
                     let return_addr = cg.do_specialized_call(entry_label, None);
-                    cg.set_deopt_with_return_addr(return_addr, evict, &labels[evict]);
+                    cg.set_deopt_with_return_addr(return_addr, evict);
                 });
             }
             // Inlined builtin method body: lower to `LInst::Inline`, the
@@ -1518,9 +1513,6 @@ impl Codegen {
             LInst::BlockBreak { pc } => {
                 self.emit_block_break(pc);
             }
-            LInst::ImmediateEvict { evict } => {
-                self.emit_immediate_evict(evict);
-            }
             LInst::ChainExit { evict, replay } => {
                 self.register_chain_exit(evict, replay);
             }
@@ -1554,8 +1546,8 @@ impl Codegen {
             LInst::EnsureEnd { loop_jit_spill_bytes } => {
                 self.emit_ensure_end(loop_jit_spill_bytes);
             }
-            LInst::Yield { callid, simple, error, evict, evict_label } => {
-                self.emit_yield(callid, simple, &error, evict, &evict_label);
+            LInst::Yield { callid, simple, error, evict } => {
+                self.emit_yield(callid, simple, &error, evict);
             }
             LInst::Unreachable => {
                 self.emit_unreachable();
@@ -1653,7 +1645,6 @@ impl Codegen {
                 jit_entry,
                 jit_slot,
                 evict,
-                evict_label,
             } => {
                 self.emit_call(
                     codeptr,
@@ -1663,7 +1654,6 @@ impl Codegen {
                     jit_entry,
                     jit_slot,
                     evict,
-                    &evict_label,
                 );
             }
             other => unreachable!("encode_linst_macro: unexpected {other:?}"),

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -1567,21 +1567,33 @@ impl AbstractState {
     /// state the post-call continuation expects (it stores the result into
     /// `dst` itself).
     ///
-    /// Nothing fires the walk in a default build yet (§5 steps 4-5 are
-    /// unimplemented), so registration is compiled in only under the
-    /// `chain-deopt` feature. When the speculation lands, this becomes the
-    /// per-site decision §6 argues for rather than a build-wide switch.
+    /// Registration is unconditional: chain conversion is now the *only* way
+    /// an on-stack JIT frame is dropped to the interpreter, so every call and
+    /// yield site must be convertible from its return address alone. A site
+    /// the table does not know is a site the walk has to leave running its
+    /// compiled body — which was tolerable only while immediate eviction
+    /// existed as a fallback. When the speculation (§5 step 5) lands, the
+    /// per-site decision §6 argues for rides on top of this, not instead
+    /// of it.
     ///
     fn chain_exit(&self, ir: &mut AsmIr, evict: AsmEvict, using_fpr: UsingFpr, dst: Option<SlotId>) {
-        if cfg!(feature = "chain-deopt") {
-            let spec = Box::new(ChainExitSpec::new(self, using_fpr, dst));
-            ir.push(AsmInst::ChainExit { evict, spec });
-        }
+        let spec = Box::new(ChainExitSpec::new(self, using_fpr, dst));
+        ir.push(AsmInst::ChainExit { evict, spec });
     }
 
+    /// Post-call bookkeeping: fill in the `Evict` side-exit slot this site
+    /// reserved, and re-arm the capture guard.
+    ///
+    /// The name is historical. The `Evict` handler used to be *entered* by
+    /// immediate eviction, which overwrote this site's return continuation
+    /// with a `jmp` to it; that mechanism is gone (chain conversion is the
+    /// only way a suspended frame is dropped to the interpreter), so nothing
+    /// branches to the handler any more. The slot is still filled because
+    /// `AsmEvict` is the id under which `chain_exit` finds this call's
+    /// return address, and `gen_asm` requires every reserved slot to carry a
+    /// write-back.
     fn immediate_evict(&mut self, ir: &mut AsmIr, evict: AsmEvict) {
         let next_pc = self.pc().next();
-        ir.push(AsmInst::ImmediateEvict { evict });
         ir[evict] = SideExit::Evict(Some((next_pc, self.get_write_back())));
         if !self.no_capture_guard() {
             let deopt = ir.new_deopt_with_pc(self, next_pc);

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -916,9 +916,6 @@ pub(in crate::codegen) enum LInst {
     BlockBreak {
         pc: BytecodePtr,
     },
-    ImmediateEvict {
-        evict: AsmEvict,
-    },
     /// Register `evict`'s already-recorded call return address as the key for
     /// `replay` in the runtime chain-deopt table. Emits no machine code.
     ChainExit {
@@ -974,7 +971,6 @@ pub(in crate::codegen) enum LInst {
         simple: bool,
         error: DestLabel,
         evict: AsmEvict,
-        evict_label: DestLabel,
     },
     Unreachable,
     RestKw {
@@ -1068,7 +1064,6 @@ pub(in crate::codegen) enum LInst {
         /// `jit_entry` directly) and for uncompiled/unknown-class callees.
         jit_slot: Option<u64>,
         evict: AsmEvict,
-        evict_label: DestLabel,
     },
     /// A cold side-exit (deopt) handler block: bind `entry`, undo any loop-JIT
     /// sp bump, write `wb` back to the LFP, then resume the VM / unwind. The

--- a/monoruby/tests/add_coverage.rs
+++ b/monoruby/tests/add_coverage.rs
@@ -1417,10 +1417,10 @@ fn caller_lines_through_specialized_jit_calls() {
 
 #[test]
 fn caller_lines_survive_specialized_frame_eviction() {
-    // Redefining a basic op from inside the callee evicts the
-    // suspended specialized caller frames (immediate_eviction): the
-    // deopt path must lazily write the recorded call-site pc into the
-    // cont-frame slot, so caller() lines stay correct afterwards.
+    // Redefining a basic op from inside the callee converts the
+    // suspended specialized caller frames (`Codegen::chain_deopt`): the
+    // recorded call-site pc in the cont-frame slot must survive, so
+    // caller() lines stay correct afterwards.
     run_test(
         r##"
         class CLSE_Probe; end

--- a/monoruby/tests/redefine.rs
+++ b/monoruby/tests/redefine.rs
@@ -93,7 +93,7 @@ fn redefine_test4() {
 // The pre-existing `redefine_test*` above only redefine `Integer#*` and use
 // `100 * 100`, a compile-time **fold**, while the redefining `class Integer`
 // body runs *inside* the warm-up loop (on-stack) — so they were satisfied on
-// aarch64 by the fold-only `CheckBOP` guard + on-stack `immediate_eviction`,
+// aarch64 by the fold-only `CheckBOP` guard + the on-stack conversion walk,
 // and never exercised the **non-fold** inline integer add of an off-stack
 // method. That path carries no per-op guard on either arch, so correctness
 // relies entirely on `set_bop_redefine` reverting every compiled method to the
@@ -255,8 +255,8 @@ fn redefine_bop_offstack_osr_loop_fold() {
 
 // Regression (bug C): an ON-STACK caller must not resume its stale compiled
 // body after a callee redefines a basic op. Two aarch64 gaps conspired here:
-// (1) `emit_call` did not register normal calls' return addresses, so
-// `immediate_eviction` could not patch the caller's return continuation
+// (1) `emit_call` did not register normal calls' return addresses, so the
+// on-stack walk could not reach the caller's suspended frame
 // (x86 registers every call); (2) arch-neutral: the `check_bop_redefine`
 // eviction ran *before* the store mutation (and only on the `def` path), so
 // the very definition that set the BOP flags never triggered it — it only ran
@@ -301,9 +301,9 @@ fn redefine_bop_onstack_caller() {
 // so it also checks the frame really stopped running its compiled body: a
 // resumed fold answers 7, an interpreter answers 999.
 //
-// Both on-stack mechanisms go through this: `immediate_eviction`'s
-// return-continuation patch and, under the `chain-deopt` feature, the
-// chain-exit handler's FP-pool reload (`doc/chain_deopt.md` §8).
+// This goes through the chain-deopt walk's eager replay, which boxes the
+// suspended frame's FP-pool resident out of the call's `FprSave` area
+// (`doc/chain_deopt.md` §8.1).
 #[test]
 fn redefine_bop_onstack_caller_float_local() {
     run_test(
@@ -329,16 +329,237 @@ fn redefine_bop_onstack_caller_float_local() {
     );
 }
 
+// The suspended caller holds MORE live floats than the FP register pool has
+// registers, so its write-back has to source them from two different homes:
+// the pool residents out of the call's `FprSave` area (indexed by set-bit
+// position in the site's `UsingFpr`) and the overflow out of the frame's
+// `base`-relative spill slots. Under `stress-spill-pool` the pool is two
+// registers, so five live products guarantee both homes are populated. The
+// results are `Float#-`, which the `Integer#+` redefinition leaves alone, so
+// a float taken from the wrong home reads as a wrong number rather than a
+// crash; the trailing `3 + 4` is the fold that pins the frame to the
+// interpreter (a resumed compiled body answers 7).
+//
+// Those two homes are the two arms of `ChainReplay::replay`'s `fpr` loop
+// (`doc/chain_deopt.md` §8.1), which every build now runs — the eviction walk
+// is the chain-deopt walk.
+#[test]
+fn redefine_bop_onstack_caller_float_spill() {
+    run_test(
+        r##"
+        $flag = false
+        def fmaybe
+          Integer.class_eval("def +(o); 999; end") if $flag
+          nil
+        end
+        def float_spill(a)
+          p1 = a * 1.5
+          p2 = a * 2.5
+          p3 = a * 3.5
+          p4 = a * 4.5
+          p5 = a * 5.5
+          fmaybe
+          [p1 - p2, p3 - p4, p5 - p1, 3 + 4]
+        end
+        100.times { float_spill(2.0) }
+        $flag = true
+        float_spill(2.0)
+        "##,
+    );
+}
+
+// The suspended frame is a specialized `(...)`-forwarding trampoline whose
+// rest `Array` — and, in the second snippet, whose `**kwrest` `Hash` — is
+// still DEFERRED at the call it is suspended at, so the eviction has to
+// materialize both out of argument slots living in the trampoline's *dynamic
+// caller* frame rather than its own.
+//
+// The redefining call is reached through `*_driver` rather than from the
+// warm-up loop directly: the deferral is a specialization-only decision
+// (`forward_rest_deferral` requires `is_specialized()`), so the trampoline has
+// to be entered from JIT-compiled code — entered from the VM it runs its root
+// body, where nothing is deferred. The second `*_target(...)` consume is what
+// makes a wrong materialization visible: the interpreter builds that call's
+// arguments out of the slots the eviction just wrote, so `y` diverges from `x`
+// if they were sourced wrongly.
+#[test]
+fn redefine_bop_onstack_forwarding_trampoline() {
+    run_test(
+        r##"
+        $flag = false
+        def fwd_target(a, b)
+          Integer.class_eval("def +(o); 999; end") if $flag
+          a + b
+        end
+        def fwd_wrap(...)
+          x = fwd_target(...)
+          y = fwd_target(...)
+          [x, y, 3 + 4]
+        end
+        def fwd_driver
+          fwd_wrap(5, 3)
+        end
+        100.times { fwd_driver }
+        $flag = true
+        fwd_driver
+        "##,
+    );
+    run_test(
+        r##"
+        $flag = false
+        def kw_target(a, k: 0, j: 0)
+          Integer.class_eval("def +(o); 999; end") if $flag
+          [a, k, j]
+        end
+        def kw_wrap(...)
+          x = kw_target(...)
+          y = kw_target(...)
+          [x, y, 3 + 4]
+        end
+        def kw_driver
+          kw_wrap(5, k: 7, j: 9)
+        end
+        100.times { kw_driver }
+        $flag = true
+        kw_driver
+        "##,
+    );
+}
+
+// `Class#new` is the trampoline that carries a deferred `**kwrest` in
+// practice: the literal keywords at `KwNode.new(a: 1, b: 2)` are source-routed
+// straight into `initialize`'s declared parameters, so `new`'s own `**kwrest`
+// is still deferred while `initialize` runs. Redefining the basic op there
+// suspends `new` with that deferral outstanding, and the frame below it is a
+// SPECIALIZED call rather than the ordinary send the snippets above suspend
+// at.
+#[test]
+fn redefine_bop_onstack_new_trampoline_kwrest() {
+    run_test(
+        r##"
+        $flag = false
+        class KwNode
+          attr_reader :v
+          def initialize(a: 0, b: 0, c: 0)
+            Integer.class_eval("def +(o); 999; end") if $flag
+            @v = [a, b, c]
+          end
+        end
+        def kwnode_driver
+          [KwNode.new(a: 1, b: 2).v, 3 + 4]
+        end
+        100.times { kwnode_driver }
+        $flag = true
+        kwnode_driver
+        "##,
+    );
+}
+
+// TWO suspended JIT frames below the redefining one instead of one, so the
+// eviction walk has to carry a chain rather than a single frame, and the two
+// call-site shapes are mixed: `lvl2` is suspended at a call whose result is
+// discarded (no destination slot), `lvl1` at one whose result feeds a local.
+// Each frame carries its own post-call fold, so a frame that resumed its
+// compiled body contributes a stale 2 / 7 / 11 and its position in the result
+// array names which one it was.
+#[test]
+fn redefine_bop_onstack_multi_frame_chain() {
+    run_test(
+        r##"
+        $flag = false
+        def lvl3
+          Integer.class_eval("def +(o); 999; end") if $flag
+          nil
+        end
+        def lvl2
+          lvl3
+          [1 + 1, 3 + 4]
+        end
+        def lvl1
+          r = lvl2
+          r << (5 + 6)
+        end
+        100.times { lvl1 }
+        $flag = true
+        lvl1
+        "##,
+    );
+}
+
+// The suspended call site is an OPERATOR (`r + 5`, a 1-unit `BinOp` bytecode)
+// rather than a 2-unit send — it reaches the generic `send` emitter because
+// the receiver is neither `Integer` nor `Float`. A post-call continuation that
+// assumed the send's size would advance the resume pc one whole instruction
+// too far (`doc/chain_deopt.md` §8.2 is the record of what that costs), so the
+// trailing `3 + 4` is the instruction the frame must resume AT.
+#[test]
+fn redefine_bop_onstack_operator_site() {
+    run_test(
+        r##"
+        $flag = false
+        class OpRedef
+          def +(o)
+            Integer.class_eval("def +(o); 999; end") if $flag
+            o * 2
+          end
+        end
+        def op_caller(r)
+          v = r + 5
+          [v, 3 + 4]
+        end
+        o = OpRedef.new
+        100.times { op_caller(o) }
+        $flag = true
+        op_caller(o)
+        "##,
+    );
+}
+
+// The redefining callee RAISES instead of returning, so control leaves the
+// suspended frames by unwinding: `mid_frame` never resumes at all and
+// `outer_frame` resumes in its `rescue`. Both were evicted while suspended, so
+// this pins the eviction against the unwind path (`doc/chain_deopt.md` §8.4)
+// as well as the ordinary return path every other case here takes.
+#[test]
+fn redefine_bop_onstack_unwind_through_suspended() {
+    run_test(
+        r##"
+        $flag = false
+        def raiser
+          if $flag
+            Integer.class_eval("def +(o); 999; end")
+            raise "boom"
+          end
+          nil
+        end
+        def mid_frame
+          raiser
+          [1 + 1, 2 + 2]
+        end
+        def outer_frame
+          begin
+            mid_frame
+          rescue => e
+            [e.message, 3 + 4]
+          end
+        end
+        100.times { outer_frame }
+        $flag = true
+        outer_frame
+        "##,
+    );
+}
+
 // Same on-stack scenario reached through a GENERIC `yield` instead of a method
 // call: the yielded block redefines the basic op, and the yielding frame must
 // deopt on resume instead of running its stale compiled continuation. On
 // aarch64, `emit_yield` historically ignored its `evict` (only method calls /
 // specialized calls registered return addresses) — which both left
-// yield-suspended frames un-evictable AND broke `emit_immediate_evict`'s
+// yield-suspended frames unconvertible AND broke `register_chain_exit`'s
 // same-block-registration invariant (AsmEvict ids restart per block; a generic
-// yield's `ImmediateEvict` would read a stale same-id entry from an earlier
-// block's call and hijack that unrelated call site's patch point). The fix
-// registers the yield's block-call return address exactly like x86.
+// yield's `ChainExit` would read a stale same-id entry from an earlier
+// block's call and give that unrelated call site the wrong replay data). The
+// fix registers the yield's block-call return address exactly like x86.
 #[test]
 fn redefine_bop_onstack_yield() {
     run_test(

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -700,6 +700,7 @@
 3b7d88815bcb9d0d3527cba96db56abb	1	proc { |a,| a }.call([1, 2])\n            
 3b8b9967df243db673eead48df27af73	true	r, w = IO.pipe\n            Process.wait Process.spawn("ps -o pgid= 
 3ba3513c4e0478ac885cbf78cee7b5f7	[true, true]	f = File.open("Cargo.toml")\n            begin\n              [f.to_i
+3bbb4a698df56e60cf3137d064545e5a	["boom", 999]	$flag = false\n        def raiser\n          if $flag\n            Integer
 3bc7d9857d044df621b8aa29939fbb5a	[true, {a: 1, b: 2}, {}]	h = { a: 1, b: 2 }\n            [h.to_h.equal?(h), h.to_h, {}.to_h]\n
 3bcb429ddcf2c13f3b1284650ceddfa9	"0+1i"	class C; def to_c; Complex(0, 1); end; end; o = C.new\nComplex(o).to_s
 3bda8299aecb6e6f15c317979b7755ed	[8.0, 1.4142135623730951, 0.125, 0.0, 1.0, -8.0, 16.0]	def fa; 2 ** 3.0; end\n            def fb; 2 ** 0.5; end\n           
@@ -738,6 +739,7 @@
 3f05b99cbc38adbfbc473b701ac03671	[:solo, :solo, 42]	obj = Object.new\n            def obj.solo; 42; end\n            m = 
 3f11838333fcfd0c716211da92e940b8	[[1, 2], [true, nil], [true, nil], [42, nil], [0, 1, 2], [1, 2], [true, nil], [1, [2]]]	class Ary;  def to_ary; [1, 2]; end; end\n        class Nily; def to_ary
 3f1b46f2be220ff7e899b8081439a046	true	"abc".force_encoding("ISO-8859-16").encoding == Encoding::ISO_8859_16
+3f32366d750ee128eb90044219b638c0	[999, 999, 999]	$flag = false\n        def fwd_target(a, b)\n          Integer.class_eval
 3f4dfe13f5216cef0f89b04300d4b2aa	true	GC.enable; GC.disable; GC.enable
 3f6f1c23deee61068ec39f5295c45a16	[[], [:f]]	class S\n              def f; end\n            end\n            class 
 3f839e4337603d2011e09f2f712091a4	[:bar, :foo]	class A\n              def foo; end\n              def bar; end\n     
@@ -966,6 +968,7 @@
 509d9bea76f0e1d8349ff37b354accf3	2	k = Class.new { define_method(:m) { [1, 2, 3].each { |x| return x i
 50a5f1523f40c371eae52d5bdb271289	[:@b]	class Foo\n              def initialize\n                @a = 1\n     
 50dc75cab4d7c00e25ec748ffac45bee	"[C2, M, C1, M, Object, Kernel, BasicObject]"	module M\n            end\n            class C1\n            end\n     
+50f9e525cff9a725780f19b016aaa8f9	[-2.0, -2.0, 8.0, 999]	$flag = false\n        def fmaybe\n          Integer.class_eval("def +(o)
 5103d830753ac483d2d4c39e44bc03b5	[0, 0, nil]	["‌" =~ /[[:word:]]/, "‍" =~ /[[:word:]]/, "‌" =~ /\\w/]
 5153f5263b097f08fb57811bdbdc5aaa	[true, true, true, false, true, true, true, false, false, false, false]	class A\n          def method1; end\n          protected\n          def pr
 5174f3c6fa3195d1fbd047639e4a904d	[[true, {data: 42}], ["async", "ctx"], [[[true, ["both"]], [false, []]], true, "both", false]]	r = []\n            de = Class.new(StandardError) { attr_reader :dat
@@ -995,6 +998,7 @@
 54769890b128ed28f27f4a72e21598de	"S:#<Symbol:0xADDR>"	class Symbol; def to_s; "S:" + super; end; end\n                :foo.to_s.sub(/0x
 5495a4ecfc8034c3e6e7fc205e4e41f4	[UMS, "hello-data"]	class UMS\n              def marshal_dump; "hello-data"; end\n       
 54cec27c16a23055cb1af1f7bd0ee7f2	[nil, nil, nil, nil, 1, true, false, false, 1, :blocking]	res = []\n            res << Fiber.scheduler\n            res << Fibe
+54d6779b200cfac2264d1b13551e56a4	[10, 999]	$flag = false\n        class OpRedef\n          def +(o)\n            Inte
 54d92cf0264334597de6d135e289a10d	[[:block, 1], [:proc, 2], [:block, 2], true, [:block, 3], 1, :fired, :argerr]	res = []\n            trace_var(:$tv_spec) { |v| res << [:block, v] 
 550657b209502598ac09bdd6794b2088	[Encoding::CompatibilityError, "5!", ArgumentError]	[ (begin; format("hello %s".encode("utf-8"), "world".encode("UTF-16LE")); rescue
 55124e846ccfc03a163c2cfdf4d72203	:raised	class E\n              def initialize() @a = {k: 1} end\n            
@@ -2021,6 +2025,7 @@ ac3fd0f0d8305e489381e6ee6e5c07bd	[100, 100, 4950]	a=1\n            x=0\n        
 ac462de061f87c41bfe50ec870af58fd	[false, true]	io = IO.popen("cat", "r+")\n            begin\n              io.close
 ac47b35a8659a773ec56fdd4d59752c6	"m1+m2"	m1 = Module.new do\n          def foo; "m1"; end\n        end\n        m2 
 ac6d8683c7b77f0f7ebb11f4109c3bb2	[]	def m\n              /(?<matched>foo)/.=~("foofoo")\n              lo
+ac6e4fd980a3be18109e19cba86a1c5b	[[5, 7, 9], [5, 7, 9], 999]	$flag = false\n        def kw_target(a, k: 0, j: 0)\n          Integer.cl
 aca93977702ff68a47ea803d661ec922	[[1, 2, 3], [1, 2, nil], [1, nil, nil], [nil, nil, nil], [1, 2, 3]]	def drive3(a)\n              acc = []\n              a.each_with_yiel
 acaecec60e1d4df64f4888d1585ffb87	[[1, 5], [2, 6]]	[1, 2].each.with_index(5).to_a
 ace3583fa43b814b77f102993799e3b9	["Array", true, true, "nil", true]	res = []\n            t = Thread.new { sleep }\n            Thread.pa
@@ -2512,6 +2517,7 @@ d4718d9b7f7a7afcf1379197ca836a9a	[IO, true, [ArgumentError, "wrong number of arg
 d48868180accf425c1cce5bbb37022fc	:OVERRIDDEN	class FalseClass; def ==(o); :OVERRIDDEN; end; end; false == false
 d4b11df043d7e94411357a9fb1a4b7b9	true	"hello".index(/z/); $~.nil?
 d4b1bfe9eda9533ed079348cdba23ae4	"abcaあ"	"あ".rjust(5, "abc")
+d4e0ae9c56a69c0c332580eb22172e11	[[1, 2, 0], 999]	$flag = false\n        class KwNode\n          attr_reader :v\n          d
 d506260ac377e92b5498fb8e6ec73750	true	GC.stat(nil).is_a?(Hash)
 d52efc39591dfa6b41cc1b74f647a5cf	["ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError", "ArgumentError"]	def g(a, b) = a + b\n        def f(...) = g(10, 20, 30, ...)\n        \n\n 
 d55e1c488a964698d1d9d4f121c8d95c	[["UTF-8", nil, nil, nil], ["ISO-8859-1", "nil"], ["ISO-8859-1", "UTF-8"], ["ISO-8859-1", "UTF-8"], ["UTF-8", "ISO-8859-1"], "nil", "ISO-8859-1", "ISO-8859-1", :tohash_ok, :blockresult, [true, true], [true, true], :inner_close_ok, [MrbPipeSub, MrbPipeSub], [:init, :init], [MrbPipeSub2, MrbPipeSub2], "through\\n"]	r = []\n            IO.pipe { |a, b| r << [a.external_encoding&.to_s
@@ -2650,6 +2656,7 @@ e0aaed5b5073da72fc373f05fb574de1	true	S = Struct.new(:a, :b)\n            \n\n  
 e0ae1b5209fe6fb6e963db3c6c00894e	"UTF-8"	e = "".force_encoding("EUC-JP"); "#{""}#{e}#{"x"}".encoding.to_s
 e0c2bb61aa5c5d76757d6084b37a58e5	[:a, :b, nil]	class K\n              def initialize(n); @n = n; end\n              
 e0f9f78e42b543aa7b6cc1f45ec6316a	[true, 9]	pid = fork { sleep 5 }\n            Process.kill(:KILL, pid)\n       
+e1010476a8bc2919139c68c49e0376c2	[999, 999, 999]	$flag = false\n        def lvl3\n          Integer.class_eval("def +(o); 
 e129819270670333ff373830f6061bd4	"ruby"	def name; "ruby"; end\n        def f(name:); name; end\n        \n\n       
 e13869548fa19a771b07f33adfda8184	[true, [1, 2, 3]]	acc = []\n            initial = []\n            e = [1, 2, 3].each_wi
 e154b3c6984d91ffa32cd89a1908494b	false	File.directory?("monoruby")


### PR DESCRIPTION
There were two mechanisms for getting an on-stack JIT frame back to the interpreter. This leaves one.

## What immediate eviction did, and why it can go

When a basic op is redefined, frames already suspended on the stack are running compiled bodies that assume the old op. A version bump cannot help them — they are past their `CheckBOP`. Immediate eviction fixed them by **writing a `jmp deopt` into the machine code** at each suspended call's return continuation, so the frame deopts as control comes back to it.

That works, but it is aimed at the wrong thing. The frames needing repair are on *one* stack; patching the code deoptimizes that call site for **every** future invocation, on every stack, permanently. It also means self-modifying code, which on aarch64 carries a page-writable / I-cache-invalidate dance.

Chain deopt (#1134) already repairs suspended frames precisely: replay each frame's write-back and point its return-address slot at the shared VM continuation, leaving the compiled body untouched. It just was not being used here, because `chain_deopt_table` registration was gated behind the `chain-deopt` verification feature.

So: un-gate the registration, and immediate eviction has nothing left to do.

## Changes

**Registration is unconditional.** `AbstractState::chain_exit` loses its `if cfg!(feature = "chain-deopt")`; every call and yield site registers. This costs per-site metadata in every build, which is accepted — BOP invalidation is expensive anyway, and the alternative was keeping a whole second mechanism alive to avoid it.

**Deleted:** `patch_return_to_deopt` (both arches), `return_addr_table` and `get_deopt_with_return_addr`, `emit_immediate_evict` (both arches), `AsmInst::ImmediateEvict` / `LInst::ImmediateEvict` and their dispatch arms, and the `evict_label` plumbing through `LInst::Call` / `LInst::Yield` / `emit_call` / `emit_yield`.

**Merged:** `evict_suspended_frames` and `Codegen::chain_deopt` differed only in that fallback, so they are now one walk with one doc comment, used by both `check_bop_redefine` and `runtime::chain_deopt`.

`asm_return_addr_table` is **kept** — it is not dead. `AsmInst::ChainExit`, pushed after the call, uses it to name its own site for `register_chain_exit`.

## Two defects fixed along the way

**A write-back loop that could never run.** `WriteBack` has two constructors and only `get_gc_write_back` populates `void`; every side exit and every `ChainExitSpec` uses `get_write_back`, which hard-codes it empty. `ChainReplay::replay`'s `void` loop is therefore dead by construction, and so is `gen_write_back_for_deopt`'s, on both arches — both are now `debug_assert!(wb.void.is_empty())` with a comment naming why, matching the `gp` assert beside them. `gen_write_back` — the GC path, the one that actually receives a populated `void` — keeps its loop.

**A loud failure that had gone quiet.** #1134 turned `return_addr.unwrap()` into `if let Some(ret)`, so a frame with a null return address would be silently skipped and left running a stale compiled body. No path produces `None` — a frame with a `prev()` was entered by a `call`/`bl` — so this restores an `.expect()` with the invariant written down.

## Verification

| | |
|---|---|
| `cargo nextest run --features stress-spill-pool` | 3209 / 3209 passed |
| `cargo nextest run --features stress-spill-pool,chain-deopt` | 3209 / 3209 passed |
| `cargo check` / `cargo check --target aarch64-unknown-linux-gnu` | clean (2 pre-existing warnings) |

Both suites were re-run independently of the implementation work. 3203 → 3209 is six new tests in `tests/redefine.rs`, all BOP-eviction-driven, all verified against CRuby: the spilled-`FPReg` replay arm, a `(...)` trampoline suspended with its rest `Array` and `**kwrest` `Hash` still deferred, the same through `Class#new`, a two-frame chain mixing `dst == None` with `dst == Some`, an operator site (1-unit pc advance), and a chain left by unwinding rather than by return.

Because the diff here is mostly deletions, its own patch-coverage denominator is tiny (16/16 instrumented lines). The meaningful figure is chain deopt as landed — #1134 plus this branch, `git diff 874bd8ea..HEAD`: **238/258 = 92.25%**, against the 91.81% repo target. The residual 20 lines are all the escalation half (`runtime::chain_deopt` and the two `call runtime::chain_deopt` emissions), which `JitContext::escalate_side_exits` gates behind the feature; a `--features chain-deopt` coverage run shows those exact lines taking ~945k hits, so they are gated, not dead.

## Known follow-up

**`SideExit::Evict` handlers are now emitted but unreachable.** Immediate eviction's code patch was their only entry. The slot is still filled because `AsmEvict` is the id `chain_exit` keys on and `gen_asm` panics on `Evict(None)`. Removing the emission means unpicking the `AsmEvict` → `SideExitLabels` plumbing, which is a separate change; until then every call site carries cold code nothing can enter. Recorded in `doc/chain_deopt.md` §10 and in `immediate_evict`'s doc comment (whose name is now historical).

Docs updated: `doc/chain_deopt.md` (status, §2, §4, §5.3, §8.x, §9.1, new §10), `doc/arch_difference.md` (the eviction asymmetry no longer exists — and §4.2 was already stale before this change), `doc/bop_redefinition.md`, `doc/lir.md`, `doc/README.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk3E4n72Q6uyp4hZNN5oUU)_