### PR TITLE
Make class-guard deopt records say what the guard actually tested

### DIFF
--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -1033,7 +1033,10 @@ impl Codegen {
                 }
                 self.jit.bind_label(entry);
                 match cause {
-                    DeoptCause::Value(r) | DeoptCause::ValueVsBaked(r, _) | DeoptCause::Raw(r) => {
+                    DeoptCause::Value(r)
+                    | DeoptCause::ClassGuard(r, _)
+                    | DeoptCause::ValueVsBaked(r, _)
+                    | DeoptCause::Raw(r) => {
                         monoasm!( &mut self.jit,
                             movq [rbx + (EXECUTOR_DEOPT_CAUSE)], R(r as u64);
                         );

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -134,7 +134,7 @@ impl Codegen {
             }
             // Type guard: deopt if `r`'s runtime class is not `class`.
             AsmInst::GuardClass(r, class, deopt) => {
-                let deopt = self.deopt_label(labels, deopt, DeoptCause::Value(r));
+                let deopt = self.deopt_label(labels, deopt, DeoptCause::ClassGuard(r, class));
                 self.encode_linst(LInst::GuardClass {
                     reg: r,
                     class,

--- a/monoruby/src/codegen/jitgen/deopt_log.rs
+++ b/monoruby/src/codegen/jitgen/deopt_log.rs
@@ -65,6 +65,11 @@ use super::*;
 pub(crate) enum DeoptCause {
     /// A Ruby `Value` lives in this GP register at the branch.
     Value(GP),
+    /// A Ruby `Value` in this GP register whose *class* the guard tested
+    /// against the one baked in at compile time. Both halves matter: a
+    /// class guard's story is "expected X, got a Y", and the expected half
+    /// is not recoverable from the operand alone.
+    ClassGuard(GP, ClassId),
     /// A Ruby `Value` in this GP register, which the guard compared
     /// against a `Value` baked into the code at compile time.
     ValueVsBaked(GP, crate::Value),

--- a/monoruby/src/globals/dump.rs
+++ b/monoruby/src/globals/dump.rs
@@ -293,12 +293,38 @@ fn render_cause(
                     }
                 }
             };
-            format!(
-                "{r:?} = {}, class {} but guard expected {}",
-                decode(bits),
-                actual,
-                globals.store.debug_class_name(expected)
-            )
+            let want = globals.store.debug_class_name(expected);
+            // `GuardClass` on `Integer` / `Float` is a *representation* test,
+            // not a class test: it checks the Fixnum tag (`testq r, 0b001`)
+            // or the Flonum tag, so a heap-allocated Integer (BigInt) or
+            // Float misses it while `Value::class()` still answers `Integer`
+            // / `Float`. Rendered naively that reads "class Integer but
+            // guard expected Integer" — a contradiction, and exactly the
+            // kind of line that sends an investigation down a wrong path.
+            // Say what the guard actually tested instead.
+            if actual == want {
+                let boxed = match expected {
+                    INTEGER_CLASS => Some("an immediate Fixnum, but this is a heap Integer (BigInt)"),
+                    FLOAT_CLASS => Some("an immediate Flonum, but this is a heap Float"),
+                    _ => None,
+                };
+                match boxed {
+                    Some(what) => format!("{r:?} = {}, guard tests for {what}", decode(bits)),
+                    // Same display name, no known representation split: name
+                    // the ids so the reader can see they really do differ.
+                    None => format!(
+                        "{r:?} = {}, class {want} ({:?}) but guard expected {want} ({:?})",
+                        decode(bits),
+                        unsafe { std::mem::transmute::<u64, Value>(bits) }.class(),
+                        expected
+                    ),
+                }
+            } else {
+                format!(
+                    "{r:?} = {}, class {actual} but guard expected {want}",
+                    decode(bits)
+                )
+            }
         }
         DeoptCause::ValueVsBaked(r, expected) => {
             let mut s = format!(

--- a/monoruby/src/globals/dump.rs
+++ b/monoruby/src/globals/dump.rs
@@ -278,6 +278,28 @@ fn render_cause(
     };
     match cause {
         DeoptCause::Value(r) => format!("{r:?} = {}", decode(bits)),
+        DeoptCause::ClassGuard(r, expected) => {
+            // Name the class the value actually has, not just the value:
+            // "expected FFI::MemoryPointer, got FFI::Pointer" is the whole
+            // diagnosis for a monomorphic guard that a sibling class walks
+            // into, and reading it off the rendered object is guesswork.
+            let actual = match std::num::NonZeroU64::new(bits) {
+                None => "<null>".to_string(),
+                Some(_) => {
+                    let v = unsafe { std::mem::transmute::<u64, Value>(bits) };
+                    match v.debug_check(&globals.store) {
+                        Some(_) => globals.store.debug_class_name(v.class()),
+                        None => "<not a Value>".to_string(),
+                    }
+                }
+            };
+            format!(
+                "{r:?} = {}, class {} but guard expected {}",
+                decode(bits),
+                actual,
+                globals.store.debug_class_name(expected)
+            )
+        }
         DeoptCause::ValueVsBaked(r, expected) => {
             let mut s = format!(
                 "{r:?} = {}, expected {} (bits={:#x})",


### PR DESCRIPTION
Two follow-ups to #1163, both found by reading its own output on the activerecord workload.

## 1. A class guard now names the class it wanted

The site declared `DeoptCause::Value(reg)`, which records the operand but not the class baked into the compare — so a record showed the value and left the expected half to be guessed. `GuardClass` gets a cause of its own carrying the `ClassId`, and the record prints both halves plus the operand's actual class.

The `FFI::Function#convert_arg` storm — 67,530 deopts per run, which took a chain of separate measurements and four wrong hypotheses to attribute earlier — now reads off one line:

```
class FFI::Pointer but guard expected FFI::MemoryPointer
```

`GuardClassIn` keeps `Value`: its expected side is a set, `DeoptCause` is `Copy`, and the operand's own class already says which member missed.

## 2. A representation guard is no longer reported as a contradiction

`GuardClass` on `Integer` / `Float` does not test a class. It tests a tag — `testq r, 0b001` for the Fixnum immediate, the flonum bits for Float. A BigInt or a heap Float misses it while `Value::class()` still answers `Integer` / `Float`, so with the change above in place the record read:

```
class Integer but guard expected Integer
```

That is a contradiction on its face, and it is the exact shape of line this log exists to stop producing. It prints 1,582 times per activerecord run, at `ActiveModel::Type::Integer#out_of_range?` handling `2**63`. It now reads:

```
guard tests for an immediate Fixnum, but this is a heap Integer (BigInt)
```

If two class names ever collide without a known representation split, the fallback prints both class ids rather than two identical names.

## Why this was worth doing now

The steady-state census on current master is 18,393 deopts, and every one of the top sites is self-explanatory from a single line:

```
3,185  Association#initialize  BelongsToReflection, guard expected HasManyReflection
3,100  fetch_value             Type::Text, guard expected SQLite3Integer
1,582  out_of_range?           immediate Fixnum expected, got heap Integer (BigInt)
1,018  fetch_value             Attribute::FromDatabase, guard expected Attribute::FromUser
```

Incidentally, that census is why `convert_arg` is absent: #1164 took the sqlite3 bridge off the ffi gem and its 67.5k deopts (78% of the previous total, 86,585) went with it. No JIT change was needed, and the fix I had started for it was dropped rather than landed against a workload that no longer exists.

## Verification

`cargo test --release` (70 suites), x86 default + `deopt`, and the aarch64 cross-check under `deopt` — all clean. Both changes are inside `cfg(feature = "deopt")` rendering or the cause declaration; no normal-build codegen is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_