### PR TITLE
Extend class-version salvage to specialized and loop recompiles

### DIFF
--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -692,6 +692,13 @@ pub(crate) struct SpecializedPatchEntry {
     /// #1140) — a recompile request rebuilds the whole root compilation
     /// unit instead, re-arming the speculation under fresh inline caches.
     pub(crate) speculated_root: Option<(ISeqId, ClassId, Option<BytecodePtr>)>,
+    /// The compilation unit this body was installed under (its root). All
+    /// guards of one compilation — the root's and every inlined child's —
+    /// read the *same* class-version word, and the unit's inline-cache map
+    /// covers them all, so a child's class-version guard failure can be
+    /// salvaged by re-validating the owner unit (`salvage_method_unit` /
+    /// `salvage_loop_unit`) instead of recompiling this body.
+    pub(crate) owner: (ISeqId, ClassId, Option<BytecodePtr>),
 }
 
 ///
@@ -1911,6 +1918,10 @@ pub(crate) mod jit_stats {
     pub static CONST_VER_INC: AtomicUsize = AtomicUsize::new(0);
     pub static RECOVERY_ATTEMPT: AtomicUsize = AtomicUsize::new(0);
     pub static SALVAGE_OK: AtomicUsize = AtomicUsize::new(0);
+    pub static RECOVERY_ATTEMPT_LOOP: AtomicUsize = AtomicUsize::new(0);
+    pub static SALVAGE_OK_LOOP: AtomicUsize = AtomicUsize::new(0);
+    pub static RECOVERY_ATTEMPT_SPEC: AtomicUsize = AtomicUsize::new(0);
+    pub static SALVAGE_OK_SPEC: AtomicUsize = AtomicUsize::new(0);
     pub static SALVAGE_FAIL_NO_ENTRY: AtomicUsize = AtomicUsize::new(0);
     pub static SALVAGE_FAIL_RESOLUTION_CHANGED: AtomicUsize = AtomicUsize::new(0);
     pub static RECOMPILE_METHOD_CLASS_VER: AtomicUsize = AtomicUsize::new(0);
@@ -1936,6 +1947,10 @@ pub(crate) mod jit_stats {
         eprintln!("  const_version incs:                {}", g(&CONST_VER_INC));
         eprintln!("  recovery attempts (class guard):   {}", g(&RECOVERY_ATTEMPT));
         eprintln!("    salvaged (re-resolution ok):     {}", g(&SALVAGE_OK));
+        eprintln!("  recovery attempts (loop guard):    {}", g(&RECOVERY_ATTEMPT_LOOP));
+        eprintln!("    salvaged (re-resolution ok):     {}", g(&SALVAGE_OK_LOOP));
+        eprintln!("  recovery attempts (spec guard):    {}", g(&RECOVERY_ATTEMPT_SPEC));
+        eprintln!("    salvaged (re-resolution ok):     {}", g(&SALVAGE_OK_SPEC));
         eprintln!("    fail: resolution changed:        {}", g(&SALVAGE_FAIL_RESOLUTION_CHANGED));
         eprintln!("    fail: no cache/entry:            {}", g(&SALVAGE_FAIL_NO_ENTRY));
         eprintln!("  whole recompiles  class-ver:       {}", g(&RECOMPILE_METHOD_CLASS_VER));

--- a/monoruby/src/codegen/compiler.rs
+++ b/monoruby/src/codegen/compiler.rs
@@ -479,20 +479,21 @@ impl Codegen {
             });
         }
 
