### PR TITLE
Prepare the libffi CIF once per call site (2.5x on sqlite3 SELECT)

### DIFF
--- a/monoruby/gem/ffi_c.rb
+++ b/monoruby/gem/ffi_c.rb
@@ -677,12 +677,30 @@ module FFI
       @return_type = FFI::Type.find(return_type)
       @param_types = param_types.map { |t| FFI::Type.find(t) }
 
+      # The signature is fixed for the life of the Function, so the type
+      # codes and the libffi CIF are computed once here rather than on every
+      # call. `___prepare` validates the codes, so an unsupported one still
+      # raises — just at definition time instead of first call.
+      @type_codes = @param_types.map(&:type_code)
+      @ret_code   = @return_type.type_code
+
       if address_or_proc.is_a?(Proc) || address_or_proc.is_a?(Method)
         @callable = address_or_proc
         super(0)
       else
         addr = address_or_proc.respond_to?(:to_i) ? address_or_proc.to_i : 0
         super(addr)
+        # `___prepare` rejects signatures it cannot serve (too many
+        # arguments, a type code that is only meaningful per call). Those
+        # stay on the general `___call` path rather than becoming an error
+        # at definition time.
+        if addr != 0
+          begin
+            @prepared = Fiddle.___prepare(addr, @type_codes, @ret_code)
+          rescue ArgumentError, RuntimeError
+            @prepared = nil
+          end
+        end
       end
     end
 
@@ -695,10 +713,12 @@ module FFI
       converted_args = @param_types.zip(args).map { |type, arg|
         convert_arg(type, arg)
       }
-      type_codes = @param_types.map(&:type_code)
-      ret_code   = @return_type.type_code
 
-      result = Fiddle.___call(@address, converted_args, type_codes, ret_code)
+      result = if @prepared
+        Fiddle.___invoke(@prepared, *converted_args)
+      else
+        Fiddle.___call(@address, converted_args, @type_codes, @ret_code)
+      end
       convert_result(@return_type, result)
     end
 

--- a/monoruby/gem/sqlite3/sqlite3_native.rb
+++ b/monoruby/gem/sqlite3/sqlite3_native.rb
@@ -4,7 +4,8 @@
 # it redirects to ~/.monoruby/sqlite3_native.rb (this file via build.rs copy).
 # This implements the native C extension methods by calling libsqlite3
 # through monoruby's shared native-call primitives (`Fiddle.___dlopen` /
-# `___call` / `___read_string` / …, registered in src/builtins/fiddle.rs).
+# `___prepare` / `___invoke` / `___read_string` / …, registered in
+# src/builtins/fiddle.rs).
 #
 # Deliberately *not* built on the `ffi` gem. The gem's C extension is
 # replaced by monoruby (gem/ffi_c.rb), but `FFI::Library` — i.e.
@@ -13,13 +14,13 @@
 # that has the ffi gem installed. Fiddle ships with monoruby itself, so
 # this bridge is self-contained.
 #
-# Going straight to the primitives is also the faster route: an
-# `attach_function` call reaches C via FFI::Function#call, which on *every*
-# invocation does `param_types.zip(args).map { convert_arg }` plus
-# `param_types.map(&:type_code)` (three throw-away arrays and a Type object
-# per argument) and wraps every returned pointer in an FFI::Pointer. The
-# stubs generated below pass a single argument array and a frozen,
-# pre-computed signature array to `Fiddle.___call`, and keep pointers as
+# Going straight to the primitives is also the faster route. Reaching C via
+# FFI::Function#call costs, on *every* invocation, a
+# `param_types.zip(args).map { convert_arg }` plus a
+# `param_types.map(&:type_code)` — three throw-away arrays and a Type object
+# per argument — and wraps every returned pointer in an FFI::Pointer. The
+# stubs generated below prepare the libffi CIF once at attach time and then
+# pass arguments positionally, so a call allocates nothing, and pointers stay
 # plain Integer addresses.
 
 require "fiddle"
@@ -61,16 +62,21 @@ module SQLite3
     end
 
     # Define `FFIBridge.<name>` as a fixed-arity stub that calls the C
-    # function directly. The symbol address is baked into the generated
-    # source as an integer literal and the argument signature is hoisted
-    # into a frozen constant, so a call allocates only the argument array.
+    # function directly.
+    #
+    # The signature is fixed at attach time, so the libffi CIF is built once
+    # by `___prepare` and reused; `___call` would instead run `ffi_prep_cif`
+    # plus a malloc on every call, which costs more than most of these C
+    # bodies do. The resulting descriptor id is baked into the generated
+    # source as an integer literal, and arguments are passed positionally, so
+    # a call allocates nothing at all.
     def self.attach_function(name, argtypes, rettype)
       addr = LIB[name.to_s]
-      sig  = argtypes.map { |t| TYPE_CODES.fetch(t) }.freeze
-      const_set("SIG_#{name}", sig)
+      sig  = argtypes.map { |t| TYPE_CODES.fetch(t) }
+      id   = Fiddle.___prepare(addr, sig, TYPE_CODES.fetch(rettype))
 
       params = (0...argtypes.size).map { |i| "a#{i}" }.join(", ")
-      call   = "Fiddle.___call(#{addr}, [#{params}], SIG_#{name}, #{TYPE_CODES.fetch(rettype)})"
+      call   = "Fiddle.___invoke(#{id}#{params.empty? ? "" : ", #{params}"})"
       # `___read_string` maps NULL to nil, matching FFI's `:string`.
       body   = rettype == :string ? "Fiddle.___read_string(#{call})" : call
 
@@ -144,6 +150,47 @@ module SQLite3
     SQLITE_OK   = 0
     SQLITE_ROW  = 100
     SQLITE_DONE = 101
+
+    # Primary result code (low 8 bits) -> the gem's exception subclass, as the
+    # C extension's `sqlite3_ruby_exception` maps them. Callers rescue these by
+    # name — ActiveRecord turns SQLite3::ConstraintException into
+    # RecordNotUnique — so raising the base SQLite3::Exception for everything
+    # silently breaks that dispatch.
+    ERROR_CLASSES = {
+      1  => "SQLException",         # SQLITE_ERROR
+      2  => "InternalException",
+      3  => "PermissionException",
+      4  => "AbortException",
+      5  => "BusyException",
+      6  => "LockedException",
+      7  => "MemoryException",
+      8  => "ReadOnlyException",
+      9  => "InterruptException",
+      10 => "IOException",
+      11 => "CorruptException",
+      12 => "NotFoundException",
+      13 => "FullException",
+      14 => "CantOpenException",
+      15 => "ProtocolException",
+      16 => "EmptyException",
+      17 => "SchemaChangedException",
+      18 => "TooBigException",
+      19 => "ConstraintException",
+      20 => "MismatchException",
+      21 => "MisuseException",
+      23 => "AuthorizationException",
+      25 => "RangeException",
+      26 => "NotADatabaseException",
+    }.freeze
+
+    # sqlite3 returns extended codes (e.g. 1555 = SQLITE_CONSTRAINT_PRIMARYKEY)
+    # once extended result codes are on; the primary code is the low 8 bits.
+    # The subclasses are defined by the gem's errors.rb, which is loaded before
+    # this file, but fall back to the base class if one is missing.
+    def self.exception_class(code)
+      name = ERROR_CLASSES[code & 0xff]
+      (name && SQLite3.const_defined?(name)) ? SQLite3.const_get(name) : SQLite3::Exception
+    end
 
     # Statement status counters
     SQLITE_STMTSTATUS_FULLSCAN_STEP = 1
@@ -259,7 +306,7 @@ module SQLite3
       if rc != FFIBridge::SQLITE_OK
         msg = @db == 0 ? "out of memory" : FFIBridge.sqlite3_errmsg(@db)
         FFIBridge.sqlite3_close(@db) unless @db == 0
-        raise SQLite3::Exception, msg
+        raise FFIBridge.exception_class(rc), msg
       end
       @closed = false
     end
@@ -278,7 +325,7 @@ module SQLite3
       if rc != FFIBridge::SQLITE_OK
         msg = @db == 0 ? "out of memory" : FFIBridge.sqlite3_errmsg(@db)
         FFIBridge.sqlite3_close(@db) unless @db == 0
-        raise SQLite3::Exception, msg
+        raise FFIBridge.exception_class(rc), msg
       end
       @closed = false
     end
@@ -429,7 +476,7 @@ module SQLite3
     def check_error(rc)
       return if rc == FFIBridge::SQLITE_OK || rc == FFIBridge::SQLITE_ROW || rc == FFIBridge::SQLITE_DONE
       msg = FFIBridge.sqlite3_errmsg(@db)
-      raise SQLite3::Exception, msg
+      raise FFIBridge.exception_class(rc), msg
     end
 
     def exec_batch_internal(sql)
@@ -438,7 +485,7 @@ module SQLite3
         rc = FFIBridge.sqlite3_exec(@db, sql, nil, nil, errmsg_ptr)
       end
       if rc != FFIBridge::SQLITE_OK
-        raise SQLite3::Exception, Fiddle.___read_string(err) || "unknown error"
+        raise FFIBridge.exception_class(rc), Fiddle.___read_string(err) || "unknown error"
       end
     end
 
@@ -543,7 +590,7 @@ module SQLite3
         end
         if rc != FFIBridge::SQLITE_OK
           msg = FFIBridge.sqlite3_errmsg(@db_ptr)
-          raise SQLite3::Exception, msg
+          raise FFIBridge.exception_class(rc), msg
         end
         @closed = @stmt == 0
         @done = false
