### PR TITLE
Release the loop-JIT spill region on the MethodRet / BlockBreak exits

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -660,7 +660,7 @@ impl Codegen {
     /// `entry_raise` passes PC straight to `handle_error` without the x86 `-16`
     /// fixup, so a `pc + 1` here would leave `handle_error`'s exception-table
     /// lookup off by one and skip the `ensure` body protecting the `return`.
-    fn a64_method_ret(&mut self, pc: BytecodePtr) {
+    fn a64_method_ret(&mut self, pc: BytecodePtr, loop_jit_spill_bytes: usize) {
         let pc0 = pc.as_ptr() as u64;
         let f = runtime::err_method_return as *const () as u64;
         let raise = self.entry_raise();
@@ -671,6 +671,17 @@ impl Codegen {
             mov x1, x20;      // globals
             mov x9, (f);
             blr x9;
+        );
+        // Release the loop-JIT spill region before resuming the VM, like
+        // every other exit that leaves through `entry_raise` (`emit_raise`,
+        // retry/redo/ensure_end). After the `blr` — the runtime call may
+        // push below sp, and undoing first would let those pushes overwrite
+        // the spill slots (`a64_gen_deopt`'s ordering, regalloc_separation
+        // §39). `entry_raise`'s no-handler path restores sp from x29 anyway;
+        // this matters for its `goto` path, which resumes the VM with sp
+        // untouched.
+        self.a64_undo_loop_rsp_bump(loop_jit_spill_bytes);
+        monoasm_arm64!(&mut self.jit,
             b raise;
         );
     }
@@ -684,7 +695,7 @@ impl Codegen {
     /// aarch64's `entry_raise` hands PC to `handle_error` without the x86 `-16`
     /// fixup, so storing `pc` (the value x86 reaches via `pc + 1` then `-16`)
     /// keeps the exception-table lookup aligned with the raising instruction.
-    fn a64_block_break(&mut self, pc: BytecodePtr) {
+    fn a64_block_break(&mut self, pc: BytecodePtr, loop_jit_spill_bytes: usize) {
         let pc0 = pc.as_ptr() as u64;
         let f = runtime::err_block_break as *const () as u64;
         let raise = self.entry_raise();
@@ -695,6 +706,11 @@ impl Codegen {
             mov x1, x20;      // globals
             mov x9, (f);
             blr x9;
+        );
+        // Same ordering as `a64_method_ret`: undo after the runtime call,
+        // before `b raise`.
+        self.a64_undo_loop_rsp_bump(loop_jit_spill_bytes);
+        monoasm_arm64!(&mut self.jit,
             b raise;
         );
     }
@@ -2483,13 +2499,21 @@ impl Codegen {
     }
 
     /// Return through the method-return path, resuming the caller at `pc + 1`.
-    pub(in crate::codegen::jitgen) fn emit_method_ret(&mut self, pc: BytecodePtr) {
-        self.a64_method_ret(pc);
+    pub(in crate::codegen::jitgen) fn emit_method_ret(
+        &mut self,
+        pc: BytecodePtr,
+        loop_jit_spill_bytes: usize,
+    ) {
+        self.a64_method_ret(pc, loop_jit_spill_bytes);
     }
 
     /// Non-local exit through the block-break path (a `break` out of a block).
-    pub(in crate::codegen::jitgen) fn emit_block_break(&mut self, pc: BytecodePtr) {
-        self.a64_block_break(pc);
+    pub(in crate::codegen::jitgen) fn emit_block_break(
+        &mut self,
+        pc: BytecodePtr,
+        loop_jit_spill_bytes: usize,
+    ) {
+        self.a64_block_break(pc, loop_jit_spill_bytes);
     }
 
     /// Store the call-site pc into the outgoing cont-frame slot

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -2039,7 +2039,14 @@ impl Codegen {
     }
 
     /// Return through the method-return path, resuming the caller at `pc + 1`.
-    pub(in crate::codegen::jitgen) fn emit_method_ret(&mut self, pc: BytecodePtr) {
+    // `_loop_jit_spill_bytes` is deliberately unused, like the other
+    // `entry_raise` exits (`emit_raise` etc.): x86's VM frames are
+    // rbp-relative, so a stale `rsp` at the resume is unobservable.
+    pub(in crate::codegen::jitgen) fn emit_method_ret(
+        &mut self,
+        pc: BytecodePtr,
+        _loop_jit_spill_bytes: usize,
+    ) {
         monoasm! { &mut self.jit,
             movq r13, ((pc + 1).as_ptr());
         };
@@ -2047,7 +2054,11 @@ impl Codegen {
     }
 
     /// Non-local exit through the block-break path, resuming at `pc + 1`.
-    pub(in crate::codegen::jitgen) fn emit_block_break(&mut self, pc: BytecodePtr) {
+    pub(in crate::codegen::jitgen) fn emit_block_break(
+        &mut self,
+        pc: BytecodePtr,
+        _loop_jit_spill_bytes: usize,
+    ) {
         monoasm! { &mut self.jit,
             movq r13, ((pc + 1).as_ptr());
         };

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -522,8 +522,14 @@ impl Codegen {
             // method-return path; `BlockBreak` does the same through the
             // block-break path (a non-local `break` out of a block).
             AsmInst::Ret => self.encode_linst(LInst::Ret),
-            AsmInst::MethodRet(pc) => self.encode_linst(LInst::MethodRet { pc }),
-            AsmInst::BlockBreak(pc) => self.encode_linst(LInst::BlockBreak { pc }),
+            AsmInst::MethodRet(pc) => self.encode_linst(LInst::MethodRet {
+                pc,
+                loop_jit_spill_bytes: frame.loop_jit_spill_bytes,
+            }),
+            AsmInst::BlockBreak(pc) => self.encode_linst(LInst::BlockBreak {
+                pc,
+                loop_jit_spill_bytes: frame.loop_jit_spill_bytes,
+            }),
             // Emits nothing; registers this call's return address -> replay
             // data so `Codegen::chain_deopt` can convert a frame suspended
             // here from its return-address slot alone (`doc/chain_deopt.md`
@@ -1600,11 +1606,11 @@ impl Codegen {
             LInst::Ret => {
                 self.emit_ret();
             }
-            LInst::MethodRet { pc } => {
-                self.emit_method_ret(pc);
+            LInst::MethodRet { pc, loop_jit_spill_bytes } => {
+                self.emit_method_ret(pc, loop_jit_spill_bytes);
             }
-            LInst::BlockBreak { pc } => {
-                self.emit_block_break(pc);
+            LInst::BlockBreak { pc, loop_jit_spill_bytes } => {
+                self.emit_block_break(pc, loop_jit_spill_bytes);
             }
             LInst::ChainExit { evict, replay } => {
                 self.register_chain_exit(evict, replay);

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -960,9 +960,17 @@ pub(in crate::codegen) enum LInst {
     Ret,
     MethodRet {
         pc: BytecodePtr,
+        /// The frame's loop-JIT spill region, released before resuming the
+        /// VM — like every other exit that leaves through `entry_raise`
+        /// (`Raise` / `Retry` / `Redo` / `EnsureEnd`). aarch64 needs it
+        /// because its VM builds callee frames sp-relative; x86-64 ignores
+        /// it (rbp-relative VM frames, a stale `rsp` is unobservable).
+        loop_jit_spill_bytes: usize,
     },
     BlockBreak {
         pc: BytecodePtr,
+        /// See [`LInst::MethodRet::loop_jit_spill_bytes`].
+        loop_jit_spill_bytes: usize,
     },
     /// Register `evict`'s already-recorded call return address as the key for
     /// `replay` in the runtime chain-deopt table. Emits no machine code.

--- a/monoruby/tests/loop_jit_exit_sp.rs
+++ b/monoruby/tests/loop_jit_exit_sp.rs
@@ -99,7 +99,9 @@ fn block_break_out_of_a_loop_jit_unit() {
 }
 
 /// A pre-existing JIT divergence found while building the shapes above,
-/// recorded so it is not lost. **Not** the sp-undo defect: it reproduces
+/// recorded so it is not lost — filed as issue #1179; removing the
+/// `#[ignore]` below turns this into its regression test once fixed.
+/// **Not** the sp-undo defect: it reproduces
 /// identically before and after that fix, at both FPR pool sizes, and
 /// `--no-jit` agrees with CRuby.
 ///
@@ -112,7 +114,7 @@ fn block_break_out_of_a_loop_jit_unit() {
 /// reached the loop's view. Same family as the block-passing-call float
 /// staleness (#1172/#1173), but through the non-local-exit path.
 #[test]
-#[ignore = "pre-existing JIT divergence: an ensure run by `break` writes an outer local the loop unit then reads stale"]
+#[ignore = "issue #1179: an ensure run by `break` writes an outer local the loop unit then reads stale"]
 fn break_running_an_ensure_that_writes_an_outer_local() {
     run_test(
         r#"

--- a/monoruby/tests/loop_jit_exit_sp.rs
+++ b/monoruby/tests/loop_jit_exit_sp.rs
@@ -1,0 +1,138 @@
+//! The two `entry_raise` exits that used to skip the loop-JIT sp undo.
+//!
+//! Every aarch64 exit that leaves a loop-JIT body for the VM must release
+//! the spill region the entry pinned `sp` below (`a64_undo_loop_rsp_bump`)
+//! — the aarch64 VM builds callee frames sp-relative, so the leftover
+//! region stays between the VM and its own local area otherwise. `Raise` /
+//! `Retry` / `Redo` / `EnsureEnd` always did; `MethodRet` and `BlockBreak`
+//! did not even take the byte count.
+//!
+//! Reaching those two lowerings takes several conditions at once, which
+//! these shapes were built to meet (verified by probe):
+//!
+//! - the exit sits in a **loop-JIT (OSR) unit** — the `while` loops trip
+//!   the loop threshold inside a single call;
+//! - the **non-specialized** `MethodRet` / `BlockBreak` is lowered — a
+//!   `return` inside a block is a non-local method return whose home
+//!   frame is outside the OSR unit (`method_caller_specialized_ids` has
+//!   no chain), and an exception handler between the frames does the
+//!   same for `break` (`iter_caller_specialized_ids` refuses a chain
+//!   that crosses one);
+//! - for the `MethodRet` shape, the unit also has a non-empty **spill
+//!   region** under `stress-spill-pool` (the floats are locals of the
+//!   frame the loop belongs to, so they live in FPRs and spill at pool
+//!   2), and the `ensure` makes `handle_error` find a handler, so
+//!   `entry_raise` takes its `goto` path — the one that resumes the VM
+//!   without restoring `sp` from `x29`.
+//!
+//! Measured on aarch64 before the fix: the VM resumed with `sp` still at
+//! the pinned depth — 32 bytes below its own local area on the `MethodRet`
+//! shape — and with it after. That is the *safe* direction (deeper, so
+//! nothing is overwritten) and no misbehavior was ever observed; the undo
+//! closes the inconsistency and these tests pin the reaching shapes down.
+extern crate monoruby;
+use monoruby::tests::*;
+
+/// Non-specialized `MethodRet` out of a spilling loop-JIT unit: the
+/// `return` is inside a block, so it is a non-local method return, and the
+/// OSR unit rooted at the block has no chain to the home method frame.
+/// The `ensure` gives the unwind a handler to land in.
+#[test]
+fn method_ret_out_of_a_spilling_loop_jit_unit() {
+    run_test(
+        r#"
+        def f
+          [1].each do |x|
+            a = 0.5; b = 1.5; c = 2.5; d = 3.5
+            i = 0
+            begin
+              while i < 300
+                a += b * c * d
+                b += 0.25
+                c += 0.125
+                return a + b + c + d if i == 250
+                i += 1
+              end
+            ensure
+              a += 0.0625
+            end
+          end
+          0.0
+        end
+        f
+        "#,
+    );
+}
+
+/// Non-specialized `BlockBreak` inside a loop-JIT unit: the block is
+/// inlined into the OSR unit of `g`'s `while`, and the `begin`/`ensure`
+/// inside it forces the non-specialized lowering.
+///
+/// The `ensure` deliberately writes only a *block-local* (`t`): an
+/// `ensure` that writes an outer local (`c += 0.5`) trips a separate,
+/// pre-existing JIT divergence — see
+/// [`break_running_an_ensure_that_writes_an_outer_local`].
+#[test]
+fn block_break_out_of_a_loop_jit_unit() {
+    run_test(
+        r#"
+        def g
+          a = 0.0; b = 1.0; c = 2.0; d = 3.0
+          i = 0
+          while i < 300
+            [1, 2, 3].each do |x|
+              t = 0.0
+              begin
+                a += b * c * d * x
+                break if i == 200
+              ensure
+                t += 0.5
+              end
+            end
+            i += 1
+          end
+          a
+        end
+        g
+        "#,
+    );
+}
+
+/// A pre-existing JIT divergence found while building the shapes above,
+/// recorded so it is not lost. **Not** the sp-undo defect: it reproduces
+/// identically before and after that fix, at both FPR pool sizes, and
+/// `--no-jit` agrees with CRuby.
+///
+/// When a `break` unwinds through an `ensure` that writes an *outer*
+/// local (`c += 0.5` below, a dynvar of the loop-JIT frame), the write
+/// happens in the VM — but the loop unit keeps reading its own stale view
+/// of `c` for the remaining iterations. Measured: monoruby 22975.5 vs
+/// CRuby 23025.0 — short by exactly 0.5 x the 99 iterations after the
+/// `break`, i.e. the breaking iteration's `ensure` increment never
+/// reached the loop's view. Same family as the block-passing-call float
+/// staleness (#1172/#1173), but through the non-local-exit path.
+#[test]
+#[ignore = "pre-existing JIT divergence: an ensure run by `break` writes an outer local the loop unit then reads stale"]
+fn break_running_an_ensure_that_writes_an_outer_local() {
+    run_test(
+        r#"
+        def g
+          a = 0.0; c = 2.0
+          i = 0
+          while i < 300
+            [1].each do |x|
+              begin
+                a += c
+                break if i == 200
+              ensure
+                c += 0.5
+              end
+            end
+            i += 1
+          end
+          a
+        end
+        g
+        "#,
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -504,6 +504,7 @@
 27bbd9728c02599e57c39a078921ec2f	["X", "X"]	$/ = "X"; r = [$/, $-0]; $/ = "\\n"; r
 27e09cfb8d3e196da639bfe49a480262	"----hi----"	class Foo; def to_str; "-"; end; end\n            "hi".center(10, Fo
 27fffd6b30a640af5c225b8f9b0b1edb	[false, [:a, :b]]	S = Struct.new(:a, :b, keyword_init: false)\n            \n\n         
+280a0903d95ccdf58909745441b59564	665703.140625	def f\n          [1].each do |x|\n            a = 0.5; b = 1.5; c = 2.5; 
 2813eaf79f8e7054ca4fc122c2c44ce9	[[:singleton_method_added, [:method_missing]], [:singleton_method_added, [:foo]]]	$result = []\n        class C\n          class << self\n            undef_
 2817d91ed55d25899a6cafb76ddebc3d	"hi"	class Foo\n              def hi\n                "hi"\n              e
 28212edb8e5f6d2cf627a2eff37d1fb2	["7", "11"]	def crsl_foo\n          begin\n            raise "oops"\n          rescue\n
@@ -673,6 +674,7 @@
 362197c8ba0c107c5b63c4c8b7e930e6	false	t = Thread.new { IO.select(nil, nil, nil, 2**62) }\n            Thre
 366101f3454d9c3ba104d799233170e4	14	class Foo\n              def with_block; yield 7; end\n            en
 367c0b57251ec6d8861445efce15a4a2	[3, 4, 5]	class MyNum; def to_int; 2; end; end\nn = MyNum.new\n[1,2,3,4,5].drop(n)
+369964a9ab023c59c6982e160cd552b5	10770.0	def g\n          a = 0.0; b = 1.0; c = 2.0; d = 3.0\n          i = 0\n    
 36e28f3b4bad007127519f2712f4d570	[39, :receiver_class, "constant", "nil", :receiver_class, "class variable access from toplevel"]	$r = []\n        m = Module.new\n        $r << m.class_eval("@@cv1 = 39; 
 36ef6bae649b437bac48a49db4df0dd2	[false, false, false]	a = "\\xff".dup.force_encoding("UTF-8")\n              b = "\\xff".d
 36f30f53930311aedc7940de7a521902	true	FileTest.writable?("/tmp")
@@ -2565,6 +2567,7 @@ cea4ac40f2ed783a751cc211c9f49b2c	["seed", 4, true, true]	def eapp(s, e, n)\n    
 ceb00f8b8ea6a7e9a44636698f8e1014	[0, 123, 321, "TypeError"]	res = [$.]\n        $. = 123.5\n        res << $.\n        obj = Object.ne
 cec2e4a4735508727ba059b9404b5c1e	[true, true]	klass = Class.new do\n          def self.allocate\n            raise "all
 ced5712f3f56898e6479ddda935644e9	5	class C\n            end\n            c = C.new\n            def c.f; 
+cf06b2d035c13e7fd3e3fafa28934cb8	1219026.0	def g\n          a = 0.0; b = 1.0; c = 2.0; d = 3.0\n          i = 0\n    
 cf154d83dbefe1d87cac17d0b188f7dd	[5, 8, 6, 9, 7, 10, 8, 11, 9, 12, 10, 13, 11, 14, 12, 15, 13, 16, 14, 17, 15, 18]	def f(x,y)\n            yield x,y\n          end\n          \n          r
 cf1d7ef2fb786f57a3cf9e0f019f1486	true	Regexp.private_instance_methods.include?(:initialize)
 cf347485acd73ea7a73489e5f1fbd249	"ASCII-8BIT"	("hello %s" % 195.chr).encoding.to_s


### PR DESCRIPTION
Follow-up requested from the x86-64 session's instruction document: `a64_method_ret` / `a64_block_break` were the only two `entry_raise` exits that did not release the loop-JIT spill region (`a64_undo_loop_rsp_bump`) — they did not even take the byte count.

## Fix

Exactly the shape the instruction document prescribed: `LInst::MethodRet` / `BlockBreak` carry `loop_jit_spill_bytes`, `compile_shared` passes `frame.loop_jit_spill_bytes` (the `Raise` pattern), and the aarch64 lowerings undo **after** the runtime call and **before** `b raise` — same ordering as `emit_raise`, since the call's pushes may overwrite spill slots (regalloc_separation §39). x86-64 accepts and ignores the parameter like its other `entry_raise` exits (rbp-relative VM frames; stale `rsp` unobservable).

## Reach — candidate A could not work, and why

Candidate A (a plain `return` in a method body) **cannot** reach `AsmInst::MethodRet`: bytecodegen emits `MethodRet` only when `return_escapes()`, i.e. for the non-local return out of a block; a method-body `return` is a plain `Ret` (epilogue). The shape that reaches it is a **block-rooted OSR unit**:

```ruby
[1].each do |x|
  a = 0.5; ...          # block-locals -> live FPRs -> spill at pool 2
  begin
    while i < 300
      ...
      return ... if i == 250   # non-local return, home frame outside the unit
    end
  ensure ... end        # handle_error finds a handler -> entry_raise's goto path
end
```

Candidate B reaches `BlockBreak` as an inlined child of the `while`'s OSR unit (probe-verified), with one adjustment — see below.

## Measurement (aarch64 native, `stress-spill-pool`, spill = 32)

| | `blr err_method_return` | VM resume (post `handle_error`) |
|---|---|---|
| before | x29−sp = 208 | **208** (pinned depth kept) |
| after | 208 (undo is after the call, by design) | **176** = `base − PROLOGUE_OVERHEAD` |

The stale depth was the **safe** direction (deeper — nothing overwritten), confirming the instruction document's §3 harmlessness analysis; no misbehavior was ever observed from it. Both reaching shapes are kept as regression tests (`tests/loop_jit_exit_sp.rs`).

## Found along the way: a pre-existing JIT divergence (recorded as an `#[ignore]` test)

Candidate B as written trips an **unrelated** bug: when a `break` unwinds through an `ensure` that writes an *outer* local (`c += 0.5`), the VM performs the write but the loop unit keeps reading its stale view of `c` for the remaining iterations:

```
monoruby (JIT): 22975.5     CRuby / --no-jit: 23025.0
```

— short by exactly 0.5 × the 99 post-break iterations. Not this defect: it reproduces identically before/after this fix, at **both** pool sizes, and `--no-jit` agrees with CRuby. Same family as the block-passing-call float staleness (#1172/#1173), through the non-local-exit path. Recorded as `break_running_an_ensure_that_writes_an_outer_local` (`#[ignore]`) so it is not lost; the committed BlockBreak test writes a block-local in its `ensure` instead.

## Testing

| | result |
|---|---|
| aarch64 native, default pool | 3320 passed, 2 skipped |
| aarch64 native, `stress-spill-pool` | 3320 passed, 2 skipped |

(2 skipped = 1 pre-existing + the new `#[ignore]` divergence record.) The change touches the arch-neutral LIR layer, so an x86-64 run is needed before merge — the x86 side is parameter-plumbing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
