### PR TITLE
Pin the loop-JIT entry to the depth the prologue already reserved

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -2604,10 +2604,35 @@ impl Codegen {
         off <= 32760 && off % 8 == 0
     }
 
-    /// Loop-JIT entry stack bump (large bumps go through `a64_sp_sub`).
-    pub(in crate::codegen::jitgen) fn emit_loop_jit_rsp_bump(&mut self, offset: LoopRspOffset) -> bool {
+    /// Loop-JIT entry stack setup: pin `sp` to this frame's canonical depth
+    /// (`a64_addr_sub` materializes an out-of-immediate-range offset).
+    pub(in crate::codegen::jitgen) fn emit_loop_jit_rsp_bump(
+        &mut self,
+        offset: LoopRspOffset,
+        base: usize,
+    ) -> bool {
         let bytes = offset.unwrap_concrete();
-        self.a64_sp_sub(bytes as u32);
+        // This body is reached by `loop_start` from *either* producer of a
+        // Ruby frame, and inherits that frame's `sp`. The two do not reserve
+        // the same thing: the VM's `init_method` reserves the iseq's
+        // `FnInitInfo::stack_offset` (`base - PROLOGUE_OVERHEAD`) and knows
+        // nothing of spill slots, while an `AsmInst::Init` prologue reserves
+        // `total - PROLOGUE_OVERHEAD` — the same area *plus this unit's
+        // spill region*, since the region is part of `total`. Subtracting
+        // `total - base` from what we inherit therefore counts the spill
+        // region twice on the JIT-prologue path, landing `total - base`
+        // deeper than on the VM path.
+        //
+        // Pin `sp` to the frame's canonical depth instead, so both producers
+        // agree: `total - PROLOGUE_OVERHEAD`, exactly what the prologue
+        // reserves. The frames this body then builds below `sp` stay where
+        // the compile assumed, which is what the fixed `x29`-relative
+        // offsets addressing them (`LoadDynVarSpecialized`, the spill slots)
+        // require. `x29` is dependable here — `x29 - lfp` is invariant
+        // across entries.
+        let below = base - PROLOGUE_OVERHEAD + bytes;
+        self.a64_addr_sub(10, 29, below as u32);
+        monoasm_arm64!(&mut self.jit, mov sp, x10;);
         true
     }
 

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -318,14 +318,20 @@ impl Codegen {
         }
     }
 
-    /// Undo the loop-JIT entry sp-bump (`emit_loop_jit_rsp_bump`) before
-    /// resuming the interpreter. Unlike x86 — whose VM frame is rbp-relative,
-    /// so a stale sp is harmless — the aarch64 VM sets up callee frames
-    /// sp-relative, so every loop-JIT exit that resumes the VM (deopt, error,
-    /// raise, retry, redo) must restore sp first. `bytes` is
-    /// `frame.loop_jit_spill_bytes` (0 for a non-loop frame or a loop without
-    /// spill); large bumps go through `a64_sp_add` (mirroring the entry
-    /// `a64_sp_sub`).
+    /// Release the spill region the loop-JIT entry pinned sp below
+    /// (`emit_loop_jit_rsp_bump`) before resuming the interpreter. Unlike x86
+    /// — whose VM frame is rbp-relative, so a stale sp is harmless — the
+    /// aarch64 VM sets up callee frames sp-relative, so every loop-JIT exit
+    /// that resumes the VM (deopt, error, raise, retry, redo) must restore sp
+    /// first. `bytes` is `frame.loop_jit_spill_bytes` (0 for a non-loop frame
+    /// or a loop without spill).
+    ///
+    /// Not the inverse of the entry, which pins an absolute depth rather than
+    /// subtracting: adding the spill region back to
+    /// `x29 - (total - PROLOGUE_OVERHEAD)` lands at
+    /// `x29 - (base - PROLOGUE_OVERHEAD)` — the local area the VM's
+    /// `init_method` reserves — whichever producer built the frame.
+    /// Deliberate: the VM resumes here, and that is its own depth.
     fn a64_undo_loop_rsp_bump(&mut self, bytes: usize) {
         if bytes > 0 {
             self.a64_sp_add(bytes as u32);
@@ -2609,9 +2615,7 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn emit_loop_jit_rsp_bump(
         &mut self,
         offset: LoopRspOffset,
-        base: usize,
     ) -> bool {
-        let bytes = offset.unwrap_concrete();
         // This body is reached by `loop_start` from *either* producer of a
         // Ruby frame, and inherits that frame's `sp`. The two do not reserve
         // the same thing: the VM's `init_method` reserves the iseq's
@@ -2619,18 +2623,18 @@ impl Codegen {
         // nothing of spill slots, while an `AsmInst::Init` prologue reserves
         // `total - PROLOGUE_OVERHEAD` — the same area *plus this unit's
         // spill region*, since the region is part of `total`. Subtracting
-        // `total - base` from what we inherit therefore counts the spill
-        // region twice on the JIT-prologue path, landing `total - base`
+        // `total - base` from what we inherit would therefore count the
+        // spill region twice on the JIT-prologue path, landing that much
         // deeper than on the VM path.
         //
         // Pin `sp` to the frame's canonical depth instead, so both producers
         // agree: `total - PROLOGUE_OVERHEAD`, exactly what the prologue
-        // reserves. The frames this body then builds below `sp` stay where
-        // the compile assumed, which is what the fixed `x29`-relative
-        // offsets addressing them (`LoadDynVarSpecialized`, the spill slots)
-        // require. `x29` is dependable here — `x29 - lfp` is invariant
-        // across entries.
-        let below = base - PROLOGUE_OVERHEAD + bytes;
+        // reserves, which is what `offset` carries. The frames this body
+        // then builds below `sp` stay where the compile assumed, which is
+        // what the fixed `x29`-relative offsets addressing them
+        // (`LoadDynVarSpecialized`, the spill slots) require. `x29` is
+        // dependable here — `x29 - lfp` is invariant across entries.
+        let below = offset.unwrap_concrete();
         self.a64_addr_sub(10, 29, below as u32);
         monoasm_arm64!(&mut self.jit, mov sp, x10;);
         true

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -2185,23 +2185,20 @@ impl Codegen {
     pub(in crate::codegen::jitgen) fn emit_loop_jit_rsp_bump(
         &mut self,
         offset: LoopRspOffset,
-        base: usize,
     ) -> bool {
-        let bytes = offset.unwrap_concrete();
         // Pin rather than subtract, for the same reason aarch64 does: this
         // body is reached from *either* producer of a frame — the VM's
-        // `init_method`, which reserves `base - PROLOGUE_OVERHEAD` and knows
+        // `init_method`, which reserves the iseq's local area and knows
         // nothing of spill slots, or a JIT prologue, which reserves that
-        // plus this unit's spill region — so subtracting `total - base` from
-        // the inherited `rsp` counts the spill region twice on the prologue
-        // path.
+        // plus this unit's spill region — so subtracting from the inherited
+        // `rsp` would count the spill region twice on the prologue path.
         //
         // x86 is insensitive to the *addressing* consequences (its frames
         // are rbp-relative, so a body at the wrong depth still reads its own
         // slots correctly), but the inlined frames it builds below `rsp` do
         // move, and `resolve_specialized_id_chain`'s rbp-to-rbp distances
         // are fixed at compile time.
-        let below = base - PROLOGUE_OVERHEAD + bytes;
+        let below = offset.unwrap_concrete();
         monoasm! { &mut self.jit, lea rsp, [rbp - (below as i32)]; }
         true
     }

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -2181,15 +2181,28 @@ impl Codegen {
         }
     }
 
-    /// Loop-JIT entry: reserve the loop body's spill area on the native stack.
+    /// Loop-JIT entry stack setup: pin `rsp` to this frame's canonical depth.
     pub(in crate::codegen::jitgen) fn emit_loop_jit_rsp_bump(
         &mut self,
         offset: LoopRspOffset,
+        base: usize,
     ) -> bool {
         let bytes = offset.unwrap_concrete();
-        if bytes > 0 {
-            monoasm! { &mut self.jit, subq rsp, (bytes as i32); }
-        }
+        // Pin rather than subtract, for the same reason aarch64 does: this
+        // body is reached from *either* producer of a frame — the VM's
+        // `init_method`, which reserves `base - PROLOGUE_OVERHEAD` and knows
+        // nothing of spill slots, or a JIT prologue, which reserves that
+        // plus this unit's spill region — so subtracting `total - base` from
+        // the inherited `rsp` counts the spill region twice on the prologue
+        // path.
+        //
+        // x86 is insensitive to the *addressing* consequences (its frames
+        // are rbp-relative, so a body at the wrong depth still reads its own
+        // slots correctly), but the inlined frames it builds below `rsp` do
+        // move, and `resolve_specialized_id_chain`'s rbp-to-rbp distances
+        // are fixed at compile time.
+        let below = base - PROLOGUE_OVERHEAD + bytes;
+        monoasm! { &mut self.jit, lea rsp, [rbp - (below as i32)]; }
         true
     }
 

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -1570,12 +1570,18 @@ impl Codegen {
         // box a code pointer back to the VM). See the deopt-bridge
         // analysis in doc/regalloc_separation.md §39.
         self.gen_write_back_for_deopt(wb, base);
-        // Now undo the rsp bump that Loop JIT applied at its entry (see
-        // `AsmInst::LoopJitRspBump`). Method / specialized JITs restore
-        // rsp implicitly via their `leave; ret` epilogue, so the
-        // adjustment is Loop-specific. `loop_jit_spill_bytes` is `0` for
-        // non-Loop frames or Loop frames without spill, matching the
-        // entry-side `subq rsp, _` exactly.
+        // Now release the spill region that Loop JIT entry pinned rsp
+        // below (see `AsmInst::LoopJitRspBump`). Method / specialized
+        // JITs restore rsp implicitly via their `leave; ret` epilogue, so
+        // the adjustment is Loop-specific. `loop_jit_spill_bytes` is `0`
+        // for non-Loop frames or Loop frames without spill.
+        //
+        // This is not the inverse of the entry, which pins an absolute
+        // depth rather than subtracting: adding the spill region back to
+        // `rbp - (total - PROLOGUE_OVERHEAD)` lands at
+        // `rbp - (base - PROLOGUE_OVERHEAD)` — the local area the VM's
+        // `init_method` reserves — whichever producer built the frame.
+        // Deliberate: the VM resumes here, and that is its own depth.
         if loop_jit_spill_bytes > 0 {
             monoasm!( &mut self.jit,
                 addq rsp, (loop_jit_spill_bytes as i32);

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1278,17 +1278,18 @@ impl PrologueOffset {
 }
 
 ///
-/// Bytes the Loop JIT entry should subtract from `rsp` (and the
-/// matching side-exit handler should add back). Only the bytes that
-/// the JIT itself owns — the invoker / interpreter prologue is left
-/// untouched, so this captures the JIT-managed spill slots that sit
-/// on top of the surrounding interpreter frame.
+/// How far below `rbp`/`x29` the Loop JIT entry should pin `rsp`/`sp`:
+/// the frame's local area, `total - PROLOGUE_OVERHEAD`.
 ///
-/// Pass 1 emits `Hint(id)` — the current frame's [`SpecializedId`].
-/// The pre-codegen resolve pass derives the byte count as
-/// `stack_offset - base_stack_offset` of that frame, so any future
-/// VirtFPReg spill space added to the frame's recorded size flows
-/// through to the JIT-emitted bump automatically.
+/// It is an *absolute* depth rather than a delta because the entry
+/// cannot trust the `sp` it inherits: a loop body is reached by
+/// `loop_start` from either producer of a Ruby frame, and the two do not
+/// reserve the same thing (see `Codegen::emit_loop_jit_rsp_bump`).
+///
+/// Pass 1 emits `Hint(id)` — the current frame's [`SpecializedId`]. The
+/// pre-codegen resolve pass reads that frame's recorded `total`, so
+/// VirtFPReg spill space added to the frame's size flows through to the
+/// pinned depth automatically.
 ///
 #[derive(Debug, Clone)]
 pub(crate) enum LoopRspOffset {

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -818,7 +818,10 @@ impl Codegen {
             }),
             // Loop-JIT entry stack bump (aarch64 bails on a frame larger than
             // the 12-bit sub-sp immediate).
-            AsmInst::LoopJitRspBump { offset } => self.encode_linst(LInst::LoopJitRspBump { offset }),
+            AsmInst::LoopJitRspBump { offset } => self.encode_linst(LInst::LoopJitRspBump {
+                offset,
+                base: frame.base_stack_offset,
+            }),
             // Inline argument-setup stores into the callee frame, at a
             // (raw) rsp-relative offset the encoder legalizes per arch.
             AsmInst::RegToRSPOffset(r, ofs) => self.encode_linst(LInst::Store {
@@ -1610,8 +1613,8 @@ impl Codegen {
             LInst::Init { info, prologue_offset } => {
                 self.emit_init(info, prologue_offset);
             }
-            LInst::LoopJitRspBump { offset } => {
-                self.emit_loop_jit_rsp_bump(offset);
+            LInst::LoopJitRspBump { offset, base } => {
+                self.emit_loop_jit_rsp_bump(offset, base);
             }
             LInst::BlockArgProxy { ret, outer } => {
                 self.emit_block_arg_proxy(ret, outer);

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -816,12 +816,11 @@ impl Codegen {
                 lhs: reg.into(),
                 rhs: LOperand::Imm(i as i64),
             }),
-            // Loop-JIT entry stack bump (aarch64 bails on a frame larger than
-            // the 12-bit sub-sp immediate).
-            AsmInst::LoopJitRspBump { offset } => self.encode_linst(LInst::LoopJitRspBump {
-                offset,
-                base: frame.base_stack_offset,
-            }),
+            // Loop-JIT entry: pin the stack pointer to the frame's local-area
+            // depth, which `offset` already carries.
+            AsmInst::LoopJitRspBump { offset } => {
+                self.encode_linst(LInst::LoopJitRspBump { offset })
+            }
             // Inline argument-setup stores into the callee frame, at a
             // (raw) rsp-relative offset the encoder legalizes per arch.
             AsmInst::RegToRSPOffset(r, ofs) => self.encode_linst(LInst::Store {
@@ -1613,8 +1612,8 @@ impl Codegen {
             LInst::Init { info, prologue_offset } => {
                 self.emit_init(info, prologue_offset);
             }
-            LInst::LoopJitRspBump { offset, base } => {
-                self.emit_loop_jit_rsp_bump(offset, base);
+            LInst::LoopJitRspBump { offset } => {
+                self.emit_loop_jit_rsp_bump(offset);
             }
             LInst::BlockArgProxy { ret, outer } => {
                 self.emit_block_arg_proxy(ret, outer);

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -1650,10 +1650,15 @@ impl<'a> JitContext<'a> {
             AsmInst::LoopJitRspBump { offset } => {
                 if let LoopRspOffset::Hint(id) = offset {
                     let sizes = self.frame_sizes_or_panic(*id);
-                    // Loop JIT lives inside an invoker-owned
-                    // prologue, so the JIT-managed bump is exactly
-                    // the spill region grown on top of `base`.
-                    *offset = LoopRspOffset::Concrete(sizes.total - sizes.base);
+                    // The depth to pin `rsp`/`sp` to, not a delta: the
+                    // frame this body runs in may have been built by
+                    // either producer, and only one of them reserved
+                    // this unit's spill region (see
+                    // `Codegen::emit_loop_jit_rsp_bump`). Both reach the
+                    // same local area, which is the one rule
+                    // `resolve_specialized_id_chain` relies on.
+                    debug_assert!(sizes.total >= PROLOGUE_OVERHEAD);
+                    *offset = LoopRspOffset::Concrete(sizes.total - PROLOGUE_OVERHEAD);
                 }
             }
             _ => {}

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -1553,8 +1553,18 @@ impl<'a> JitContext<'a> {
     }
 
     ///
-    /// Resolve a `DynVarOffset::Hint` chain by summing the recorded
-    /// frame `total` sizes. Used by [`Self::resolve_dyn_var_offsets`].
+    /// Resolve a `DynVarOffset::Hint` chain: the distance from the current
+    /// frame's `rbp`/`x29` out to the target frame's, summed frame by
+    /// frame. Used by [`Self::resolve_dyn_var_offsets`].
+    ///
+    /// Each frame in the chain contributes its local area
+    /// (`total - PROLOGUE_OVERHEAD`) plus what an inlined callee consumes to
+    /// establish a frame on top of it, and the caller adds the `extra` (the
+    /// `FprSave` areas live at the call). Every frame kind reaches that one
+    /// local area: it is what the `Init` prologue reserves, and what the
+    /// loop-JIT entry pins `sp`/`rsp` to — see `emit_loop_jit_rsp_bump`,
+    /// whose two producers would otherwise disagree by this unit's spill
+    /// region.
     ///
     pub(super) fn resolve_specialized_id_chain(&self, ids: &[SpecializedId]) -> usize {
         ids.iter()
@@ -1623,12 +1633,17 @@ impl<'a> JitContext<'a> {
             } => {
                 if let PrologueOffset::Hint(id) = prologue_offset {
                     let sizes = self.frame_sizes_or_panic(*id);
-                    // The recorded `total` includes the iseq's
-                    // bookkeeping `+ 16` and the `CONTINUATION_FRAME_SIZE`
-                    // (= 16). The prologue subtracts only the locals area,
-                    // so subtract the 32-byte overhead. Spill slots that
-                    // grow `total` flow through automatically.
-                    let prologue_bytes = sizes.total - (CONTINUATION_FRAME_SIZE + 16);
+                    // Reserve exactly what the VM's `init_method` reserves
+                    // for the same iseq, plus this compile's spill region.
+                    //
+                    // The VM reserves the bytecode operand,
+                    // `FnInitInfo::stack_offset * 16`. Note that this is
+                    // *not* `ISeqInfo::stack_offset()`, which is the same
+                    // expression plus a further 16 — so the VM's reservation
+                    // is `base_stack_offset - PROLOGUE_OVERHEAD`, and adding
+                    // the spill region (the rest of `total`) gives
+                    // `total - PROLOGUE_OVERHEAD`.
+                    let prologue_bytes = sizes.total - PROLOGUE_OVERHEAD;
                     *prologue_offset = PrologueOffset::Concrete(prologue_bytes);
                 }
             }

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -976,10 +976,6 @@ pub(in crate::codegen) enum LInst {
     },
     LoopJitRspBump {
         offset: LoopRspOffset,
-        /// The frame's `base_stack_offset`. aarch64 pins `sp` to this
-        /// frame's canonical depth instead of subtracting from the `sp` it
-        /// inherits; x86-64 ignores it. See `emit_loop_jit_rsp_bump`.
-        base: usize,
     },
     BlockArgProxy {
         ret: SlotId,

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -976,6 +976,10 @@ pub(in crate::codegen) enum LInst {
     },
     LoopJitRspBump {
         offset: LoopRspOffset,
+        /// The frame's `base_stack_offset`. aarch64 pins `sp` to this
+        /// frame's canonical depth instead of subtracting from the `sp` it
+        /// inherits; x86-64 ignores it. See `emit_loop_jit_rsp_bump`.
+        base: usize,
     },
     BlockArgProxy {
         ret: SlotId,

--- a/monoruby/src/lib.rs
+++ b/monoruby/src/lib.rs
@@ -106,7 +106,7 @@ const FIBER_STACK_BUDGET: usize = 64 * 1024;
 const CONTINUATION_FRAME_SIZE: usize = 16;
 /// How much of a JIT frame's recorded `total` sits *above* its local area:
 /// the continuation frame plus the 16 bytes of iseq bookkeeping that
-/// [`ISeqInfo::stack_offset`] adds on top of the `FnInitInfo::stack_offset`
+/// `ISeqInfo::stack_offset` adds on top of the `FnInitInfo::stack_offset`
 /// the VM's `init_method` actually reserves. So a frame's local area is
 /// `total - PROLOGUE_OVERHEAD` — what `AsmInst::Init` reserves, and the depth
 /// the loop-JIT entry pins `sp`/`rsp` to.

--- a/monoruby/src/lib.rs
+++ b/monoruby/src/lib.rs
@@ -104,6 +104,13 @@ const MAIN_STACK_SIZE: usize = 1024 * 1024;
 /// Rust headroom below the limit before the guard page can be hit.
 const FIBER_STACK_BUDGET: usize = 64 * 1024;
 const CONTINUATION_FRAME_SIZE: usize = 16;
+/// How much of a JIT frame's recorded `total` sits *above* its local area:
+/// the continuation frame plus the 16 bytes of iseq bookkeeping that
+/// [`ISeqInfo::stack_offset`] adds on top of the `FnInitInfo::stack_offset`
+/// the VM's `init_method` actually reserves. So a frame's local area is
+/// `total - PROLOGUE_OVERHEAD` — what `AsmInst::Init` reserves, and the depth
+/// the loop-JIT entry pins `sp`/`rsp` to.
+const PROLOGUE_OVERHEAD: usize = CONTINUATION_FRAME_SIZE + 16;
 
 type RubyMap<K, V> = rubymap::RubyMap<K, V, Executor, Globals, MonorubyErr>;
 type RubySet<T> = rubymap::RubySet<T, Executor, Globals, MonorubyErr, fxhash::FxBuildHasher>;

--- a/monoruby/tests/float_across_block_call.rs
+++ b/monoruby/tests/float_across_block_call.rs
@@ -165,8 +165,8 @@ fn a_block_call_inside_a_loop() {
 /// the call may keep the frame's constants. The analysis predicted a kept
 /// `C(3)`; codegen gave it up. See `AsmIr::note_analysis_deopt`.
 ///
-/// Compiling it at all then uncovered *two* further, unrelated defects,
-/// which is why one configuration is still excluded below.
+/// Compiling it at all then uncovered two further, unrelated defects,
+/// both since fixed.
 ///
 /// The first was not about the spill pool at all, and is fixed:
 /// `Codegen::set_class_version` patched a unit's version snapshot word —
@@ -175,32 +175,49 @@ fn a_block_call_inside_a_loop() {
 /// every successful class-version salvage was a SIGBUS on Apple Silicon at
 /// *any* pool size. See `Codegen::set_const_version`'s comment.
 ///
-/// The second is real and still open: on aarch64 with `stress-spill-pool`
-/// this segfaults in compiled code. `LoadDynVarSpecialized` addresses the
-/// outer frame at a fixed `[x29 + offset]`, and here that offset is 16
-/// bytes too small, so the block reads the word below the slot it wants.
-/// Measured at the faulting site: the block's `x29` sits 368 bytes below
-/// `f`'s, `a` (4.5) is at `x29 + 280`, and the emitted offset is 264.
+/// The second was a frame-layout disagreement, now fixed. On aarch64 with
+/// `stress-spill-pool` this segfaulted in the `[x29 + offset]` load that
+/// `LoadDynVarSpecialized` emits for the block's `a` — but the offset was
+/// right: breaking on that one instruction and walking the frame chain on
+/// every execution, 288 of 289 hits measured exactly the emitted 352, and
+/// the odd one measured 368, with the same call chain and byte-identical
+/// `bl` targets. It was `sp` that moved, not the offset.
 ///
-/// What is *ruled out*, so nobody re-walks it:
-/// - the offset does not differ by pool — `resolve_specialized_id_chain`
-///   yields the same 352 at pool 2 and pool 14, and pool 14 measures a
-///   physical 352, so only the layout moves;
-/// - the modelled FP-save (`specialized_compile`'s `using_fpr_offset`) and
-///   the emitted one (`emit_fpr_save`) agree — 45/45 call sites matched;
-/// - `frame_sizes.total` being calibrated for `Init`-prologue frames
-///   (`total - 32`) while a loop-JIT root reserves `total - 16` looks like
-///   the discrepancy, but adding `CONTINUATION_FRAME_SIZE` back for
-///   `is_loop` frames is **not** the fix — with or without excluding the
-///   `MethodRetSpecialized` / `BlockBreakSpecialized` twins it fixes this
-///   case and breaks a `while` loop + block-passing call that has no
-///   redefinition churn (which reaches a loop-JIT chain and is correct
-///   today). So `is_loop` is not the axis that discriminates.
+/// Breaking instead on `a64_op_loop_start`'s `br x10` found one and the
+/// same compiled loop entered at *two* depths — `x29 - sp` of 144 and of
+/// 160, with `x29 - lfp` an invariant 24 — which is the loop-JIT entry
+/// counting this unit's spill region twice on one of its two entry paths.
+/// `LoopJitRspBump` subtracts `total - base` (the spill region) from the
+/// `sp` it inherits. From a VM frame that is right: `init_method` reserves
+/// the bytecode's `FnInitInfo::stack_offset * 16` and knows nothing of
+/// spill slots. From a JIT-prologue frame it is not: that prologue
+/// reserves `total - PROLOGUE_OVERHEAD`, which already *includes* the
+/// spill region. Both kinds of frame reach a `loop_start`, so the same
+/// body ran at two depths, `spill_bytes` apart — 16 at pool 2, 0 at pool
+/// 14, hence the pool dependence. The inlined specialized frames it builds
+/// below `sp` moved with it, while the `x29`-relative offsets addressing
+/// them are fixed at compile time.
+///
+/// The fix is to pin `sp` to the frame's canonical depth, `total -
+/// PROLOGUE_OVERHEAD`, rather than subtracting from what it inherits, so
+/// both producers agree on the depth the compile assumed.
+///
+/// An earlier attempt instead *raised* every frame to `total -
+/// CONTINUATION_FRAME_SIZE`, on the premise that `init_method` reserves
+/// `iseq.stack_offset()`. It does not: `ISeqInfo::stack_offset()` is the
+/// bytecode operand's expression plus a further 16, so the prologue's
+/// `total - PROLOGUE_OVERHEAD` already matched the VM. Raising it broke
+/// that match and needed a compensating `+ 16` per frame in
+/// `resolve_specialized_id_chain`, which then over-counted for every
+/// loop-JIT root a chain crossed — on x86-64 that surfaced as a nil `i`
+/// read out of `Array#repeated_combination`'s outer frame
+/// (`builtins::array::tests::sort`).
+///
+/// Still open, and unrelated to this test (it has no explicit `return` or
+/// `break`): `a64_method_ret` and `a64_block_break` `b raise` without
+/// restoring `sp`, unlike every sibling exit, which all take
+/// `loop_jit_spill_bytes`.
 #[test]
-#[cfg_attr(
-    all(target_arch = "aarch64", feature = "stress-spill-pool"),
-    ignore = "open aarch64 defect: specialized-dynvar chain offset is 16 short through a loop-JIT root"
-)]
 fn a_while_loop_around_a_block_passing_call() {
     run_test_with_prelude(
         r#"


### PR DESCRIPTION
Follow-up to #1175, which was merged at its first commit — the `MAP_JIT` W^X fix. The second defect that test uncovered is still open on `master`, and this is its fix.

## What

`LoopJitRspBump` subtracts the spill region (`total - base`) from the `sp` it inherits. But a loop-JIT body is reached by `loop_start` from **either** producer of a Ruby frame, and the two do not reserve the same thing:

- the VM's `init_method` reserves the iseq's `FnInitInfo::stack_offset`, and knows nothing of spill slots;
- an `AsmInst::Init` prologue reserves that same area **plus this unit's spill region**, since the region is part of `total`.

Subtracting from what we inherit therefore counts the spill region twice on the JIT-prologue path, and one compiled loop runs at two depths, `spill_bytes` apart.

## Why it corrupts

Everything the body builds below `sp` — the inlined specialized frames of a block-passing call — moves with `sp`, while the offsets that address those frames from `rbp`/`x29` (`LoadDynVarSpecialized`, the spill slots) are fixed at compile time. At the depth the compile did not assume, they read the neighbouring word.

Measured on `a_while_loop_around_a_block_passing_call`, breaking on `a64_op_loop_start`'s `br x10` and logging every entry into one and the same compiled loop:

```
OSR-> 0x3000b6d50  x29-sp=144  x29-lfp=24
OSR-> 0x3000b6d50  x29-sp=160  x29-lfp=24
```

`x29 - lfp` is invariant, so `x29` is dependable and it is `sp` that moves. And breaking on the faulting `LoadDynVarSpecialized` itself: 288 of 289 executions measured exactly the emitted offset of 352, the odd one measured 368 — same call chain, byte-identical `bl` targets.

It surfaces as a segfault on aarch64 and as a silently wrong value on x86 (a nil `i` out of `Array#repeated_combination`). Only under `stress-spill-pool`, because `spill_bytes` is 0 at the default pool size, which makes the two depths coincide.

## Fix

Pin `sp`/`rsp` at the entry to `total - PROLOGUE_OVERHEAD` — the depth `AsmInst::Init` already reserves — so both producers agree and `resolve_specialized_id_chain`'s single local-area rule holds for every frame kind. `LoopRspOffset` now carries that absolute depth instead of a delta. The prologue rule and the chain sum are unchanged from `master`.

`PROLOGUE_OVERHEAD` names the part of a frame's recorded `total` that sits above its local area. Worth flagging for future readers: `ISeqInfo::stack_offset()` is **not** what the VM reserves — it is the `FnInitInfo::stack_offset` expression plus a further 16.

## Testing

| | result |
|---|---|
| aarch64 (arm64-apple-darwin, native), default pool | 3318 passed, 1 skipped |
| aarch64, `stress-spill-pool` | 3318 passed, 1 skipped |
| x86-64, plain and `stress-spill-pool` | 67 targets green |

Removes the `stress-spill-pool` exclusion on `a_while_loop_around_a_block_passing_call`, so that test now runs everywhere.

## Left for a separate change

`a64_method_ret` and `a64_block_break` `b raise` without restoring `sp`, unlike every sibling exit, which all take `loop_jit_spill_bytes`. Not on this test's path (it has no explicit `return` or `break`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
