### PR TITLE
Keep a frame's float view across the call that hands out its block

### DIFF
--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -375,7 +375,7 @@ impl<'a> JitContext<'a> {
                 && !self.in_dispatch_arm()
                 && state.no_capture_guard();
             if inlined_block {
-                state.locals_unbox_to_S_keeping_const(ir);
+                state.locals_unbox_to_S_keeping_claims(ir);
             } else {
                 state.all_frames_unbox_to_S(self, ir);
             }

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -127,13 +127,13 @@ impl AbstractState {
 
     ///
     /// Home every unboxed local of *this* frame in its slot, keeping the
-    /// rest of the abstract state — each `C` included.
+    /// rest of the abstract state — each `C` and each `Sf` view included.
     ///
     /// Only for a callee whose every store into this frame the compiler
     /// can see; the bet is confirmed after the fact in `specialized_iseq`.
     ///
     #[allow(non_snake_case)]
-    pub(super) fn locals_unbox_to_S_keeping_const(&mut self, ir: &mut AsmIr) {
+    pub(super) fn locals_unbox_to_S_keeping_claims(&mut self, ir: &mut AsmIr) {
         for i in self.locals() {
             self.unbox_to_S(ir, i, true);
         }

--- a/monoruby/src/codegen/jitgen/state/join.rs
+++ b/monoruby/src/codegen/jitgen/state/join.rs
@@ -200,8 +200,12 @@ impl JoinAction {
             JoinAction::TryFreshFKeep | JoinAction::TryFreshFElseS => {
                 JoinAction::SetS(Guarded::Float)
             }
-            JoinAction::SetSf(_, guarded)
-            | JoinAction::TryFreshSfElseKeep(_, guarded)
+            // `SetSf` is the arm where both predecessors already agree on
+            // the register, so it binds no new one — the only fpr-shaped
+            // decision an outer frame can act on without a register
+            // operation (see `AbstractFrame::bridge_at`).
+            JoinAction::SetSf(x, guarded) => JoinAction::SetSf(x, guarded),
+            JoinAction::TryFreshSfElseKeep(_, guarded)
             | JoinAction::TryFreshSfElseS(guarded) => JoinAction::SetS(guarded.into()),
             other => other,
         }

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1097,7 +1097,7 @@ impl SlotState {
         &mut self,
         ir: &mut AsmIr,
         slot: SlotId,
-        keep_const: bool,
+        keep_claims: bool,
     ) {
         // Same GP-resident caveat as `to_S_unguarded`: re-home a dirty pool
         // register before the mode change drops it unspilled.
@@ -1111,6 +1111,16 @@ impl SlotState {
                 self.set_mode(slot, LinkMode::S(guarded));
                 ir.spill(Spill::Fpr(fpr, slot));
             }
+            // `Sf` needs nothing done to it either way: the slot already
+            // holds the boxed value, and the fpr is a read-only view of it.
+            // Whether the *view* survives is `keep_claims` — the call saves
+            // and restores this frame's physical fprs around itself
+            // (`fpr_save_cont` / `fpr_restore_cont`), so the register still
+            // holds this float when we resume. What would invalidate the
+            // view is the callee writing the slot, and that arrives as a
+            // `StoreDynVar` through `widen_outer_slot`, which drops the
+            // whole binding. The same hook `C` rides on.
+            LinkMode::Sf(_, _) if keep_claims => {}
             LinkMode::Sf(_, _) => {
                 let guarded = self.guarded(slot);
                 self.clear(slot);
@@ -1129,7 +1139,7 @@ impl SlotState {
             // at its call site, and a block literal this frame hands out
             // that the callee turns into a Proc is caught by
             // `immediate_evict`'s capture guard.
-            LinkMode::C(_) if keep_const => {}
+            LinkMode::C(_) if keep_claims => {}
             LinkMode::C(v) => self.give_up_const(ir, slot, v),
             LinkMode::V => ir.spill(Spill::Lit(Value::nil(), slot)),
             LinkMode::S(_) | LinkMode::MaybeNone | LinkMode::None => {}
@@ -2079,8 +2089,16 @@ impl AbstractFrame {
         if outer == 0 {
             return self.bridge(ir, target, slot, pc);
         }
+        // An outer frame's fpr is not in a register while we run: the call
+        // that suspended that frame saved its physical fprs
+        // (`fpr_save_cont`) and restores them on the way back. So nothing
+        // here may emit a register operation on one. That leaves exactly
+        // two transitions for a slot holding `Sf` — keep the same binding,
+        // or drop to `S`, which is free because the slot holds the boxed
+        // value — and rules out `F`, whose only copy *is* the register.
+        // `AbstractState::join` is what keeps it to those.
         debug_assert!(
-            !matches!(self.mode(slot), LinkMode::F(_) | LinkMode::Sf(_, _)),
+            !matches!(self.mode(slot), LinkMode::F(_)),
             "outer{outer} {slot:?} holds {:?}",
             self.mode(slot),
         );
@@ -2091,6 +2109,10 @@ impl AbstractFrame {
             (_, LinkMode::V) => self.discard(slot),
             (_, LinkMode::MaybeNone) => self.set_MaybeNone(slot),
             (LinkMode::C(l), LinkMode::C(r)) if l == r => {}
+            (LinkMode::Sf(l, _), LinkMode::Sf(r, _)) if l == r => {}
+            (LinkMode::Sf(_, guarded), LinkMode::S(_)) => {
+                self.set_S_with_guard(slot, guarded.into());
+            }
             (LinkMode::C(v), LinkMode::S(_)) => {
                 self.set_mode(slot, LinkMode::S(Guarded::from_concrete_value(v)));
             }
@@ -2119,15 +2141,22 @@ impl AbstractFrame {
             return false;
         }
         debug_assert!(
-            !matches!(self.mode(slot), LinkMode::F(_) | LinkMode::Sf(_, _)),
+            !matches!(self.mode(slot), LinkMode::F(_)),
             "outer{outer} {slot:?} holds {:?}",
             self.mode(slot),
         );
-        if let LinkMode::C(_) = self.mode(slot) {
-            self.set_mode(slot, LinkMode::S(Guarded::Value));
-            return true;
+        match self.mode(slot) {
+            // The slot holds the boxed value; only the read-only view goes.
+            LinkMode::Sf(_, _) => {
+                self.set_mode(slot, LinkMode::S(Guarded::Value));
+                true
+            }
+            LinkMode::C(_) => {
+                self.set_mode(slot, LinkMode::S(Guarded::Value));
+                true
+            }
+            _ => false,
         }
-        false
     }
 
     ///


### PR DESCRIPTION
`LinkMode::Sf` is a slot whose boxed value is on the stack and whose float is *also* cached, read-only, in an fpr. At a block-passing call that cache was dropped unconditionally, so every float the frame touched after the call was decoded out of the box again.

It need not be. The call saves and restores this frame's physical fprs around itself (`fpr_save_cont` / `fpr_restore_cont`), so the register still holds this float when the frame resumes. What would invalidate the view is the callee writing the slot, and that arrives as a `StoreDynVar` through `widen_outer_slot`, which drops the whole binding — the same hook `C` already rides on since #1171. So `Sf` joins `C` in what a block-passing call may keep, under the same after-the-fact confirmation (`had_deopt || generic_yield`).

## Keeping the view and letting an outer frame hold one are one change

Keeping `Sf` at the boundary means the frame carries it into the compilations nested below, where it *is* an outer frame. The `bridge_at` assertion #1171 left behind caught that immediately (`builtins::numeric::tests::numeric_step` — `outer1 %7 holds Sf(FPReg(2), Float)`), which is what the assertion was for.

The rule for an outer frame follows from where its floats actually are: **in its call's save area, not in registers**. So nothing in a nested compile may emit a register operation on one. That leaves exactly two transitions:

* keep a binding both predecessors already agree on — nothing to emit;
* drop to `S` — free, because the slot holds the boxed value.

`join` is what enforces it. `JoinAction::SetSf` is the arm `decide_join` produces when the two predecessors' registers already agree, so it binds nothing fresh; that one an outer frame may act on. `TryFreshSfElseKeep` / `TryFreshSfElseS` would allocate, so they fall to `S`.

`F` stays out entirely: its only copy *is* the register, so a nested compile reading one needs the save-area address. That is the next piece — the arithmetic already exists as `ChainReplay::fpr_save_index`, and `PhysMap::resolve` is the seam it belongs behind. The `bridge_at` assertion narrows to `F` alone and goes on guarding it.

## Testing

- `cargo test --lib --tests`: 66/66 targets green, which is the 3322-test lib suite plus the integration targets — the scope CI's `bin/test` actually runs. (A `--test '*'` run excludes the lib suite, and missing that is what let a bad `Guarded` through in #1171.)
- **gc-stress**: 66/66 green with `--features gc-stress,stress-spill-pool` and `GC_STRESS=1`, same scope.
- **aarch64 under qemu**: 127/127 of the codegen + bytecodegen tests, no panics.
- `cargo check` clean on x86-64 and aarch64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_