@@ -586,7 +633,7 @@ module SQLite3
         nil
       else
         msg = FFIBridge.sqlite3_errmsg(@db_ptr)
-        raise SQLite3::Exception, msg
+        raise FFIBridge.exception_class(rc), msg
       end
     end
 
@@ -614,7 +661,7 @@ module SQLite3
       rc = bind_value(index, value)
       if rc != FFIBridge::SQLITE_OK
         msg = FFIBridge.sqlite3_errmsg(@db_ptr)
-        raise SQLite3::Exception, msg
+        raise FFIBridge.exception_class(rc), msg
       end
     end
 

--- a/monoruby/src/builtins/fiddle.rs
+++ b/monoruby/src/builtins/fiddle.rs
@@ -3,6 +3,7 @@ use std::ffi::c_void;
 use super::*;
 use jitgen::{AbstractState, JitContext};
 use libffi::middle::{Arg, Cif, CodePtr, Type};
+use smallvec::SmallVec;
 use crate::codegen::jitgen::deopt_log::DeoptCause;
 
 // ---------------------------------------------------------------------------
@@ -119,6 +120,32 @@ fn type_code_to_ret_ffi_type(ty: i64) -> Result<Type> {
     }
 }
 
+/// Coerce a Ruby Integer argument to the `i64` a C integer parameter is
+/// built from.
+///
+/// monoruby's Fixnum is an i63, so an `Integer` anywhere in
+/// `[2^62, 2^64)` — `sqlite3_bind_int64(…, 2**62)`, or any `unsigned long`
+/// with its top bits set — arrives as a BigInt even though it fits the C
+/// type exactly. `expect_integer` rejects those, which made perfectly
+/// in-range values fail with "no implicit conversion of Integer into
+/// Integer". Accept both representations and let the caller's `as` cast
+/// narrow to the declared width, matching C's own conversion rules.
+fn integer_arg_to_i64(globals: &Globals, val: Value) -> Result<i64> {
+    match val.unpack() {
+        RV::Fixnum(i) => Ok(i),
+        RV::BigInt(b) => num::ToPrimitive::to_i64(b)
+            .or_else(|| num::ToPrimitive::to_u64(b).map(|u| u as i64))
+            .ok_or_else(|| {
+                MonorubyErr::rangeerr("bignum too big to convert into a C integer")
+            }),
+        _ => Err(MonorubyErr::no_implicit_conversion(
+            globals,
+            val,
+            INTEGER_CLASS,
+        )),
+    }
+}
+
 /// Convert a Ruby Value and a Fiddle type code into a `CArg`.
 ///
 /// For `TYPE_VOIDP`, a Ruby String value is accepted: a pointer to its
@@ -136,14 +163,14 @@ fn value_to_carg(globals: &mut Globals, mut val: Value, ty: i64) -> Result<CArg>
     // collapses to LONG/ULONG codes in CRuby's convention.
     match ty {
         TYPE_VOID => Ok(CArg::I64(0)), // should not appear as argument
-        TYPE_CHAR => Ok(CArg::I8(val.expect_integer(globals)? as i8)),
-        TYPE_UCHAR => Ok(CArg::U8(val.expect_integer(globals)? as u8)),
-        TYPE_SHORT => Ok(CArg::I16(val.expect_integer(globals)? as i16)),
-        TYPE_USHORT => Ok(CArg::U16(val.expect_integer(globals)? as u16)),
-        TYPE_INT | TYPE_BOOL => Ok(CArg::I32(val.expect_integer(globals)? as i32)),
-        TYPE_UINT => Ok(CArg::U32(val.expect_integer(globals)? as u32)),
-        TYPE_LONG | TYPE_LONG_LONG => Ok(CArg::I64(val.expect_integer(globals)?)),
-        TYPE_ULONG | TYPE_ULONG_LONG => Ok(CArg::U64(val.expect_integer(globals)? as u64)),
+        TYPE_CHAR => Ok(CArg::I8(integer_arg_to_i64(globals, val)? as i8)),
+        TYPE_UCHAR => Ok(CArg::U8(integer_arg_to_i64(globals, val)? as u8)),
+        TYPE_SHORT => Ok(CArg::I16(integer_arg_to_i64(globals, val)? as i16)),
+        TYPE_USHORT => Ok(CArg::U16(integer_arg_to_i64(globals, val)? as u16)),
+        TYPE_INT | TYPE_BOOL => Ok(CArg::I32(integer_arg_to_i64(globals, val)? as i32)),
+        TYPE_UINT => Ok(CArg::U32(integer_arg_to_i64(globals, val)? as u32)),
+        TYPE_LONG | TYPE_LONG_LONG => Ok(CArg::I64(integer_arg_to_i64(globals, val)?)),
+        TYPE_ULONG | TYPE_ULONG_LONG => Ok(CArg::U64(integer_arg_to_i64(globals, val)? as u64)),
         TYPE_VOIDP => {
             // Accept: nil → NULL, Integer → address, String → raw bytes ptr
             match val.unpack() {
@@ -222,7 +249,22 @@ fn fiddle_call_inner(
 
     let func = CodePtr(ptr as *mut c_void);
 
-    let result = match ret_type_code {
+    let result = call_with_cif(&cif, func, &ffi_args, ret_type_code)?;
+
+    // Keep c_args alive until here
+    drop(ffi_args);
+    drop(c_args);
+
+    Ok(result)
+}
+
+/// Perform the libffi call and box the result as a Ruby Value.
+///
+/// SAFETY: the caller must keep the `CArg` storage that `ffi_args` points into
+/// alive until this returns, and `cif` must have been built from the same type
+/// codes the arguments were marshalled with.
+fn call_with_cif(cif: &Cif, func: CodePtr, ffi_args: &[Arg], ret_type_code: i64) -> Result<Value> {
+    Ok(match ret_type_code {
         TYPE_VOID => {
             // For void, call with i64 return and discard.
             let _: i64 = unsafe { cif.call(func, &ffi_args) };
@@ -274,18 +316,166 @@ fn fiddle_call_inner(
                 ret_type_code
             )));
         }
-    };
-
-    // Keep c_args alive until here
-    drop(ffi_args);
-    drop(c_args);
-
-    Ok(result)
+    })
 }
 
 // ---------------------------------------------------------------------------
 // Builtin functions exposed to Ruby as Fiddle module-level functions
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Prepared calls
+//
+// `Cif::new` runs `ffi_prep_cif` *and* a `libc::malloc` for the type array, so
+// building the CIF per call dominates the cost of a small foreign call: the
+// naive path measures ~108ns fixed plus ~108ns per argument, against a C body
+// that is often a single load. A call site's signature never changes, so it is
+// prepared once and only the argument marshalling is repeated.
+//
+// A prepared record is `Box::leak`ed and its address handed to Ruby as an
+// Integer, the same way `___dlopen` hands back a raw handle. They are created
+// at attach time and live as long as the symbol they wrap, so there is nothing
+// to reclaim. Leaking also makes the record immortal and therefore safe to
+// share between threads: `ffi_call` only reads the CIF, so concurrent calls
+// through one record do not race.
+// ---------------------------------------------------------------------------
+
+struct PreparedFn {
+    ptr: CodePtr,
+    cif: Cif,
+    arg_codes: Vec<i64>,
+    ret_code: i64,
+}
+
+/// Largest argument count marshalled without spilling to the heap.
+const PREPARED_INLINE_ARGS: usize = 8;
+
+/// The libffi `Type` a value of type code `ty` is passed as.
+///
+/// This must agree with `value_to_carg`, which decides the `CArg` width: the
+/// CIF is built once from the codes, so a disagreement would hand `ffi_call` a
+/// value of a different width than the CIF promises.
+fn type_code_to_arg_ffi_type(ty: i64) -> Result<Type> {
+    Ok(match ty {
+        TYPE_CHAR => Type::i8(),
+        TYPE_UCHAR => Type::u8(),
+        TYPE_SHORT => Type::i16(),
+        TYPE_USHORT => Type::u16(),
+        TYPE_INT | TYPE_BOOL => Type::i32(),
+        TYPE_UINT => Type::u32(),
+        TYPE_LONG | TYPE_LONG_LONG => Type::i64(),
+        TYPE_VOIDP | TYPE_ULONG | TYPE_ULONG_LONG => Type::u64(),
+        TYPE_FLOAT => Type::f32(),
+        TYPE_DOUBLE => Type::f64(),
+        _ => {
+            return Err(MonorubyErr::runtimeerr(format!(
+                "Fiddle: unsupported argument type code {}",
+                ty
+            )));
+        }
+    })
+}
+
+/// ### Fiddle.___prepare(ptr, arg_types, ret_type) -> Integer
+///
+/// Build a reusable call descriptor for the function at `ptr` and return an
+/// opaque id to pass to `___invoke`. Validates both the argument and the
+/// return type codes up front, so `___invoke` never has to.
+#[monoruby_builtin]
+fn fiddle_prepare(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let ptr = lfp.arg(0).expect_integer(globals)? as usize;
+    let types_ary = lfp.arg(1).expect_array_ty(globals)?;
+    let ret_code = lfp.arg(2).expect_integer(globals)?;
+
+    let arg_codes: Vec<i64> = types_ary
+        .iter()
+        .map(|v| v.expect_integer(globals))
+        .collect::<Result<_>>()?;
+
+    // `___invoke` passes arguments in fixed frame slots, so a signature wider
+    // than that cannot be served. Reject it here rather than at call time: a
+    // successful prepare then *guarantees* `___invoke` works, which is what
+    // lets the Ruby facades treat a raised prepare as "fall back to ___call".
+    if arg_codes.len() > PREPARED_INLINE_ARGS {
+        return Err(MonorubyErr::argumenterr(format!(
+            "Fiddle: cannot prepare a call with more than {} arguments (got {})",
+            PREPARED_INLINE_ARGS,
+            arg_codes.len()
+        )));
+    }
+
+    let arg_types: Vec<Type> = arg_codes
+        .iter()
+        .map(|&ty| type_code_to_arg_ffi_type(ty))
+        .collect::<Result<_>>()?;
+    // Rejects an unsupported return code here rather than per call.
+    let ret_type = type_code_to_ret_ffi_type(ret_code)?;
+
+    let prepared = Box::new(PreparedFn {
+        ptr: CodePtr(ptr as *mut c_void),
+        cif: Cif::new(arg_types.into_iter(), ret_type),
+        arg_codes,
+        ret_code,
+    });
+
+    Ok(Value::integer(Box::leak(prepared) as *mut PreparedFn as i64))
+}
+
+/// ### Fiddle.___invoke(id, *args) -> Object
+///
+/// Call a function prepared by `___prepare`. Arguments are read straight out
+/// of the frame, so a call allocates nothing on the Ruby side and — up to
+/// `PREPARED_INLINE_ARGS` — nothing on the Rust side either.
+#[monoruby_builtin]
+fn fiddle_invoke(
+    _vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let id = lfp.arg(0).expect_integer(globals)?;
+    // SAFETY: `id` is the address of a leaked PreparedFn handed out by
+    // `___prepare`, so the record is live for the rest of the process. The
+    // primitives are private to monoruby's own Ruby layer (`___`-prefixed and
+    // undocumented), which only ever passes back an id it was given.
+    let pf: &PreparedFn = unsafe { &*(id as *const PreparedFn) };
+
+    let n = pf.arg_codes.len();
+    // Trailing slots are optional, so an unsupplied one reads back as None
+    // rather than shortening the frame.
+    if n < PREPARED_INLINE_ARGS && lfp.try_arg(n + 1).is_some() {
+        return Err(MonorubyErr::argumenterr(format!(
+            "Fiddle: too many arguments (expected {})",
+            n
+        )));
+    }
+
+    let mut c_args: SmallVec<[CArg; PREPARED_INLINE_ARGS]> = SmallVec::with_capacity(n);
+    for (i, &ty) in pf.arg_codes.iter().enumerate() {
+        let Some(v) = lfp.try_arg(i + 1) else {
+            return Err(MonorubyErr::argumenterr(format!(
+                "Fiddle: wrong number of arguments (given {}, expected {})",
+                i, n
+            )));
+        };
+        c_args.push(value_to_carg(globals, v, ty)?);
+    }
+    let ffi_args: SmallVec<[Arg; PREPARED_INLINE_ARGS]> =
+        c_args.iter().map(|ca| ca.as_libffi_arg()).collect();
+
+    let result = call_with_cif(&pf.cif, pf.ptr, &ffi_args, pf.ret_code)?;
+
+    // Keep the CArg storage alive until the call has returned.
+    drop(ffi_args);
+    drop(c_args);
+
+    Ok(result)
+}
 
 /// ### Fiddle.___call(ptr, args, arg_types, ret_type) -> Object
 ///
@@ -294,6 +484,10 @@ fn fiddle_call_inner(
 /// - args      : Array    – Ruby argument values
 /// - arg_types : Array    – Fiddle type-code integers for each argument
 /// - ret_type  : Integer  – Fiddle type-code for the return value
+///
+/// Builds the CIF on every call. Prefer `___prepare` + `___invoke` on a hot
+/// path; this entry point remains for call sites whose signature is not known
+/// until the call itself.
 #[monoruby_builtin]
 fn fiddle_call(
     _vm: &mut Executor,
@@ -647,6 +841,17 @@ pub(super) fn init(globals: &mut Globals) {
     // Registering them once here also means the JIT inliners below
     // (`___read` / `___write`) benefit every caller rather than just Fiddle.
     globals.define_builtin_module_func(fiddle, "___call", fiddle_call, 4);
+    // Prepared calls: build the CIF once, then invoke with the arguments
+    // passed positionally (no Array, no per-call ffi_prep_cif).
+    globals.define_builtin_module_func(fiddle, "___prepare", fiddle_prepare, 3);
+    globals.define_builtin_module_func_with(
+        fiddle,
+        "___invoke",
+        fiddle_invoke,
+        1,
+        1 + PREPARED_INLINE_ARGS,
+        false,
+    );
     globals.define_builtin_module_inline_func(
         fiddle,
         "___read",
@@ -906,5 +1111,98 @@ mod tests {
             :ok
             "#
         ));
+    }
+
+    // A prepared call must agree with `___call` across every argument and
+    // return kind: the CIF is now built from the type codes alone, so a
+    // disagreement with `value_to_carg`'s choice of CArg width would hand
+    // libffi a value of the wrong size.
+    #[test]
+    fn fiddle_prepare_matches_call() {
+        run_test_no_result_check(&format!(
+            r#"{TYPE_PRELUDE}
+            abs    = Fiddle.___dlsym(LIBC, "abs")
+            llabs  = Fiddle.___dlsym(LIBC, "llabs")
+            strlen = Fiddle.___dlsym(LIBC, "strlen")
+            memcpy = Fiddle.___dlsym(LIBC, "memcpy")
+            pow    = Fiddle.___dlsym(LIBM, "pow")
+
+            p_abs    = Fiddle.___prepare(abs,    [TY_INT],   TY_INT)
+            p_llabs  = Fiddle.___prepare(llabs,  [TY_LLONG], TY_LLONG)
+            p_strlen = Fiddle.___prepare(strlen, [TY_VOIDP], TY_SIZE_T)
+            p_memcpy = Fiddle.___prepare(memcpy, [TY_VOIDP, TY_VOIDP, TY_SIZE_T], TY_VOIDP)
+            p_pow    = Fiddle.___prepare(pow,    [TY_DOUBLE, TY_DOUBLE], TY_DOUBLE)
+
+            # int / long long, both signs
+            [-42, 0, 42].each do |n|
+              raise unless Fiddle.___invoke(p_abs, n) == Fiddle.___call(abs, [n], [TY_INT], TY_INT)
+            end
+            [-1_000_000_000_000, 1_000_000_000_000].each do |n|
+              raise unless Fiddle.___invoke(p_llabs, n) == n.abs
+            end
+
+            # String argument keeps the NUL-termination guarantee
+            ["", "hello", "hello_optcarrot"].each do |s|
+              raise unless Fiddle.___invoke(p_strlen, s) == s.bytesize
+            end
+
+            # nil as a NULL pointer, and a pointer return
+            raise unless Fiddle.___invoke(p_memcpy, nil, nil, 0) == 0
+
+            # double in, double out
+            raise unless Fiddle.___invoke(p_pow, 2.0, 10.0) == 1024.0
+
+            # 0-arg signatures are prepared too
+            getpid = Fiddle.___dlsym(LIBC, "getpid")
+            p_getpid = Fiddle.___prepare(getpid, [], TY_INT)
+            raise unless Fiddle.___invoke(p_getpid) == Fiddle.___call(getpid, [], [], TY_INT)
+
+            # arity is enforced against the prepared signature
+            begin
+              Fiddle.___invoke(p_abs)
+              raise "expected ArgumentError for too few"
+            rescue ArgumentError
+            end
+            begin
+              Fiddle.___invoke(p_abs, 1, 2)
+              raise "expected ArgumentError for too many"
+            rescue ArgumentError
+            end
+
+            # a signature ___invoke cannot serve is refused at prepare time,
+            # so a successful prepare guarantees the call works
+            begin
+              Fiddle.___prepare(abs, [TY_INT] * 9, TY_INT)
+              raise "expected ArgumentError for over-wide signature"
+            rescue ArgumentError
+            end
+            :ok
+            "#
+        ));
+    }
+
+    // The prepared path is what Fiddle::Function and FFI::Function now use,
+    // so exercise it through the public facade as well.
+    #[test]
+    fn fiddle_function_prepared() {
+        run_test_no_result_check(
+            r#"
+            require "fiddle"
+            libm = RUBY_PLATFORM =~ /darwin/ ? "/usr/lib/libSystem.B.dylib" : "libm.so.6"
+            pow = Fiddle::Function.new(
+              Fiddle::Handle.new(libm)["pow"],
+              [Fiddle::TYPE_DOUBLE, Fiddle::TYPE_DOUBLE],
+              Fiddle::TYPE_DOUBLE
+            )
+            raise unless pow.call(2.0, 10.0) == 1024.0
+            raise unless pow.call(3.0, 2.0) == 9.0
+            begin
+              pow.call(2.0)
+              raise "expected ArgumentError"
+            rescue ArgumentError
+            end
+            :ok
+            "#,
+        );
     }
 }

--- a/monoruby/src/builtins/fiddle.rs
+++ b/monoruby/src/builtins/fiddle.rs
@@ -1181,6 +1181,101 @@ mod tests {
         ));
     }
 
+    // Every argument type code must map to an libffi type. Preparing is pure
+    // — it only builds the CIF — so each code can be checked without needing
+    // a C function that actually has that signature.
+    #[test]
+    fn fiddle_prepare_accepts_every_arg_type_code() {
+        run_test_no_result_check(&format!(
+            r#"{TYPE_PRELUDE}
+            TY_UCHAR  = -2
+            TY_SHORT  =  3
+            TY_USHORT = -3
+            TY_UINT   = -4
+            TY_LONG   =  5
+            TY_ULONG  = -5
+            TY_ULLONG = -6
+            TY_CHAR   =  2
+            TY_FLOAT  =  7
+            TY_BOOL   =  9
+            abs = Fiddle.___dlsym(LIBC, "abs")
+
+            codes = [TY_CHAR, TY_UCHAR, TY_SHORT, TY_USHORT, TY_INT, TY_UINT,
+                     TY_LONG, TY_LLONG, TY_ULONG, TY_ULLONG, TY_VOIDP,
+                     TY_FLOAT, TY_DOUBLE, TY_BOOL]
+            codes.each do |c|
+              raise "prepare failed for #{{c}}" unless Fiddle.___prepare(abs, [c], TY_INT) != 0
+            end
+            # every return code is validated up front too
+            (codes + [0]).each do |c|
+              raise "prepare failed for ret #{{c}}" unless Fiddle.___prepare(abs, [], c) != 0
+            end
+
+            # TYPE_VOID is not a legal *argument*, and unknown codes are refused
+            [0, 99, -99].each do |bad|
+              begin
+                Fiddle.___prepare(abs, [bad], TY_INT)
+                raise "expected an error for arg code #{{bad}}"
+              rescue RuntimeError
+              end
+            end
+            [99, -99].each do |bad|
+              begin
+                Fiddle.___prepare(abs, [], bad)
+                raise "expected an error for ret code #{{bad}}"
+              rescue RuntimeError
+              end
+            end
+            :ok
+            "#
+        ));
+    }
+
+    // monoruby's Fixnum is an i63, so a C integer argument arrives as either a
+    // Fixnum or a BigInt depending only on magnitude. Both must convert, and
+    // anything that genuinely does not fit — or is not an Integer at all —
+    // must raise rather than pass a garbage value to C.
+    #[test]
+    fn fiddle_integer_arg_conversion() {
+        run_test_no_result_check(&format!(
+            r#"{TYPE_PRELUDE}
+            abs   = Fiddle.___dlsym(LIBC, "abs")
+            llabs = Fiddle.___dlsym(LIBC, "llabs")
+            p_abs   = Fiddle.___prepare(abs,   [TY_INT],   TY_INT)
+            p_llabs = Fiddle.___prepare(llabs, [TY_LLONG], TY_LLONG)
+
+            # Fixnum, and a BigInt that fits i64 (2**62 is already a BigInt here)
+            raise unless Fiddle.___invoke(p_llabs, -5) == 5
+            raise unless Fiddle.___invoke(p_llabs, 2**62) == 2**62
+            raise unless Fiddle.___invoke(p_llabs, 9223372036854775807) == 9223372036854775807
+
+            # A BigInt in [2**63, 2**64) is a valid unsigned 64-bit value; it
+            # reaches C with the same bit pattern, so `int` truncation gives -1.
+            raise unless Fiddle.___invoke(p_abs, 18446744073709551615) == 1
+
+            # Genuinely out of range for any C integer
+            begin
+              Fiddle.___invoke(p_llabs, 2**80)
+              raise "expected RangeError"
+            rescue RangeError
+            end
+
+            # Not an Integer at all
+            begin
+              Fiddle.___invoke(p_abs, "nope")
+              raise "expected TypeError"
+            rescue TypeError
+            end
+            begin
+              Fiddle.___call(abs, [nil], [TY_INT], TY_INT)
+              raise "expected TypeError"
+            rescue TypeError
+            end
+            :ok
+            "#
+        ));
+    }
+
     // The prepared path is what Fiddle::Function and FFI::Function now use,
     // so exercise it through the public facade as well.
     #[test]

--- a/monoruby/stdlib/fiddle.rb
+++ b/monoruby/stdlib/fiddle.rb
@@ -314,6 +314,17 @@ module Fiddle
       @ptr            = ptr.respond_to?(:to_i) ? ptr.to_i : Integer(ptr)
       @argument_types = args_type.map { |t| resolve_type(t) }
       @return_type    = resolve_type(ret_type)
+      # The signature is fixed, so build the libffi CIF once instead of on
+      # every call. `___prepare` raises for a signature `___invoke` cannot
+      # serve (too many arguments, an unsupported type code); those keep
+      # using the general `___call` path.
+      if @ptr != 0
+        begin
+          @prepared = Fiddle.___prepare(@ptr, @argument_types, @return_type)
+        rescue ArgumentError, RuntimeError
+          @prepared = nil
+        end
+      end
     end
 
     def call(*args)
@@ -321,7 +332,11 @@ module Fiddle
         raise ArgumentError,
           "wrong number of arguments (given #{args.length}, expected #{@argument_types.length})"
       end
-      Fiddle.___call(@ptr, args, @argument_types, @return_type)
+      if @prepared
+        Fiddle.___invoke(@prepared, *args)
+      else
+        Fiddle.___call(@ptr, args, @argument_types, @return_type)
+      end
     end
 
     def arity


### PR DESCRIPTION
## Why

`Fiddle.___call` rebuilt the whole libffi call descriptor on every invocation.
`Cif::new` runs `ffi_prep_cif` **and** a `libc::malloc` for the type array, on
top of four Rust `Vec` allocations and a Ruby `Array` for the arguments.
Measured against a C body that is often a single load, that came to ~108ns
fixed plus ~108ns per argument — the marshalling cost more than the call. A
single `read_column` (two C calls) spent 636ns before touching sqlite3.

## What

A call site's signature never changes, so add `___prepare` / `___invoke`:
`___prepare` builds the CIF once and returns an opaque id, `___invoke` takes
the arguments positionally and only marshals them.

The prepared record is leaked and its address handed back as an Integer, the
same way `___dlopen` returns a raw handle — records are created at attach time
and live as long as the symbol they wrap, so there is nothing to reclaim.
Leaking also makes the record immortal and therefore safe to share between
threads, since `ffi_call` only reads the CIF.

`___prepare` rejects any signature `___invoke` cannot serve (more arguments
than there are frame slots, an unsupported type code), so a successful prepare
*guarantees* the call works. That is what lets the Ruby facades treat a raised
prepare as "stay on the general `___call` path" rather than an error at
definition time. `___call` keeps working unchanged for call sites whose
signature is not known until the call itself.

All three facades now prepare: the sqlite3 bridge bakes the descriptor id into
its generated stubs as an integer literal, and `Fiddle::Function` /
`FFI::Function` hoist it into the constructor alongside the type codes FFI was
recomputing on every call.

## Performance

| | before | after |
| --- | --- | --- |
| 0-arg call | 122.5 ns | **47.5 ns** |
| 1-arg call | 292.9 ns | **69.8 ns** |
| 2-arg call | 381.9 ns | **104.2 ns** |
| per extra argument | 129.7 ns | **28.3 ns** |

| | before | after | CRuby 4.0.2 + YJIT |
| --- | --- | --- | --- |
| `SELECT` 2000 rows × 50 | 396 ms | **155 ms** | 52 ms |
| point query × 30000 | 104 ms | **53 ms** | 23 ms |
| `INSERT` 20000 rows | 65 ms | **35 ms** | 20 ms |

Sweeping the column count 1→4, SELECT time is linear in the number of C calls
at a flat ~132ns each:

```
cols  C-calls/row     ms     ns/row   ns/C-call
   1           4     54.8      547.6       136.9
   2           6     80.8      807.8       134.6
   3           8    104.6     1045.9       130.7
   4          10    131.4     1313.6       131.4
```

So the bridge has no Ruby-side fat left — the next lever is a JIT inline gen
for `___invoke`, as `___read` / `___write` already have.

## Two correctness fixes

Both predate this change and both reproduce on the old `___call` path; they
surfaced while diffing the bridge against CRuby.

- **An Integer argument in `[2^62, 2^64)` was rejected.** monoruby's Fixnum is
  an i63, so `sqlite3_bind_int64(…, 2**62)` — or any `unsigned long` with its
  top bits set — arrives as a BigInt, and `expect_integer` refused it.
  Perfectly in-range values failed with `no implicit conversion of Integer into
  Integer`. Both representations are now accepted.

- **Every result code raised the base `SQLite3::Exception`.** Callers rescue
  the subclasses by name — ActiveRecord turns `SQLite3::ConstraintException`
  into `RecordNotUnique` — so raising the base class silently breaks that
  dispatch. The primary result code (low 8 bits, since extended codes may be
  enabled) now maps to the gem's subclass as the C extension does.

## Verification

- `cargo nextest run --no-fail-fast` — **3303 passed, 0 failed, 0 skipped**
- New `fiddle_prepare_matches_call` checks `___invoke` against `___call` across
  int / long long / string / NULL-pointer / double / 0-arg signatures, and
  covers both arity errors and the over-wide-signature rejection. The CIF is
  now built from the type codes alone, so this is what catches a disagreement
  with `value_to_carg`'s choice of `CArg` width.
- New `fiddle_function_prepared` exercises the prepared path through the public
  `Fiddle::Function` facade.
- A CRUD / prepared-statement / named-bind / blob / int64-boundary /
  float-special / error-path script produces **byte-identical output** under
  monoruby and CRuby.

---
_Generated by [Claude Code](https://claude.ai/code/session_011nsgwMopV95G3pfLbLMAPA)_