-        let ret = if self
-            .compile(
-                globals,
-                iseq_id,
-                self_class,
-                Some(pc),
-                entry_label.clone(),
-                class_version,
-                is_recompile,
-            )
-            .is_some()
-        {
+        let ret = if let Some((cache, version_label)) = self.compile(
+            globals,
+            iseq_id,
+            self_class,
+            Some(pc),
+            entry_label.clone(),
+            class_version,
+            is_recompile,
+        ) {
             let codeptr = self.jit.get_label_address(&entry_label);
             pc.write2(codeptr.as_ptr() as u64);
+            // Record the unit's salvage info so a later class-version guard
+            // failure can re-validate and patch instead of recompiling.
+            let index = globals.store[iseq_id].get_pc_index(Some(pc));
+            globals.store[iseq_id].set_loop_jit_info(self_class, index, version_label, cache);
             Some(())
         } else {
             None
@@ -551,6 +552,7 @@ impl Codegen {
             self_class,
             patch_point,
             speculated_root,
+            owner: _,
         } = self.specialized_info[idx].clone();
         #[cfg(feature = "jit-log")]
         eprintln!(
@@ -607,6 +609,7 @@ impl Codegen {
             self_class,
             patch_point,
             speculated_root,
+            owner: _,
         } = self.specialized_info[idx].clone();
         if let Some(root) = speculated_root {
             return self.recompile_speculated_root(globals, root, reason);
@@ -646,11 +649,57 @@ extern "C" fn jit_recompile_specialized(
     idx: usize,
     reason: RecompileReason,
 ) {
+    if salvage_specialized(globals, idx, reason) {
+        return;
+    }
     CODEGEN.with(|codegen| {
         codegen
             .borrow_mut()
             .recompile_specialized(globals, idx, reason);
     });
+}
+
+/// ④: before recompiling a specialized body whose class-version guard failed,
+/// try to salvage the *owning* compilation unit (all of its guards read the
+/// same version word). On success nothing is recompiled; the current
+/// invocation deopts to the VM once and the healed code passes its guards
+/// from the next call on.
+///
+/// This runs *outside* the CODEGEN borrow that `recompile_specialized` takes:
+/// the salvage validation re-resolves methods through caches that read
+/// `Globals::class_version()`, which borrows the same thread-local.
+fn salvage_specialized(globals: &mut Globals, idx: usize, reason: RecompileReason) -> bool {
+    if !matches!(reason, RecompileReason::ClassVersionGuardFailed) {
+        return false;
+    }
+    #[cfg(feature = "jit-log")]
+    crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::RECOVERY_ATTEMPT_SPEC);
+    let (owner_iseq, owner_class, owner_pos) =
+        CODEGEN.with(|codegen| codegen.borrow().specialized_info[idx].owner);
+    let salvaged = match owner_pos {
+        None => globals
+            .store
+            .salvage_method_unit(owner_iseq, owner_class, None),
+        Some(pc) => {
+            let index = globals.store[owner_iseq].get_pc_index(Some(pc));
+            globals
+                .store
+                .salvage_loop_unit(owner_iseq, owner_class, index, None)
+        }
+    };
+    if let Some(version_label) = salvaged {
+        let version = Globals::class_version();
+        CODEGEN.with(|codegen| {
+            codegen
+                .borrow_mut()
+                .set_class_version(version, &version_label);
+        });
+        #[cfg(feature = "jit-log")]
+        crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::SALVAGE_OK_SPEC);
+        true
+    } else {
+        false
+    }
 }
 
 /// aarch64 specialized recompile entry, called from the
@@ -668,6 +717,9 @@ pub(in crate::codegen) extern "C" fn jit_recompile_specialized(
     idx: usize,
     reason: RecompileReason,
 ) {
+    if salvage_specialized(globals, idx, reason) {
+        return;
+    }
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         CODEGEN.with(|codegen| {
             codegen
@@ -800,6 +852,9 @@ pub(in crate::codegen) extern "C" fn jit_recompile_loop(
     pc: BytecodePtr,
     reason: RecompileReason,
 ) -> Option<Value> {
+    if salvage_loop(globals, lfp, pc, reason) {
+        return Some(Value::nil());
+    }
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         CODEGEN.with(|codegen| {
             codegen
@@ -884,7 +939,49 @@ extern "C" fn jit_recompile_loop(
     pc: BytecodePtr,
     reason: RecompileReason,
 ) {
+    if salvage_loop(globals, lfp, pc, reason) {
+        return;
+    }
     compile_loop(globals, lfp, pc, Some(reason));
+}
+
+/// ④: before recompiling a loop body whose class-version guard failed,
+/// try to salvage it — re-resolve the unit's cached callees and, when
+/// nothing changed, patch its version word. The current invocation still
+/// deopts to the VM once; the healed body passes its guard from the next
+/// iteration on. `lfp` is the loop's own frame, so `super` sites re-resolve
+/// soundly.
+fn salvage_loop(globals: &mut Globals, lfp: Lfp, pc: BytecodePtr, reason: RecompileReason) -> bool {
+    if !matches!(reason, RecompileReason::ClassVersionGuardFailed) {
+        return false;
+    }
+    #[cfg(feature = "jit-log")]
+    crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::RECOVERY_ATTEMPT_LOOP);
+    let self_class = lfp.self_val().class();
+    let func_id = lfp.func_id();
+    let iseq_id = globals.store[func_id].as_iseq();
+    let index = globals.store[iseq_id].get_pc_index(Some(pc));
+    if let Some(version_label) = globals
+        .store
+        .salvage_loop_unit(iseq_id, self_class, index, Some(lfp))
+    {
+        // Patch here rather than inside the salvage helper: this entry point
+        // is called *outside* any CODEGEN borrow, but the helper is shared
+        // with `recompile_specialized`, which runs inside one. Read the
+        // version before the mutable borrow — it borrows the same
+        // thread-local.
+        let version = Globals::class_version();
+        CODEGEN.with(|codegen| {
+            codegen
+                .borrow_mut()
+                .set_class_version(version, &version_label);
+        });
+        #[cfg(feature = "jit-log")]
+        crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::SALVAGE_OK_LOOP);
+        true
+    } else {
+        false
+    }
 }
 
 fn compile_loop(

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -733,6 +733,7 @@ impl Codegen {
                     // A body compiled under the root's armed speculation
                     // recompiles by rebuilding the root unit (#1140).
                     speculated_root: speculated.then_some(root),
+                    owner: root,
                 });
             }
             let entry = frame.resolve_label(&mut self.jit, specialized_entry);

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -2532,7 +2532,7 @@ impl Store {
 
     fn check_method_for_name(
         &self,
-        lfp: Lfp,
+        lfp: Option<Lfp>,
         recv_class: ClassId,
         name: Option<IdentId>,
         refinements: RefinementSetId,
@@ -2546,17 +2546,61 @@ impl Store {
                 .map(|entry| entry.func_id())
                 .flatten()
         } else {
-            let func_id = lfp.method_func_id();
+            // A `super` site re-resolves relative to the *executing frame of
+            // the owning unit*. Without that frame (a salvage triggered from
+            // an inlined specialized child, whose own lfp is not the
+            // owner's) there is no sound answer — return None so the
+            // comparison fails and the salvage falls back to a recompile.
+            let func_id = lfp?.method_func_id();
             let name = self[func_id].name().unwrap();
             self.check_super(recv_class, func_id, name)
         }
     }
 
     pub(crate) fn update_inline_cache(&mut self, lfp: Lfp) -> bool {
-        let class_version = Globals::class_version();
         let func_id = lfp.func_id();
         let self_class = lfp.self_val().class();
         let iseq_id = self[func_id].as_iseq();
+        if let Some(version_label) = self.salvage_method_unit(iseq_id, self_class, Some(lfp)) {
+            // Read the version *before* taking the mutable borrow below —
+            // `Globals::class_version` borrows the same thread-local.
+            let version = Globals::class_version();
+            CODEGEN.with(|codegen| {
+                codegen
+                    .borrow_mut()
+                    .set_class_version(version, &version_label);
+            });
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Try to *salvage* the whole-method compilation unit keyed by
+    /// `(iseq_id, self_class)` after its class-version guard failed:
+    /// re-resolve every inline-cached callee of the unit (the map covers the
+    /// root body *and* all its inlined specialized children — they were
+    /// collected into one `inline_method_cache` per compilation), and when
+    /// every resolution is unchanged, return the unit's shared class-version
+    /// label for the caller to patch with the current global version instead
+    /// of recompiling. Returns `None` when the unit must be recompiled.
+    ///
+    /// The *caller* writes the version word (`Codegen::set_class_version`)
+    /// because callers differ in how they may touch `CODEGEN`: a call from
+    /// inside a `Codegen` method already holds the thread-local's mutable
+    /// borrow, so borrowing it again here would panic.
+    ///
+    /// `lfp` is the executing frame of the owning unit when available; it is
+    /// only consulted for `super` re-resolution (see
+    /// [`Self::check_method_for_name`]). A salvage triggered from an inlined
+    /// specialized child passes `None`, so units containing a cached `super`
+    /// site conservatively fall back to a recompile there.
+    pub(crate) fn salvage_method_unit(
+        &mut self,
+        iseq_id: ISeqId,
+        self_class: ClassId,
+        lfp: Option<Lfp>,
+    ) -> Option<DestLabel> {
         let iseq = &self[iseq_id];
         let Some(cache_map) = iseq.get_cache_map(self_class) else {
             // JIT entry was invalidated (e.g. by BOP redefinition). Fall back to recompile.
@@ -2567,13 +2611,13 @@ impl Store {
                 if n % 8192 == 0 {
                     eprintln!(
                         "[JIT] salvage-noentry sample: {} self_class={:?} invalidated={}",
-                        self.func_description(func_id),
+                        self.func_description(self[iseq_id].func_id()),
                         self_class,
                         iseq.jit_invalidated(),
                     );
                 }
             }
-            return false;
+            return None;
         };
         for entry in cache_map {
             let func_id =
@@ -2583,23 +2627,51 @@ impl Store {
                 crate::codegen::jit_stats::bump(
                     &crate::codegen::jit_stats::SALVAGE_FAIL_RESOLUTION_CHANGED,
                 );
-                return false;
+                return None;
             }
         }
-        let Some(version_label) = self[iseq_id].get_jit_class_version(lfp.self_val().class())
-        else {
+        let version_label = self[iseq_id].get_jit_class_version(self_class);
+        #[cfg(feature = "jit-log")]
+        if version_label.is_none() {
             // JIT entry was invalidated between cache_map check and here.
+            crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::SALVAGE_FAIL_NO_ENTRY);
+        }
+        version_label
+    }
+
+    /// The loop (OSR) twin of [`Self::salvage_method_unit`], keyed by the
+    /// loop's `(self_class, LoopStart index)` — see
+    /// [`crate::globals::ISeqInfo::loop_jit_info`]. As there, the caller
+    /// patches the returned label.
+    pub(crate) fn salvage_loop_unit(
+        &mut self,
+        iseq_id: ISeqId,
+        self_class: ClassId,
+        index: crate::bytecodegen::BcIndex,
+        lfp: Option<Lfp>,
+    ) -> Option<DestLabel> {
+        let Some(info) = self[iseq_id].get_loop_jit_info(self_class, index) else {
             #[cfg(feature = "jit-log")]
             crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::SALVAGE_FAIL_NO_ENTRY);
-            return false;
+            return None;
         };
-        CODEGEN.with(|codegen| {
-            codegen
-                .borrow_mut()
-                .set_class_version(class_version, &version_label);
-        });
-
-        true
+        let version_label = info.class_version_label.clone();
+        let cache_map = &self[iseq_id]
+            .get_loop_jit_info(self_class, index)
+            .unwrap()
+            .inline_cache_map;
+        for entry in cache_map {
+            let func_id =
+                self.check_method_for_name(lfp, entry.recv_class, entry.name, entry.refinements);
+            if func_id != Some(entry.func_id) {
+                #[cfg(feature = "jit-log")]
+                crate::codegen::jit_stats::bump(
+                    &crate::codegen::jit_stats::SALVAGE_FAIL_RESOLUTION_CHANGED,
+                );
+                return None;
+            }
+        }
+        Some(version_label)
     }
 
     ///

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -92,6 +92,15 @@ pub struct JitInfo {
     pub inline_cache_map: Vec<InlineCacheEntry>,
 }
 
+/// The salvage-relevant half of a loop (OSR) compilation unit — see
+/// [`ISeqInfo::loop_jit_info`]. Loops need no `entry` label here: the entry
+/// address lives in the `LoopStart` operand itself.
+#[derive(Debug, Clone)]
+pub struct LoopJitInfo {
+    pub class_version_label: DestLabel,
+    pub inline_cache_map: Vec<InlineCacheEntry>,
+}
+
 ///
 /// Hint for ISeq optimization.
 /// When an ISeq is detected as a trivial method during bytecode compilation,
@@ -190,6 +199,13 @@ pub struct ISeqInfo {
     /// JIT code info for each class of *self*.
     ///
     pub(super) jit_entry: HashMap<ClassId, JitInfo>,
+    /// Per-loop (OSR) compilation units, keyed by `(self_class, LoopStart
+    /// index)`: the inline-cache map and shared class-version word of the
+    /// last installed loop body, so a class-version guard failure can be
+    /// *salvaged* (re-resolve, patch the word) exactly like a whole-method
+    /// unit. Dropped together with the code it describes
+    /// (`drop_jit_code`).
+    pub(super) loop_jit_info: HashMap<(ClassId, BcIndex), LoopJitInfo>,
     /// aarch64 only: per-self-class address of the indirect-dispatch slot
     /// (the wrapper's / a class-guard chain link's heap word). Recorded at
     /// `compile_patch` so the recompiler can overwrite the slot in place
@@ -390,6 +406,7 @@ impl ISeqInfo {
             lexical_context: vec![],
             sourceinfo,
             jit_entry: HashMap::default(),
+            loop_jit_info: HashMap::default(),
             #[cfg(target_arch = "aarch64")]
             jit_slot: HashMap::default(),
             #[cfg(target_arch = "aarch64")]
@@ -849,6 +866,35 @@ impl ISeqInfo {
             .map(|info| info.class_version_label.clone())
     }
 
+    /// Record the salvage info of a freshly installed loop body (replacing
+    /// any previous body's for the same `(self_class, LoopStart)` site).
+    pub(crate) fn set_loop_jit_info(
+        &mut self,
+        self_class: ClassId,
+        index: BcIndex,
+        class_version_label: DestLabel,
+        inline_cache_map: Vec<InlineCacheEntry>,
+    ) {
+        self.loop_jit_info.insert(
+            (self_class, index),
+            LoopJitInfo {
+                class_version_label,
+                inline_cache_map,
+            },
+        );
+    }
+
+    pub(crate) fn get_loop_jit_info(
+        &self,
+        self_class: ClassId,
+        index: BcIndex,
+    ) -> Option<&LoopJitInfo> {
+        if self.jit_invalidated {
+            return None;
+        }
+        self.loop_jit_info.get(&(self_class, index))
+    }
+
     /// Permanently give up on JIT-compiling this iseq (the front-end bailed).
     pub(crate) fn invalidate_jit_code(&mut self) {
         self.jit_invalidated = true;
@@ -861,6 +907,7 @@ impl ISeqInfo {
     /// whether the iseq may be compiled again.
     fn drop_jit_code(&mut self) {
         self.jit_entry.clear();
+        self.loop_jit_info.clear();
         self.jit_class_profile.clear();
         #[cfg(target_arch = "aarch64")]
         {


### PR DESCRIPTION
## Summary

#1151's class-version salvage (re-validate the unit's cached method resolutions on a guard failure and patch the version word instead of recompiling) only covered **whole-method** recompiles. The other two recompile paths still re-emitted code on every class-version guard failure, even when nothing they cached had changed — on a ruby/spec core run that meant a recompile storm of **90,593 specialized + 12,395 loop recompiles** (roughly "every spec file's method definitions invalidate everything hot").

This PR extends the salvage to both remaining paths.

## Changes

### Loop (OSR) units get salvage records
- `ISeqInfo` gains `loop_jit_info: HashMap<(ClassId, BcIndex), LoopJitInfo>`; `compile_partial_by_id` stores each loop compile's class-version label + inline cache map. `drop_jit_code` clears it alongside the method-level `JitInfo`.
- `jit_recompile_loop` (both arches) first tries `salvage_loop_unit`: re-resolve every cached callee, and if all unchanged, patch the loop's version word. The current invocation still deopts to the VM once; the healed body passes its guard from the next iteration.

### Specialized bodies salvage their *owning* unit
- `SpecializedPatchEntry` records `owner: (ISeqId, ClassId, Option<BytecodePtr>)` — the compilation unit (root method or loop) the body was inlined into. All guards of one compilation read the **same** version word, so salvaging the owner heals every inlined child at once.
- The salvage runs in the `extern "C"` entry `jit_recompile_specialized` **before** the `CODEGEN` borrow. This is load-bearing: the validation itself reads `Globals::class_version()` through the same thread-local, so attempting it inside `recompile_specialized` aborts with `RefCell already mutably borrowed` (found the hard way — a full core spec run crashed on exactly this).

### Borrow-safe salvage helpers
- `salvage_method_unit` / `salvage_loop_unit` are pure validators returning `Option<DestLabel>`; each caller patches the version word in its own borrow context (`self.set_class_version` inside `Codegen`, `CODEGEN.with` outside).
- `check_method_for_name` takes `Option<Lfp>`: a salvage triggered from an inlined child has no owner frame, so units containing a cached `super` site conservatively fall back to a recompile (soundness preserved).
- jit-log gains `recovery attempts (loop guard)` / `(spec guard)` counters.

## Results (ruby/spec core, 2,144 files / 23,034 examples, CI-identical invocation)

| metric | master (ef06051e) | this PR | change |
|---|---|---|---|
| specialized recompiles (class-ver) | 90,593 | **68** | −99.9% |
| loop recompiles (class-ver) | 12,395 | **0** | −100% |
| whole recompiles (class-ver) | 30 | 14 | |
| total JIT compile time | 22.40s | **15.61s** | **−30%** |
| peak code emission | 350.7MB | 327.7MB | −6.6% |

Salvage success rates: spec guard 262,824/262,892 (the 82 failures are genuine resolution changes), loop guard 12,765/12,765.

The remaining emission is dominated by **4,148 const-version whole recompiles** — const-version guard failures have no salvage path (the folded constant *values* aren't recorded per unit, so there is nothing to re-validate). A const-version analogue (record folded sites + values, re-resolve on guard failure) is the natural follow-up.

## Verification

- `cargo nextest run`: 3,293/3,293 pass
- `cargo check` clean on x86_64 and aarch64 (both backends' recompile entries changed)
- Storm micro-benchmarks: per-iteration `def`/`define_singleton_method`/`Class.new` loops drop from 54 Hash#each compiles to 1; loop class-ver recompiles 53 → 0
- core spec failures match master (the two differing specs — `Module#autoload (concurrently)` and `Time#inspect` local-time — fail identically standalone on a master-built binary; pre-existing order/environment flakes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_