### PR TITLE
Tell the analysis pass a guarded unbox can deopt

### DIFF
--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -229,6 +229,23 @@ impl AsmIr {
         self.had_deopt
     }
 
+    ///
+    /// Record that this frame can deopt, without materializing a side exit.
+    ///
+    /// Only for the analysis pass. A guarded transfer record is not emitted
+    /// there (see [`Self::codegen_mode`]), so the `deopt_from_point` that
+    /// would have set the flag never runs — and the flag is not merely
+    /// bookkeeping for the emitted code: `specialized_iseq` reads it to
+    /// decide whether a block-passing call may keep this frame's constants.
+    /// Left unset, the analysis pass predicts a kept constant that the real
+    /// pass gives up, and the loop-entry target it produces then disagrees
+    /// with the back edge the real pass actually reaches.
+    ///
+    pub(in crate::codegen::jitgen) fn note_analysis_deopt(&mut self) {
+        debug_assert!(!self.codegen_mode);
+        self.had_deopt = true;
+    }
+
     pub(super) fn deferred_rest(&self) -> bool {
         self.deferred_rest
     }

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -60,6 +60,13 @@ pub(in crate::codegen::jitgen) enum FprLoad {
 }
 
 impl FprLoad {
+    /// Whether [`Self::emit`] would materialize a deopt side exit. Mirrors
+    /// the match below: only `FromStack` is guarded; the rest are literal
+    /// conversions with nothing to check.
+    pub(in crate::codegen::jitgen) fn deopts(self) -> bool {
+        matches!(self, FprLoad::FromStack(_, _))
+    }
+
     /// `deopt` (the program point) is required by the guarded (`FromStack` /
     /// `FromAcc`) variants and ignored by the guard-free ones; the guard-free
     /// `load_fpr_from_C_state` path passes `None`. The side-exit is materialized
@@ -158,6 +165,18 @@ pub(in crate::codegen::jitgen) enum FprFixnumLoad {
 }
 
 impl FprFixnumLoad {
+    /// Whether [`Self::emit`] would materialize a deopt side exit, given
+    /// whether the wrapper holds a program point. Mirrors the match below:
+    /// the `FromStack` arm materializes one whenever the point is `Some`
+    /// (even with `guard` false), and `Numeric` emits with `None`.
+    pub(in crate::codegen::jitgen) fn deopts(self, has_point: bool) -> bool {
+        match self {
+            FprFixnumLoad::None => false,
+            FprFixnumLoad::FromStack(_, _, _) => has_point,
+            FprFixnumLoad::Numeric(_) => false,
+        }
+    }
+
     /// `deopt` (the program point) is `Some` for the guarded `S` arm and
     /// `None` for the guard-free ones. The side-exit is materialized for the
     /// `S` arm whenever the point is `Some` — even if `guard` is false, so
@@ -200,7 +219,10 @@ impl AsmIr {
 
     /// Emit a deopt-carrying unbox-to-float load record (`load_fpr`, always
     /// guarded). A no-op in analysis mode — skipping it also avoids the dead
-    /// `side_exit` growth `deopt_from_point` would cause there.
+    /// `side_exit` growth `deopt_from_point` would cause there. The *fact*
+    /// that the record deopts is still recorded there: it is what
+    /// `specialized_iseq` keys `forget_constants` on, so the two passes have
+    /// to agree on it even when only one of them emits.
     pub(in crate::codegen::jitgen) fn fpr_load(
         &mut self,
         load: FprLoad,
@@ -209,11 +231,14 @@ impl AsmIr {
     ) {
         if self.codegen_mode() {
             load.emit(self, slot, Some(&deopt));
+        } else if load.deopts() {
+            self.note_analysis_deopt();
         }
     }
 
     /// Emit a fixnum unbox-to-float load record (`load_fpr_fixnum`); `deopt` is
-    /// present only for the guarded `S`/`G` arms. A no-op in analysis mode.
+    /// present only for the guarded `S`/`G` arms. A no-op in analysis mode,
+    /// bar the deopt fact — see [`Self::fpr_load`].
     pub(in crate::codegen::jitgen) fn fpr_fixnum_load(
         &mut self,
         load: FprFixnumLoad,
@@ -222,6 +247,8 @@ impl AsmIr {
     ) {
         if self.codegen_mode() {
             load.emit(self, slot, deopt.as_ref());
+        } else if load.deopts(deopt.is_some()) {
+            self.note_analysis_deopt();
         }
     }
 }

--- a/monoruby/tests/float_across_block_call.rs
+++ b/monoruby/tests/float_across_block_call.rs
@@ -146,27 +146,25 @@ fn a_block_call_inside_a_loop() {
     );
 }
 
-/// The same with a `while` loop instead of `Integer#times`, which trips a
-/// hole that predates any of this and is not about floats at all: the
-/// caller's argument reaches the loop entry as `C(3)` (folded from the
-/// call site) and reaches the back edge as `S(Value)` (a `forget_constants`
-/// on the path through the block-passing call), and `bridge_at` has no
-/// `S -> C` transition for a frame below the innermost one — it cannot
-/// prove the slot holds the constant the target claims. It panics:
+/// The same with a `while` loop, which used to abort the compiler with
 ///
 /// ```text
 /// unreachable code: %1 S(Value)->C(3)
 /// ```
 ///
-/// This is the third of the three open items `compile_method_call` names
-/// where it decides what a block-passing call may keep ("the bridge must
-/// be able to carry the claim across a merge in a frame *below* this one,
-/// which it cannot"). It reproduces on x86-64 with no stress features and
-/// with the `F -> Sf` boundary change reverted, so it is not arch- or
-/// float-specific; `Integer#times` above escapes it only because the
-/// callee's loop is not in the block's own chain.
+/// `%1` is `n`. It reached the loop entry as `C(3)`, folded from the call
+/// site, and reached the back edge as `S(Value)`, given up by the
+/// `forget_constants` on the path through the block-passing call — and
+/// `bridge` has no `S -> C`, because nothing can prove a slot holds the
+/// constant the target claims.
+///
+/// The disagreement was between the two passes, not between the paths:
+/// the loop-entry target comes from the back-edge fixpoint, which runs in
+/// analysis mode, where a guarded unbox emits nothing and so never set
+/// `had_deopt` — the very flag `specialized_iseq` reads to decide whether
+/// the call may keep the frame's constants. The analysis predicted a kept
+/// `C(3)`; codegen gave it up. See `AsmIr::note_analysis_deopt`.
 #[test]
-#[ignore = "pre-existing: bridge_at has no S -> C for an outer frame"]
 fn a_while_loop_around_a_block_passing_call() {
     run_test_with_prelude(
         r#"

--- a/monoruby/tests/float_across_block_call.rs
+++ b/monoruby/tests/float_across_block_call.rs
@@ -164,7 +164,21 @@ fn a_block_call_inside_a_loop() {
 /// `had_deopt` — the very flag `specialized_iseq` reads to decide whether
 /// the call may keep the frame's constants. The analysis predicted a kept
 /// `C(3)`; codegen gave it up. See `AsmIr::note_analysis_deopt`.
+///
+/// Compiling it at all then uncovered a *second*, unrelated defect, which
+/// is why one configuration is excluded below: on aarch64 with
+/// `stress-spill-pool` — the pool shrunk to 2, so nearly every fpr is a
+/// spill slot — this segfaults in the compiled code. It is not about the
+/// float claims a block-passing call keeps: it reproduces with the `Sf`
+/// and `F -> Sf` boundary arms both removed, i.e. with the frame keeping
+/// no float across the call at all. x86-64 at either pool size and
+/// aarch64 with the full pool are unaffected, so it is the aarch64 spill
+/// addressing, reachable only now that this shape compiles.
 #[test]
+#[cfg_attr(
+    all(target_arch = "aarch64", feature = "stress-spill-pool"),
+    ignore = "separate aarch64 spill-path defect: segfaults in compiled code"
+)]
 fn a_while_loop_around_a_block_passing_call() {
     run_test_with_prelude(
         r#"

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -2170,6 +2170,7 @@ afe017e12ee32ba781bc419214f2db54	"e\\n\\nCopyright (c) 202"	File.binread("../LIC
 afecc303354ce360b53ad03479bdb2f0	2	t = Time.utc(1970, 1, 1, 0, 0, 0); def t.succ; self + 1; end\n      
 b017ead69b837578afee4295eb840ed7	"#<Class:Time>"	Time.singleton_class.to_s
 b041b0aaea8a7d40b26a35b251c0f897	[[:req, :a], [:nokey]]	def m(a, **nil); end\n            method(:m).parameters\n            
+b050bdfac1ec47f5eeda5dc5e12bd05a	45.0	def call_block\n      yield\n    end\n    def call_block_twice\n      yield\n   
 b06f00715b283fa26e9acda37466978d	[1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub]	class MyArray < Array\n              def [](i) = :sub\n            en
 b07897e1515470c5f367e6c838cd3ca3	true	h = {a: 1}.compare_by_identity\n            Marshal.load(Marshal.dum
 b127614a38e6a826e83df4733ad1c138	[true, true]	require "openssl"\n        [OpenSSL::Cipher::CipherError < OpenSSL::Open


### PR DESCRIPTION
A `while` loop around a block-passing call whose block writes an outer local aborted the compiler. Plain Ruby, x86-64, no stress features:

```ruby
def call_block; yield; end
def f(n)
  i = 0; a = 0.0
  while i < 5
    a = n * 1.5
    call_block { a *= 2.0 }
    i += 1
  end
  a
end
200.times { f(3) }
```
```
unreachable code: %1 S(Value)->C(3)
```

`%1` is `n`. It reached the loop entry as `C(3)`, folded from the call site, and reached the back edge as `S(Value)`, given up by `specialized_iseq`'s `forget_constants` on the path through the block-passing call. `bridge` has no `S -> C` arm and should not have one: nothing can prove a slot holds the constant the target claims.

### The two passes disagreed, not the two paths

The loop-entry target comes from the back-edge fixpoint, which runs in analysis mode, and `forget_constants` is gated on `had_deopt`:

```rust
if had_deopt || generic_yield { state.forget_constants(ir); }
```

`had_deopt` is set by `deopt_from_point`, which runs only inside a guarded transfer record's `emit` — and analysis mode skips `emit` entirely, to avoid growing a `side_exit` table it will throw away. The block reads its outer float through a guarded unbox, so codegen set the flag and analysis did not:

| | `had_deopt` | `forget_constants` | back-edge `%1` |
|---|---|---|---|
| analysis | **false** | not called | `C(3)` |
| codegen | true | called | `S(Value)` |

The target built from the prediction then contradicted the back edge the real pass reached. `had_deopt` is not only bookkeeping for emitted code — it is what decides whether a block-passing call may keep the frame's constants — so the two passes have to agree on it even when only one of them emits.

### The fix

Keep skipping the emit; record the fact on its own. `deopts()` mirrors each record's `emit` match (`FprLoad::FromStack` is the guarded arm; `FprFixnumLoad::FromStack` materializes a point whenever it has one), and `note_analysis_deopt` sets the flag without a label.

This errs safe in the one direction that matters. Over-reporting only makes the analysis give up a constant codegen would have kept, and `C -> S` is a bridge that always exists; it is under-reporting that produces a target no predecessor can reach. `had_deopt` has exactly one consumer, the gate above, so nothing else shifts.

### A second, unrelated defect this uncovered

Compiling that shape at all turned up a segfault in the compiled code on **aarch64 with `stress-spill-pool`** — the pool shrunk to 2, so nearly every fpr is a spill slot.

It is not about what float claims a block-passing call keeps: it reproduces with both boundary arms removed (the `Sf` keep from #1172 and the `F -> Sf` landing from #1173), i.e. with the frame holding no float across the call at all. x86-64 at either pool size and aarch64 with the full pool all pass, which places it in the aarch64 spill addressing, reachable only now that this shape compiles.

Gated precisely rather than dropped, so the test keeps running in the three configurations where it is valid and the excluded one names what is wrong. Fixing it is separate work.

### Verification

| pass | result |
|---|---|
| `cargo test --lib --tests` | 67 targets green (lib 2366) |
| `cargo test --features stress-spill-pool --lib --tests` | 67 targets green (lib 2366) |
| `GC_STRESS=1 cargo test --features gc-stress,stress-spill-pool --lib --tests` | 67 targets green (lib 2365, 1256s) |
| aarch64 under qemu — the JIT-relevant integration targets × `stress-spill-pool` | green |
| `float_across_block_call` on x86-64 and aarch64 × plain and `stress-spill-pool` | green |

Two notes on the aarch64 side. The **full** lib suite cannot be run under qemu-user — it dies with `QEMU internal SIGSEGV` or `failed to set up alternative stack guard page: Cannot allocate memory` partway through 2366 parallel tests — so aarch64 coverage here is the JIT-relevant integration targets plus the `codegen::`/`bytecodegen::` lib subset. And `method_call::toplevel_return_argument_warns` fails under qemu on master too; it is environmental and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_