### PR TITLE
PIC: dispatch set-guarded calls through the wrapper (soundness); readmit the warmed class on rebuild

### DIFF
--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -1490,6 +1490,18 @@ impl Codegen {
                 monoasm!( &mut self.jit,
                     movq rcx, (Value::symbol_from_str("__immediate_evict").id());
                 );
+            } else if let Some((_, target)) = &recompile {
+                // Temporary P0 instrumentation: name the counter-gated
+                // recompile exits so the deopt census can tell them from
+                // plain guards (rdi is not a meaningful cause here).
+                let tag = match target {
+                    RecompileTarget::Whole(None) => "__recompile_exit_method",
+                    RecompileTarget::Whole(Some(_)) => "__recompile_exit_loop",
+                    RecompileTarget::Specialized(_) => "__recompile_exit_spec",
+                };
+                monoasm!( &mut self.jit,
+                    movq rcx, (Value::symbol_from_str(tag).id());
+                );
             } else {
                 monoasm!( &mut self.jit,
                     movq rcx, rdi; // the Value which caused this deopt.

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1673,7 +1673,18 @@ pub(super) enum AsmInst {
     ///
     Call {
         callee_fid: FuncId,
-        recv_class: ClassId,
+        /// The receiver class this call site *proved* (class-version +
+        /// single-class receiver guard precede the call) — the precondition
+        /// for dispatching straight to that class's JIT body, skipping the
+        /// wrapper's `self.class` re-guard. `None` when the site only
+        /// narrowed the receiver to a *set* (a `GuardClassIn` class-set
+        /// guard, a multi-class PIC dispatch arm): the call must then go
+        /// through the callee's wrapper entry, which re-dispatches on the
+        /// actual class at runtime. Baking one member's body in would run
+        /// it for every other member — observed as `nil` ivar reads when
+        /// two subclasses with different ivar layouts shared an inherited
+        /// method behind one dispatch arm.
+        recv_class: Option<ClassId>,
         evict: AsmEvict,
         pc: BytecodePtr,
     },

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -593,18 +593,25 @@ impl Codegen {
                 let callee = &store[callee_fid];
                 let is_iseq = callee.is_iseq();
                 let (_, codeptr, callee_pc) = callee.get_data();
+                // Class-keyed direct-entry lookups are only sound when the
+                // call site *proved* a single receiver class (`recv_class`
+                // is `Some`) — a set-guarded site must go through the
+                // wrapper (`codeptr`), which re-dispatches at runtime. See
+                // the field's doc on `AsmInst::Call`.
                 // x86 JIT-entry lookup (aarch64 ignores it; the lookup is a
                 // side-effect-free table read, so pre-resolving here is safe).
-                let jit_entry = is_iseq.and_then(|iseq| store[iseq].get_jit_entry(recv_class));
+                let jit_entry = recv_class
+                    .and_then(|rc| is_iseq.and_then(|iseq| store[iseq].get_jit_entry(rc)));
                 // aarch64 guard-free dispatch-slot lookup (x86 ignores it).
-                // `recv_class` is statically established at this call site
-                // (class-version + receiver guards precede every AsmInst::Call),
-                // which is exactly the precondition for skipping the wrapper's
-                // `self.class` re-guard — same soundness argument as x86's
-                // direct `call jit_entry`.
+                // A `Some` recv_class is statically established at this call
+                // site (class-version + single-class receiver guard precede
+                // it), which is exactly the precondition for skipping the
+                // wrapper's `self.class` re-guard — same soundness argument
+                // as x86's direct `call jit_entry`.
                 #[cfg(target_arch = "aarch64")]
-                let jit_slot =
-                    is_iseq.and_then(|iseq| store[iseq].get_jit_guard_free_slot(recv_class));
+                let jit_slot = recv_class.and_then(|rc| {
+                    is_iseq.and_then(|iseq| store[iseq].get_jit_guard_free_slot(rc))
+                });
                 #[cfg(not(target_arch = "aarch64"))]
                 let jit_slot = None;
                 self.encode_linst(LInst::Call {

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -202,6 +202,31 @@ impl<'a> JitContext<'a> {
     /// reader's slot index is per-class, so for all of them the set's
     /// members must not funnel into one compiled body.
     ///
+    ///
+    /// The recompile target a receiver-class-guard `Learn` exit uses for
+    /// this compilation unit, or `None` when no sound one exists.
+    ///
+    /// A block ROOT cannot take a whole-recompile: the side exit recompiles
+    /// whatever `lfp.func_id()` names as if it were a method, which rebuilds
+    /// a block body under the wrong argument convention (see
+    /// `guard_const_version`, which learned this the hard way). Loop JITs
+    /// (position = Some) and specialized block bodies (idx route) recompile
+    /// fine.
+    ///
+    pub(super) fn recv_miss_recompile_target(&self) -> Option<RecompileTarget> {
+        match self.jit_type() {
+            JitType::Specialized { idx, .. } => Some(RecompileTarget::Specialized(*idx)),
+            _ => {
+                let position = self.position();
+                if position.is_none() && self.store[self.func_id()].is_block_style() {
+                    None
+                } else {
+                    Some(RecompileTarget::Whole(position))
+                }
+            }
+        }
+    }
+
     fn pmc_same_target_classes(
         &mut self,
         callid: CallSiteId,
@@ -414,32 +439,9 @@ impl<'a> JitContext<'a> {
                     RecvMissMode::Learn => self.store[callid].pmc.entries().len() < 2,
                     RecvMissMode::Plain => false,
                 };
-                // A block ROOT cannot take a whole-recompile: the side exit
-                // recompiles whatever `lfp.func_id()` names as if it were a
-                // method, which rebuilds a block body under the wrong argument
-                // convention (see `guard_const_version`, which learned this
-                // the hard way). Loop JITs (position = Some) and specialized
-                // block bodies (idx route) recompile fine.
-                let target = if use_recompile {
-                    match self.jit_type() {
-                        JitType::Specialized { idx, .. } => {
-                            Some(RecompileTarget::Specialized(*idx))
-                        }
-                        _ => {
-                            let position = self.position();
-                            if position.is_none()
-                                && self.store[self.func_id()].is_block_style()
-                            {
-                                None
-                            } else {
-                                Some(RecompileTarget::Whole(position))
-                            }
-                        }
-                    }
-                } else {
-                    None
-                };
-                let deopt = if let Some(target) = target {
+                let deopt = if let Some(target) =
+                    use_recompile.then(|| self.recv_miss_recompile_target()).flatten()
+                {
                     ir.new_recompile_deopt(state, RecompileReason::BecamePolymorphic, target)
                 } else {
                     ir.new_deopt(state)
@@ -871,7 +873,12 @@ impl<'a> JitContext<'a> {
             self.poison_float_speculations();
         }
 
-        state.send(ir, &self.store, callid, fid, recv_class, outer_lfp);
+        // Behind a class-set guard (or a multi-class dispatch arm) the
+        // receiver is only narrowed to a set, so the call may not bake in
+        // `recv_class`'s JIT body — hand `None` so the lowering dispatches
+        // through the callee's wrapper (see `AsmInst::Call::recv_class`).
+        let proven_recv_class = (!same_target_set_guarded).then_some(recv_class);
+        state.send(ir, &self.store, callid, fid, proven_recv_class, outer_lfp);
 
         Ok(CompileResult::Continue)
     }
@@ -1738,7 +1745,10 @@ impl AbstractState {
         store: &Store,
         callid: CallSiteId,
         callee_fid: FuncId,
-        recv_class: ClassId,
+        // `Some` only when the site proved this exact receiver class — the
+        // licence for the class-keyed direct-entry dispatch. See
+        // `AsmInst::Call::recv_class`.
+        recv_class: Option<ClassId>,
         outer_lfp: Option<Lfp>,
     ) {
         let evict = ir.new_evict();

--- a/monoruby/src/codegen/jitgen/compile/pic.rs
+++ b/monoruby/src/codegen/jitgen/compile/pic.rs
@@ -265,9 +265,28 @@ impl<'a> JitContext<'a> {
             let mut arm = entry.clone();
             if last {
                 // Falling out of the last arm's set is a class the VM never
-                // observed here: deopt, exactly as the monomorphic guard did
-                // for every off-class receiver.
-                let deopt = ir.new_deopt(&arm);
+                // observed here — or one it *undercounted*: the class a
+                // previous mono compile served never misses the bytecode
+                // cache (the JIT handles it), so its PMC count can sit below
+                // the share threshold while the classes that were deopting
+                // pile up counts. If this chain still has arm capacity, exit
+                // through a counter-gated recompile rather than a plain
+                // deopt: each miss here re-executes in the VM, whose cache
+                // miss *does* record the class, so the rebuilt chain admits
+                // it (a 3-class site that warmed monomorphic used to strand
+                // its original hot class in a 2-arm chain, deopting on every
+                // call — the exact shape the mono guard's `Learn` exit was
+                // built to end). At full capacity a rebuild could not add an
+                // arm, so the miss stays a plain deopt, exactly as the
+                // monomorphic guard did for every off-class receiver.
+                let admitted: usize = groups.iter().map(|g| g.classes.len()).sum();
+                let deopt = if admitted < PIC_WAYS
+                    && let Some(target) = self.recv_miss_recompile_target()
+                {
+                    ir.new_recompile_deopt(&arm, RecompileReason::BecamePolymorphic, target)
+                } else {
+                    ir.new_deopt(&arm)
+                };
                 ir.push(AsmInst::GuardClassIn(
                     GP::Rdi,
                     group.classes.clone().into_boxed_slice(),
@@ -454,6 +473,57 @@ mod tests {
             50.times { res << outer(Sa.new) }
             vals = [Sa.new, Sb.new]
             100.times { |i| res << outer(vals[i % 2]) }
+            res.tally.sort_by { |k, _| k.to_s }
+            "#,
+        );
+    }
+
+    /// A multi-class dispatch arm (two subclasses sharing one inherited
+    /// body) must dispatch through the callee's wrapper, not bake one
+    /// member's class-keyed JIT body into the arm: the subclasses here have
+    /// *different ivar layouts*, so running `Pb` through the body compiled
+    /// for `Pa` reads the wrong slot and silently answers `nil`. The
+    /// warm-up gives `Base#val` a `Pa`-keyed body first, which is exactly
+    /// what the unsound direct call used to pick up.
+    #[test]
+    fn pic_multiclass_arm_layout_soundness() {
+        run_test(
+            r#"
+            class Vbase; def val = @v; end
+            class Va < Vbase; def initialize = (@x = 1; @y = 2; @v = :pa); end
+            class Vb < Vbase; def initialize = (@v = :pb); end
+            class Vc; def val = :pc; end
+            pa = Va.new
+            2000.times { pa.val }
+            def probe(o) = o.val
+            vals = [Va.new, Vb.new, Vc.new]
+            res = []
+            3000.times { |i| res << probe(vals[i % 3]) }
+            res.tally.sort_by { |k, _| k.to_s }
+            "#,
+        );
+    }
+
+    /// A site that warms monomorphic and then rotates through three classes:
+    /// the class the mono compile served never misses the bytecode cache, so
+    /// its PMC count sits below the share threshold at the first rebuild and
+    /// the chain rejects it — the last arm's recompiling exit must then feed
+    /// it back through the VM and rebuild with it admitted, instead of
+    /// deopting on every one of its calls forever.
+    #[test]
+    fn pic_readmits_the_warmed_class() {
+        run_test(
+            r#"
+            class Wbase; def val = @v; end
+            class Wa < Wbase; def initialize = (@v = :wa); end
+            class Wb < Wbase; def initialize = (@v = :wb); end
+            class Wc; def val = :wc; end
+            def probe(o) = o.val
+            wa = Wa.new
+            2000.times { probe(wa) }
+            vals = [Wa.new, Wb.new, Wc.new]
+            res = []
+            3000.times { |i| res << probe(vals[i % 3]) }
             res.tally.sort_by { |k, _| k.to_s }
             "#,
         );

--- a/monoruby/src/codegen/jitgen/compile/pic.rs
+++ b/monoruby/src/codegen/jitgen/compile/pic.rs
@@ -101,20 +101,39 @@ impl<'a> JitContext<'a> {
     /// rewrite it as.
     ///
     fn pic_groups(&mut self, callid: CallSiteId) -> Option<Vec<PicGroup>> {
+        // Temporary diagnosis (logging builds only): name every refusal, so a
+        // polymorphic site that stays on the deopting mono guard can be
+        // attributed to the exact gate that turned it away.
+        macro_rules! refuse {
+            ($why:literal) => {{
+                #[cfg(feature = "deopt")]
+                eprintln!(
+                    "### pic refuse [{}] {}",
+                    $why,
+                    self.store[callid].name.map_or_else(
+                        || "?".to_string(),
+                        |n| format!("{:?}", n)
+                    )
+                );
+                return None;
+            }};
+        }
         let callsite = &self.store[callid];
-        let name = callsite.name?;
+        let Some(name) = callsite.name else {
+            refuse!("no-name")
+        };
         // A block argument makes the callee able to capture the frame, and
         // `locals_to_S` inside one arm would describe a frame layout the other
         // arms do not share.
         if callsite.block_fid.is_some() {
-            return None;
+            refuse!("block-fid")
         }
         let pmc = &callsite.pmc;
         let observations = pmc.observations();
         let mut classes: Vec<(ClassId, u32)> =
             pmc.entries().iter().map(|e| (e.recv, e.count)).collect();
         if classes.len() < 2 {
-            return None;
+            refuse!("pmc-mono")
         }
         classes.sort_unstable_by_key(|(_, count)| std::cmp::Reverse(*count));
         let mut groups: Vec<PicGroup> = Vec::with_capacity(classes.len());
@@ -139,16 +158,22 @@ impl<'a> JitContext<'a> {
             // not be allowed to fire mid-chain, where there is nothing to
             // back out to.
             let Some((func_id, visibility)) = self.jit_check_call(class, Some(name)) else {
+                #[cfg(feature = "deopt")]
+                eprintln!("### pic drop [no-resolve] {:?} class={:?}", name, class);
                 continue;
             };
             if self.jit_visibility_blocks(callid, visibility)
                 || self.store[func_id].possibly_capture_without_block()
             {
+                #[cfg(feature = "deopt")]
+                eprintln!("### pic drop [vis/capture] {:?} class={:?}", name, class);
                 continue;
             }
             if let Some(iseq) = self.store[func_id].is_iseq()
                 && self.store[iseq].has_block_arg()
             {
+                #[cfg(feature = "deopt")]
+                eprintln!("### pic drop [callee-block-arg] {:?} class={:?}", name, class);
                 continue;
             }
             // An attr/Struct accessor target whose callsite shape is
@@ -175,13 +200,13 @@ impl<'a> JitContext<'a> {
             }
         }
         if admitted < 2 {
-            return None;
+            refuse!("admitted<2")
         }
         // One target for every class is the class-set guard's case, and one
         // membership guard over the set beats an arm that tests the same set
         // and then falls into the only call sequence there is.
         if groups.len() < 2 {
-            return None;
+            refuse!("single-target")
         }
         Some(groups)
     }

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -283,6 +283,7 @@
 15da316533ccb78f7d7f0508db3a1421	[789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789, 789]	def g(a, b, c) = a * 100 + b * 10 + c\n        def f(...) = g(7, 8, 9, .
 15f147302ae38efd304fc2637a1918d3	["Foo", 1, 2]	class Foo\n              attr_accessor :x, :y\n              def init
 15f8efdf56e50c197d2957085d4fc34f	[true, true, -65536, -2, [1, 2], true, :ts_err, :rtp_err, :frozen_err, true, true, true, true, true, true, true]	nan = 0.0 / 0.0\n            inf = 1.0 / 0.0\n            to_ary_nil 
+16230a3957c6e03b4477391cf1f6923e	[[:wa, 1000], [:wb, 1000], [:wc, 1000]]	class Wbase; def val = @v; end\n            class Wa < Wbase; def in
 16306cca3195a660ca2a70f2fe2de20c	:OVERRIDDEN	class Integer; def <=(o); :OVERRIDDEN; end; end; 3 <= 4
 16367eeef19311ae409181e79f860e76	[3, 12, true, 8, 2, :OVERRIDDEN]	class Float; def +(o); :OVERRIDDEN; end; end\n            # Integer 
 16466a31d783d5117c875050d939771e	["#<data M2 amount=42, unit=#<data M2:...>>", "#<data M2 amount=1, unit=#<data M2 amount=2, unit=\\"m\\">>"]	M2 = Data.define(:amount, :unit)\n            a = M2.allocate\n      
@@ -1692,6 +1693,7 @@
 8c83bb3ecc9ac2c1e06a16d061103347	Array	class C < Array; end\n(C[1,2,2] & [2,3]).class
 8c8d2f17496ea5fcffabf17deeb83042	["a", "b"]	base = "/tmp/monoruby_dir_eachinst_#{Process.pid}_#{rand(100000)}"\n
 8cccb4747cfdbfa71bed00dbdaf949ab	[["RuntimeError", "TypeError"], ["RuntimeError", nil], "TypeError", ["RuntimeError", nil], "ArgumentError"]	def t; yield; rescue Exception => e; [e.class.to_s, (e.cause && e.c
+8cf4538ff9dc5775c6aa04d3c95d1924	[[:pa, 1000], [:pb, 1000], [:pc, 1000]]	class Vbase; def val = @v; end\n            class Va < Vbase; def in
 8cf61f75f99a0e9c53f3bf071168dad0	[:foo]	class P\n              def foo; end\n              def bar; end\n     
 8d0d1f75a100d8c5b699b633c2b00f08	[64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, ["Z-0", "Z-1", "Z-2", "Z-3", "Z-4", "Z-5", "Z-6", "Z-7", "Z-8", "Z-9", "-10", "-11", "-12", "-13", "-14", "-15", "-16", "-17", "-18", "-19"], 20, 201]	r = []\n        copies = []\n        20.times do |i|\n            t = "abc
 8d2889917a7f7f98ff652806d0833021	[195]	"\\xC3".dup.force_encoding("UTF-8").reverse.bytes


### PR DESCRIPTION
Two PIC fixes found while quantifying the residual activerecord deopts (Stage-2 P0), one **correctness** and one performance, plus the diagnosis instrumentation that found them.

## 1. Soundness: a multi-class dispatch arm ran one member's body for every member

A multi-class arm (several receiver classes sharing one inherited body) lowered its call like any proven-class site: the `AsmInst::Call` lowering resolved the **class-keyed JIT entry** (x86) / **guard-free dispatch slot** (aarch64) for the arm's representative class and called it directly, skipping the wrapper's `self.class` re-guard. Every other member of the arm's set then ran a body compiled for the representative.

Repro (silent wrong answers on current master): two subclasses with different ivar layouts sharing an inherited reader behind one arm —

```
monoruby: {pa: 1000, pb: 13, pc: 1000, nil => 987}   # 987 Pb calls read Pa's ivar slot → nil
CRuby:    {pa: 1000, pb: 1000, pc: 1000}
```

`AsmInst::Call::recv_class` is now `Option<ClassId>`: `None` (any set-guarded site — `GuardClassIn` or a multi-class arm) skips the class-keyed lookups, so the call goes through the callee's **wrapper entry**, which re-dispatches on the actual class at runtime. This is also the precondition for ever widening the class-set guard to ISeq targets (the `convert_arg` follow-up below).

## 2. Rebuilding a mono-compiled site as a PIC dropped the class it had been serving

The class a mono body serves never misses the bytecode inline cache (the JIT handles it), so its PMC count sits below the 1/8 share threshold while the deopting classes pile up counts. The `Learn` rebuild (#1156) then produced a chain that **rejected the original hot class on every call, forever** — a 3-class site warmed on one class logged 994 post-rebuild deopts out of its 1000 calls.

The last arm's miss now exits through the same counter-gated `BecamePolymorphic` recompile the mono guard's Learn exit uses (extracted as `recv_miss_recompile_target`, same block-ROOT gate): each miss re-executes in the VM, whose cache miss *does* record the class, and the next rebuild admits it. The repro converges after 20 deopts. A chain already at `PIC_WAYS` capacity keeps the plain deopt (a rebuild could not add an arm), bounding rebuild churn.

## Verification

| | |
|---|---|
| full suite / `gc-stress` suite | **3,501 / 3,500 pass** (incl. 2 new tests) |
| `pic_multiclass_arm_layout_soundness` | byte-equal to CRuby (was 987× nil) |
| `pic_readmits_the_warmed_class` | converges (994 → 20 deopts) |
| activerecord bench ×3 (on #1158) | 2,406–2,525ms — neutral vs base (2,435–2,637ms) |
| fib | 205ms — unchanged |
| both arches | cargo check clean; aarch64 exercises the same `Option` plumbing |

Note: fix 1 routes more traffic through the wrapper's guard-chain miss path, which made the pre-#1158 no-op-branch bug (`jit_class_guard_fail` unbound outside `profile` builds) catastrophic — the two fixes measured 7× *slower* on the pre-#1158 base and neutral on it. #1158 is a prerequisite for this branch.

Also included: two logging-build-only diagnosis commits (deopt-cause tags for counter-gated recompile exits; per-gate `pic_groups` refusal logs) — these are what attributed the remaining steady-state AR deopts to their exact gates, surfacing both bugs. Known residuals from that census, left as follow-ups: `FFI::Pointer#address` (`pic refuse [single-target]` — needs the ISeq class-set guard) and `deserialize` in a block ROOT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_