### PR TITLE
Drop code orphaned by #1149; fix the x86-64 recompile-discard livelock (3.4x on activerecord)

### DIFF
--- a/monoruby/src/builtins/exception.rs
+++ b/monoruby/src/builtins/exception.rs
@@ -316,13 +316,7 @@ fn nameerr_initialize(
                 .set_ivar(self_, IdentId::_NAME, name)?;
         }
     }
-    // Trailing keyword hash (`receiver:`).
-    if let Some(kwargs) = lfp.try_arg(2)
-        && kwargs.try_hash_ty().is_some()
-    {
-        store_exception_kwargs(vm, globals, self_, kwargs)?;
-    }
-    // Real `receiver:` keyword (slot 3) — the `Class#new` dispatch path.
+    // `receiver:` keyword (slot 3).
     if let Some(v) = lfp.try_arg(3)
         && !v.is_nil()
     {
@@ -362,15 +356,7 @@ fn nomethoderr_initialize(
             .store
             .set_ivar(self_, IdentId::get_id("/args"), args)?;
     }
-    // The keyword hash (`receiver:`) lands in the last given slot.
-    for i in 2..4 {
-        if let Some(kwargs) = lfp.try_arg(i)
-            && kwargs.try_hash_ty().is_some()
-        {
-            store_exception_kwargs(vm, globals, self_, kwargs)?;
-        }
-    }
-    // Real `receiver:` keyword (slot 4) — the `Class#new` dispatch path.
+    // `receiver:` keyword (slot 4).
     if let Some(v) = lfp.try_arg(4)
         && !v.is_nil()
     {
@@ -415,25 +401,13 @@ fn initialize(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
     let message = if let Some(msg) = lfp.try_arg(0)
         && !msg.is_nil()
     {
-        if msg.try_hash_ty().is_some() {
-            // Keyword arguments hash passed as positional arg; use default message.
-            store_exception_kwargs(vm, globals, self_, msg)?;
-            globals.store.get_class_name(class_id)
+        if msg.is_rstring().is_some() {
+            msg.coerce_to_string(vm, globals)?
         } else {
-            // Check if there's a keyword hash as second arg
-            if let Some(kwargs) = lfp.try_arg(1) {
-                if kwargs.try_hash_ty().is_some() {
-                    store_exception_kwargs(vm, globals, self_, kwargs)?;
-                }
-            }
-            if msg.is_rstring().is_some() {
-                msg.coerce_to_string(vm, globals)?
-            } else {
-                // CRuby accepts any message object and stringifies it
-                // via #to_s (`Exception#to_s calls #to_s on the message`).
-                let s = vm.invoke_method_inner(globals, IdentId::TO_S, msg, &[], None, None)?;
-                s.coerce_to_string(vm, globals)?
-            }
+            // CRuby accepts any message object and stringifies it
+            // via #to_s (`Exception#to_s calls #to_s on the message`).
+            let s = vm.invoke_method_inner(globals, IdentId::TO_S, msg, &[], None, None)?;
+            s.coerce_to_string(vm, globals)?
         }
     } else {
         globals.store.get_class_name(class_id)
@@ -454,27 +428,6 @@ fn initialize(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr
         globals.store.set_ivar(self_, IdentId::get_id("/key"), v)?;
     }
     Ok(Value::nil())
-}
-
-/// Store keyword arguments (receiver:, key:) from a Hash into exception ivars.
-fn store_exception_kwargs(
-    vm: &mut Executor,
-    globals: &mut Globals,
-    self_: Value,
-    kwargs: Value,
-) -> Result<()> {
-    let hash = kwargs.as_hash();
-    let recv_key = Value::symbol_from_str("receiver");
-    if let Ok(Some(v)) = hash.get(recv_key, vm, globals) {
-        globals
-            .store
-            .set_ivar(self_, IdentId::get_id("/receiver"), v)?;
-    }
-    let key_key = Value::symbol_from_str("key");
-    if let Ok(Some(v)) = hash.get(key_key, vm, globals) {
-        globals.store.set_ivar(self_, IdentId::get_id("/key"), v)?;
-    }
-    Ok(())
 }
 
 ///
@@ -1404,7 +1357,19 @@ mod tests {
             r#"
             k = KeyError.new("m", receiver: :r, key: :k)
             n = NameError.new("m", :nm, receiver: 42)
-            [k.message, k.receiver, k.key, n.message, n.name, n.receiver]
+            f = FrozenError.new("m", receiver: :frozen_recv)
+            nm = NoMethodError.new("m", :meth, [1, 2], receiver: :nm_recv)
+            [k.message, k.receiver, k.key, n.message, n.name, n.receiver,
+             f.receiver, nm.name, nm.args, nm.receiver]
+            "#,
+        );
+        // Error-kind → Ruby-class mapping arms for the base Exception and
+        // NotImplementedError.
+        run_test_once(
+            r#"
+            a = (begin; raise Exception, "top"; rescue Exception => e; [e.class.to_s, e.message]; end)
+            b = (begin; raise NotImplementedError, "todo"; rescue NotImplementedError => e; [e.class.to_s, e.message]; end)
+            a + b
             "#,
         );
     }

--- a/monoruby/src/builtins/time.rs
+++ b/monoruby/src/builtins/time.rs
@@ -3399,6 +3399,27 @@ mod tests {
     }
 
     #[test]
+    fn frozen_time_reinitialize_raises() {
+        // Documented divergence from CRuby (which raises TypeError for any
+        // re-initialize): monoruby permits re-initializing a Time, but a
+        // *frozen* receiver still fails with FrozenError. Pinned as a
+        // monoruby-only expectation.
+        let v = run_test_no_result_check(
+            r#"
+            t = Time.new(2020, 1, 1, 0, 0, 0, "+00:00")
+            t.freeze
+            begin
+              t.send(:initialize)
+              "no_error"
+            rescue FrozenError
+              "frozen_error"
+            end
+            "#,
+        );
+        assert_eq!("frozen_error", v.as_str());
+    }
+
+    #[test]
     fn time_new_with() {
         run_tests(&[
             // `Time.new` previously ignored its arguments and returned the

--- a/monoruby/src/codegen/compiler.rs
+++ b/monoruby/src/codegen/compiler.rs
@@ -309,6 +309,28 @@ impl Codegen {
         self_class: ClassId,
         reason: RecompileReason,
     ) -> Option<()> {
+        // Bail *before* compiling when there is no patch point to install
+        // into — after a BOP eviction, or when the method only ever ran as a
+        // specialized child of some root (its own `jit_entry` map was never
+        // populated). Compiling first and then discarding used to livelock:
+        // the stale body kept requesting a whole recompile on every call,
+        // each one paying a full compile + `finalize` over the ever-growing
+        // relocation table, only to be thrown away (mirrors the aarch64
+        // variant, which has always early-outed on an unknown slot).
+        let patch_point = match globals.store[iseq_id].get_jit_entry(self_class) {
+            Some(patch_point) => patch_point,
+            None => {
+                #[cfg(feature = "jit-log")]
+                eprintln!(
+                    "[JIT] recompilation skipped for invalidated method: {:?} (jit_invalidated={}, entry_classes={:?}, wanted={:?})",
+                    globals.store[globals.store[iseq_id].func_id()].name(),
+                    globals.store[iseq_id].jit_invalidated(),
+                    globals.store[iseq_id].jit_entry_classes(),
+                    self_class,
+                );
+                return None;
+            }
+        };
         let jit_entry = self.jit.label();
         let class_version = self.class_version();
         let (cache, _) = self.compile_method(
@@ -319,22 +341,9 @@ impl Codegen {
             class_version,
             Some(reason),
         )?;
-        // get_jit_code() must not be None.
-        // After BOP redefinition occurs, recompilation in invalidated methods cause None.
-        if let Some(patch_point) = globals.store[iseq_id].get_jit_entry(self_class) {
-            globals.store[iseq_id].set_cache_map(self_class, cache);
-            let patch_point = self.jit.get_label_address(&patch_point);
-            self.jit.apply_jmp_patch_address(patch_point, &jit_entry);
-        } else {
-            // JIT entry was invalidated (e.g. by BOP redefinition).
-            // The compiled code is discarded; execution falls back to the VM interpreter.
-            #[cfg(feature = "jit-log")]
-            eprintln!(
-                "[JIT] recompilation skipped for invalidated method: {:?}",
-                globals.store[globals.store[iseq_id].func_id()].name()
-            );
-            return None;
-        }
+        globals.store[iseq_id].set_cache_map(self_class, cache);
+        let patch_point = self.jit.get_label_address(&patch_point);
+        self.jit.apply_jmp_patch_address(patch_point, &jit_entry);
         Some(())
     }
 

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -829,6 +829,11 @@ impl ISeqInfo {
         }
     }
 
+    #[cfg(feature = "jit-log")]
+    pub(crate) fn jit_entry_classes(&self) -> Vec<ClassId> {
+        self.jit_entry.keys().copied().collect()
+    }
+
     pub(crate) fn get_jit_entry(&self, self_class: ClassId) -> Option<DestLabel> {
         if self.jit_invalidated {
             return None;

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -1126,9 +1126,6 @@ impl Value {
         RValue::new_string_scanned(s).pack()
     }
 
-    pub fn string_with_class(s: &str, class_id: ClassId) -> Self {
-        RValue::new_string_with_class(s, class_id).pack()
-    }
 
     pub fn bytes(s: Vec<u8>) -> Self {
         RValue::new_bytes(s).pack()
@@ -1363,21 +1360,10 @@ impl Value {
         RValue::new_arithmetic_sequence(begin, end, step, exclude_end).pack()
     }
 
-    pub fn range_with_class(
-        start: Value,
-        end: Value,
-        exclude_end: bool,
-        class_id: ClassId,
-    ) -> Self {
-        // Not frozen: this constructor is used by `Range.allocate` and by
-        // the allocator for `Range` subclasses. CRuby only freezes direct
-        // `Range` instances (literal, `Range.new`, marshal load) — those
-        // go through `Value::range`.
-        RValue::new_range_with_class(start, end, exclude_end, class_id).pack()
-    }
-
     /// A `Range.allocate`d, not-yet-initialized range: `Range#initialize`
-    /// fills it in (and rejects a second call per CRuby).
+    /// fills it in (and rejects a second call per CRuby). Not frozen —
+    /// CRuby only freezes direct `Range` instances, which `#initialize`
+    /// handles after populating the fields.
     pub fn range_uninit_with_class(class_id: ClassId) -> Self {
         RValue::new_range_uninit_with_class(class_id).pack()
     }

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -1830,13 +1830,6 @@ impl RValue {
         }
     }
 
-    pub(super) fn new_string_with_class(s: &str, class_id: ClassId) -> Self {
-        RValue {
-            header: Header::new(class_id, ObjTy::STRING),
-            kind: ObjKind::string_from_str(s),
-            var_table: None,
-        }
-    }
 
     pub(super) fn new_string_from_inner(inner: RStringInner) -> Self {
         RValue {
@@ -2056,19 +2049,6 @@ impl RValue {
     pub(super) fn new_range(start: Value, end: Value, exclude_end: bool) -> Self {
         RValue {
             header: Header::new(RANGE_CLASS, ObjTy::RANGE),
-            kind: ObjKind::range(start, end, exclude_end),
-            var_table: None,
-        }
-    }
-
-    pub(super) fn new_range_with_class(
-        start: Value,
-        end: Value,
-        exclude_end: bool,
-        class_id: ClassId,
-    ) -> Self {
-        RValue {
-            header: Header::new(class_id, ObjTy::RANGE),
             kind: ObjKind::range(start, end, exclude_end),
             var_table: None,
         }

--- a/monoruby/src/value/rvalue/module.rs
+++ b/monoruby/src/value/rvalue/module.rs
@@ -287,10 +287,6 @@ impl ModuleInner {
         self.superclass.map(|m| m.0)
     }
 
-    pub fn superclass_id(&self) -> Option<ClassId> {
-        self.superclass.map(|m| m.id())
-    }
-
     pub fn class_type(&self) -> &ModuleType {
         &self.class_type
     }

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -251,6 +251,7 @@
 121e42097ec2d1d15351f0bc5ecc27d5	5.955087954701154e+22	r = 0.0\n        for i in 0..50\n          f = i * 1.1; g = i * 0.9; h = 
 123a397b90ab67e4ccd83ca59fc29237	2	def f(a = ($x = 2)); nil; end\n        f\n        $x\n        
 1244f1881c878c3dc6d1b1caed0b9f68	:jit	def base2; yield :s; end\n        def relay2; base2 { |s| yield(s) }; en
+12a9e585ad7e62c7384adb2ddbbe2374	["m", :r, :k, "m", :nm, 42, :frozen_recv, :meth, [1, 2], :nm_recv]	k = KeyError.new("m", receiver: :r, key: :k)\n            n = NameEr
 12ac69d0e3d7829ff39cbbddc61b3277	["elefant", 4]	S = Struct.new(:name, :legs, keyword_init: true)\n            \n\n    
 12b1a598797e50c460f3d7646ca37481	[:y]	class B\n              def x; end\n            end\n            class 
 12cd2297f4d6ac25a476739a253c9292	["RUBZ", "RUBZ", 7, 8, false, true, 7]	class C\n              def succ(s); s.succ; end\n              def po
@@ -1852,6 +1853,7 @@
 9b02a82f966d4d820be0698417d35987	[5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5, 5, 2.5, -5, -6, -2.5]	def drive\n              res = []\n              j = 0\n              
 9b1676026ef1fc1fd87a66af89a92bd5	[A, Array]	class A < Array\n        end\n        [A, A.superclass]\n        
 9b1c7db19e056adb0f3971b0c50b245c	[21]	class C\n          def g(&)\n            $res << yield(7)\n          end\n\n
+9b1d43f83036f78ea55a849753f35cc4	["Exception", "top", "NotImplementedError", "todo"]	a = (begin; raise Exception, "top"; rescue Exception => e; [e.class
 9b1dae5be5d8cbce138449b60606501e	"RUBZ"	succ = proc { |s| s.succ }; upcase = proc { |s| s.upcase }; (succ >> upcase).cal
 9b2b571524ea1228fd5b6b7d00cef540	:OVERRIDDEN	class Complex; def +(o); :OVERRIDDEN; end; end; Complex(1,2) + Complex(3,4)
 9b54107b18369e699d5c69bc43d74fac	[]	def boom; raise "no"; end\n            def test; [1].select { begin;


### PR DESCRIPTION
Two follow-ups to #1149 on this branch.

## 1. Coverage cleanup (commit `98feed3`)

Resolves the indirect coverage drop codecov reported on #1149. A local base-vs-head `cargo llvm-cov` line diff identified the newly-uncovered lines: almost all were code that #1149's routing changes had orphaned, plus a few mapping arms that had never been exercised.

**Dead code removed (−97 lines)**
- Exception initializers: the positional-hash keyword arms and `store_exception_kwargs` — their only producer was the removed `exception_new` flattener; real keyword arguments arrive in the trailing kw slots now.
- `Value::string_with_class` / `RValue::new_string_with_class` — the String allocator builds from an `RStringInner` now.
- `Value::range_with_class` / `RValue::new_range_with_class` — subclass ranges go through `allocate` + `Range#initialize`.
- `Module::superclass_id` — its last caller was the `get_metaclass` walk, which now uses `get_real_superclass`.

**Tests added**: `FrozenError.new("m", receiver:)`, `NoMethodError.new(msg, name, args, receiver:)`, `raise Exception` / `raise NotImplementedError` (the `MonorubyErrKind::{Exception, Unimplemented}` mapping arms), and a pinned frozen-Time re-`initialize` → `FrozenError` expectation.

## 2. x86-64 recompile-discard livelock fix (commit `73298a3`)

`recompile_method_by_id` compiled first and only then looked up the method's `jit_entry` patch point, discarding the fresh code when the lookup failed (BOP-evicted entries, or methods that only ever ran as specialized children of some root and never had a wrapper entry of their own).

On the ruby-bench **activerecord** workload (runnable since #1149) that discard path livelocked: a stale specialized body kept requesting a whole recompile on every call, each request paying a full compile plus a `finalize()` over the ever-growing relocation table, only for the result to be thrown away. Sampled stacks showed **>50% of steady-state wall time inside monoasm's `fill_relocs`**, and the cumulative JIT compile time over a 25-iteration run was **136.7s**.

The fix checks for the patch point **before** compiling, mirroring the aarch64 variant (which has always early-outed on an unknown dispatch slot).

| | before | after |
|---|---|---|
| activerecord iter (avg of last 10) | 9.5s | **2.8s** |
| RSS | 877 MiB | **176 MiB** |
| cumulative JIT compile time | 136.7s | **1.2s** |

`--no-jit` baseline is 3.5s/iter, so the JIT now wins on this workload instead of losing 3×. (CRuby 4.0.2 without YJIT runs it at 0.45s/iter — the remaining gap is future work; the biggest known contributors are warm-up-phase whole-JIT invalidation on every method/constant definition, and monoasm's per-finalize relocation scan.)

Full suite: 3,491 tests pass on both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM