### PR TITLE
Const-version salvage: two-tier validation (per-name epochs + VM-cache value re-check) instead of recompiling

### DIFF
--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -558,6 +558,16 @@ impl JitModule {
         unsafe { *p = version };
     }
 
+    /// Patch a compilation unit's const-version snapshot word (see
+    /// `Codegen::unit_const_version`) to *version*, re-validating every
+    /// `GuardConstVersion` in the unit after a successful const salvage.
+    pub fn set_const_version(&mut self, version: u64, label: &DestLabel) {
+        let p = self.jit.get_label_address(label).as_ptr() as *mut u64;
+        // SAFETY: the label names an 8-byte data word emitted by
+        // `jit_compile` in the JIT data area, which stays writable.
+        unsafe { *p = version };
+    }
+
     #[cfg(feature = "perf")]
     pub(crate) fn perf_write(info: (CodePtr, usize, CodePtr, usize), desc: &str) {
         use std::io::Write;
@@ -698,7 +708,12 @@ pub(crate) struct SpecializedPatchEntry {
     /// covers them all, so a child's class-version guard failure can be
     /// salvaged by re-validating the owner unit (`salvage_method_unit` /
     /// `salvage_loop_unit`) instead of recompiling this body.
-    pub(crate) owner: (ISeqId, ClassId, Option<BytecodePtr>),
+    ///
+    /// Cleared (`None`) when the body is *individually* recompiled: the
+    /// fresh compile reads its own freshly-created version words, which the
+    /// owner's records no longer name — a "successful" owner salvage would
+    /// patch words this body never reads, deopting it on every call forever.
+    pub(crate) owner: Option<(ISeqId, ClassId, Option<BytecodePtr>)>,
 }
 
 ///
@@ -765,6 +780,13 @@ pub struct Codegen {
     alloc_cell: DestLabel,
     pub(crate) specialized_info: Vec<SpecializedPatchEntry>,
     pub(crate) specialized_base: usize,
+    /// The const-version snapshot word of the unit currently being compiled:
+    /// every `GuardConstVersion` / `GuardConstVersionSpecialized` lowered for
+    /// the unit compares the global const counter against this one word
+    /// (compilation is atomic at one const version). Set by `jit_compile`
+    /// for the duration of the unit's machine-code generation; `None`
+    /// outside a compilation.
+    pub(in crate::codegen) unit_const_version: Option<DestLabel>,
     vm_code_position: (Option<CodePtr>, usize, Option<CodePtr>, usize),
     vm_entry: DestLabel,
     vm_fetch: DestLabel,
@@ -1145,6 +1167,7 @@ impl Codegen {
             alloc_cell: entry_panic.clone(),
             specialized_info: Vec::new(),
             specialized_base: 0,
+            unit_const_version: None,
             vm_entry: entry_panic.clone(),
             vm_code_position: (None, 0, None, 0),
             vm_fetch: entry_panic.clone(),
@@ -1934,6 +1957,11 @@ pub(crate) mod jit_stats {
     pub static RECOMPILE_SPEC_CLASS_VER: AtomicUsize = AtomicUsize::new(0);
     pub static RECOMPILE_SPEC_CONST_VER: AtomicUsize = AtomicUsize::new(0);
     pub static RECOMPILE_SPEC_OTHER: AtomicUsize = AtomicUsize::new(0);
+    pub static CONST_RECOVERY_ATTEMPT: AtomicUsize = AtomicUsize::new(0);
+    pub static CONST_SALVAGE_OK: AtomicUsize = AtomicUsize::new(0);
+    pub static CONST_SALVAGE_VALUECMP: AtomicUsize = AtomicUsize::new(0);
+    pub static CONST_SALVAGE_FAIL_STALE: AtomicUsize = AtomicUsize::new(0);
+    pub static CONST_SALVAGE_FAIL_CHANGED: AtomicUsize = AtomicUsize::new(0);
 
     pub fn bump(c: &AtomicUsize) {
         c.fetch_add(1, Ordering::Relaxed);
@@ -1953,6 +1981,11 @@ pub(crate) mod jit_stats {
         eprintln!("    salvaged (re-resolution ok):     {}", g(&SALVAGE_OK_SPEC));
         eprintln!("    fail: resolution changed:        {}", g(&SALVAGE_FAIL_RESOLUTION_CHANGED));
         eprintln!("    fail: no cache/entry:            {}", g(&SALVAGE_FAIL_NO_ENTRY));
+        eprintln!("  recovery attempts (const guard):   {}", g(&CONST_RECOVERY_ATTEMPT));
+        eprintln!("    salvaged:                        {}", g(&CONST_SALVAGE_OK));
+        eprintln!("    value-compared sites:            {}", g(&CONST_SALVAGE_VALUECMP));
+        eprintln!("    fail: cache stale:               {}", g(&CONST_SALVAGE_FAIL_STALE));
+        eprintln!("    fail: value changed:             {}", g(&CONST_SALVAGE_FAIL_CHANGED));
         eprintln!("  whole recompiles  class-ver:       {}", g(&RECOMPILE_METHOD_CLASS_VER));
         eprintln!("  whole recompiles  const-ver:       {}", g(&RECOMPILE_METHOD_CONST_VER));
         eprintln!("  whole recompiles  other:           {}", g(&RECOMPILE_METHOD_OTHER));

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -1038,18 +1038,47 @@ impl Codegen {
                 self.jit.bcond_label(monoasm::Cond::Ne, &deopt);
             }
             // Constant-load version guard.
-            LInst::GuardConstVersion { const_version, deopt } => {
+            // The snapshot side is the unit's shared patchable word
+            // (`Codegen::unit_const_version`), so a successful const salvage
+            // re-validates every guard in the unit with one store (mirrors
+            // x86). With `recompile = Some(position)` a miss first calls the
+            // salvaging recompile entry and then deopts (the class-version
+            // guard's shape); `None` plain-deopts.
+            LInst::GuardConstVersion { const_version: _, recompile, deopt } => {
                 let gv_addr = self
                     .jit
                     .get_label_address(&self.const_version_label())
                     .as_ptr() as u64;
+                let unit_word = self
+                    .unit_const_version
+                    .clone()
+                    .expect("const guard emitted outside a constant-folding unit");
+                let unit_addr = self.jit.get_label_address(&unit_word).as_ptr() as u64;
                 monoasm_arm64!(&mut self.jit,
                     mov x9, (gv_addr);
                     ldr x9, [x9];
-                    mov x10, (const_version as u64);
+                    mov x10, (unit_addr);
+                    ldr x10, [x10];
                     cmp x9, x10;
                 );
-                self.jit.bcond_label(monoasm::Cond::Ne, &deopt);
+                match recompile {
+                    None => {
+                        self.jit.bcond_label(monoasm::Cond::Ne, &deopt);
+                    }
+                    Some(position) => {
+                        let miss = self.jit.label();
+                        let done = self.jit.label();
+                        self.jit.bcond_label(monoasm::Cond::Ne, &miss);
+                        monoasm_arm64!(&mut self.jit, b done;);
+                        self.jit.bind_label(miss);
+                        self.a64_call_recompile(
+                            position,
+                            RecompileReason::ConstVersionGuardFailed,
+                        );
+                        monoasm_arm64!(&mut self.jit, b deopt;);
+                        self.jit.bind_label(done);
+                    }
+                }
             }
             // Block-passing side-effect guard: deopt if the frame was captured
             // or invalidated.
@@ -2283,11 +2312,12 @@ impl Codegen {
     }
 
     /// Inline-cache class-version guard: deopt if the global class version moved
-    /// since compilation. aarch64 has no recompiler, so the x86 recompile params
-    /// (`class_version`/`position`/`with_recovery`) are unused here.
+    /// since compilation (compared against the unit's patchable snapshot word,
+    /// so a salvage can heal the unit in place). x86's `with_recovery`
+    /// (resume-in-place) is still not ported — a salvaged miss deopts once.
     pub(in crate::codegen::jitgen) fn emit_guard_class_version(
         &mut self,
-        _class_version: DestLabel,
+        class_version: DestLabel,
         position: Option<BytecodePtr>,
         _with_recovery: bool,
         deopt: DestLabel,
@@ -2309,7 +2339,7 @@ impl Codegen {
         // propagates the fatal (matching the specialized twin).
         let miss = self.jit.label();
         let done = self.jit.label();
-        self.a64_guard_class_version(&miss); // version mismatch -> miss
+        self.a64_guard_class_version(&class_version, &miss); // version mismatch -> miss
         monoasm_arm64!(&mut self.jit, b done;); // match -> continue in JIT
         self.jit.bind_label(miss);
         self.a64_call_recompile(position, RecompileReason::ClassVersionGuardFailed);
@@ -2769,7 +2799,7 @@ impl Codegen {
         _frame: &mut AsmInfo,
         labels: &SideExitLabels,
         inst: AsmInst,
-        _class_version: DestLabel,
+        class_version: DestLabel,
     ) -> bool {
         // The specialized (inlined-frame) AsmInst family is lowered here; every
         // other variant is handled by the shared `compile_asmir` dispatcher.
@@ -2796,7 +2826,7 @@ impl Codegen {
                 let deopt = labels[deopt].clone();
                 let miss = self.jit.label();
                 let done = self.jit.label();
-                self.a64_guard_class_version(&miss); // mismatch -> miss
+                self.a64_guard_class_version(&class_version, &miss); // mismatch -> miss
                 monoasm_arm64!(&mut self.jit, b done;); // match -> continue
                 self.jit.bind_label(miss.clone());
                 self.a64_call_recompile_specialized(
@@ -2810,7 +2840,7 @@ impl Codegen {
             // version move, recompile this specialized entry (re-folding the
             // constants at the new version), then deopt.
             AsmInst::GuardConstVersionSpecialized {
-                const_version,
+                const_version: _,
                 idx,
                 deopt,
             } => {
@@ -2822,10 +2852,16 @@ impl Codegen {
                     .jit
                     .get_label_address(&self.const_version_label())
                     .as_ptr() as u64;
+                let unit_word = self
+                    .unit_const_version
+                    .clone()
+                    .expect("const guard emitted outside a constant-folding unit");
+                let unit_addr = self.jit.get_label_address(&unit_word).as_ptr() as u64;
                 monoasm_arm64!(&mut self.jit,
                     mov x9, (gv_addr);
                     ldr x9, [x9];
-                    mov x10, (const_version as u64);
+                    mov x10, (unit_addr);
+                    ldr x10, [x10];
                     cmp x9, x10;
                 );
                 self.jit.bcond_label(monoasm::Cond::Ne, &miss); // mismatch -> miss

--- a/monoruby/src/codegen/arch/aarch64/guard.rs
+++ b/monoruby/src/codegen/arch/aarch64/guard.rs
@@ -114,19 +114,27 @@ impl Codegen {
     }
 
     /// Class-version guard: branch to `fail` if the global class version no
-    /// longer matches the version this method was compiled against. The cached
-    /// version is baked in as an immediate (compilation is atomic at a fixed
-    /// version). Unlike x86 we do not recompile on miss yet — just deopt.
-    pub(in crate::codegen) fn a64_guard_class_version(&mut self, fail: &DestLabel) {
+    /// longer matches the *unit's snapshot word* — the patchable per-unit
+    /// `class_version_label` created by `jit_compile`. Reading the word
+    /// (rather than baking the version as an immediate, as this used to)
+    /// lets a successful salvage re-validate the unit's code in place by
+    /// storing the current version into the word (`set_class_version`),
+    /// exactly like x86's `check_version`.
+    pub(in crate::codegen) fn a64_guard_class_version(
+        &mut self,
+        unit_word: &DestLabel,
+        fail: &DestLabel,
+    ) {
         let gv_addr = self
             .jit
             .get_label_address(&self.class_version_label())
             .as_ptr() as u64;
-        let cached = self.class_version();
+        let unit_addr = self.jit.get_label_address(unit_word).as_ptr() as u64;
         monoasm_arm64!(&mut self.jit,
             mov x9, (gv_addr);
             ldr w9, [x9];
-            mov x10, (cached as u64);
+            mov x10, (unit_addr);
+            ldr w10, [x10];
             cmp x9, x10;
         );
         self.jit.bcond_label(monoasm::Cond::Ne, fail);

--- a/monoruby/src/codegen/arch/x86_64/compile/constants.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/constants.rs
@@ -19,17 +19,51 @@ impl Codegen {
     ///
     /// Guard for constant version.
     ///
+    /// The snapshot side of the compare is the unit's shared patchable word
+    /// (`Codegen::unit_const_version`), so a successful const salvage can
+    /// re-validate every guard in the unit with one store.
+    ///
+    /// With `recompile = Some(position)` a miss first calls the salvaging
+    /// recompile entry (whole method / the loop at `position`) and then
+    /// deopts — the class-version guard's shape. `None` is a plain deopt.
+    ///
     /// ### destroy
     /// - rax
     ///
-    pub(super) fn guard_const_version(&mut self, cached_version: usize, deopt: &DestLabel) {
-        let cached_const_version = self.jit.data_i64(cached_version as _);
+    pub(super) fn guard_const_version(
+        &mut self,
+        recompile: Option<Option<BytecodePtr>>,
+        deopt: &DestLabel,
+    ) {
+        let cached_const_version = self
+            .unit_const_version
+            .clone()
+            .expect("const guard emitted outside a constant-folding unit");
         let global_const_version = self.const_version_label();
+        let Some(position) = recompile else {
+            monoasm! { &mut self.jit,
+                movq rax, [rip + global_const_version];
+                cmpq rax, [rip + cached_const_version];
+                jne  deopt;
+            }
+            return;
+        };
+        assert_eq!(0, self.jit.get_page());
+        let fail = self.jit.label();
         monoasm! { &mut self.jit,
             movq rax, [rip + global_const_version];
             cmpq rax, [rip + cached_const_version];
-            jne  deopt;
+            jne  fail;
         }
+        self.jit.select_page(1);
+        self.gen_recompile(
+            position,
+            fail,
+            RecompileReason::ConstVersionGuardFailed,
+            None,
+        );
+        self.version_guard_fail(deopt);
+        self.jit.select_page(0);
     }
 
     ///
@@ -45,13 +79,16 @@ impl Codegen {
     ///
     pub(super) fn guard_const_version_specialized(
         &mut self,
-        cached_version: usize,
+        _cached_version: usize,
         idx: usize,
         deopt: &DestLabel,
     ) {
         assert_eq!(0, self.jit.get_page());
         let fail = self.jit.label();
-        let cached_const_version = self.jit.data_i64(cached_version as _);
+        let cached_const_version = self
+            .unit_const_version
+            .clone()
+            .expect("const guard emitted outside a constant-folding unit");
         let global_const_version = self.const_version_label();
         monoasm! { &mut self.jit,
             movq rax, [rip + global_const_version];

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -699,10 +699,11 @@ impl Codegen {
                 }
             }
             LInst::GuardConstVersion {
-                const_version,
+                const_version: _,
+                recompile,
                 deopt,
             } => {
-                self.guard_const_version(const_version, &deopt);
+                self.guard_const_version(recompile, &deopt);
             }
             // Fixnum fast-path arithmetic with an overflow deopt.
             LInst::IntegerBinOp {

--- a/monoruby/src/codegen/compiler.rs
+++ b/monoruby/src/codegen/compiler.rs
@@ -12,7 +12,7 @@ impl Codegen {
         jit_entry: DestLabel,
         class_version: u32,
         is_recompile: Option<RecompileReason>,
-    ) -> Option<(Vec<InlineCacheEntry>, DestLabel)> {
+    ) -> Option<(Vec<InlineCacheEntry>, DestLabel, ConstSalvageMap)> {
         self.compile(
             globals,
             iseq_id,
@@ -159,7 +159,7 @@ impl Codegen {
         entry_label: DestLabel,
         class_version: u32,
         _is_recompile: Option<RecompileReason>,
-    ) -> Option<(Vec<InlineCacheEntry>, DestLabel)> {
+    ) -> Option<(Vec<InlineCacheEntry>, DestLabel, ConstSalvageMap)> {
         if position.is_none() && globals.store[iseq_id].jit_invalidated() {
             return None;
         }
@@ -227,7 +227,7 @@ impl Codegen {
             class_version,
             const_version,
         ) {
-            Ok((cache, specialized_info, class_version_label, bop_deps)) => {
+            Ok((cache, specialized_info, class_version_label, bop_deps, const_map)) => {
                 globals.store[iseq_id].add_bop_deps(bop_deps);
                 let codeptr = self.jit.get_label_address(&entry_label);
                 let (end0, end1) = self.get_address_pair();
@@ -276,7 +276,7 @@ impl Codegen {
                     self.jit.select_page(0);
                 }
 
-                Some((cache, class_version_label))
+                Some((cache, class_version_label, const_map))
             }
             Err(_) => {
                 if position.is_none() {
@@ -375,7 +375,7 @@ impl Codegen {
         };
         let jit_entry = self.jit.label();
         let class_version = self.class_version();
-        let (cache, _) = self.compile_method(
+        let (cache, _, const_map) = self.compile_method(
             globals,
             iseq_id,
             self_class,
@@ -383,7 +383,7 @@ impl Codegen {
             class_version,
             Some(reason),
         )?;
-        globals.store[iseq_id].set_cache_map(self_class, cache);
+        globals.store[iseq_id].set_cache_map(self_class, cache, const_map);
         let patch_point = self.jit.get_label_address(&patch_point);
         self.jit.apply_jmp_patch_address(patch_point, &jit_entry);
         Some(())
@@ -408,20 +408,21 @@ impl Codegen {
         let slot = globals.store[iseq_id].get_jit_slot(self_class)?;
         let jit_entry = self.jit.label();
         let class_version = self.class_version();
-        let compiled = self
-            .compile_method(
-                globals,
-                iseq_id,
-                self_class,
-                jit_entry.clone(),
-                class_version,
-                Some(reason),
-            )
-            .is_some();
-        if !compiled {
+        let compiled = self.compile_method(
+            globals,
+            iseq_id,
+            self_class,
+            jit_entry.clone(),
+            class_version,
+            Some(reason),
+        );
+        let Some((cache, _, const_map)) = compiled else {
             self.jit.finalize();
             return None;
-        }
+        };
+        // Refresh the salvage record so later guard failures re-validate
+        // against what *this* body folded (mirrors the x86 variant).
+        globals.store[iseq_id].set_cache_map(self_class, cache, const_map);
         let guard = self.a64_gen_class_guard_stub(self_class, &jit_entry);
         self.jit.finalize();
         let guard_addr = self.jit.get_label_address(&guard).as_ptr() as u64;
@@ -479,7 +480,7 @@ impl Codegen {
             });
         }
 
-        let ret = if let Some((cache, version_label)) = self.compile(
+        let ret = if let Some((cache, version_label, const_map)) = self.compile(
             globals,
             iseq_id,
             self_class,
@@ -493,7 +494,13 @@ impl Codegen {
             // Record the unit's salvage info so a later class-version guard
             // failure can re-validate and patch instead of recompiling.
             let index = globals.store[iseq_id].get_pc_index(Some(pc));
-            globals.store[iseq_id].set_loop_jit_info(self_class, index, version_label, cache);
+            globals.store[iseq_id].set_loop_jit_info(
+                self_class,
+                index,
+                version_label,
+                cache,
+                const_map,
+            );
             Some(())
         } else {
             None
@@ -589,6 +596,9 @@ impl Codegen {
 
         let patch_point = self.jit.get_label_address(&patch_point);
         self.jit.apply_jmp_patch_address(patch_point, &entry);
+        // The fresh body reads its own version words; the owner's salvage
+        // records no longer cover it (see `SpecializedPatchEntry::owner`).
+        self.specialized_info[idx].owner = None;
         Some(())
     }
 
@@ -635,6 +645,9 @@ impl Codegen {
         }
         let patch_point = self.jit.get_label_address(&patch_point);
         self.patch_call_to_entry(patch_point, &entry);
+        // The fresh body reads its own version words; the owner's salvage
+        // records no longer cover it (see `SpecializedPatchEntry::owner`).
+        self.specialized_info[idx].owner = None;
         Some(())
     }
 }
@@ -669,37 +682,99 @@ extern "C" fn jit_recompile_specialized(
 /// the salvage validation re-resolves methods through caches that read
 /// `Globals::class_version()`, which borrows the same thread-local.
 fn salvage_specialized(globals: &mut Globals, idx: usize, reason: RecompileReason) -> bool {
-    if !matches!(reason, RecompileReason::ClassVersionGuardFailed) {
+    // `owner: None` means this body was individually recompiled: it reads
+    // its own version words, which no owner record names — fall through to
+    // the recompile.
+    let Some((owner_iseq, owner_class, owner_pos)) =
+        CODEGEN.with(|codegen| codegen.borrow().specialized_info[idx].owner)
+    else {
+        return false;
+    };
+    match reason {
+        RecompileReason::ClassVersionGuardFailed => {
+            #[cfg(feature = "jit-log")]
+            crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::RECOVERY_ATTEMPT_SPEC);
+            let salvaged = match owner_pos {
+                None => globals
+                    .store
+                    .salvage_method_unit(owner_iseq, owner_class, None),
+                Some(pc) => {
+                    let index = globals.store[owner_iseq].get_pc_index(Some(pc));
+                    globals
+                        .store
+                        .salvage_loop_unit(owner_iseq, owner_class, index, None)
+                }
+            };
+            if let Some(version_label) = salvaged {
+                let version = Globals::class_version();
+                CODEGEN.with(|codegen| {
+                    codegen
+                        .borrow_mut()
+                        .set_class_version(version, &version_label);
+                });
+                #[cfg(feature = "jit-log")]
+                crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::SALVAGE_OK_SPEC);
+                true
+            } else {
+                false
+            }
+        }
+        RecompileReason::ConstVersionGuardFailed => {
+            let loop_index = owner_pos.map(|pc| globals.store[owner_iseq].get_pc_index(Some(pc)));
+            salvage_const(globals, owner_iseq, owner_class, loop_index)
+        }
+        _ => false,
+    }
+}
+
+/// Two-tier const-version salvage of the unit `(iseq_id, self_class[,
+/// loop_index])` — validation in `Store::salvage_const_unit`, word patch
+/// here. Like the class-version twin this runs *outside* the CODEGEN borrow
+/// (`Globals::const_version` reads the same thread-local). On success (or a
+/// bounded stale deferral) the current invocation deopts to the VM once and
+/// the salvage retries or the healed unit passes its guards from the next
+/// execution on.
+fn salvage_const(
+    globals: &mut Globals,
+    iseq_id: ISeqId,
+    self_class: ClassId,
+    loop_index: Option<crate::bytecodegen::BcIndex>,
+) -> bool {
+    #[cfg(feature = "jit-log")]
+    crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::CONST_RECOVERY_ATTEMPT);
+    match globals
+        .store
+        .salvage_const_unit(iseq_id, self_class, loop_index)
+    {
+        ConstSalvage::Healed(word) => {
+            let version = Globals::const_version();
+            CODEGEN.with(|codegen| {
+                codegen.borrow_mut().set_const_version(version, &word);
+            });
+            #[cfg(feature = "jit-log")]
+            crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::CONST_SALVAGE_OK);
+            true
+        }
+        // Skip the recompile but leave the guard failing: this invocation
+        // deopts to the VM, whose execution refreshes the suspect site's
+        // cache, and the next miss retries the salvage.
+        ConstSalvage::Defer => true,
+        ConstSalvage::Recompile => false,
+    }
+}
+
+/// Whole-method const salvage entry: on a `GuardConstVersion` failure, try
+/// the two-tier validation for the frame's unit before recompiling. Unlike
+/// the class-version guard (whose x86 recovery resumes in place), a const
+/// salvage lets this invocation deopt to the VM once; the healed unit
+/// passes its guard from the next call.
+fn salvage_method_const(globals: &mut Globals, lfp: Lfp, reason: RecompileReason) -> bool {
+    if !matches!(reason, RecompileReason::ConstVersionGuardFailed) {
         return false;
     }
-    #[cfg(feature = "jit-log")]
-    crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::RECOVERY_ATTEMPT_SPEC);
-    let (owner_iseq, owner_class, owner_pos) =
-        CODEGEN.with(|codegen| codegen.borrow().specialized_info[idx].owner);
-    let salvaged = match owner_pos {
-        None => globals
-            .store
-            .salvage_method_unit(owner_iseq, owner_class, None),
-        Some(pc) => {
-            let index = globals.store[owner_iseq].get_pc_index(Some(pc));
-            globals
-                .store
-                .salvage_loop_unit(owner_iseq, owner_class, index, None)
-        }
-    };
-    if let Some(version_label) = salvaged {
-        let version = Globals::class_version();
-        CODEGEN.with(|codegen| {
-            codegen
-                .borrow_mut()
-                .set_class_version(version, &version_label);
-        });
-        #[cfg(feature = "jit-log")]
-        crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::SALVAGE_OK_SPEC);
-        true
-    } else {
-        false
-    }
+    let self_class = lfp.self_val().class();
+    let iseq_id = globals.store[lfp.func_id()].as_iseq();
+    salvage_const(globals, iseq_id, self_class, None)
 }
 
 /// aarch64 specialized recompile entry, called from the
@@ -789,6 +864,9 @@ pub(in crate::codegen) extern "C" fn jit_profile_patch(
 
 #[cfg(target_arch = "x86_64")]
 extern "C" fn jit_recompile_method(globals: &mut Globals, lfp: Lfp, reason: RecompileReason) {
+    if salvage_method_const(globals, lfp, reason) {
+        return;
+    }
     //let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
     CODEGEN.with(|codegen| {
         codegen.borrow_mut().recompile_method(globals, lfp, reason);
@@ -819,6 +897,22 @@ pub(in crate::codegen) extern "C" fn jit_recompile_method(
     lfp: Lfp,
     reason: RecompileReason,
 ) -> Option<Value> {
+    // Salvage first (the per-unit version words are patchable on aarch64
+    // too): a successful validation heals the unit in place — this
+    // invocation deopts to the VM once and the guards pass from the next
+    // call on, skipping the full recompile below.
+    if matches!(reason, RecompileReason::ClassVersionGuardFailed) {
+        #[cfg(feature = "jit-log")]
+        crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::RECOVERY_ATTEMPT);
+        if globals.store.update_inline_cache(lfp) {
+            #[cfg(feature = "jit-log")]
+            crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::SALVAGE_OK);
+            return Some(Value::nil());
+        }
+    }
+    if salvage_method_const(globals, lfp, reason) {
+        return Some(Value::nil());
+    }
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         CODEGEN.with(|codegen| {
             codegen.borrow_mut().recompile_method(globals, lfp, reason);
@@ -952,15 +1046,18 @@ extern "C" fn jit_recompile_loop(
 /// iteration on. `lfp` is the loop's own frame, so `super` sites re-resolve
 /// soundly.
 fn salvage_loop(globals: &mut Globals, lfp: Lfp, pc: BytecodePtr, reason: RecompileReason) -> bool {
+    let self_class = lfp.self_val().class();
+    let func_id = lfp.func_id();
+    let iseq_id = globals.store[func_id].as_iseq();
+    let index = globals.store[iseq_id].get_pc_index(Some(pc));
+    if matches!(reason, RecompileReason::ConstVersionGuardFailed) {
+        return salvage_const(globals, iseq_id, self_class, Some(index));
+    }
     if !matches!(reason, RecompileReason::ClassVersionGuardFailed) {
         return false;
     }
     #[cfg(feature = "jit-log")]
     crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::RECOVERY_ATTEMPT_LOOP);
-    let self_class = lfp.self_val().class();
-    let func_id = lfp.func_id();
-    let iseq_id = globals.store[func_id].as_iseq();
-    let index = globals.store[iseq_id].get_pc_index(Some(pc));
     if let Some(version_label) = globals
         .store
         .salvage_loop_unit(iseq_id, self_class, index, Some(lfp))

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -628,6 +628,7 @@ impl Codegen {
         SpecializedCodeInfo,
         DestLabel,
         Vec<(ClassId, IdentId)>,
+        ConstSalvageMap,
     )> {
         let jit_type = if let Some(pos) = position {
             JitType::Loop(pos)
@@ -657,6 +658,7 @@ impl Codegen {
         ctx.resolve_dyn_var_offsets(&mut frame.asm_info);
 
         let inline_cache = std::mem::take(&mut ctx.inline_method_cache);
+        let const_folds = std::mem::take(&mut ctx.const_fold_cache);
         // The basic-op invariants this body inlined without a runtime guard.
         // Handed back so the iseq can remember what a later redefinition
         // would actually invalidate (see `JitContext::assume_basic_op`).
@@ -669,6 +671,18 @@ impl Codegen {
         // fall back to the interpreter).
         self.jit.finalize();
         let class_version_label = self.jit.const_i32(class_version as _);
+        // The unit's single const-version snapshot word: only materialized
+        // when the body folded a constant (otherwise no const guard exists
+        // and there is nothing to patch). All const guards in the unit —
+        // children included — read this one word.
+        let const_version_label = (!const_folds.is_empty())
+            .then(|| self.jit.const_i64(const_version as _));
+        self.unit_const_version = const_version_label.clone();
+        // Bind the fresh snapshot words now: the aarch64 lowering bakes their
+        // *addresses* into the guard sequences as immediates, so the labels
+        // must be resolved before `gen_machine_code` runs (x86 reads them
+        // rip-relative and doesn't care).
+        self.jit.finalize();
         // Stage-1 placement shadow (§24): bracket the whole ③ emission (the
         // `gen_machine_code` driver recurses into inlined callees, so one
         // begin/take pair captures the entire compilation unit's FP placement).
@@ -698,7 +712,31 @@ impl Codegen {
         // emission (e.g. the class-guard stub).
         #[cfg(target_arch = "x86_64")]
         self.jit.finalize();
-        Ok((inline_cache, specialized_info, class_version_label, bop_deps))
+        self.unit_const_version = None;
+        // Snapshot the involved names' epochs *at compile time*; a later
+        // guard failure compares against these to prove the folds unchanged.
+        let mut name_epochs: Vec<(IdentId, u64)> = vec![];
+        for site in &const_folds {
+            for &name in &site.names {
+                if !name_epochs.iter().any(|(n, _)| *n == name) {
+                    name_epochs.push((name, crate::globals::const_epoch::name_epoch(name)));
+                }
+            }
+        }
+        let const_map = ConstSalvageMap {
+            name_epochs,
+            wildcard: crate::globals::const_epoch::wildcard(),
+            sites: const_folds,
+            version_word: const_version_label,
+            stale_defers: 0,
+        };
+        Ok((
+            inline_cache,
+            specialized_info,
+            class_version_label,
+            bop_deps,
+            const_map,
+        ))
     }
 }
 
@@ -733,7 +771,7 @@ impl Codegen {
                     // A body compiled under the root's armed speculation
                     // recompiles by rebuilding the root unit (#1140).
                     speculated_root: speculated.then_some(root),
-                    owner: root,
+                    owner: Some(root),
                 });
             }
             let entry = frame.resolve_label(&mut self.jit, specialized_entry);

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -2087,6 +2087,12 @@ pub(super) enum AsmInst {
     ///
     GuardConstVersion {
         const_version: usize,
+        /// `Some(position)` — on a miss, call the (salvaging) recompile entry
+        /// for the unit (`None` = whole method, `Some(pc)` = the loop at that
+        /// pc) before falling into `deopt`, exactly like the class-version
+        /// guard. `None` — plain deopt (block-style roots, whose whole-method
+        /// recompile entry would rebuild the wrong frame shape).
+        recompile: Option<Option<BytecodePtr>>,
         deopt: AsmDeopt,
     },
     ///

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -196,10 +196,11 @@ impl Codegen {
             }
             // Constant version guard: deopt if the global constant version moved
             // since compilation.
-            AsmInst::GuardConstVersion { const_version, deopt } => {
+            AsmInst::GuardConstVersion { const_version, recompile, deopt } => {
                 let deopt = labels[deopt].clone();
                 self.encode_linst(LInst::GuardConstVersion {
                     const_version,
+                    recompile,
                     deopt,
                 });
             }

--- a/monoruby/src/codegen/jitgen/compile/variables.rs
+++ b/monoruby/src/codegen/jitgen/compile/variables.rs
@@ -120,6 +120,19 @@ impl<'a> JitContext<'a> {
             self.guard_const_version(state, ir, cache.version);
             state.load_constant(ir, dst, cache);
             state.unset_side_effect_guard();
+            // Record the fold for const-version salvage: the cache tuple the
+            // emitted code now relies on, and every name whose redefinition
+            // could change this site's resolution (qualifiers included).
+            {
+                let site = &self.store[id];
+                let mut names = site.prefix.clone();
+                names.push(site.name);
+                self.const_fold_cache.push(ConstFoldSite {
+                    id,
+                    cache: cache.clone(),
+                    names,
+                });
+            }
             Ok(CompileResult::Continue)
         } else {
             Ok(CompileResult::Recompile(RecompileReason::NotCached))
@@ -176,17 +189,24 @@ impl<'a> JitContext<'a> {
             state.set_const_version_guard();
             return;
         }
-        let deopt = if self.store[self.func_id()].is_block_style() {
-            ir.new_deopt(state)
+        // Non-block roots route a miss through the (salvaging) recompile
+        // entry *unconditionally* — mirroring the class-version guard's
+        // shape rather than the old counter-gated `RecompileDeoptimize`
+        // side exit. The one-shot counter was tuned for expensive
+        // recompiles; with const salvage the entry is cheap, and gating it
+        // meant the second version move after a successful salvage would
+        // strand the body in the interpreter forever (the counter never
+        // re-arms). Block roots keep the plain deopt: their whole-method
+        // recompile entry would rebuild the wrong frame shape (see above).
+        let recompile = if self.store[self.func_id()].is_block_style() {
+            None
         } else {
-            ir.new_recompile_deopt(
-                state,
-                RecompileReason::ConstVersionGuardFailed,
-                RecompileTarget::Whole(self.position()),
-            )
+            Some(self.position())
         };
+        let deopt = ir.new_deopt(state);
         ir.push(AsmInst::GuardConstVersion {
             const_version: version,
+            recompile,
             deopt,
         });
         state.set_const_version_guard();

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -772,6 +772,13 @@ pub(crate) struct JitContext<'a> {
     pub(crate) inline_method_cache: Vec<InlineCacheEntry>,
 
     ///
+    /// Every constant this compilation folded (root body and inlined
+    /// specialized children alike), recorded for const-version salvage —
+    /// see [`crate::globals::ConstSalvageMap`].
+    ///
+    pub(crate) const_fold_cache: Vec<ConstFoldSite>,
+
+    ///
     /// The `(class, operator)` basic-op invariants this body inlined *without*
     /// a runtime guard — integer/float arithmetic, comparisons, and constant
     /// folds. The emitted code is correct only while each of them is still the
@@ -825,6 +832,7 @@ impl<'a> JitContext<'a> {
             const_version,
             refinements,
             inline_method_cache: vec![],
+            const_fold_cache: vec![],
             bop_deps: vec![],
             stack_frame,
             next_specialized_id: 0,
@@ -848,6 +856,7 @@ impl<'a> JitContext<'a> {
             const_version: self.const_version,
             refinements: self.refinements,
             inline_method_cache: vec![],
+            const_fold_cache: vec![],
             bop_deps: vec![],
             stack_frame,
             // The cloned context emits AsmIr only for analysis (it is

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -487,9 +487,12 @@ pub(in crate::codegen) enum LInst {
         deopt: DestLabel,
     },
     /// Constant-load guard: deopt if the global constant version moved away from
-    /// `const_version` since compilation.
+    /// the unit's snapshot word since compilation. `recompile` mirrors
+    /// `AsmInst::GuardConstVersion`: `Some(position)` routes a miss through
+    /// the salvaging recompile entry first; `None` is a plain deopt.
     GuardConstVersion {
         const_version: usize,
+        recompile: Option<Option<BytecodePtr>>,
         deopt: DestLabel,
     },
     /// Block-passing side-effect guard: deopt if the current frame was captured

--- a/monoruby/src/codegen/patch.rs
+++ b/monoruby/src/codegen/patch.rs
@@ -47,13 +47,19 @@ impl Codegen {
         let jit_entry = self.jit.label();
         // `jit_entry` is bound by `gen_machine_code` (even on the bail path)
         // so it always resolves at `finalize`.
-        let compiled = self
-            .compile_method(globals, iseq_id, self_class, jit_entry.clone(), class_version, None)
-            .is_some();
-        if !compiled {
+        let compiled =
+            self.compile_method(globals, iseq_id, self_class, jit_entry.clone(), class_version, None);
+        let Some((cache, class_version_label, const_map)) = compiled else {
             self.jit.finalize();
             return None;
-        }
+        };
+        // Register the unit's salvage record (inline caches, version word,
+        // const folds) so class/const guard failures can re-validate instead
+        // of recompiling. On aarch64 dispatch goes through `jit_slot`, so the
+        // `jit_entry` table exists purely as this record — a republish for the
+        // same class simply replaces it.
+        globals.store[iseq_id].add_jit_code(self_class, jit_entry.clone(), class_version_label);
+        globals.store[iseq_id].set_cache_map(self_class, cache, const_map);
         // Front the compiled `jit_entry` with a self-class guard. The JIT body
         // assumes `self == self_class`, but a single per-method slot is shared
         // by every receiver class of an inherited method — so publishing the
@@ -124,7 +130,7 @@ impl Codegen {
             self.jit.finalize();
             return None;
         }
-        if let Some((cache, class_version_label)) = self.compile_method(
+        if let Some((cache, class_version_label, const_map)) = self.compile_method(
             globals,
             iseq_id,
             self_class,
@@ -145,7 +151,7 @@ impl Codegen {
                     globals.store[iseq_id].name()
                 );
             }
-            globals.store[iseq_id].set_cache_map(self_class, cache);
+            globals.store[iseq_id].set_cache_map(self_class, cache, const_map);
             self.jit.apply_jmp_patch_address(entry, &guard);
             self.jit.finalize();
             Some(())

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -1482,18 +1482,69 @@ impl Globals {
     /// being assigned — for example after `Module#include` /
     /// `Module#prepend` adds a new iclass to a class chain that earlier
     /// callers have already resolved against.
+    ///
+    /// This entry point has no constant *name* to attribute the change to,
+    /// so it also bumps the per-name table's wildcard epoch — every unit's
+    /// const salvage fast path is invalidated (see [`const_epoch`]).
     pub(crate) fn const_version_inc() {
+        const_epoch::bump_wildcard();
         CODEGEN.with(|codegen| codegen.borrow_mut().const_version_inc());
     }
 
+    pub(crate) fn const_version() -> u64 {
+        CODEGEN.with(|codegen| codegen.borrow().const_version())
+    }
+
     pub fn set_constant(&mut self, class_id: ClassId, name: IdentId, val: Value) {
+        const_epoch::bump_name(name);
         CODEGEN.with(|codegen| codegen.borrow_mut().const_version_inc());
         self.store.set_constant(class_id, name, val);
     }
 
     pub fn remove_constant(&mut self, class_id: ClassId, name: IdentId) -> Option<Value> {
+        const_epoch::bump_name(name);
         CODEGEN.with(|codegen| codegen.borrow_mut().const_version_inc());
         self[class_id].remove_constant(name)
+    }
+}
+
+/// Per-name epochs for constant-cache salvage.
+///
+/// The global const version (a single counter read by every compiled
+/// `GuardConstVersion`) moves on *any* constant event anywhere, so a guard
+/// failure says nothing about whether the constants a unit actually folded
+/// changed. This table refines that: every event that bumps the global
+/// version also bumps the epoch of the constant *name* it touched (or the
+/// wildcard, when the event has no single name — `include`/`prepend`).
+/// A salvage attempt can then prove "none of the names this unit folded
+/// were touched" without re-resolving anything.
+///
+/// Thread-local like `CODEGEN`: each interpreter thread (one per test) has
+/// its own table, mirroring the global version counter it refines.
+pub(crate) mod const_epoch {
+    use crate::IdentId;
+    use std::cell::{Cell, RefCell};
+    use std::collections::HashMap;
+
+    thread_local! {
+        static WILDCARD: Cell<u64> = const { Cell::new(0) };
+        static NAMES: RefCell<HashMap<IdentId, u64>> = RefCell::new(HashMap::new());
+    }
+
+    pub(crate) fn bump_name(name: IdentId) {
+        NAMES.with_borrow_mut(|m| *m.entry(name).or_insert(0) += 1);
+    }
+
+    pub(crate) fn bump_wildcard() {
+        WILDCARD.with(|w| w.set(w.get() + 1));
+    }
+
+    pub(crate) fn name_epoch(name: IdentId) -> u64 {
+        NAMES.with_borrow(|m| m.get(&name).copied().unwrap_or(0))
+    }
+
+    pub(crate) fn wildcard() -> u64 {
+        WILDCARD.with(|w| w.get())
     }
 }
 

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -2639,6 +2639,130 @@ impl Store {
         version_label
     }
 
+    /// Two-tier const-version salvage of a compilation unit (whole-method
+    /// when `loop_index` is `None`, the loop unit at that `LoopStart`
+    /// otherwise). Returns the unit's const-version snapshot word for the
+    /// caller to patch to the current global version, a deferral, or a
+    /// recompile request — see [`ConstSalvage`].
+    ///
+    /// Tier 1 — per-name epochs: if none of the names the unit folded were
+    /// touched since compilation (and the wildcard didn't move), no fold can
+    /// have changed; the whole unit validates without a single lookup.
+    ///
+    /// Tier 2 — value re-check: a site whose name *was* touched is compared
+    /// against its VM inline cache. If a cache refreshed at the current
+    /// version equals the fold, the assignment wrote the same value and the
+    /// code is still exact. A still-stale cache defers (bounded) so the
+    /// deopted execution can refresh it; a diverging cache recompiles.
+    ///
+    /// On success the record's epoch snapshots are refreshed in place so the
+    /// next failure diffs against *this* validation point.
+    pub(crate) fn salvage_const_unit(
+        &mut self,
+        iseq_id: ISeqId,
+        self_class: ClassId,
+        loop_index: Option<crate::bytecodegen::BcIndex>,
+    ) -> ConstSalvage {
+        let current_version = Globals::const_version();
+        let current_wildcard = crate::globals::const_epoch::wildcard();
+        let map_slot = match loop_index {
+            None => self[iseq_id].get_const_map_mut(self_class),
+            Some(index) => self[iseq_id].get_loop_const_map_mut(self_class, index),
+        };
+        let Some(map_slot) = map_slot else {
+            #[cfg(feature = "jit-log")]
+            crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::SALVAGE_FAIL_NO_ENTRY);
+            return ConstSalvage::Recompile;
+        };
+        // Take the record out: validation reads other parts of the store
+        // (the sites' VM caches), which a live borrow of the map would block.
+        let mut map = std::mem::take(map_slot);
+        let mut outcome = self.salvage_const_map(&mut map, current_version, current_wildcard);
+        match outcome {
+            ConstSalvage::Healed(_) => map.stale_defers = 0,
+            // Let the deopt run the site in the VM (refreshing its cache)
+            // and retry on the next miss — but bounded: a fold whose site
+            // the deopted execution never reaches would defer forever.
+            ConstSalvage::Defer => {
+                if map.stale_defers >= 3 {
+                    outcome = ConstSalvage::Recompile;
+                } else {
+                    map.stale_defers += 1;
+                }
+            }
+            ConstSalvage::Recompile => {}
+        }
+        // Put the (possibly refreshed) record back even on failure — the
+        // recompile that follows replaces it wholesale anyway.
+        if let Some(map_slot) = match loop_index {
+            None => self[iseq_id].get_const_map_mut(self_class),
+            Some(index) => self[iseq_id].get_loop_const_map_mut(self_class, index),
+        } {
+            *map_slot = map;
+        }
+        outcome
+    }
+
+    fn salvage_const_map(
+        &self,
+        map: &mut ConstSalvageMap,
+        current_version: u64,
+        current_wildcard: u64,
+    ) -> ConstSalvage {
+        use crate::globals::const_epoch;
+        let Some(word) = map.version_word.clone() else {
+            // The unit folded no constants — no const guard exists, so a
+            // const-version failure cannot have come from it (stale record).
+            return ConstSalvage::Recompile;
+        };
+        let wildcard_moved = map.wildcard != current_wildcard;
+        let moved: Vec<IdentId> = map
+            .name_epochs
+            .iter()
+            .filter(|(n, e)| const_epoch::name_epoch(*n) != *e)
+            .map(|(n, _)| *n)
+            .collect();
+        for site in &mut map.sites {
+            let suspect = wildcard_moved || site.names.iter().any(|n| moved.contains(n));
+            if !suspect {
+                continue;
+            }
+            // Tier 2: only a VM cache already refreshed at the current
+            // version can prove the fold still exact.
+            let stale = match &self[site.id].cache {
+                None => true,
+                Some(cur) if cur.version as u64 != current_version => true,
+                Some(_) => false,
+            };
+            if stale {
+                #[cfg(feature = "jit-log")]
+                crate::codegen::jit_stats::bump(
+                    &crate::codegen::jit_stats::CONST_SALVAGE_FAIL_STALE,
+                );
+                return ConstSalvage::Defer;
+            }
+            let cur = self[site.id].cache.as_ref().unwrap();
+            if cur.value != site.cache.value
+                || cur.base_class != site.cache.base_class
+                || cur.self_class != site.cache.self_class
+            {
+                #[cfg(feature = "jit-log")]
+                crate::codegen::jit_stats::bump(
+                    &crate::codegen::jit_stats::CONST_SALVAGE_FAIL_CHANGED,
+                );
+                return ConstSalvage::Recompile;
+            }
+            #[cfg(feature = "jit-log")]
+            crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::CONST_SALVAGE_VALUECMP);
+            site.cache = cur.clone();
+        }
+        for (n, e) in &mut map.name_epochs {
+            *e = const_epoch::name_epoch(*n);
+        }
+        map.wildcard = current_wildcard;
+        ConstSalvage::Healed(word)
+    }
+
     /// The loop (OSR) twin of [`Self::salvage_method_unit`], keyed by the
     /// loop's `(self_class, LoopStart index)` — see
     /// [`crate::globals::ISeqInfo::loop_jit_info`]. As there, the caller

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -90,6 +90,7 @@ pub struct JitInfo {
     pub entry: DestLabel,
     pub class_version_label: DestLabel,
     pub inline_cache_map: Vec<InlineCacheEntry>,
+    pub const_map: ConstSalvageMap,
 }
 
 /// The salvage-relevant half of a loop (OSR) compilation unit — see
@@ -99,6 +100,79 @@ pub struct JitInfo {
 pub struct LoopJitInfo {
     pub class_version_label: DestLabel,
     pub inline_cache_map: Vec<InlineCacheEntry>,
+    pub const_map: ConstSalvageMap,
+}
+
+/// One constant the JIT folded at compile time: the site it came from, the
+/// full cache tuple the fold relied on, and the names whose redefinition
+/// could change the site's resolution (the final name plus every path
+/// qualifier). See [`ConstSalvageMap`].
+#[derive(Debug, Clone)]
+pub struct ConstFoldSite {
+    pub id: ConstSiteId,
+    pub cache: ConstCache,
+    pub names: Vec<IdentId>,
+}
+
+/// The constant-fold half of a compilation unit's salvage record.
+///
+/// A `GuardConstVersion` failure only says "some constant event happened
+/// somewhere"; this record lets the recompile entry prove the unit's folds
+/// are still exact and *sync* the unit instead:
+///
+/// 1. **Per-name fast path** — every event that bumps the global const
+///    version also bumps a per-name epoch ([`crate::globals::const_epoch`]).
+///    If none of the folded names' epochs moved (and the wildcard didn't),
+///    no fold can have changed: patch `version_word` to the current global
+///    version and keep the code.
+/// 2. **Value re-check** — for a site whose name *was* touched, compare the
+///    fold against the site's VM inline cache: the deopted executions that
+///    precede a salvage retry re-run the site in the VM, refreshing its
+///    cache at the current version. If the refreshed tuple matches the
+///    fold, the assignment wrote the same value — sync as above. Otherwise
+///    recompile.
+///
+/// `version_word` is the unit's single patchable snapshot word: every
+/// `GuardConstVersion` / `GuardConstVersionSpecialized` in the unit
+/// (children included — one compilation is atomic at one const version)
+/// compares the global counter against it.
+#[derive(Debug, Clone, Default)]
+pub struct ConstSalvageMap {
+    /// Deduped folded names with their per-name epochs at compile time.
+    pub name_epochs: Vec<(IdentId, u64)>,
+    /// Wildcard epoch at compile time (bumped by nameless events:
+    /// `include`/`prepend`).
+    pub wildcard: u64,
+    pub sites: Vec<ConstFoldSite>,
+    /// The unit's const-version snapshot word, `None` when the unit folded
+    /// no constants (no guard emitted, nothing to salvage).
+    pub version_word: Option<DestLabel>,
+    /// Consecutive tier-2 *stale* deferrals (the suspect site's VM cache had
+    /// not yet been refreshed at the current version, so the salvage asked
+    /// for a plain deopt to let the VM re-run the site). Bounded so a fold
+    /// whose site never re-executes in the interpreter can't defer forever;
+    /// reset on every successful salvage.
+    pub stale_defers: u8,
+}
+
+/// Outcome of a const-version salvage attempt (see
+/// [`crate::globals::store::Store::salvage_const_unit`]).
+pub enum ConstSalvage {
+    /// Every fold validated — patch this word to the current version.
+    Healed(DestLabel),
+    /// A suspect site's VM cache is not yet refreshed: deopt this invocation
+    /// to the VM (which re-runs the site) and retry on the next miss.
+    Defer,
+    /// A fold's value changed (or deferral ran out) — recompile.
+    Recompile,
+}
+
+impl alloc::GC<RValue> for ConstSalvageMap {
+    fn mark(&self, alloc: &mut alloc::Allocator<RValue>) {
+        for site in &self.sites {
+            site.cache.mark(alloc);
+        }
+    }
 }
 
 ///
@@ -374,6 +448,14 @@ impl std::fmt::Debug for ISeqInfo {
 impl alloc::GC<RValue> for ISeqInfo {
     fn mark(&self, alloc: &mut alloc::Allocator<RValue>) {
         self.literals.iter().for_each(|v| v.mark(alloc));
+        // The salvage records snapshot folded constant Values; they must stay
+        // alive as long as the compiled code that baked them in.
+        self.jit_entry
+            .values()
+            .for_each(|info| info.const_map.mark(alloc));
+        self.loop_jit_info
+            .values()
+            .for_each(|info| info.const_map.mark(alloc));
     }
 }
 
@@ -712,6 +794,7 @@ impl ISeqInfo {
                 entry,
                 class_version_label,
                 inline_cache_map: Vec::new(),
+                const_map: ConstSalvageMap::default(),
             },
         )
     }
@@ -775,10 +858,41 @@ impl ISeqInfo {
         &mut self,
         self_class: ClassId,
         cache: Vec<InlineCacheEntry>,
+        const_map: ConstSalvageMap,
     ) {
+        self.jit_entry.get_mut(&self_class).map(|info| {
+            info.inline_cache_map = cache;
+            info.const_map = const_map;
+        });
+    }
+
+    /// The const-fold salvage record of the whole-method unit for
+    /// `self_class`, mutable so a successful salvage can refresh its
+    /// epoch snapshots in place. `None` once invalidated.
+    pub(crate) fn get_const_map_mut(
+        &mut self,
+        self_class: ClassId,
+    ) -> Option<&mut ConstSalvageMap> {
+        if self.jit_invalidated {
+            return None;
+        }
         self.jit_entry
             .get_mut(&self_class)
-            .map(|info| info.inline_cache_map = cache);
+            .map(|info| &mut info.const_map)
+    }
+
+    /// The loop twin of [`Self::get_const_map_mut`].
+    pub(crate) fn get_loop_const_map_mut(
+        &mut self,
+        self_class: ClassId,
+        index: BcIndex,
+    ) -> Option<&mut ConstSalvageMap> {
+        if self.jit_invalidated {
+            return None;
+        }
+        self.loop_jit_info
+            .get_mut(&(self_class, index))
+            .map(|info| &mut info.const_map)
     }
 
     pub(crate) fn jit_invalidated(&self) -> bool {
@@ -874,12 +988,14 @@ impl ISeqInfo {
         index: BcIndex,
         class_version_label: DestLabel,
         inline_cache_map: Vec<InlineCacheEntry>,
+        const_map: ConstSalvageMap,
     ) {
         self.loop_jit_info.insert(
             (self_class, index),
             LoopJitInfo {
                 class_version_label,
                 inline_cache_map,
+                const_map,
             },
         );
     }

--- a/monoruby/tests/add_coverage.rs
+++ b/monoruby/tests/add_coverage.rs
@@ -1583,3 +1583,94 @@ fn super_skips_visibility_shadow_entries() {
         "##,
     );
 }
+
+//
+// Const-version salvage on loop (OSR) units: a constant folded inside a
+// JIT'd loop body whose guard then fails routes through
+// `jit_recompile_loop` → `salvage_const(.., Some(index))` →
+// `get_loop_const_map_mut` (the whole-method twin is exercised by the many
+// existing tests that fold constants in plain hot methods).
+//
+
+// Tier-1 fast path: per-iteration constant definitions touch only
+// *unrelated* names, so every loop-unit guard failure re-validates via the
+// per-name epochs and the folded code survives untouched.
+#[test]
+fn loop_const_salvage_unrelated_names() {
+    run_test(
+        r##"
+        LCS_K1 = 42
+        def lcs_hot1
+          s = 0
+          i = 0
+          while i < 30
+            s += LCS_K1
+            i += 1
+          end
+          s
+        end
+        r = 0
+        5.times do |i|
+          r += lcs_hot1
+          Object.const_set("LCS_A_#{i}", 1)
+        end
+        r
+        "##,
+    );
+}
+
+// Tier-2 value re-check: the folded name itself is reassigned each round
+// with the *same* value, so the salvage proves the fold still exact against
+// the VM cache (or defers once while the cache is stale) instead of
+// recompiling.
+#[test]
+fn loop_const_salvage_same_value() {
+    run_test(
+        r##"
+        LCS_K2 = 7
+        def lcs_hot2
+          s = 0
+          i = 0
+          while i < 30
+            s += LCS_K2
+            i += 1
+          end
+          s
+        end
+        r = 0
+        5.times do
+          r += lcs_hot2
+          Object.const_set(:LCS_K2, 7)
+        end
+        r
+        "##,
+    );
+}
+
+// Correctness backstop: the folded constant genuinely changes value each
+// round — the salvage must *fail* and the recompiled loop must observe every
+// new value.
+#[test]
+fn loop_const_salvage_value_change() {
+    run_test(
+        r##"
+        Object.const_set(:LCS_K3, 0)
+        def lcs_hot3
+          s = 0
+          i = 0
+          while i < 30
+            s += LCS_K3
+            i += 1
+          end
+          s
+        end
+        r = []
+        5.times do |i|
+          r << lcs_hot3
+          Object.const_set(:LCS_K3, i + 1)
+        end
+        Object.const_set(:LCS_K3, 0)
+        r
+        "##,
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -610,6 +610,7 @@
 3216e8a4e5532edd1d8a9a107a61cb60	"nil"	def t; end; (public).inspect
 323248fe474a5afa887e12205ed145d2	C	a = class C\n          self\n        end\n        a\n        
 3241d752b39412d4f6c02d9dd853ba08	["foo"]	class A; def a(*r); r; end; end\n            class B < A; def a(*r);
+3264d96fa4dfb35b3aea4883fe7dbebb	[0, 30, 60, 90, 120]	Object.const_set(:LCS_K3, 0)\n        def lcs_hot3\n          s = 0\n     
 3279027e38a42e302879e0467940338a	[[1, 100], [3, 100], [4, 100], [:attr, 150], [:plain, 150]]	class Ra\n              attr_reader :tag\n              def initializ
 3285c4fda20a8f8870e882093119ec6c	[1, 10, 20, 30]	def f(p, x:, y:, z:)\n          [p, x, y, z]\n        end\n        \n\n     
 3295f884bc7723fc9fb6dbf1936f7316	[-7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5, -7, 7, -8, -1.5, 1.5]	def drive\n              res = []\n              j = 0\n              
@@ -1654,6 +1655,7 @@
 88d4180cc8261b799934c513e7ea401c	13	def f(a,b)\n          a + b\n        end\n        f(5,7)\n        f(4,9)\n  
 88f8e9f112097e82f8a521e470848673	["<1>", "'x'"]	module AncInner\n              refine(Integer) { def wrap; "<#{to_s}
 88fba5d2266fa4ee0bba24a92af6c067	[[], 1]	->((*a, b)) { [a, b] }.call([1])
+8933c621a2a4cce4cee3e798523d76cd	1050	LCS_K2 = 7\n        def lcs_hot2\n          s = 0\n          i = 0\n       
 898daf8bc776af90627957e0256ba48d	[0, 0, 0, 0, 0, 0, 0, 0, 0, 76, 31, 0, 78, 6, 0, 31, 27, 28, 14, 78, 20, 84, 5, 0, 26, 15, 0, 25, 6, 84, 29, 83, 11, 9, 85, 25, 83, 6, 9, 27, 24, 69, 13, 27, 29]	def bxor!(a, b)\n          l = a.bytesize\n          lb = b.bytesize\n    
 89a90f1ae033d44d7cd236ed88be4129	:bar	class Foo\n              def bar; end\n            end\n            \n\n
 89c218222121411715e9cbdc51498eb5	[21, 28, 35, 42, 49, 56, 63, 70, 77, 84, 91, 98, 105, 112, 119, 126, 133, 140, 147, 154, 161, 168, 175, 182, 189, 196, 203, 210, 217, 224]	def g(a, b, c, d, e, f, g) = [a, b, c, d, e, f, g].sum\n        def f(..
@@ -2002,6 +2004,7 @@ a55b98e9b8eb1d3f7e509f6d3ac592c0	"missing keyword: :x"	def msg; yield; "no error
 a5b4244b815843859e162c8ca4f4db2a	[4, 8, 67, 58, 10, 77, 121, 65, 114, 114, 91, 7, 105, 6, 105, 7]	class MyArr < Array; end\n            Marshal.dump(MyArr.new([1, 2])
 a5d8327abff55336ba0aca5e5b3d3676	[[:r0, []], [:r0, [1, 2, 3]], [:r1, 1, []], [:r1, 1, [2, 3]], [:ro, 1, :dy, []], [:ro, 1, 2, []], [:ro, 1, 2, [3, 4]], [:rk, [], {}], [:rk, [1, 2], {}], [:ro, :L, :dy, []], [:ro, :L, 1, [2, 3]], "wrong number of arguments (given 0, expected 1+)", [1, 2, 3], [1, 2]]	def r0(*a) = [:r0, a]\n            def r1(x, *a) = [:r1, x, a]\n     
 a5d96ad6d6abcfbe7ebc92d3c098653f	:no_raise	begin\n          eval("x=1; y=2; x..y if x")\n          :no_raise\n       
+a5e8a1abbd22d21896ec370b765bf2fb	6300	LCS_K1 = 42\n        def lcs_hot1\n          s = 0\n          i = 0\n      
 a5ea42a5d2799be99e3f391567c82039	nil	class C; end\nArray.try_convert(C.new)
 a5ed14348511ba792e4c20ead35820a6	[:undefined_local_or_method, true]	begin\n          undefined_local_or_method\n        rescue NameError => e
 a5f3bf74322a39a42bd747ced6b91e31	[48, "ISO-8859-1", true]	def iso_app(s, t, n)\n          i = 0\n          while i < n\n            


### PR DESCRIPTION
## Summary

A `GuardConstVersion` failure only says "some constant event happened somewhere": the global const version bumps on every constant assignment, removal, and `include`/`prepend`, so a spec-style workload that defines constants per file recompiled every hot body that folded any constant — **4,148 whole recompiles per ruby/spec core run**, the bulk of the JIT emission remaining after #1155's class-version salvage.

This PR teaches the recompile entries to *salvage* the unit with a two-tier validation instead:

1. **Per-name epochs** (`globals::const_epoch`) — every event that bumps the global const version also bumps the epoch of the constant *name* it touched (`include`/`prepend` bump a wildcard). If none of the names a unit folded were touched, no fold can have changed: patch the unit's snapshot word to the current version and keep the code. No lookup at all.
2. **Value re-check** — a site whose name *was* touched is compared against its VM inline cache: a cache refreshed at the current version whose tuple (`value`, `base_class`, `self_class`) equals the fold proves the assignment wrote the same value — sync as above. A still-stale cache defers (bounded at 3) so the deopted execution can refresh it; a diverging value recompiles.

## Mechanics

- Each compilation unit gets **one patchable const-version snapshot word** (mirroring the class-version word); every `GuardConstVersion` / `GuardConstVersionSpecialized` in the unit — inlined children included, since one compilation is atomic at one const version — compares the global counter against it, so a single store re-validates the whole unit. `JitInfo` / `LoopJitInfo` carry the fold record (`ConstSalvageMap`: folded sites + cache tuples + name-epoch snapshots), GC-marked so recorded fold Values stay alive with the code.
- The non-specialized const guard now routes a miss through the salvaging recompile entry **unconditionally** (the class-version guard's shape) instead of the counter-gated `RecompileDeoptimize` side exit. That counter is one-shot — tuned for expensive recompiles — so the *second* version move after a successful salvage would strand the body in the interpreter forever. Block-style roots keep the plain deopt (their whole-method recompile entry would rebuild the wrong frame shape).
- Specialized bodies salvage through their **owner** unit, and `SpecializedPatchEntry::owner` becomes `Option`, cleared when a body is individually recompiled: the fresh compile reads its own version words, which the owner's records no longer name — a "successful" owner salvage would patch words the body never reads, deopting it on every call forever (a latent issue in #1155 as well).

### aarch64 fix (also heals #1155 on aarch64)

The aarch64 class/const version guards compared a version baked as an **immediate**, so salvage's word-patching never re-validated compiled aarch64 code — every guard kept failing and each miss re-entered the salvage/recompile entry forever. Both guards now read the unit's patchable word, and aarch64's whole-method recompile entry gains the same `update_inline_cache` class salvage as x86, so all three salvage paths (whole / loop / specialized, class and const) are now effective on aarch64.

## Results

ruby/spec core, CI-identical invocation (2,144 files / 23,034 examples), this branch: **whole const-ver recompiles 157** (was 4,148 before this change, measured on the pre-#1156 base: **−96%**), spec const-ver 29 → 6, loop 0. Const-guard salvage: 15,740 attempts, 10,485 healed (13,309 tier-2 value comparisons), **0 genuine value changes** — the constant events during a spec run never actually changed a folded constant's value. On the pre-#1156 A/B (both runs completed): total JIT compile time 15.6s → 12.8s (22.4s before #1155), peak emission 328MB → 298MB.

Note: the same measurement on current master could not be completed for a direct A/B — the run reproducibly (×2) aborts at mspec's 60s per-example timeout in `Class#subclasses works when creating subclasses concurrently`, which triggers ~15k singleton-class `Object#should` whole compiles on both binaries; this branch's runs complete (×2), staying under the timeout with the salvage-reduced compile load. That compile storm itself looks worth a separate look.

Micro-benchmarks (500 iterations each, self-checking):
- unrelated-name constant definitions per iteration → **506/506 tier-1 salvages, zero recompiles** (previously a recompile per version move)
- same-value reassignment of the folded name → tier-2 heals all (499 value comparisons), zero recompiles
- genuine value change per iteration → correctly recompiles every time, exact results

## Verification

- `cargo nextest run`: 3,295/3,295 pass; `cargo check` clean on x86_64 and aarch64
- ruby/spec core failure set matches the baseline modulo known TZ/order flakes (398F/223E, several exit!-family flakes flipped to passing)
- GC safety: fold records are marked via `ISeqInfo::mark`; tier-2 compares are bit-level (`Value` identity), never dereferencing a recorded value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_