### PR TITLE
Box an `F` into its slot at a block-passing call without dropping the register

### DIFF
--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1074,8 +1074,10 @@ impl SlotState {
     /// The callee is handed this frame, so every mode that does *not* keep
     /// the value in the frame has to write it there first:
     ///
-    /// * `F` — the fpr held the only copy: box it into the slot and hand
-    ///   the xmm back (the callee starts with an empty pool).
+    /// * `F` — the fpr held the only copy, so it is boxed into the slot.
+    ///   Under `keep_claims` the register is not handed back with it: the
+    ///   binding lands on `Sf`, the box in the slot and the float still in
+    ///   the register, which is exactly what `F` plus that store *is*.
     /// * `Sf` — the slot already holds the boxed value; only the read-only
     ///   fpr view is dropped.
     /// * `C` — the constant lives in the compiler, *not* in the slot, so
@@ -1105,6 +1107,26 @@ impl SlotState {
             ir.reg2stack(reg, slot);
         }
         match self.mode(slot) {
+            // The store has to happen either way — the callee can read this
+            // slot and the float is only in the register — but there is no
+            // reason to also forget the register. Boxing an `F` into its
+            // slot leaves both copies live, and a slot with the box on the
+            // stack and the float in an fpr is `Sf`, whose survival across
+            // this call is settled: the call saves and restores the frame's
+            // physical fprs (`fpr_save_cont` / `fpr_restore_cont`), and the
+            // one thing that would invalidate the view — the callee writing
+            // the slot — arrives as a `StoreDynVar` through
+            // `widen_outer_slot`. Dropping to `S` instead made every float
+            // the frame touched after the call decode itself out of the box
+            // the store had just written.
+            //
+            // `SfGuarded::Float` because the value came out of an fpr: the
+            // box the store writes is a `Value::float` (the same reasoning
+            // as `bridge_at`'s `F -> Sf` arm).
+            LinkMode::F(fpr) if keep_claims => {
+                ir.spill(Spill::Fpr(fpr, slot));
+                self.set_Sf(slot, fpr, SfGuarded::Float);
+            }
             LinkMode::F(fpr) => {
                 let guarded = self.guarded(slot);
                 self.clear(slot);

--- a/monoruby/tests/float_across_block_call.rs
+++ b/monoruby/tests/float_across_block_call.rs
@@ -132,6 +132,44 @@ fn a_store_through_two_outer_levels() {
 fn a_block_call_inside_a_loop() {
     run_test_with_prelude(
         r#"
+        def g(n)
+          total = 0.0
+          5.times do |i|
+            a = n * 1.5 + i
+            call_block { total += a }
+          end
+          total
+        end
+        g(3)
+        "#,
+        PRELUDE,
+    );
+}
+
+/// The same with a `while` loop instead of `Integer#times`, which trips a
+/// hole that predates any of this and is not about floats at all: the
+/// caller's argument reaches the loop entry as `C(3)` (folded from the
+/// call site) and reaches the back edge as `S(Value)` (a `forget_constants`
+/// on the path through the block-passing call), and `bridge_at` has no
+/// `S -> C` transition for a frame below the innermost one — it cannot
+/// prove the slot holds the constant the target claims. It panics:
+///
+/// ```text
+/// unreachable code: %1 S(Value)->C(3)
+/// ```
+///
+/// This is the third of the three open items `compile_method_call` names
+/// where it decides what a block-passing call may keep ("the bridge must
+/// be able to carry the claim across a merge in a frame *below* this one,
+/// which it cannot"). It reproduces on x86-64 with no stress features and
+/// with the `F -> Sf` boundary change reverted, so it is not arch- or
+/// float-specific; `Integer#times` above escapes it only because the
+/// callee's loop is not in the block's own chain.
+#[test]
+#[ignore = "pre-existing: bridge_at has no S -> C for an outer frame"]
+fn a_while_loop_around_a_block_passing_call() {
+    run_test_with_prelude(
+        r#"
         def f(n)
           total = 0.0
           i = 0
@@ -143,15 +181,7 @@ fn a_block_call_inside_a_loop() {
           end
           total
         end
-        def g(n)
-          total = 0.0
-          5.times do |i|
-            a = n * 1.5 + i
-            call_block { total += a }
-          end
-          total
-        end
-        [f(3), g(3)]
+        f(3)
         "#,
         PRELUDE,
     );

--- a/monoruby/tests/float_across_block_call.rs
+++ b/monoruby/tests/float_across_block_call.rs
@@ -1,0 +1,177 @@
+//! What survives of a frame's *float* registers across the call that hands
+//! out its block.
+//!
+//! At such a call every unboxed local is boxed into its slot, because the
+//! block can read the slot behind the compiler's back. Boxing an `F` — a
+//! slot whose only copy is an fpr — leaves both copies live, so the binding
+//! lands on `Sf` and the frame keeps reading the float out of the register
+//! after the call instead of decoding it out of the box again.
+//!
+//! That is only correct while the register and the slot still agree, and
+//! the block is exactly the thing that can make them disagree. Each case
+//! below reports a stale float if the view is kept where it should have
+//! been dropped, or reads an unwritten slot if the box is not stored.
+extern crate monoruby;
+use monoruby::tests::*;
+
+const PRELUDE: &str = r#"
+    def call_block
+      yield
+    end
+    def call_block_twice
+      yield
+      yield
+    end
+"#;
+
+/// The block reads the outer float: the box has to be in the slot, since
+/// a `LoadDynVar` reads the slot and never the caller's register.
+#[test]
+fn the_block_reads_the_float() {
+    run_test_with_prelude(
+        r#"
+        def f(n)
+          a = n * 1.5
+          b = call_block { a + 1.0 }
+          [a, b, a + 0.25]
+        end
+        f(3)
+        "#,
+        PRELUDE,
+    );
+}
+
+/// The block writes it, so the register the caller kept is stale and the
+/// binding has to go.
+#[test]
+fn the_block_writes_the_float() {
+    run_test_with_prelude(
+        r#"
+        def f(n)
+          a = n * 1.5
+          call_block { a = a + 2.0 }
+          a
+        end
+        def g(n)
+          a = n * 1.5
+          call_block_twice { a += 2.0 }
+          a * 2.0
+        end
+        [f(3), g(3)]
+        "#,
+        PRELUDE,
+    );
+}
+
+/// The block replaces the float with something that is not a float, so
+/// what has to be dropped is not only the register but the `Float` type
+/// the `Sf` binding asserts about the slot.
+#[test]
+fn the_block_changes_the_type() {
+    run_test_with_prelude(
+        r#"
+        def f(n)
+          a = n * 1.5
+          call_block { a = "str" }
+          a
+        end
+        def g(n)
+          a = n * 1.5
+          call_block { a = 7 }
+          a + 1
+        end
+        [f(3), g(3)]
+        "#,
+        PRELUDE,
+    );
+}
+
+/// The callee is a builtin, so the block is a unit of its own and its
+/// stores never reach the compiler: nothing about the float may be kept.
+#[test]
+fn a_builtin_callee() {
+    run_test_with_prelude(
+        r#"
+        def f(n)
+          a = n * 1.5
+          3.times { a += 1.0 }
+          a
+        end
+        def g(n)
+          a = n * 1.5
+          [1, 2].each { a *= 2.0 }
+          a
+        end
+        [f(3), g(3)]
+        "#,
+        PRELUDE,
+    );
+}
+
+/// The store is two frames down, and reaches past its immediate outer
+/// frame to a float the frame above that was holding in a register.
+#[test]
+fn a_store_through_two_outer_levels() {
+    run_test_with_prelude(
+        r#"
+        def f(n)
+          a = n * 1.5
+          b = n * 0.25
+          call_block { call_block { a += b } }
+          [a, b, a - b]
+        end
+        f(3)
+        "#,
+        PRELUDE,
+    );
+}
+
+/// A loop whose body hands a block out: the merge at the loop head sees
+/// one path with the register view still held and one without.
+#[test]
+fn a_block_call_inside_a_loop() {
+    run_test_with_prelude(
+        r#"
+        def f(n)
+          total = 0.0
+          i = 0
+          while i < 5
+            a = n * 1.5
+            call_block { a *= 2.0 }
+            total += a
+            i += 1
+          end
+          total
+        end
+        def g(n)
+          total = 0.0
+          5.times do |i|
+            a = n * 1.5 + i
+            call_block { total += a }
+          end
+          total
+        end
+        [f(3), g(3)]
+        "#,
+        PRELUDE,
+    );
+}
+
+/// The float is live across the call but the block never touches it, so
+/// the register is the only thing that has to still be right — this is
+/// the case the change exists for.
+#[test]
+fn a_float_untouched_by_the_block() {
+    run_test_with_prelude(
+        r#"
+        def f(n)
+          a = n * 1.5
+          b = n * 2.5
+          c = call_block { 1 }
+          [a + 1.0, b * 2.0, a * b, c]
+        end
+        f(3)
+        "#,
+        PRELUDE,
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -157,6 +157,7 @@
 0a113daaabe1d4a623096c5f5d1b9ad3	"/home/user/monoruby"	File.expand_path("..")
 0a8fcb3472ef6869da4abdbb99763b0d	[2, :redefined, false]	def probe(a, b) = a == b\n                def probe_ne(a, b) = a
 0aa2fa3cce375400b399c989bb80cc19	[1, 0, 0, 2, 1, 1, 3, 2, 2, 5, 3, 3, 8, 4, 4, 13, 5, 5, 21, 6, 6, 34, 7, 7, 55, 8, 8, 89, 9, 9, 144, 10, 10, 233, 11, 11, 377, 12, 12, 610, 13, 13, 987, 14, 14, 1597, 15, 15]	e = Enumerator.new do |y|\n            a = b = 1\n            loop do\n   
+0abce90d3ad088b0bf89b96ec125cc4a	[5.25, 0.75, 4.5]	def call_block\n      yield\n    end\n    def call_block_twice\n      yield\n   
 0abd6eee0fea26b57419ce161524d82a	"Module"	Module.new { using Module.new }.class.to_s
 0abee4f13c81ea36178a7ea1d3967d26	true	Process.getpgid(0) == Process.getpgrp
 0ac4a1a595e5d45cfae6000f22e5b73a	:utterly_undefined_method_name	begin\n              Object.instance_method(:utterly_undefined_metho
@@ -628,6 +629,7 @@
 33151d5f5ddac3016b0004900224a63a	["warning: the block passed to 'UBWarn#unused' may be ignored\\n", "", "", "", "", "warn-bg", "", "", "silent-strict"]	def cap\n          saved = $stderr\n          buf = +""\n          io = Ob
 3320b224735f4ca919ccdcccb8c4e5bd	-450.5353775047145	def calc(i)\n          f = i * 1.1; g = i * 0.9; h = i * 1.3; j = i * 0.
 33428047f1f658e115c637013b4660d7	[["initial", nil], ["after-match", "zzz"], ["creator-after-resume", "oo"]]	"foo" =~ /(o+)/\n            r = []\n            f = Fiber.new do\n   
+3347692ca7320ce3b96875e272dbbe81	[7.5, 18.0]	def call_block\n      yield\n    end\n    def call_block_twice\n      yield\n   
 3358715ab6d315ac23aff09b3ff0f005	102450.0	class SpecAcc\n          K = 1.25\n          def calc(n, use_k)\n         
 33a37997020cb2a326855e1801974373	"hello\\n"	r, w = IO.pipe\n            t = Thread.new { r.gets }\n            Th
 33b5711e09e6c160215318c1fd17224f	["no error", 5]	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; def m(x:)
@@ -1108,6 +1110,7 @@
 5b25596f97b36691f45783308ef66569	42	def f(handled:)\n          handled\n        end\n        \n\n        handled
 5b3483f96d997976f0f4974e1d96b628	["y", nil, "MONORUBY_ENV_TEST_DEL2!missing"]	ENV["MONORUBY_ENV_TEST_DEL2"] = "y"\n            a = ENV.delete("MON
 5b44a248a61dc40383d51a96cc748f88	14	[2, 3, 4, 5].inject {|result, item| result + item }
+5b46729462de0ea516438e53f745a399	[4.5, 5.5, 4.75]	def call_block\n      yield\n    end\n    def call_block_twice\n      yield\n   
 5b723a2cb7483967f04b7359c4f52ccd	[11, 11, 5, 3, 8, nil, nil, nil]	class C; attr_accessor :m; end\n\n        res = []\n        o = C.new\n        o.m =
 5b79cfb335c3c10194e188b3310b2096	["RuntimeError", "msg", false]	root = Fiber.current\n            fiber = Fiber.new { root.transfer;
 5b81f105b406bdc1f8f48edc118fcd74	[{a: 1, b: 2, c: 3}]	def f(*x)\n            x\n        end\n        \n\n            f(a:1, **{b:2
@@ -1816,6 +1819,7 @@
 9654828de246bee535681a18dadb92ac	["before", false]	ENV["MONORUBY_ENV_TEST_REPL2"] = "before"\n            ENV.delete("M
 967087a7b4b8b591af552ea304e4f008	["ensure", 42]	def foo\n              begin\n                eval("return 42")\n     
 9688571ca68b697dbfbba96221a9f286	Foo	class Foo\n              def bar; end\n            end\n            \n\n
+96db95681fd6127207742111ab312ee2	[45.0, 32.5]	def call_block\n      yield\n    end\n    def call_block_twice\n      yield\n   
 96e3694435312b4930df7a7be3c47ef2	[[nil, nil, 5, nil, nil, nil, nil, nil, nil, nil, 4], A]	class A < Array\n        end\n        \n\n        a = A.new(10)\n        a <
 96fd9678f0dfe97f7c36c920dd7add18	[123456789, 123456789, 123456000, 123456000, 123000000, 500000]	[Time.at(0, 123456789, :nanosecond).nsec, Time.at(0, 123456789, :nsec).nsec, Tim
 970a7c81313ab20891884b7ce441755a	false	c = Class.new do\n              def m; 1; end\n              undef :"
@@ -2260,6 +2264,7 @@ b8a48c3aa1c3407546058fae28da4256	[false, false]	def foo; end\n            def ba
 b8add92dc4f86330682dc9fa57fea596	"[nil, true]"	r, w = IO.pipe\n            pid = fork do\n              r.close\n    
 b8d3738377245420bc2378da58f5f7d9	100	p = Proc.new { 100 }\n            define_method(:foo, p)\n           
 b8d68ef10028da6842a236893e45d2cb	:local_jump	begin\n              Thread.new { return }.value\n              :no_e
+b8e73ca465704ccb728ac104f9385e74	["str", 8]	def call_block\n      yield\n    end\n    def call_block_twice\n      yield\n   
 b8fdb4f51c8e75670a1418eb17bac041	:ok	pat = "ア".encode(Encoding::EUC_JP)\n            begin\n              
 b93a89bc24fb2ce9a85934322dd7c06b	[[[:rest, :*]], [[:keyrest, :**]], [[:nokey]], [[:rest, :*], [:keyrest, :**], [:block, :&]], [[:rest, :*], [:keyrest, :**], [:block, :&]], [[:req, :_], [:req, :_], [:opt, :_], [:rest, :_], [:keyreq, :_], [:key, :_], [:keyrest, :_], [:block, :_]], [[:req, :a], [:rest, :rest], [:keyreq, :k], [:keyrest, :kw], [:block, :blk]], [[:block, :&]], [[:rest]], [[:req]]]	class C\n              def un_splat(*); end\n              def un_kwr
 b95a04e2a38f61bbd5a709fe2765858d	["US-ASCII"]	"a1b2c".dup.force_encoding("US-ASCII").split(/\\d/).map(&:encoding).map(&:to_s).u
@@ -2325,6 +2330,7 @@ bd72323eccae40b197ebea1283639273	[nil, 42]	a = []\n        a << $std\n        $s
 bd7a26e1f462e26d42e9543689bc3430	3862152.611328125	def calc(n, vals)\n          a = 0.0; b = 1.0; c = 2.0; d = 3.0\n        
 bd9970837b8009b39aca5efafe329d8e	["true", "5", "", "foo"]	[true.to_s, 5.to_s, nil.to_s, :foo.to_s]
 bd9f54fa26238d51503216b560dcfe9d	"M:C"	module M\n          def foo\n            "M:" + super\n          end\n     
+bdd4254f72e55d63b4505c0909c9bd00	[6.5, 17.0]	def call_block\n      yield\n    end\n    def call_block_twice\n      yield\n   
 bde4f5647e4c5f426e0b6b9de2ad09ab	[[], [:it], [:_1, :_2, :_3], [:it], [], [], []]	[\n              binding.implicit_parameters,\n              proc { i
 bde9a54a7762ba3fd118c904ccaac5c2	[:rescued]	def boom; raise "no"; end\n            def test; [1].map { begin; bo
 bdea9d1c4693119e7bb516fdfdf9210c	:done	r = false\n            t = Thread.new do\n              f = Fiber.new
@@ -2741,6 +2747,7 @@ de387ac8bf934d8f07086b9e2b4a50ed	42	$. = 42; $.
 de3f2322030d1ec856a9f41781bd41a8	[[:amount, :unit], [:amount, :unit]]	M = Data.define(:amount, :unit)\n[M.members, M.new(1, "m").members]
 de45ad555f2bc9cedadc3fa83f510527	:timeout_ok	m = Mutex.new\n            cv = ConditionVariable.new\n            m.
 de521c9dde3d5c4cdfdcda53477a4a7a	[7, 11, [:v, :v=, :w, :w=]]	c = class A\n          def f(x,y)\n            @v = x\n            @w = y\n
+de57150bfa4b34df0976085e285fdbdc	[5.5, 15.0, 33.75, 1]	def call_block\n      yield\n    end\n    def call_block_twice\n      yield\n   
 de66948e25a28714509d336867317012	""	require 'stringio'\n            old_stderr = $stderr\n            old
 de798d02c5c298e75dec774c3d08450b	["REFINED", "1", "[1]", "REFINED"]	module BopToS\n              refine(Integer) { def to_s; "REFINED"; 
 de8f2a99d0a0ebbc8d17c6ce43050021	["line 1\\nline 2\\n", "a\\nb\\n", "ends\\n", "noend\\n", "1\\n2\\n3\\n", "\\n", ""]	require 'stringio'\n        def cap; $stderr = StringIO.new; yield; s = 

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -514,6 +514,7 @@
 2856d276c472b3b28a51d514662d76c0	"Cargo.toml"	File.open("Cargo.toml") { |f| f.to_path }
 2857ee8562740e3a303e0b419aa33d73	["EUC-JP", true]	(f="/tmp/mono_tpe_#{Process.pid}"; File.write(f, ""); io=File.new(f.encode(Encod
 286b90c6e98dbe079e4a2b613b749cdb	"nil"	Set[1, 2, 3].freeze.flatten!.inspect
+289051905abb74616bfde774be4d9349	32.5	def call_block\n      yield\n    end\n    def call_block_twice\n      yield\n   
 2890bbfd125193c6fcb4cb125c9bd264	[999, 999]	$flag = false\n        def maybe_redefine\n          if $flag\n           
 28a4af30262d398c6994aca4ced26997	[true, false, true, false, true, false, true, true, true, false]	class C; end\n            class D < C; end\n            o = C.new\n   
 28b294682b3a75ed931f88b8ec443144	[true, false]	k = Class.new { def ==(o); false; end; def equal?(o); false; end }\n


### PR DESCRIPTION
At a call that hands out this frame's block, every unboxed local is homed in its slot first: the block can read the slot behind the compiler's back. For `F` — a slot whose only copy is an fpr — that meant a store **and** the binding falling to `S`, so the very next float op in the frame decoded the value back out of the box the store had just written.

For `a = n * 1.5; call_block { 1 }; a + 1.0`, the code after the call was:

```
mov   rdi, [rbp-0x48]     ; the box we stored on the way in
test  rdi, 0x1 / jne …    ; not a Fixnum
test  rdi, 0x2 / je  …    ; is it a flonum
…                         ; rotate the flonum payload back to an f64
movq  xmm3, rdi
movq  xmm5, xmm3
addsd xmm5, xmm4
```

The store is not the part that can be avoided; the forgetting is. A slot whose box is on the stack and whose float is in an fpr is exactly `Sf`, and boxing an `F` produces both. `Sf` across this boundary is already settled (#1172): the call saves and restores the frame's physical fprs (`fpr_save_cont` / `fpr_restore_cont`), and the one thing that invalidates the view — the callee writing the slot — arrives as a `StoreDynVar` through `widen_outer_slot`. So the arm lands on `Sf` instead of `S`, and the same code becomes:

```
movq  xmm5, xmm4
addsd xmm5, xmm3
```

`SfGuarded::Float` is the right guard because the value came out of an fpr, so the box the store writes is a `Value::float` — the same reasoning `bridge_at`'s `F -> Sf` arm already uses. Nothing else moves: the store was emitted before and is emitted now, and the slot's `Guarded` is `Float` on both sides of the change.

### What is still open

Eliding that store. It needs the block to read the caller's float out of the call's fpr save area rather than out of the slot — the address `ChainReplay::fpr_save_index` computes for chain deopt, placed behind the `PhysMap::resolve` seam. This PR deliberately keeps the store and takes only the register.

### A pre-existing crash the new tests turned up

Not fixed here, and not caused here. A `while` loop around a block-passing call whose block writes an outer local crashes the compiler:

```ruby
def call_block; yield; end
def f(n)
  i = 0; a = 0.0
  while i < 5
    a = n * 1.5
    call_block { a *= 2.0 }
    i += 1
  end
  a
end
200.times { f(3) }
```
```
panicked at state/slot.rs: unreachable code: %1 S(Value)->C(3)
```

`%1` is `n`. It reaches the loop entry as `C(3)`, folded from the call site, and reaches the back edge as `S(Value)`, a `forget_constants` on the path through the block-passing call — and `bridge_at` has no `S -> C` for a frame below the innermost, because it cannot prove the slot holds the constant the target claims. Both ingredients are needed: `f` inlined into the `times` block, so its frame is an outer one, *and* a constant argument; drop either and it passes.

This reproduces on master, on x86-64, with no stress features and with this PR's `slot.rs` change reverted, so it is neither arch- nor float-specific. It is the third of the three open items `compile_method_call` already names where it decides what a block-passing call may keep — "the bridge must be able to carry the claim across a merge in a frame *below* this one, which it cannot". It is carried here as an `#[ignore]`d test holding the repro and the diagnosis, so the finding stays in the tree; fixing it is separate work.

### Tests

`monoruby/tests/float_across_block_call.rs` pins the cases the store and the invalidation exist for: a block that reads the outer float, one that writes it, one that replaces it with a non-float (so the `Float` guard has to go with the register), a builtin callee (nothing may be kept), a store two frames out, a block-passing call inside an `Integer#times` loop, and the untouched case the change exists for. Removing the boundary store fails five of the seven, so they discriminate.

### Verification

| pass | result |
|---|---|
| `cargo test --lib --tests` | 67 targets green (lib 2366) |
| `cargo test --features stress-spill-pool --lib --tests` (CI's feature set) | 67 targets green (lib 2366) |
| `GC_STRESS=1 cargo test --features gc-stress,stress-spill-pool --lib --tests` | 67 targets green (lib 2365, 626s) |
| aarch64 under qemu, plain and `stress-spill-pool` | green |
| `cargo check` on x86-64 and aarch64 | clean |

`stress-spill-pool` is load-bearing here: with the pool shrunk to 2, most of the `Sf` views this arm creates land in spill slots rather than xmm registers, so both halves of the placement get exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM