### PR TITLE
Heal block-root constant guards; separate the measurement feature tiers

### DIFF
--- a/monoruby/Cargo.toml
+++ b/monoruby/Cargo.toml
@@ -40,7 +40,16 @@ gc-verify = []
 # code paths (LoadSpill / StoreSpill, spill-aware AsmInst lowerings,
 # 16-byte spill-region alignment).
 stress-spill-pool = []
-profile = ["dump-bc", "dump-traceir"]
+# Counters only: `profile` needs `TraceIr::format` for its deopt-site table,
+# not the bytecode dumps `dump-bc` brings.
+profile = ["dump-traceir"]
+# Trace every chain-deopt escalation to stderr. Opt-in, and deliberately not
+# implied by `deopt` / `profile`: escalation is a per-side-exit runtime
+# operation rather than a per-deopt event, and it fires hundreds of thousands
+# of times per activerecord iteration. Logging it unconditionally in `deopt`
+# builds wrote 160 MB of stderr in five iterations and made those builds 7x
+# slower than release, hiding the very costs a measurement build should show.
+chain-deopt-log = []
 perf = []
 # §5 Layer-② extraction: stage-1 *placement shadow*. Records, in emission order,
 # every physical FP placement that ③ commits (one entry per `PhysMap::resolve`),

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -1691,7 +1691,7 @@ impl Codegen {
             if !self.check_vm_address(ret)
                 && let Some(replay) = self.chain_deopt_table.get(&ret).cloned()
             {
-                #[cfg(any(feature = "deopt", feature = "profile"))]
+                #[cfg(feature = "chain-deopt-log")]
                 eprintln!("### chain deopt: frame return {ret:?} -> chain conversion");
                 plan.push(ChainConversion::new(cfp, prev_cfp, replay, stub));
             }

--- a/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
@@ -1,5 +1,6 @@
 use super::*;
 use monoasm_macro::monoasm_arm64;
+use crate::codegen::jitgen::lir::ConstMiss;
 
 // ---- Object#send inline symbol cache (aarch64 twin of the x86_64 copy in
 // arch/x86_64/compile/method_call.rs; the two files are arch-selected so the
@@ -1168,6 +1169,46 @@ impl Codegen {
             str x30, [sp, #-16]!;
             mov x9, (f);
             blr x9;                       // -> Option<Value>: None (x0 == 0) = panic
+            ldr x30, [sp], #16;
+            ldr d2, [sp, #(0)];
+            ldr d3, [sp, #(8)];
+            ldr d4, [sp, #(16)];
+            ldr d5, [sp, #(24)];
+            ldr d6, [sp, #(32)];
+            ldr d7, [sp, #(40)];
+            ldp x5, x6, [sp, #(48)];
+            ldp x7, x8, [sp, #(64)];
+            add sp, sp, #(80);
+        );
+    }
+
+    ///
+    /// Salvage-only miss handler for a constant-version guard
+    /// (`ConstMiss::Salvage`) — the aarch64 counterpart of
+    /// `Codegen::gen_salvage_const`. Re-validates the unit's folded constants
+    /// and re-stamps its version word; never recompiles, so a block root can
+    /// heal without its whole-method entry rebuilding the wrong frame shape.
+    ///
+    /// Saves the same registers as `a64_call_recompile`: the deopt write-back
+    /// that follows reads the FP pool (d2-d7) and the GP pool (x5-x8).
+    ///
+    pub(super) fn a64_call_salvage_const(&mut self) {
+        let f = crate::codegen::compiler::jit_salvage_const as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            sub sp, sp, #(80);
+            str d2, [sp, #(0)];
+            str d3, [sp, #(8)];
+            str d4, [sp, #(16)];
+            str d5, [sp, #(24)];
+            str d6, [sp, #(32)];
+            str d7, [sp, #(40)];
+            stp x5, x6, [sp, #(48)];
+            stp x7, x8, [sp, #(64)];
+            mov x0, x20;                  // globals
+            mov x1, x22;                  // lfp
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;
             ldr x30, [sp], #16;
             ldr d2, [sp, #(0)];
             ldr d3, [sp, #(8)];

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -29,6 +29,7 @@ fn a64_lreg(r: LReg) -> u32 {
 }
 use monoasm_macro::monoasm_arm64;
 use crate::codegen::jitgen::deopt_log::DeoptCause;
+use crate::codegen::jitgen::lir::ConstMiss;
 
 mod binary_op;
 mod builtin;
@@ -1097,10 +1098,14 @@ impl Codegen {
             // The snapshot side is the unit's shared patchable word
             // (`Codegen::unit_const_version`), so a successful const salvage
             // re-validates every guard in the unit with one store (mirrors
-            // x86). With `recompile = Some(position)` a miss first calls the
-            // salvaging recompile entry and then deopts (the class-version
-            // guard's shape); `None` plain-deopts.
-            LInst::GuardConstVersion { const_version: _, recompile, deopt } => {
+            // x86). A miss always deopts; `miss` says what it tries first —
+            // the salvaging recompile entry (the class-version guard's shape)
+            // or, for a block root, salvage alone.
+            LInst::GuardConstVersion {
+                const_version: _,
+                miss,
+                deopt,
+            } => {
                 let gv_addr = self
                     .jit
                     .get_label_address(&self.const_version_label())
@@ -1117,23 +1122,21 @@ impl Codegen {
                     ldr x10, [x10];
                     cmp x9, x10;
                 );
-                match recompile {
-                    None => {
-                        self.jit.bcond_label(monoasm::Cond::Ne, &deopt);
-                    }
-                    Some(position) => {
-                        let miss = self.jit.label();
-                        let done = self.jit.label();
-                        self.jit.bcond_label(monoasm::Cond::Ne, &miss);
-                        monoasm_arm64!(&mut self.jit, b done;);
-                        self.jit.bind_label(miss);
-                        self.a64_call_recompile(
+                {
+                    let miss_label = self.jit.label();
+                    let done = self.jit.label();
+                    self.jit.bcond_label(monoasm::Cond::Ne, &miss_label);
+                    monoasm_arm64!(&mut self.jit, b done;);
+                    self.jit.bind_label(miss_label);
+                    match miss {
+                        ConstMiss::Recompile(position) => self.a64_call_recompile(
                             position,
                             RecompileReason::ConstVersionGuardFailed,
-                        );
-                        monoasm_arm64!(&mut self.jit, b deopt;);
-                        self.jit.bind_label(done);
+                        ),
+                        ConstMiss::Salvage => self.a64_call_salvage_const(),
                     }
+                    monoasm_arm64!(&mut self.jit, b deopt;);
+                    self.jit.bind_label(done);
                 }
             }
             // Block-passing side-effect guard: deopt if the frame was captured

--- a/monoruby/src/codegen/arch/x86_64/compile/constants.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/constants.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::codegen::jitgen::lir::ConstMiss;
 
 impl Codegen {
     pub(super) fn store_constant(&mut self, id: ConstSiteId, using_fpr: UsingFpr) {
@@ -23,31 +24,21 @@ impl Codegen {
     /// (`Codegen::unit_const_version`), so a successful const salvage can
     /// re-validate every guard in the unit with one store.
     ///
-    /// With `recompile = Some(position)` a miss first calls the salvaging
-    /// recompile entry (whole method / the loop at `position`) and then
-    /// deopts — the class-version guard's shape. `None` is a plain deopt.
+    /// A miss always ends at `deopt`; `miss` says what it tries on the way.
+    /// `Recompile(position)` calls the salvaging recompile entry (whole
+    /// method / the loop at `position`) — the class-version guard's shape.
+    /// `Salvage` calls the salvage-only entry, which re-validates the unit's
+    /// folds and re-stamps its version word without touching any frame.
     ///
     /// ### destroy
     /// - rax
     ///
-    pub(super) fn guard_const_version(
-        &mut self,
-        recompile: Option<Option<BytecodePtr>>,
-        deopt: &DestLabel,
-    ) {
+    pub(super) fn guard_const_version(&mut self, miss: ConstMiss, deopt: &DestLabel) {
         let cached_const_version = self
             .unit_const_version
             .clone()
             .expect("const guard emitted outside a constant-folding unit");
         let global_const_version = self.const_version_label();
-        let Some(position) = recompile else {
-            monoasm! { &mut self.jit,
-                movq rax, [rip + global_const_version];
-                cmpq rax, [rip + cached_const_version];
-                jne  deopt;
-            }
-            return;
-        };
         assert_eq!(0, self.jit.get_page());
         let fail = self.jit.label();
         monoasm! { &mut self.jit,
@@ -56,12 +47,15 @@ impl Codegen {
             jne  fail;
         }
         self.jit.select_page(1);
-        self.gen_recompile(
-            position,
-            fail,
-            RecompileReason::ConstVersionGuardFailed,
-            None,
-        );
+        match miss {
+            ConstMiss::Recompile(position) => self.gen_recompile(
+                position,
+                fail,
+                RecompileReason::ConstVersionGuardFailed,
+                None,
+            ),
+            ConstMiss::Salvage => self.gen_salvage_const(fail),
+        }
         self.version_guard_fail(deopt);
         self.jit.select_page(0);
     }

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -701,10 +701,10 @@ impl Codegen {
             }
             LInst::GuardConstVersion {
                 const_version: _,
-                recompile,
+                miss,
                 deopt,
             } => {
-                self.guard_const_version(recompile, &deopt);
+                self.guard_const_version(miss, &deopt);
             }
             // Fixnum fast-path arithmetic with an overflow deopt.
             LInst::IntegerBinOp {

--- a/monoruby/src/codegen/compiler.rs
+++ b/monoruby/src/codegen/compiler.rs
@@ -112,6 +112,41 @@ impl Codegen {
         }
     }
 
+    ///
+    /// Salvage-only miss handler for a constant-version guard: re-validate the
+    /// unit's folded constants and, if they all still hold, re-stamp its
+    /// version word. Never recompiles.
+    ///
+    /// This is what a block-style root gets. Its whole-method recompile entry
+    /// would rebuild the wrong frame shape, so it used to take a bare deopt
+    /// with no healing at all — and since the global const version never moves
+    /// back, such a unit then failed its guard on *every* later call, for the
+    /// rest of the process. Salvage reads the unit's recorded folds, compares
+    /// them against the live constants and writes one word; it builds no
+    /// frame, so the reason block roots cannot recompile does not apply.
+    ///
+    /// ### in
+    /// - r12: &mut Globals
+    /// - r14: Lfp
+    ///
+    /// ### destroy
+    /// - rax
+    ///
+    #[cfg(target_arch = "x86_64")]
+    pub(super) fn gen_salvage_const(&mut self, label: DestLabel) {
+        self.jit.bind_label(label);
+        monoasm!( &mut self.jit,
+            movq rdi, r12;
+            movq rsi, r14;
+        );
+        self.save_registers();
+        monoasm!( &mut self.jit,
+            movq rax, (jit_salvage_const);
+            call rax;
+        );
+        self.restore_registers();
+    }
+
     #[cfg(target_arch = "x86_64")]
     pub(super) fn gen_recompile_specialized(
         &mut self,
@@ -888,6 +923,19 @@ pub(in crate::codegen) extern "C" fn jit_profile_patch(
         // x86); the stub passes its own counter's address.
         unsafe { *counter_addr = COUNT_START_COMPILE };
     }
+}
+
+/// Salvage-only entry for a constant-version guard miss (`ConstMiss::Salvage`).
+///
+/// [`salvage_method_const`] without the recompile fallback: on success the
+/// unit's version word is re-stamped and its guard passes again from the next
+/// call; on failure this invocation deopts and the next miss retries. Either
+/// way the caller falls through to its deopt, so there is nothing to report.
+///
+/// Both backends call this one entry: unlike the recompile entries it neither
+/// emits code nor touches a frame, so it needs no per-arch variant.
+pub(in crate::codegen) extern "C" fn jit_salvage_const(globals: &mut Globals, lfp: Lfp) {
+    salvage_method_const(globals, lfp, RecompileReason::ConstVersionGuardFailed);
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -6,6 +6,7 @@ use crate::codegen::jitgen::deopt_log;
 use crate::codegen::jitgen::lir::{LInst, LSideExitKind, Lir};
 
 use super::*;
+use crate::codegen::jitgen::lir::ConstMiss;
 
 // AsmIR→machine-code lowering. The per-arch backend (`compile`) provides the
 // emission primitives + `compile_asmir_arch`; the arch-neutral dispatcher
@@ -2156,12 +2157,8 @@ pub(super) enum AsmInst {
     ///
     GuardConstVersion {
         const_version: usize,
-        /// `Some(position)` — on a miss, call the (salvaging) recompile entry
-        /// for the unit (`None` = whole method, `Some(pc)` = the loop at that
-        /// pc) before falling into `deopt`, exactly like the class-version
-        /// guard. `None` — plain deopt (block-style roots, whose whole-method
-        /// recompile entry would rebuild the wrong frame shape).
-        recompile: Option<Option<BytecodePtr>>,
+        /// What the miss tries before deopting — see [`ConstMiss`].
+        miss: ConstMiss,
         deopt: AsmDeopt,
     },
     ///

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -205,11 +205,15 @@ impl Codegen {
             }
             // Constant version guard: deopt if the global constant version moved
             // since compilation.
-            AsmInst::GuardConstVersion { const_version, recompile, deopt } => {
+            AsmInst::GuardConstVersion {
+                const_version,
+                miss,
+                deopt,
+            } => {
                 let deopt = self.deopt_label(labels, deopt, DeoptCause::Static("const version"));
                 self.encode_linst(LInst::GuardConstVersion {
                     const_version,
-                    recompile,
+                    miss,
                     deopt,
                 });
             }

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -436,7 +436,24 @@ impl<'a> JitContext<'a> {
                     // at *this* compile and declined; a recompile would
                     // reproduce this very body, so deopt plainly (ratchet —
                     // no recompile-per-N-misses livelock).
-                    RecvMissMode::Learn => self.store[callid].pmc.entries().len() < 2,
+                    // The PMC counts *classes*, so it cannot see a miss that
+                    // splits one class by representation: `guard_class` for
+                    // `Integer` is a Fixnum-immediate tag test, and a heap
+                    // Integer (BigInt) carries the same `ClassId` and fails
+                    // it. The PMC therefore stays at one entry, the ratchet
+                    // below never engages, and every recompile re-emits the
+                    // identical tag test. `ActiveModel::Type::Integer#
+                    // out_of_range?` compares against `1 << 63` — always a
+                    // BigInt, so its guard can never pass — and recompiled
+                    // 8,756 times over 40 activerecord iterations, a third
+                    // of all JIT compile time. A recompile provably cannot
+                    // help there, so deopt plainly. (`Float` needs no such
+                    // exclusion: its guard already admits both the flonum
+                    // and the heap representation.)
+                    RecvMissMode::Learn => {
+                        recv_class != INTEGER_CLASS
+                            && self.store[callid].pmc.entries().len() < 2
+                    }
                     RecvMissMode::Plain => false,
                 };
                 let deopt = if let Some(target) =

--- a/monoruby/src/codegen/jitgen/compile/variables.rs
+++ b/monoruby/src/codegen/jitgen/compile/variables.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::codegen::jitgen::state::Guarded;
+use crate::codegen::jitgen::lir::ConstMiss;
 
 impl<'a> JitContext<'a> {
     pub(super) fn load_ivar(
@@ -196,17 +197,28 @@ impl<'a> JitContext<'a> {
         // recompiles; with const salvage the entry is cheap, and gating it
         // meant the second version move after a successful salvage would
         // strand the body in the interpreter forever (the counter never
-        // re-arms). Block roots keep the plain deopt: their whole-method
-        // recompile entry would rebuild the wrong frame shape (see above).
-        let recompile = if self.store[self.func_id()].is_block_style() {
-            None
+        // re-arms).
+        //
+        // Block roots cannot take that entry — their whole-method recompile
+        // would rebuild the wrong frame shape (see above) — but they can
+        // still salvage, which only re-validates the recorded folds and
+        // re-stamps the unit's version word. They used to take a bare deopt
+        // instead, and that never healed: the global const version does not
+        // move back, so one `X = ...` anywhere left every affected block
+        // failing its guard on every later call for the rest of the run.
+        // On the activerecord benchmark that was 69% of all const-version
+        // deopts (59,278 of 85,818 over two iterations), concentrated in a
+        // handful of blocks — `ActiveRecord::Result#indexed_rows`'s block
+        // alone accounted for 31,400 of them.
+        let miss = if self.store[self.func_id()].is_block_style() {
+            ConstMiss::Salvage
         } else {
-            Some(self.position())
+            ConstMiss::Recompile(self.position())
         };
         let deopt = ir.new_deopt(state);
         ir.push(AsmInst::GuardConstVersion {
             const_version: version,
-            recompile,
+            miss,
             deopt,
         });
         state.set_const_version_guard();

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -315,6 +315,30 @@ pub(in crate::codegen::jitgen) enum LSideExitKind {
 /// escape hatch wraps a `Box<dyn FnOnce>` generator (see `InlineProcedure`),
 /// which is move-only. `LInst`s are produced, encoded once, and dropped, so a
 /// clone is never needed.
+///
+/// What a [`LInst::GuardConstVersion`] miss does on its way to the deopt.
+///
+/// Both arms deopt in the end — the difference is what they try first, and
+/// the distinction matters because a unit whose miss does *nothing* first is
+/// stuck: the global const version never moves back, so its guard fails on
+/// every subsequent call, forever. Block roots used to be exactly that.
+///
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(in crate::codegen) enum ConstMiss {
+    /// Call the salvaging recompile entry for the unit (`None` = whole
+    /// method, `Some(pc)` = the loop at that pc). Re-validates the folds and
+    /// re-stamps the version word; recompiles only if that fails.
+    Recompile(Option<BytecodePtr>),
+    /// Re-validate the folds and re-stamp the version word, and stop there.
+    ///
+    /// For block-style roots, whose whole-method recompile entry would
+    /// rebuild the wrong frame shape — which is why they took a bare deopt
+    /// before, and so never healed. Salvage touches no frame: it reads the
+    /// unit's recorded folds, compares them against the live constants, and
+    /// writes one word. So the objection to recompiling does not reach it.
+    Salvage,
+}
+
 #[derive(Debug)]
 pub(in crate::codegen) enum LInst {
     /// `dst <- src`. A no-op when `src == dst` (the encoder elides it).
@@ -487,12 +511,11 @@ pub(in crate::codegen) enum LInst {
         deopt: DestLabel,
     },
     /// Constant-load guard: deopt if the global constant version moved away from
-    /// the unit's snapshot word since compilation. `recompile` mirrors
-    /// `AsmInst::GuardConstVersion`: `Some(position)` routes a miss through
-    /// the salvaging recompile entry first; `None` is a plain deopt.
+    /// the unit's snapshot word since compilation. `miss` mirrors
+    /// `AsmInst::GuardConstVersion` — see [`ConstMiss`].
     GuardConstVersion {
         const_version: usize,
-        recompile: Option<Option<BytecodePtr>>,
+        miss: ConstMiss,
         deopt: DestLabel,
     },
     /// Block-passing side-effect guard: deopt if the current frame was captured

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -26,7 +26,7 @@ pub const PROCDATA_FUNCID: i64 = std::mem::offset_of!(ProcData, func_id) as _;
 /// once the now-interpreted frame eventually returns.
 pub(super) extern "C" fn chain_deopt(vm: &mut Executor) {
     let cfp = vm.cfp();
-    #[cfg(any(feature = "deopt", feature = "profile"))]
+    #[cfg(feature = "chain-deopt-log")]
     eprintln!("### chain deopt: escalated from {:?}", cfp.lfp().func_id());
     let plan = CODEGEN.with(|codegen| codegen.borrow_mut().chain_deopt(cfp));
     for conversion in plan {

--- a/monoruby/tests/redefine.rs
+++ b/monoruby/tests/redefine.rs
@@ -697,3 +697,72 @@ fn guard_free_dispatch_across_recompile() {
         "##,
     );
 }
+
+///
+/// A block that folds a constant must keep working after the global constant
+/// version moves — and must go on working, call after call.
+///
+/// A block-style root cannot take the salvaging *recompile* entry (its
+/// whole-method entry would rebuild the wrong frame shape), so its
+/// constant-version guard used to be a bare deopt with no healing at all.
+/// Since the global version never moves back, a single unrelated constant
+/// assignment left such a block failing its guard on every later call for the
+/// rest of the process — 69% of all constant-version deopts on the
+/// activerecord benchmark. The guard now calls the salvage-only entry, which
+/// re-validates the folds and re-stamps the unit's version word without
+/// touching a frame.
+///
+/// The answer was always right (a deopt is only slow, not wrong), so what
+/// this pins is the new runtime entry itself: it runs on a block frame, with
+/// that frame's `self`, and must find the unit's record and survive doing so.
+///
+#[test]
+fn const_version_block_root_heals() {
+    run_test_once(
+        r##"
+        LIMIT = 10
+        def sum_under
+          total = 0
+          (1..30).each { |x| total += x if x < LIMIT }
+          total
+        end
+        res = []
+        # Warm the block past the JIT thresholds, so it is compiled with
+        # LIMIT folded and the unit's constant-version word stamped.
+        200.times { res << sum_under }
+        # Move the global constant version out from under it.
+        OTHER = 1
+        200.times { res << sum_under }
+        # ...and again, to catch a heal that only works once.
+        ANOTHER = 2
+        200.times { res << sum_under }
+        [res.uniq, OTHER, ANOTHER]
+        "##,
+    );
+}
+
+///
+/// The same shape with the constant read inside a nested block, so the
+/// salvage entry is reached from a frame whose `self` comes from an outer
+/// block rather than the method.
+///
+#[test]
+fn const_version_nested_block_root_heals() {
+    run_test_once(
+        r##"
+        FACTOR = 3
+        def scaled
+          out = []
+          (1..5).each do |a|
+            (1..5).each { |b| out << a * b * FACTOR }
+          end
+          out.sum
+        end
+        res = []
+        200.times { res << scaled }
+        BUMP1 = :x
+        200.times { res << scaled }
+        [res.uniq, BUMP1]
+        "##,
+    );
+}


### PR DESCRIPTION
Three findings from re-measuring the activerecord benchmark after #1164/#1165. The first is the substantive one; the other two came out of the measurements themselves.

## 1. A block root can now heal its constant-version guard

A block-style root cannot take the salvaging *recompile* entry — that entry recompiles whatever `lfp.func_id()` names, and re-entering the compiler as if a block frame were a method rebuilds the body under the wrong argument convention. So block roots took a bare deopt instead, and a bare deopt never heals: the global constant version does not move back, so a single `X = ...` anywhere left every block that had folded a constant failing its guard **on every later call, for the rest of the process**.

On the activerecord benchmark that was **69% of all constant-version deopts** — 59,278 of 85,818 over two iterations — concentrated in a handful of blocks:

```
31,400  block in ActiveRecord::Result#indexed_rows
18,137  block (2 levels) in Gem::BasicSpecification#have_file?
10,840  block in Gem::BasicSpecification#have_file?
 5,919  block in Gem::Requirement#satisfied_by?
 4,000  block in ActiveRecord::PredicateBuilder::ArrayHandler#call
```

It also explains a gap that had looked like a counting error: 88,286 constant-version deopts against only 6,798 salvage attempts. The missing ~81,000 were the block roots — they called nothing at all. And the counters made the permanence visible: at `FIXED_ITERS=3` and `FIXED_ITERS=6` every constant-version counter was *identical* (`const_version incs: 2133`, `recovery attempts: 6798`, `salvaged: 3775`), i.e. all constant activity happens during warmup and none in the steady loop — so nothing was ever going to move the version back.

The objection to recompiling does not reach salvage: it re-reads the unit's recorded folds, compares them against the live constants and writes one word, building no frame. `GuardConstVersion` now carries a `ConstMiss` saying what a miss tries before deopting — the recompile entry as before, or `Salvage`. Both backends share the salvage entry, since it emits no code.

## 2. Measurement features: counter tier vs trace tier

`profile` pulled in `dump-bc`, which it never used, and the two chain-deopt trace lines were gated on `deopt`/`profile`. Chain escalation is a per-side-exit runtime operation, not a per-deopt event — hundreds of thousands of calls per iteration — so logging it wrote 160 MB of stderr in five iterations. Measured ladder (40 iterations, one session):

```
(none)              437.6 ms/iter      1 KB
jit-log             469.1 ms/iter    1.5 MB   +7%
profile             481.9 ms/iter     22 KB   +10%
chain-deopt-log    3269.4 ms/iter    265 MB   7.5x
deopt              6118.0 ms/iter    504 MB    14x
```

A `deopt` build was 14x slower than release, which hides the costs such a build exists to show. The trace lines move to an opt-in `chain-deopt-log`.

## 3. An unconvergeable recompile loop on an `Integer` receiver guard

`guard_class` for `Integer` is a Fixnum-immediate tag test, so a heap Integer (BigInt) has the same `ClassId` and fails it. The PMC counts classes and cannot see that split, so it stays at one entry, the Learn ratchet never engages, and every recompile re-emits the identical test.

`ActiveModel::Type::Integer#out_of_range?` is the case in the wild — it compares against `1 << 63` for an 8-byte column, always a BigInt, so its guard can never pass. It recompiled **8,756 times over 40 iterations**, 636 ms of the 986 ms spent in the JIT. Removing the loop cut JIT compile time to 350 ms; wall clock did not move outside noise (3% of the run, below this environment's ±5%, measured interleaved with a YJIT control).

## What was verified, and what was not

Verified here: x86-64 and aarch64 both compile clean across default / `deopt` / `profile` / `jit-log` / `emit-asm`; the `redefine` suite passes (24 tests, including two new ones that drive the salvage entry on a block frame, one of them nested so the frame's `self` comes from an outer block).

**Not verified here:** that a block root now actually heals. The container was recreated between the investigation and this implementation — the ruby-bench checkout, the activerecord gems and the probe scripts are gone, and the host Ruby is 3.3.6 rather than the pinned 4.0.2, so the benchmark cannot be re-run and the full test suite hangs spawning the wrong Ruby. Every number above is from measurements taken before that, and I have re-quoted rather than re-produced them.

I tried to substitute a micro-repro and could not build one: in every shape I tried the block was inlined into its enclosing method and ran through the specialized route, which already heals via its `idx`. The block-root body compiles but is not what executes. The failing configuration needs a hot block whose root body is the live one, as `ActiveRecord::Result#indexed_rows`'s block is — I could not arrange that in isolation, and I would rather say so than present the two passing tests as evidence they are not.

The new oracle entries the added tests generate were deliberately left out of this diff, since this container's Ruby is 3.3.6; CI will record them against 4.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_