### PR TITLE
Refresh the unit's version word on whole-method recompile

### DIFF
--- a/monoruby/src/codegen/compiler.rs
+++ b/monoruby/src/codegen/compiler.rs
@@ -375,7 +375,7 @@ impl Codegen {
         };
         let jit_entry = self.jit.label();
         let class_version = self.class_version();
-        let (cache, _, const_map) = self.compile_method(
+        let (cache, class_version_label, const_map) = self.compile_method(
             globals,
             iseq_id,
             self_class,
@@ -383,7 +383,18 @@ impl Codegen {
             class_version,
             Some(reason),
         )?;
-        globals.store[iseq_id].set_cache_map(self_class, cache, const_map);
+        // Refresh the salvage record — including the version word this fresh
+        // body reads. Leaving the previous compile's label in place made
+        // every later salvage stamp a word no live body reads, so the guard
+        // failed again on the next call (270k steady-state misses per
+        // activerecord run, and the ones whose exit had no recovery path
+        // deopted every time).
+        globals.store[iseq_id].set_salvage_record(
+            self_class,
+            class_version_label,
+            cache,
+            const_map,
+        );
         let patch_point = self.jit.get_label_address(&patch_point);
         self.jit.apply_jmp_patch_address(patch_point, &jit_entry);
         Some(())
@@ -416,13 +427,19 @@ impl Codegen {
             class_version,
             Some(reason),
         );
-        let Some((cache, _, const_map)) = compiled else {
+        let Some((cache, class_version_label, const_map)) = compiled else {
             self.jit.finalize();
             return None;
         };
         // Refresh the salvage record so later guard failures re-validate
-        // against what *this* body folded (mirrors the x86 variant).
-        globals.store[iseq_id].set_cache_map(self_class, cache, const_map);
+        // against what *this* body folded, and against the version word it
+        // actually reads (mirrors the x86 variant).
+        globals.store[iseq_id].set_salvage_record(
+            self_class,
+            class_version_label,
+            cache,
+            const_map,
+        );
         let guard = self.a64_gen_class_guard_stub(self_class, &jit_entry);
         self.jit.finalize();
         let guard_addr = self.jit.get_label_address(&guard).as_ptr() as u64;

--- a/monoruby/src/codegen/patch.rs
+++ b/monoruby/src/codegen/patch.rs
@@ -58,8 +58,12 @@ impl Codegen {
         // of recompiling. On aarch64 dispatch goes through `jit_slot`, so the
         // `jit_entry` table exists purely as this record — a republish for the
         // same class simply replaces it.
-        globals.store[iseq_id].add_jit_code(self_class, jit_entry.clone(), class_version_label);
-        globals.store[iseq_id].set_cache_map(self_class, cache, const_map);
+        globals.store[iseq_id].add_jit_code(
+            self_class,
+            jit_entry.clone(),
+            class_version_label.clone(),
+        );
+        globals.store[iseq_id].set_salvage_record(self_class, class_version_label, cache, const_map);
         // Front the compiled `jit_entry` with a self-class guard. The JIT body
         // assumes `self == self_class`, but a single per-method slot is shared
         // by every receiver class of an inherited method — so publishing the
@@ -141,8 +145,11 @@ impl Codegen {
             let patch_point = self.jit.label();
             let guard = self.jit.label();
             self.class_guard_stub(self_class, &patch_point, &jit_entry, &guard);
-            let old_entry =
-                globals.store[iseq_id].add_jit_code(self_class, patch_point, class_version_label);
+            let old_entry = globals.store[iseq_id].add_jit_code(
+                self_class,
+                patch_point,
+                class_version_label.clone(),
+            );
             if let Some(_) = old_entry {
                 globals.store[iseq_id].dump_jit_enntry();
                 panic!(
@@ -151,7 +158,12 @@ impl Codegen {
                     globals.store[iseq_id].name()
                 );
             }
-            globals.store[iseq_id].set_cache_map(self_class, cache, const_map);
+            globals.store[iseq_id].set_salvage_record(
+                self_class,
+                class_version_label,
+                cache,
+                const_map,
+            );
             self.jit.apply_jmp_patch_address(entry, &guard);
             self.jit.finalize();
             Some(())

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -854,13 +854,24 @@ impl ISeqInfo {
             .map(|info| &info.inline_cache_map)
     }
 
-    pub(crate) fn set_cache_map(
+    /// Replace the whole-method unit's salvage record for `self_class` with
+    /// the freshly compiled body's: its inline caches, its const folds, and
+    /// — critically — the class-version word *this* body reads.
+    ///
+    /// The version label must be refreshed on every republish. A salvage
+    /// stamps the label found here (`get_jit_class_version`), so a record
+    /// still naming a superseded compile's cell would "heal" a word no live
+    /// body reads: the guard fails again on the very next call, forever.
+    /// (The loop twin, `set_loop_jit_info`, has always replaced all three.)
+    pub(crate) fn set_salvage_record(
         &mut self,
         self_class: ClassId,
+        class_version_label: DestLabel,
         cache: Vec<InlineCacheEntry>,
         const_map: ConstSalvageMap,
     ) {
         self.jit_entry.get_mut(&self_class).map(|info| {
+            info.class_version_label = class_version_label;
             info.inline_cache_map = cache;
             info.const_map = const_map;
         });


### PR DESCRIPTION
Follow-up to #1161, fixing the same bug at its root for whole-method units.

## The bug

A compilation unit's class-version guard reads a `const_i32` cell created by that compile. The unit's salvage record kept the label of the **first** compile's cell forever: `add_jit_code` wrote it, and the recompile path (`set_cache_map`) replaced the inline caches and const folds but left the label alone — discarding the fresh body's own (`let (cache, _, const_map) = self.compile_method(...)`).

So after any whole-method recompile, every salvage stamped a word no live body reads. The guard failed again on the very next call, and the cycle repeated for the life of the process.

`set_loop_jit_info` (the loop twin) has always replaced all three parts, so loop units never had this.

## Measured

ruby-bench activerecord workload, steady-state phase (30 iterations), instrumented to log the raw `(global, cached)` pair at each whole-method version-guard miss:

| | before | after |
|---|---|---|
| whole-method version-guard misses | **270,617** | **0** |

Every one of those was against a stale cell (cached 18548, 18442, 18005, … against a global version pinned at 18553 with zero steady-state bumps).

**Wall clock is unchanged.** Interleaved A/B against master, 4 runs each of the activerecord benchmark: 1,933ms base vs 1,918ms with the fix — inside a run-to-run spread of 1,844–2,000ms. The salvage path is evidently cheap enough that removing a quarter-million of them does not move the benchmark. This is a correctness/consistency fix, not a speedup: a record naming a superseded compile's cell is simply wrong, and it is what made #1161's symptom possible in the first place (that change gave specialized entries their own cell to stamp, which repaired the specialized guards but left whole-method units, which have no handle other than this record, still stale).

## The change

Rename `set_cache_map` to `set_salvage_record` and have it replace all three parts of the record, version label included, so a republish cannot leave a stale one behind. Both recompile sites (x86-64 and aarch64) now pass the fresh label instead of dropping it.

`cargo test --release`: all suites green.

## Not fixed here

The largest remaining steady-state deopt source is `FFI::Function#convert_arg [:00039]` at 67,530 deopts per run. Measurement rules out both the class-version guard (0 steady misses after this change) and the same-target class-set guard (3,420 misses, and giving its miss a learn path changed nothing — that experiment was reverted). It is a third mechanism, still unidentified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_