### PR TITLE
Make a version-word salvage patch flip the MAP_JIT page writable

### DIFF
--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -553,9 +553,19 @@ impl JitModule {
         (ptr0, size0 as usize, ptr1, size1 as usize)
     }
 
+    /// Patch a compilation unit's class-version snapshot word (the
+    /// `class_version_label` created by `jit_compile`) to *version*,
+    /// re-validating every `GuardClassVersion` in the unit after a
+    /// successful class salvage.
     pub fn set_class_version(&mut self, version: u32, label: &DestLabel) {
         let p = self.jit.get_label_address(label).as_ptr() as *mut u32;
+        // The word is a `const_i32`, so it lives in a *code* page, not the
+        // data page — see `set_const_version` for why that matters here.
+        self.jit.mark_dirty(p as *const u8, 4);
+        // SAFETY: the label names a 4-byte word emitted by `jit_compile`,
+        // just made writable by `mark_dirty`.
         unsafe { *p = version };
+        self.jit.set_executable();
     }
 
     /// Patch a compilation unit's const-version snapshot word (see
@@ -563,9 +573,23 @@ impl JitModule {
     /// `GuardConstVersion` in the unit after a successful const salvage.
     pub fn set_const_version(&mut self, version: u64, label: &DestLabel) {
         let p = self.jit.get_label_address(label).as_ptr() as *mut u64;
-        // SAFETY: the label names an 8-byte data word emitted by
-        // `jit_compile` in the JIT data area, which stays writable.
+        // Both unit snapshot words are `const_i64`/`const_i32` labels, and
+        // monoasm's `resolve_constants` emits those into the *code* page
+        // (only `data_i64`/`data_i32` reach the always-writable data page —
+        // which is where every other patchable word here lives: the global
+        // `class_version` / `const_version`, `poll_flag`, `bop_flags`, the
+        // deopt counters). On Apple Silicon the code pages are `MAP_JIT`
+        // and write-protected for the thread whenever it is not emitting,
+        // which is exactly the case on the salvage path: it runs out of
+        // compiled code. Storing through the raw pointer there is a SIGBUS.
+        // `mark_dirty` flips the pages writable and records the 8 bytes so
+        // the matching `set_executable` re-protects them and flushes only
+        // that range. Both calls are no-ops on x86-64.
+        self.jit.mark_dirty(p as *const u8, 8);
+        // SAFETY: the label names an 8-byte word emitted by `jit_compile`,
+        // just made writable by `mark_dirty`.
         unsafe { *p = version };
+        self.jit.set_executable();
     }
 
     #[cfg(feature = "perf")]

--- a/monoruby/tests/float_across_block_call.rs
+++ b/monoruby/tests/float_across_block_call.rs
@@ -165,19 +165,41 @@ fn a_block_call_inside_a_loop() {
 /// the call may keep the frame's constants. The analysis predicted a kept
 /// `C(3)`; codegen gave it up. See `AsmIr::note_analysis_deopt`.
 ///
-/// Compiling it at all then uncovered a *second*, unrelated defect, which
-/// is why one configuration is excluded below: on aarch64 with
-/// `stress-spill-pool` — the pool shrunk to 2, so nearly every fpr is a
-/// spill slot — this segfaults in the compiled code. It is not about the
-/// float claims a block-passing call keeps: it reproduces with the `Sf`
-/// and `F -> Sf` boundary arms both removed, i.e. with the frame keeping
-/// no float across the call at all. x86-64 at either pool size and
-/// aarch64 with the full pool are unaffected, so it is the aarch64 spill
-/// addressing, reachable only now that this shape compiles.
+/// Compiling it at all then uncovered *two* further, unrelated defects,
+/// which is why one configuration is still excluded below.
+///
+/// The first was not about the spill pool at all, and is fixed:
+/// `Codegen::set_class_version` patched a unit's version snapshot word —
+/// a `const_i32`, which monoasm emits into a `MAP_JIT` *code* page, not
+/// the always-writable data page — without flipping the page writable, so
+/// every successful class-version salvage was a SIGBUS on Apple Silicon at
+/// *any* pool size. See `Codegen::set_const_version`'s comment.
+///
+/// The second is real and still open: on aarch64 with `stress-spill-pool`
+/// this segfaults in compiled code. `LoadDynVarSpecialized` addresses the
+/// outer frame at a fixed `[x29 + offset]`, and here that offset is 16
+/// bytes too small, so the block reads the word below the slot it wants.
+/// Measured at the faulting site: the block's `x29` sits 368 bytes below
+/// `f`'s, `a` (4.5) is at `x29 + 280`, and the emitted offset is 264.
+///
+/// What is *ruled out*, so nobody re-walks it:
+/// - the offset does not differ by pool — `resolve_specialized_id_chain`
+///   yields the same 352 at pool 2 and pool 14, and pool 14 measures a
+///   physical 352, so only the layout moves;
+/// - the modelled FP-save (`specialized_compile`'s `using_fpr_offset`) and
+///   the emitted one (`emit_fpr_save`) agree — 45/45 call sites matched;
+/// - `frame_sizes.total` being calibrated for `Init`-prologue frames
+///   (`total - 32`) while a loop-JIT root reserves `total - 16` looks like
+///   the discrepancy, but adding `CONTINUATION_FRAME_SIZE` back for
+///   `is_loop` frames is **not** the fix — with or without excluding the
+///   `MethodRetSpecialized` / `BlockBreakSpecialized` twins it fixes this
+///   case and breaks a `while` loop + block-passing call that has no
+///   redefinition churn (which reaches a loop-JIT chain and is correct
+///   today). So `is_loop` is not the axis that discriminates.
 #[test]
 #[cfg_attr(
     all(target_arch = "aarch64", feature = "stress-spill-pool"),
-    ignore = "separate aarch64 spill-path defect: segfaults in compiled code"
+    ignore = "open aarch64 defect: specialized-dynvar chain offset is 16 short through a loop-JIT root"
 )]
 fn a_while_loop_around_a_block_passing_call() {
     run_test_with_prelude(


### PR DESCRIPTION
## What

`Codegen::set_class_version` / `set_const_version` patch a compilation unit's version snapshot word through a raw pointer into JIT memory, without flipping the page writable first. On aarch64/macOS that store is a `SIGBUS`.

Both words come from `jit.const_i32()` / `const_i64()`, and monoasm's `resolve_constants` emits those into a **code** page (`self[Page(id)]`) — only `data_i32` / `data_i64` reach the separately-allocated, always-writable data page. That is where every *other* patchable word here lives (the global `class_version` / `const_version`, `poll_flag`, `bop_flags`, the deopt counters), which is exactly why those were fine and these two were not.

On Apple Silicon the code pages are `MAP_JIT` and stay write-protected for the thread whenever it is not emitting. The salvage path runs out of compiled code, so it is *always* in that state. `set_const_version`'s `SAFETY` comment asserted the opposite — *"in the JIT data area, which stays writable"* — and that mistaken premise is the bug.

## Not a `stress-spill-pool` issue

This was previously attributed to the aarch64 spill path. It isn't: a **default (pool 14)** build crashes on any successful class-version salvage.

```ruby
class Foo; def bar; 1; end; end
def loopy; s = 0; i = 0; while i < 300; s += Foo.new.bar; i += 1; end; s; end
p loopy
class Foo; def baz; 2; end; end   # bumps the class version
p loopy                            # SIGBUS before this change
```

```
frame #0: <JitModule>::set_class_version at codegen.rs:558
->  str  w21, [x1]      ; x1 = 0x300041f88
stop reason = EXC_BAD_ACCESS (code=2, address=0x300041f88)   # protection failure
```

## Fix

Patch under `mark_dirty` — monoasm's documented API for an out-of-band write, which flips the pages writable and records just the 4/8 bytes — then re-protect with the matching `set_executable`, so the I-cache flush covers only that range instead of the whole region. Both calls are no-ops on x86-64 (`JitProtect` there is a ZST with empty methods), so this is behaviour-identical on that backend.

## Testing

| | result |
|---|---|
| `cargo nextest run` (aarch64, pool 14) | 3318 passed, 1 skipped |
| `cargo nextest run --features stress-spill-pool` (aarch64, pool 2) | 3317 passed, 2 skipped |

Run natively on arm64-apple-darwin.

## Known issue left open

`float_across_block_call::a_while_loop_around_a_block_passing_call` stays excluded on aarch64 + `stress-spill-pool`. Fixing the `SIGBUS` uncovered a **second**, genuinely spill-pool-dependent defect underneath it: `LoadDynVarSpecialized` addresses the outer frame at a fixed `[x29 + offset]` that is 16 bytes too small, so the inlined block reads the word below the slot it wants. Measured at the faulting site: the block's `x29` sits 368 bytes below `f`'s, `a` (4.5) is at `x29 + 280`, the emitted offset is 264.

The test's doc comment now records the measurements and what has already been ruled out, so the next attempt does not re-walk them:

- the offset does **not** differ by pool — `resolve_specialized_id_chain` yields 352 at both pool 2 and pool 14, and pool 14 measures a physical 352, so only the layout moves;
- the modelled FP-save (`specialized_compile`'s `using_fpr_offset`) and the emitted one (`emit_fpr_save`) agree — 45/45 call sites matched;
- `frame_sizes.total` is calibrated for `Init`-prologue frames (`total - 32`) while a loop-JIT root reserves `total - 16`, which *looks* like the discrepancy — but adding `CONTINUATION_FRAME_SIZE` back for `is_loop` frames is **not** the fix. With or without excluding the `MethodRetSpecialized` / `BlockBreakSpecialized` twins, it corrects this case and breaks a `while` loop + block-passing call with no redefinition churn, which reaches a loop-JIT chain and is correct today. `is_loop` is not the discriminating axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
