### PR TITLE
JIT invalidation follow-ups: heal const-stranded specialized bodies; unreachable-ize bailed whole-compiles (~8% on activerecord)

### DIFF
--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -1349,6 +1349,8 @@ impl Codegen {
 
     pub(crate) fn class_version_inc(&self) {
         unsafe { *self.class_version_addr += 1 }
+        #[cfg(feature = "jit-log")]
+        jit_stats::bump(&jit_stats::CLASS_VER_INC);
     }
 
     pub(crate) fn const_version(&self) -> u64 {
@@ -1357,6 +1359,8 @@ impl Codegen {
 
     pub(crate) fn const_version_inc(&self) {
         unsafe { *self.const_version_addr += 1 }
+        #[cfg(feature = "jit-log")]
+        jit_stats::bump(&jit_stats::CONST_VER_INC);
     }
 
     /// Record that a basic op was redefined. `bop` names the VM assembly
@@ -1894,5 +1898,55 @@ mod tests {
                 assert_eq!(Value::float(f).try_float(), func(f).try_float());
             }
         }
+    }
+}
+
+/// Temporary investigation counters (jit-log only): how often the two global
+/// version words move, and how the class-version guard's recovery path fares.
+#[cfg(feature = "jit-log")]
+pub(crate) mod jit_stats {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    pub static CLASS_VER_INC: AtomicUsize = AtomicUsize::new(0);
+    pub static CONST_VER_INC: AtomicUsize = AtomicUsize::new(0);
+    pub static RECOVERY_ATTEMPT: AtomicUsize = AtomicUsize::new(0);
+    pub static SALVAGE_OK: AtomicUsize = AtomicUsize::new(0);
+    pub static SALVAGE_FAIL_NO_ENTRY: AtomicUsize = AtomicUsize::new(0);
+    pub static SALVAGE_FAIL_RESOLUTION_CHANGED: AtomicUsize = AtomicUsize::new(0);
+    pub static RECOMPILE_METHOD_CLASS_VER: AtomicUsize = AtomicUsize::new(0);
+    pub static RECOMPILE_METHOD_CONST_VER: AtomicUsize = AtomicUsize::new(0);
+    pub static RECOMPILE_METHOD_OTHER: AtomicUsize = AtomicUsize::new(0);
+    pub static RECOMPILE_METHOD_SKIPPED: AtomicUsize = AtomicUsize::new(0);
+    pub static RECOMPILE_LOOP_CLASS_VER: AtomicUsize = AtomicUsize::new(0);
+    pub static RECOMPILE_LOOP_CONST_VER: AtomicUsize = AtomicUsize::new(0);
+    pub static RECOMPILE_LOOP_OTHER: AtomicUsize = AtomicUsize::new(0);
+    pub static RECOMPILE_SPEC_CLASS_VER: AtomicUsize = AtomicUsize::new(0);
+    pub static RECOMPILE_SPEC_CONST_VER: AtomicUsize = AtomicUsize::new(0);
+    pub static RECOMPILE_SPEC_OTHER: AtomicUsize = AtomicUsize::new(0);
+
+    pub fn bump(c: &AtomicUsize) {
+        c.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn dump() {
+        let g = |c: &AtomicUsize| c.load(Ordering::Relaxed);
+        eprintln!();
+        eprintln!("version / salvage stats:");
+        eprintln!("  class_version incs:                {}", g(&CLASS_VER_INC));
+        eprintln!("  const_version incs:                {}", g(&CONST_VER_INC));
+        eprintln!("  recovery attempts (class guard):   {}", g(&RECOVERY_ATTEMPT));
+        eprintln!("    salvaged (re-resolution ok):     {}", g(&SALVAGE_OK));
+        eprintln!("    fail: resolution changed:        {}", g(&SALVAGE_FAIL_RESOLUTION_CHANGED));
+        eprintln!("    fail: no cache/entry:            {}", g(&SALVAGE_FAIL_NO_ENTRY));
+        eprintln!("  whole recompiles  class-ver:       {}", g(&RECOMPILE_METHOD_CLASS_VER));
+        eprintln!("  whole recompiles  const-ver:       {}", g(&RECOMPILE_METHOD_CONST_VER));
+        eprintln!("  whole recompiles  other:           {}", g(&RECOMPILE_METHOD_OTHER));
+        eprintln!("  whole recompiles  skipped(noinst): {}", g(&RECOMPILE_METHOD_SKIPPED));
+        eprintln!("  loop  recompiles  class-ver:       {}", g(&RECOMPILE_LOOP_CLASS_VER));
+        eprintln!("  loop  recompiles  const-ver:       {}", g(&RECOMPILE_LOOP_CONST_VER));
+        eprintln!("  loop  recompiles  other:           {}", g(&RECOMPILE_LOOP_OTHER));
+        eprintln!("  spec  recompiles  class-ver:       {}", g(&RECOMPILE_SPEC_CLASS_VER));
+        eprintln!("  spec  recompiles  const-ver:       {}", g(&RECOMPILE_SPEC_CONST_VER));
+        eprintln!("  spec  recompiles  other:           {}", g(&RECOMPILE_SPEC_OTHER));
     }
 }

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -2838,6 +2838,38 @@ impl Codegen {
                 monoasm_arm64!(&mut self.jit, b deopt;);
                 self.jit.bind_label(done);
             }
+            // Constant-version twin of GuardClassVersionSpecialized: on a
+            // version move, recompile this specialized entry (re-folding the
+            // constants at the new version), then deopt.
+            AsmInst::GuardConstVersionSpecialized {
+                const_version,
+                idx,
+                deopt,
+            } => {
+                let global_idx = self.specialized_base + idx;
+                let deopt = labels[deopt].clone();
+                let miss = self.jit.label();
+                let done = self.jit.label();
+                let gv_addr = self
+                    .jit
+                    .get_label_address(&self.const_version_label())
+                    .as_ptr() as u64;
+                monoasm_arm64!(&mut self.jit,
+                    mov x9, (gv_addr);
+                    ldr x9, [x9];
+                    mov x10, (const_version as u64);
+                    cmp x9, x10;
+                );
+                self.jit.bcond_label(monoasm::Cond::Ne, &miss); // mismatch -> miss
+                monoasm_arm64!(&mut self.jit, b done;); // match -> continue
+                self.jit.bind_label(miss.clone());
+                self.a64_call_recompile_specialized(
+                    global_idx,
+                    RecompileReason::ConstVersionGuardFailed,
+                );
+                monoasm_arm64!(&mut self.jit, b deopt;);
+                self.jit.bind_label(done);
+            }
             // Counter-gated specialized recompile-or-deopt point (mirrors x86
             // `recompile_and_deopt_specialized`).
             AsmInst::RecompileDeoptSpecialized { idx, deopt, reason } => {

--- a/monoruby/src/codegen/arch/x86_64/compile/constants.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/constants.rs
@@ -31,4 +31,36 @@ impl Codegen {
             jne  deopt;
         }
     }
+
+    ///
+    /// Constant version guard for a specialized (inlined-frame) body.
+    ///
+    /// Check the cached constant version; if it moved, recompile this
+    /// specialized entry (re-pointing the caller's patch point at the fresh
+    /// body, which folds the constants at the new version), then deopt.
+    /// Mirrors `guard_class_version_specialized`.
+    ///
+    /// ### destroy
+    /// - rax
+    ///
+    pub(super) fn guard_const_version_specialized(
+        &mut self,
+        cached_version: usize,
+        idx: usize,
+        deopt: &DestLabel,
+    ) {
+        assert_eq!(0, self.jit.get_page());
+        let fail = self.jit.label();
+        let cached_const_version = self.jit.data_i64(cached_version as _);
+        let global_const_version = self.const_version_label();
+        monoasm! { &mut self.jit,
+            movq rax, [rip + global_const_version];
+            cmpq rax, [rip + cached_const_version];
+            jne  fail;
+        }
+        self.jit.select_page(1);
+        self.gen_recompile_specialized(idx, fail, RecompileReason::ConstVersionGuardFailed);
+        self.version_guard_fail(deopt);
+        self.jit.select_page(0);
+    }
 }

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -217,6 +217,18 @@ impl Codegen {
                     deopt,
                 );
             }
+            AsmInst::GuardConstVersionSpecialized {
+                const_version,
+                idx,
+                deopt,
+            } => {
+                let deopt = &labels[deopt];
+                self.guard_const_version_specialized(
+                    const_version,
+                    self.specialized_base + idx,
+                    deopt,
+                );
+            }
             AsmInst::RecompileDeoptSpecialized { idx, deopt, reason } => {
                 let deopt = &labels[deopt];
                 self.recompile_and_deopt_specialized(deopt, self.specialized_base + idx, reason)

--- a/monoruby/src/codegen/arch/x86_64/guard.rs
+++ b/monoruby/src/codegen/arch/x86_64/guard.rs
@@ -10,7 +10,7 @@ impl Codegen {
         }
     }
 
-    fn version_guard_fail(&mut self, deopt: &DestLabel) {
+    pub(super) fn version_guard_fail(&mut self, deopt: &DestLabel) {
         monoasm! { &mut self.jit,
             movq rdi, (Value::symbol_from_str("__version_guard").id());
             jmp  deopt;

--- a/monoruby/src/codegen/compiler.rs
+++ b/monoruby/src/codegen/compiler.rs
@@ -498,6 +498,13 @@ impl Codegen {
             patch_point,
             speculated_root,
         } = self.specialized_info[idx].clone();
+        #[cfg(feature = "jit-log")]
+        eprintln!(
+            "[JIT] recompile_specialized idx={idx} iseq={:?} ({:?}) speculated={}",
+            globals.store[iseq_id].name(),
+            reason,
+            speculated_root.is_some(),
+        );
         if let Some(root) = speculated_root {
             return self.recompile_speculated_root(globals, root, reason);
         }

--- a/monoruby/src/codegen/compiler.rs
+++ b/monoruby/src/codegen/compiler.rs
@@ -277,6 +277,30 @@ impl Codegen {
             Err(_) => {
                 if position.is_none() {
                     globals.store[iseq_id].invalidate_jit_code();
+                    // The permanent give-up dropped every jit_entry, but on
+                    // x86 the wrapper's entry jump may still point at the old
+                    // class-guard chain (a whole-compile for one self class
+                    // can bail after others compiled fine — `Class#new` bails
+                    // this way, since its `(...)` forward is only compilable
+                    // specialized). Left as-is, every call re-enters the
+                    // stale body, fails its version guard, requests a
+                    // recompile that `recompile_method_by_id` must skip, and
+                    // deopts — per call, forever. Revert the entry to
+                    // `vm_entry` so the method just interprets (mirrors the
+                    // BOP-evict revert in `invalidate_bop_fast_paths`; the
+                    // aarch64 twin already zeroes its dispatch slots in
+                    // `invalidate_jit_code`). Trivial hints never point their
+                    // entry at compiled bytecode — skip them, as the BOP
+                    // revert does.
+                    #[cfg(target_arch = "x86_64")]
+                    if globals.store[iseq_id].hint == ISeqHint::Normal {
+                        let func_id = globals.store[iseq_id].func_id();
+                        let entry = self
+                            .jit
+                            .get_label_address(&globals.store[func_id].entry_label());
+                        let vm_entry = self.vm_entry();
+                        self.jit.apply_jmp_patch_address(entry, &vm_entry);
+                    }
                 }
                 #[cfg(any(feature = "jit-log", feature = "jit-debug"))]
                 if self.startup_flag {

--- a/monoruby/src/codegen/compiler.rs
+++ b/monoruby/src/codegen/compiler.rs
@@ -309,6 +309,16 @@ impl Codegen {
         self_class: ClassId,
         reason: RecompileReason,
     ) -> Option<()> {
+        #[cfg(feature = "jit-log")]
+        crate::codegen::jit_stats::bump(match reason {
+            RecompileReason::ClassVersionGuardFailed => {
+                &crate::codegen::jit_stats::RECOMPILE_METHOD_CLASS_VER
+            }
+            RecompileReason::ConstVersionGuardFailed => {
+                &crate::codegen::jit_stats::RECOMPILE_METHOD_CONST_VER
+            }
+            _ => &crate::codegen::jit_stats::RECOMPILE_METHOD_OTHER,
+        });
         // Bail *before* compiling when there is no patch point to install
         // into — after a BOP eviction, or when the method only ever ran as a
         // specialized child of some root (its own `jit_entry` map was never
@@ -320,6 +330,10 @@ impl Codegen {
         let patch_point = match globals.store[iseq_id].get_jit_entry(self_class) {
             Some(patch_point) => patch_point,
             None => {
+                #[cfg(feature = "jit-log")]
+                crate::codegen::jit_stats::bump(
+                    &crate::codegen::jit_stats::RECOMPILE_METHOD_SKIPPED,
+                );
                 #[cfg(feature = "jit-log")]
                 eprintln!(
                     "[JIT] recompilation skipped for invalidated method: {:?} (jit_invalidated={}, entry_classes={:?}, wanted={:?})",
@@ -424,6 +438,18 @@ impl Codegen {
     ) -> Option<()> {
         let entry_label = self.jit.label();
         let class_version = self.class_version();
+        #[cfg(feature = "jit-log")]
+        if let Some(reason) = is_recompile {
+            crate::codegen::jit_stats::bump(match reason {
+                RecompileReason::ClassVersionGuardFailed => {
+                    &crate::codegen::jit_stats::RECOMPILE_LOOP_CLASS_VER
+                }
+                RecompileReason::ConstVersionGuardFailed => {
+                    &crate::codegen::jit_stats::RECOMPILE_LOOP_CONST_VER
+                }
+                _ => &crate::codegen::jit_stats::RECOMPILE_LOOP_OTHER,
+            });
+        }
 
         let ret = if self
             .compile(
@@ -505,6 +531,16 @@ impl Codegen {
             reason,
             speculated_root.is_some(),
         );
+        #[cfg(feature = "jit-log")]
+        crate::codegen::jit_stats::bump(match reason {
+            RecompileReason::ClassVersionGuardFailed => {
+                &crate::codegen::jit_stats::RECOMPILE_SPEC_CLASS_VER
+            }
+            RecompileReason::ConstVersionGuardFailed => {
+                &crate::codegen::jit_stats::RECOMPILE_SPEC_CONST_VER
+            }
+            _ => &crate::codegen::jit_stats::RECOMPILE_SPEC_OTHER,
+        });
         if let Some(root) = speculated_root {
             return self.recompile_speculated_root(globals, root, reason);
         }
@@ -759,7 +795,11 @@ extern "C" fn jit_recompile_method_with_recovery(
     lfp: Lfp,
     reason: RecompileReason,
 ) -> u64 {
+    #[cfg(feature = "jit-log")]
+    crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::RECOVERY_ATTEMPT);
     if globals.store.update_inline_cache(lfp) {
+        #[cfg(feature = "jit-log")]
+        crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::SALVAGE_OK);
         return 1;
     };
     //    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -2089,6 +2089,21 @@ pub(super) enum AsmInst {
         const_version: usize,
         deopt: AsmDeopt,
     },
+    ///
+    /// Constant-version guard inside a specialized (inlined-frame) body: on a
+    /// version move, recompile this specialized entry via its `idx` (re-pointing
+    /// the caller's patch point at the fresh body), then side-exit. The whole /
+    /// loop shapes instead recompile through their `RecompileDeoptimize` side
+    /// exit — see `guard_const_version` in `jitgen/compile/variables.rs`.
+    ///
+    /// ### destroy
+    /// - rax
+    ///
+    GuardConstVersionSpecialized {
+        const_version: usize,
+        idx: usize,
+        deopt: AsmDeopt,
+    },
     StoreConstant {
         id: ConstSiteId,
         using_fpr: UsingFpr,

--- a/monoruby/src/codegen/jitgen/compile/variables.rs
+++ b/monoruby/src/codegen/jitgen/compile/variables.rs
@@ -148,19 +148,35 @@ impl<'a> JitContext<'a> {
         if state.const_version_guard() {
             return;
         }
-        // Two shapes stay on the plain deopt. A specialized (inlined-frame)
-        // compile recompiles via an idx, not a position, so it has no
-        // recompile side exit to take — the same restriction the
-        // receiver-class guard makes in `compile_method_call`. And a *block*
-        // body must not take it either: the side exit recompiles whatever
-        // `lfp.func_id()` names, and `Codegen::recompile_method` re-enters
-        // the compiler as if that were a method — for a block frame that
-        // rebuilds the body under the wrong argument convention, which showed
-        // up as `Kernel#caller_locations`' block losing the argument it
-        // forwards to `Thread::Backtrace::Location.new`.
-        let deopt = if matches!(self.jit_type(), JitType::Specialized { .. })
-            || self.store[self.func_id()].is_block_style()
-        {
+        // Every shape gets a healing side exit. A specialized (inlined-frame)
+        // compile recompiles via its idx — the same route the class-version
+        // guard takes (`GuardClassVersionSpecialized`) — re-pointing the
+        // caller's patch point at a body folded against the new version.
+        // Leaving it on a plain deopt used to strand every specialized body
+        // compiled before a constant assignment: the folded constant's guard
+        // failed on *every* call for the rest of the run (the ruby-bench
+        // activerecord workload logged 78k such deopts in `Array#initialize`
+        // alone). A *block* ROOT stays on the plain deopt: the whole-method
+        // side exit recompiles whatever `lfp.func_id()` names, and
+        // `Codegen::recompile_method` re-enters the compiler as if that were
+        // a method — for a block frame that rebuilds the body under the wrong
+        // argument convention, which showed up as `Kernel#caller_locations`'
+        // block losing the argument it forwards to
+        // `Thread::Backtrace::Location.new`. (A block compiled *specialized*
+        // takes the idx route above, exactly as its class-version guard
+        // already does.)
+        if let JitType::Specialized { idx, .. } = self.jit_type() {
+            let idx = *idx;
+            let deopt = ir.new_deopt(state);
+            ir.push(AsmInst::GuardConstVersionSpecialized {
+                const_version: version,
+                idx,
+                deopt,
+            });
+            state.set_const_version_guard();
+            return;
+        }
+        let deopt = if self.store[self.func_id()].is_block_style() {
             ir.new_deopt(state)
         } else {
             ir.new_recompile_deopt(

--- a/monoruby/src/globals/dump.rs
+++ b/monoruby/src/globals/dump.rs
@@ -176,6 +176,7 @@ impl Globals {
                 "elapsed JIT compile time: {:?}",
                 CODEGEN.with(|codegen| codegen.borrow().jit_compile_time)
             );
+            crate::codegen::jit_stats::dump();
         }
     }
 }

--- a/monoruby/src/globals/dump.rs
+++ b/monoruby/src/globals/dump.rs
@@ -222,7 +222,11 @@ pub(crate) extern "C" fn log_deoptimize(
                 | TraceIr::LoadIvar(..)         // inline ivar cache miss
                 | TraceIr::StoreIvar(..) => {
                     eprint!("<-- deopt occurs in <{}> {:?}.", name, func_id);
-                    eprintln!("    [{:05}] {fmt}", bc_pos);
+                    if let Some(v) = reason {
+                        eprintln!("    [{:05}] {fmt} caused by {}", bc_pos, v.debug(&globals.store));
+                    } else {
+                        eprintln!("    [{:05}] {fmt}", bc_pos);
+                    }
                 },
                 _ => if let Some(v) = reason {
                     eprint!("<-- deopt occurs in <{}> {:?}.", name, func_id);

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -2560,18 +2560,37 @@ impl Store {
         let iseq = &self[iseq_id];
         let Some(cache_map) = iseq.get_cache_map(self_class) else {
             // JIT entry was invalidated (e.g. by BOP redefinition). Fall back to recompile.
+            #[cfg(feature = "jit-log")]
+            {
+                let n = crate::codegen::jit_stats::SALVAGE_FAIL_NO_ENTRY
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                if n % 8192 == 0 {
+                    eprintln!(
+                        "[JIT] salvage-noentry sample: {} self_class={:?} invalidated={}",
+                        self.func_description(func_id),
+                        self_class,
+                        iseq.jit_invalidated(),
+                    );
+                }
+            }
             return false;
         };
         for entry in cache_map {
             let func_id =
                 self.check_method_for_name(lfp, entry.recv_class, entry.name, entry.refinements);
             if func_id != Some(entry.func_id) {
+                #[cfg(feature = "jit-log")]
+                crate::codegen::jit_stats::bump(
+                    &crate::codegen::jit_stats::SALVAGE_FAIL_RESOLUTION_CHANGED,
+                );
                 return false;
             }
         }
         let Some(version_label) = self[iseq_id].get_jit_class_version(lfp.self_val().class())
         else {
             // JIT entry was invalidated between cache_map check and here.
+            #[cfg(feature = "jit-log")]
+            crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::SALVAGE_FAIL_NO_ENTRY);
             return false;
         };
         CODEGEN.with(|codegen| {

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -1218,7 +1218,7 @@ impl FuncInfo {
         self.ext.owner.push(class);
     }
 
-    pub(super) fn entry_label(&self) -> DestLabel {
+    pub(crate) fn entry_label(&self) -> DestLabel {
         self.ext.entry.clone().unwrap()
     }
 

--- a/monoruby/tests/language_fixes.rs
+++ b/monoruby/tests/language_fixes.rs
@@ -775,6 +775,33 @@ fn accessor_called_with_wrong_arity_does_not_abort_jit() {
 }
 
 #[test]
+fn const_reassignment_reaches_specialized_bodies() {
+    // A constant folded into a JIT-specialized (inlined) callee must observe
+    // a later reassignment: the const-version guard in the specialized body
+    // recompiles the entry via its idx (GuardConstVersionSpecialized) and
+    // side-exits, so the next call folds the new value.
+    run_test_once(
+        r#"
+        SPECIALIZED_CONST_K = 7
+        def specialized_const_callee
+          SPECIALIZED_CONST_K * 2
+        end
+        def specialized_const_driver
+          s = 0
+          30.times { s += specialized_const_callee }
+          s
+        end
+        a = specialized_const_driver
+        Object.send(:remove_const, :SPECIALIZED_CONST_K)
+        SPECIALIZED_CONST_K = 40
+        b = specialized_const_driver
+        c = specialized_const_driver
+        [a, b, c]
+        "#,
+    );
+}
+
+#[test]
 fn end_block_registers_at_exit() {
     // `END { ... }` desugars through an `at_exit` registration (the
     // ArgList::with_block constructor path). The block runs at process

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -2166,6 +2166,7 @@ b2581c86d8fd4f38392d54c50df9db10	[5, 2, "hABlo", 2, "hABzz", "not opened for wri
 b2795cc1ad41c83216d600a75460cd44	[nil, false, 19, nil, nil, 12, 17, :again, 18]	h = {}\n        20.times { |i| h["k#{i}"] = i }\n        h.delete("k3")\n 
 b2795d944c1781663b943914a7470a30	:OVERRIDDEN	class Integer; def -@; :OVERRIDDEN; end; end; -(3)
 b289172cd420abd93cd3d2aa0cec0079	["handler-ran", 0]	r, w = IO.pipe\n            pid = fork do\n              r.close\n    
+b29d598259eea11e931b8fa6d90cc331	[420, 2400, 2400]	SPECIALIZED_CONST_K = 7\n        def specialized_const_callee\n          
 b29dca01dfe62ecc7a28c6ee542bc4af	[true, false, true, true, true, false, true, 42]	h = Hash.ruby2_keywords_hash(a: 1)\n        res = [Hash.ruby2_keywords_h
 b2a13b68902e5e530165d4399ed89c18	[1.5, 42, "s", :none]	def nlr_y\n          yield\n        end\n        def pick(k)\n          nlr
 b2d38391b3ffe286d499d5b0f8b8425c	[12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345, 12345]	def g = 12345\n        def f(...) = g(...)\n        \n\n        $r = []\n   


### PR DESCRIPTION
Follow-ups to #1150, from profiling the remaining per-call deopt traffic on the ruby-bench activerecord workload. Three commits.

## 1. Heal specialized bodies stranded by a constant-version move (`c4f1825c`)

The constant-version guard in a **specialized (inlined-frame) body** was a plain deopt with no healing side exit — the shape the receiver-class guard once had. Any body specialized before a constant assignment kept failing that guard on **every call for the rest of the run**: the folded constant's snapshot never refreshed, and nothing ever replaced the body (activerecord logged 78k such deopts in `Array#initialize` alone during warmup).

This gives it the same heal the class-version guard already has: a new `GuardConstVersionSpecialized` lowering (both arches) that, on a version move, recompiles the specialized entry via its idx — re-pointing the caller's patch point at a body folded against the new version — then side-exits. A block **root** stays on the plain deopt (the whole-method side exit would rebuild a block frame under the wrong argument convention); a block compiled *specialized* takes the idx route, exactly as its class-version guard already does.

Also improves diagnostics: `log_deoptimize` now prints the deopt-reason value for the LoadConst/LoadIvar family (previously dropped — this hid that most remaining activerecord deopts are argument-type polymorphism, not constant staleness), and `recompile_specialized` logs idx/iseq/reason under `jit-log`.

## 2. jit-log: version-bump / recovery-salvage counters (`dbb16389`)

Instrumentation used for this investigation, kept under `jit-log`: counts class/const version bumps and the recovery path's salvage-vs-recompile outcomes, printed at exit. Measured on activerecord: 6,096 class-version bumps and 2,277 const-version bumps, all during warmup (steady state is 0/run); the with-recovery class-version guard salvages ~10.9M guard failures per bench run by re-resolving the method and re-entering the same body, with only ~1.4k falling through to a real recompile.

## 3. x86-64: revert the wrapper entry to `vm_entry` when a whole-compile bails (`0885110c`)

`invalidate_jit_code` (the permanent front-end give-up) dropped every `jit_entry`, but on x86 the wrapper's entry jump kept pointing at the old class-guard chain. A whole-compile can bail for one self class after others compiled fine, and the stale chain then stayed reachable: every call re-entered the stale body, failed its version guard, requested a whole recompile that `recompile_method_by_id` must skip (invalidated), and deopted. Per call, forever (~33k skipped requests in a 10-run window, all for `Class#new`).

How `Class#new` hits this (correcting the commit message's shorthand): its whole compile inlines the target class's `initialize` via the forwarded-initialize specialization, and specialization refuses a callee that declares a `&block` parameter (inlining would break the `move_frame_to_heap` promotion protocol — `compile/method_call.rs`). Compiling `Class#new` for `#<Class:Concurrent::Map>` inlines `Concurrent::Map#initialize(options = nil, &default_proc)` → `CompileError` → the shared `Class#new` iseq is permanently invalidated while its earlier per-class compilations stay reachable. (The other whole-compile bail shapes: a `->` lambda literal anywhere in the unit, and a specialized callee that may capture its frame without a block.)

The fix reverts the entry jump to `vm_entry` alongside the invalidation, mirroring the BOP-evict revert in `invalidate_bop_fast_paths` (trivial-hint wrappers skipped there too; the aarch64 twin already zeroes its dispatch slots). The counter block is bypassed, so the method just interprets from then on — which is the correct terminal state, since `compile_patch` would refuse the invalidated iseq anyway; its specialized (inlined) copies in parent bodies are unaffected.

## Results

| activerecord (avg of last 10 iters, 3 runs each) | |
|---|---|
| base (`566473ce`) | ~2974ms |
| + const-heal (commit 1) | ~3009ms (noise; win is bounding the stranded case) |
| + wrapper revert (commit 3) | **~2740ms (−8%)** |

Invalidated-method skip requests: 33,598 → **0**. Full suite: **3,492 tests pass** at each commit. New differential test covers a constant reassignment observed through a hot specialized callee.

Remaining known deopt traffic (out of scope here): argument-type polymorphism in specialized bodies (`caused by` an unexpected receiver/argument class), and chain-deopt escalation requesting whole recompiles of specialized-only bodies (early-outed, cheap). A per-constant-name version cell (CRuby 3.2-style, two-tier with the global epoch to keep guard dedup) is sketched as future work for the constant side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM