### PR TITLE
Ask whether the exiting instruction itself sits in a protected region

### DIFF
--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -907,7 +907,6 @@ impl<'a> JitContext<'a> {
             TraceIr::MethodRet(ret) => {
                 state.flush_gp(ir);
                 assert!(state.no_capture_guard());
-                state.load(ir, ret, GP::Rax);
                 // A non-local `return` written inside a protected region must
                 // unwind through `handle_error`, which runs this frame's
                 // `ensure` (and restores `$!` when leaving a rescue clause) on
@@ -915,9 +914,22 @@ impl<'a> JitContext<'a> {
                 // frame pop and would skip both. `check_exception_handler`
                 // covers only the *suspended* frames of the chain, so the
                 // exiting instruction's own coverage is checked here (#1179).
-                if !self.in_protected_region(bc_pos)
-                    && let Some((spec_ids, extra)) = self.method_caller_specialized_ids()
-                {
+                let specialized = (!self.in_protected_region(bc_pos))
+                    .then(|| self.method_caller_specialized_ids())
+                    .flatten();
+                if specialized.is_none() {
+                    // Mirror `Raise`: when this frame's own `ensure` covers
+                    // the exit, `handle_error` sends the VM into it straight
+                    // from `entry_raise` — *before* any error side exit has
+                    // run, i.e. before the chain-deopt walk has materialized
+                    // anything — so this frame's locals must be slot-true
+                    // now. (An `ensure` in an *intermediate* frame is safe
+                    // without this: it only runs after that frame's own side
+                    // exit wrote back and escalated.)
+                    state.locals_to_S(ir);
+                }
+                state.load(ir, ret, GP::Rax);
+                if let Some((spec_ids, extra)) = specialized {
                     ir.push(AsmInst::MethodRetSpecialized {
                         rbp_offset: DynVarOffset::Hint {
                             ids: spec_ids,
@@ -934,14 +946,21 @@ impl<'a> JitContext<'a> {
             TraceIr::BlockBreak(ret) => {
                 state.flush_gp(ir);
                 assert!(state.no_capture_guard());
-                state.load(ir, ret, GP::Rax);
                 // Same as `MethodRet` above: a `break` inside a protected
                 // region relies on `handle_error` to run this frame's `ensure`
                 // during the unwind; the specialized teardown would skip it —
-                // observed as issue #1179's silently-lost `c += 0.5`.
-                if !self.in_protected_region(bc_pos)
-                    && let Some((spec_ids, extra)) = self.iter_caller_specialized_ids()
-                {
+                // observed as issue #1179's silently-lost `c += 0.5`. And on
+                // the generic path this frame's locals must be slot-true
+                // before the raise, for the same pre-escalation-`ensure`
+                // reason as in `MethodRet`.
+                let specialized = (!self.in_protected_region(bc_pos))
+                    .then(|| self.iter_caller_specialized_ids())
+                    .flatten();
+                if specialized.is_none() {
+                    state.locals_to_S(ir);
+                }
+                state.load(ir, ret, GP::Rax);
+                if let Some((spec_ids, extra)) = specialized {
                     ir.push(AsmInst::BlockBreakSpecialized {
                         rbp_offset: DynVarOffset::Hint {
                             ids: spec_ids,

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -908,7 +908,16 @@ impl<'a> JitContext<'a> {
                 state.flush_gp(ir);
                 assert!(state.no_capture_guard());
                 state.load(ir, ret, GP::Rax);
-                if let Some((spec_ids, extra)) = self.method_caller_specialized_ids() {
+                // A non-local `return` written inside a protected region must
+                // unwind through `handle_error`, which runs this frame's
+                // `ensure` (and restores `$!` when leaving a rescue clause) on
+                // the way out. The specialized teardown is a pure machine-level
+                // frame pop and would skip both. `check_exception_handler`
+                // covers only the *suspended* frames of the chain, so the
+                // exiting instruction's own coverage is checked here (#1179).
+                if !self.in_protected_region(bc_pos)
+                    && let Some((spec_ids, extra)) = self.method_caller_specialized_ids()
+                {
                     ir.push(AsmInst::MethodRetSpecialized {
                         rbp_offset: DynVarOffset::Hint {
                             ids: spec_ids,
@@ -926,7 +935,13 @@ impl<'a> JitContext<'a> {
                 state.flush_gp(ir);
                 assert!(state.no_capture_guard());
                 state.load(ir, ret, GP::Rax);
-                if let Some((spec_ids, extra)) = self.iter_caller_specialized_ids() {
+                // Same as `MethodRet` above: a `break` inside a protected
+                // region relies on `handle_error` to run this frame's `ensure`
+                // during the unwind; the specialized teardown would skip it —
+                // observed as issue #1179's silently-lost `c += 0.5`.
+                if !self.in_protected_region(bc_pos)
+                    && let Some((spec_ids, extra)) = self.iter_caller_specialized_ids()
+                {
                     ir.push(AsmInst::BlockBreakSpecialized {
                         rbp_offset: DynVarOffset::Hint {
                             ids: spec_ids,

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -1527,6 +1527,24 @@ impl<'a> JitContext<'a> {
     }
 
     ///
+    /// Whether the *current* frame's instruction at `bc_pos` is covered by
+    /// an entry of its iseq's exception table.
+    ///
+    /// The companion to [`Self::check_exception_handler`], which covers only
+    /// the chain's *suspended* frames (each at its in-progress call site) —
+    /// the frame currently being compiled is not in that range, so a
+    /// non-local exit (`MethodRet` / `BlockBreak`) written inside a
+    /// `begin`..`ensure` region asks this before choosing the specialized
+    /// teardown: that teardown is a pure machine-level frame pop, and only
+    /// the generic path's `handle_error` unwind runs the `ensure` bodies
+    /// (and the `$!` restore on leaving a rescue clause). Conservative like
+    /// its companion: any table entry forces the generic path (#1179).
+    ///
+    pub(super) fn in_protected_region(&self, bc_pos: BcIndex) -> bool {
+        self.iseq().get_exception_dest(bc_pos).is_some()
+    }
+
+    ///
     /// Hint variant of stack-offset computation for `LoadDynVar` /
     /// `StoreDynVar`. Returns the chain of [`SpecializedId`]s for
     /// frames `[outer..current)` together with `extra` — the sum

--- a/monoruby/tests/loop_jit_exit_sp.rs
+++ b/monoruby/tests/loop_jit_exit_sp.rs
@@ -98,23 +98,21 @@ fn block_break_out_of_a_loop_jit_unit() {
     );
 }
 
-/// A pre-existing JIT divergence found while building the shapes above,
-/// recorded so it is not lost — filed as issue #1179; removing the
-/// `#[ignore]` below turns this into its regression test once fixed.
-/// **Not** the sp-undo defect: it reproduces
-/// identically before and after that fix, at both FPR pool sizes, and
-/// `--no-jit` agrees with CRuby.
+/// The JIT divergence found while building the shapes above, filed as
+/// issue #1179 and since fixed — this is its regression test (the
+/// `#[ignore]` this carried while open is dropped). **Not** the sp-undo
+/// defect: it reproduced identically before and after that fix, at both
+/// FPR pool sizes, and `--no-jit` agreed with CRuby.
 ///
-/// When a `break` unwinds through an `ensure` that writes an *outer*
-/// local (`c += 0.5` below, a dynvar of the loop-JIT frame), the write
-/// happens in the VM — but the loop unit keeps reading its own stale view
-/// of `c` for the remaining iterations. Measured: monoruby 22975.5 vs
-/// CRuby 23025.0 — short by exactly 0.5 x the 99 iterations after the
-/// `break`, i.e. the breaking iteration's `ensure` increment never
-/// reached the loop's view. Same family as the block-passing-call float
-/// staleness (#1172/#1173), but through the non-local-exit path.
+/// The record above attributed the lost `c += 0.5` to a stale view (the
+/// #1172/#1173 family); probes said otherwise — the breaking iteration's
+/// `ensure` never ran at all. The `break` inside the block's own
+/// `begin`..`ensure` still lowered to `BlockBreakSpecialized`, a pure
+/// machine-level teardown that never enters `handle_error`, because the
+/// specialization check covered only the chain's *suspended* frames, not
+/// the exiting instruction's own coverage. See
+/// `JitContext::in_protected_region` and `tests/nonlocal_exit_ensure.rs`.
 #[test]
-#[ignore = "issue #1179: an ensure run by `break` writes an outer local the loop unit then reads stale"]
 fn break_running_an_ensure_that_writes_an_outer_local() {
     run_test(
         r#"

--- a/monoruby/tests/nonlocal_exit_ensure.rs
+++ b/monoruby/tests/nonlocal_exit_ensure.rs
@@ -50,6 +50,69 @@ fn a_break_through_an_ensure_writing_an_outer_local() {
     );
 }
 
+/// The ordering hazard behind the generic path: an `ensure` covering the
+/// exit *in the raising frame itself* is interpreted by the VM straight
+/// from `entry_raise` — before any error side exit has run, i.e. before
+/// the chain-deopt walk has materialized anything into slots. The
+/// raising frame's own locals must therefore be slot-true at the exit,
+/// exactly as `TraceIr::Raise` already ensures via `locals_to_S`. Here
+/// `f` lives only in an fpr at the `break`; without the homing the
+/// VM-run `ensure` read the frame's nil-filled slot instead
+/// (`NilClass can't be coerced into Float`).
+#[test]
+fn an_ensure_reading_the_raising_frames_own_float() {
+    run_test(
+        r#"
+        def m2
+          out = 0.0
+          [1].each do |x|
+            f = 1.5 * x
+            begin
+              break if x == 1
+            ensure
+              out += f
+            end
+          end
+          out
+        end
+        r = 0
+        300.times { r = m2 }
+        r
+        "#,
+    );
+}
+
+/// An `ensure` in an *intermediate* frame is safe without that homing:
+/// it only runs after that frame's own error side exit has written back
+/// and escalated (the chain-deopt walk converts every suspended frame —
+/// constant claims included — before the VM interprets the handler).
+/// Pinned here so the ordering contract stays observable: `d` is a
+/// constant-claimed outer local, and the `return` raises in the inner
+/// block while the `ensure` reading `d` sits one frame out.
+#[test]
+fn an_intermediate_ensure_reading_an_outer_constant() {
+    run_test(
+        r#"
+        $log = []
+        def m
+          d = 7
+          [1].each do |x|
+            begin
+              [2].each do |y|
+                return 5 if y == 2
+              end
+            ensure
+              $log << d
+            end
+          end
+          99
+        end
+        300.times { m }
+        $log.uniq
+        "#,
+    );
+}
+
 /// The `MethodRet` twin: a non-local `return` out of a block, written
 /// inside the block's `begin`..`ensure`. Hot enough that the whole
 /// chain (method, `each`, block) inlines into one unit, where the

--- a/monoruby/tests/nonlocal_exit_ensure.rs
+++ b/monoruby/tests/nonlocal_exit_ensure.rs
@@ -1,0 +1,78 @@
+//! A non-local exit written inside a protected region must run the
+//! `ensure` bodies it escapes through.
+//!
+//! `break` out of a block and non-local `return` normally unwind through
+//! `handle_error`, which walks the frames and runs each `ensure` on the
+//! way out. But when the whole chain is specialized-inlined into one JIT
+//! unit, the exits lower to `BlockBreakSpecialized` /
+//! `MethodRetSpecialized` — a pure machine-level frame teardown
+//! (`lea rbp += Σ; leave; ret`) that never enters `handle_error`.
+//!
+//! The chain check (`check_exception_handler`) covered only the
+//! *suspended* frames, each at its in-progress call site. The frame being
+//! compiled — the block whose own `begin`..`ensure` contains the exiting
+//! instruction — was not in that range, so the specialized teardown was
+//! chosen and silently skipped the block's own `ensure` (issue #1179):
+//! the break shape below lost exactly one `c += 0.5` (`22975.5` /
+//! `151.5` / `299` against CRuby's `23025.0` / `152.0` / `300`), and the
+//! return shape lost every post-warmup increment (`$m == 38`, not `300`).
+//! `JitContext::in_protected_region` is the missing half of the check.
+extern crate monoruby;
+use monoruby::tests::*;
+
+/// Issue #1179's shape: a `break` unwinding through an `ensure` that
+/// writes an outer local of the enclosing loop-JIT frame. The `ensure`
+/// must run exactly once per iteration — the breaking one included.
+#[test]
+fn a_break_through_an_ensure_writing_an_outer_local() {
+    run_test(
+        r#"
+        $n = 0
+        def g
+          a = 0.0; c = 2.0
+          i = 0
+          while i < 300
+            [1].each do |x|
+              begin
+                a += c
+                break if i == 200
+              ensure
+                c += 0.5
+                $n += 1
+              end
+            end
+            i += 1
+          end
+          [a, c, $n]
+        end
+        g
+        "#,
+    );
+}
+
+/// The `MethodRet` twin: a non-local `return` out of a block, written
+/// inside the block's `begin`..`ensure`. Hot enough that the whole
+/// chain (method, `each`, block) inlines into one unit, where the
+/// specialized teardown used to skip the `ensure` on every post-warmup
+/// call.
+#[test]
+fn a_return_through_an_ensure_in_a_block() {
+    run_test(
+        r#"
+        $m = 0
+        def h
+          [1].each do |x|
+            begin
+              return 42 if x == 1
+            ensure
+              $m += 1
+            end
+          end
+          99
+        end
+        res = 0
+        300.times { res = h }
+        [res, $m]
+        "#,
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -2313,6 +2313,7 @@ bba413775b9fdc4e5a5520013caecba6	true	Process.getpriority(Process::PRIO_USER, 0)
 bbb536d6446e4acae479f2a76bbc22b8	[false, true, "payload"]	base = "/tmp/monoruby_test_rename_#{Process.pid}_#{rand(100000)}"\n 
 bbc6b60d27eb5cad82b53e233df0c6e8	280	class Object\n          def tag = 7\n        end\n        \n\n        res = 
 bbf39b957f63dc57cf6be6b238e3322a	"HELLO world"	s = "hello world"; s.bytesplice(0..4, "HELLO WORLD", 0..-7); s
+bbf88be1f5615be8cbe5cfdbb37cd357	[23025.0, 152.0, 300]	$n = 0\n        def g\n          a = 0.0; c = 2.0\n          i = 0\n       
 bc0ccc0a16c986d29598ed69b9038ff8	[false, true, true]	h = {}\n        before = h.compare_by_identity?\n        ret = h.compare_
 bc2025afe3d4e746f87d06a3bac3e3db	[[]]	r = []; Enumerator.new { |y| y.yield }.each { |*a| r << a }; r
 bc2e5f3b4a16256b7dc6b55712d5a785	nil	Encoding.default_internal
@@ -2704,6 +2705,7 @@ da071b966818f27d5bc0ddb0f84eb172	[false, true, true, true, false, true, false, t
 da0f0adcfe40c1b122d44d207d5921fb	[[1, 2], [:scalar, nil], [:pk, :pv], [:s1, :s2], [nil, nil], [4.5, nil]]	def drive(a)\n              acc = []\n              a.each_with_yield
 da20ef8164c16f9d050189c7530ccdda	13	case 4\n        when 0\n          a = 10\n        when 1\n          a = 11\n
 da337801ffb5841d6913419d4806674b	[[1, 2, 3], [1, 2, 3], 1, 3, [1, 3]]	a = [3, 1, 2]\n            [\n              a.sort { |x, y| (x <=> y)
+da4116da4a0b35a76e2faef0a98c7685	[42, 300]	$m = 0\n        def h\n          [1].each do |x|\n            begin\n      
 da424b8ae2f6063fa60766fab8bac34a	false	t = Thread.new { sleep(2**62) }\n            Thread.pass while t.sta
 da5e06d1fe5eed1ee4258f71a99b2332	0	a = "abc".dup.force_encoding("UTF-8")\n              b = "abc".dup
 da64841b8187b9d8951f84703a56f5e9	[true, false]	$x = []\n            path = "/tmp/monoruby_test_mkdir_#{Process.pid}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -2045,6 +2045,7 @@ a6e76941b428102c2ba4a628d8639080	1000	S = Struct.new(:counter)\n            \n\n
 a6f799b2f3bd4b9cbb9608e44dd52dbc	true	Process.warmup
 a6ffb30dedbdb58fc281fe6682f6497c	[3, :first_store_raises]	class Q\n          def fill(i)\n            @a = i\n            @b = i\n   
 a71e54a7d566380aaed8baaea63868be	99	def make_proc\n          Proc.new { yield }\n        end\n        def get_
+a7842c388edf1fd9f074cafd5774cb4e	23025.0	def g\n          a = 0.0; c = 2.0\n          i = 0\n          while i < 30
 a7bbd186c86ac3ce9091503517f8a4c7	[true, true, false]	class Foo\n              def bar; 1; end\n              alias_method 
 a7d85b5b4b74fdccaa32b812610588e7	true	d = +"foo"\n            h = Hash.new(d)\n            h[:any].equal?(d
 a7dfe3e551ac8402163609fb863ca4e0	["US-ASCII"]	s = "abcabc".dup.force_encoding("US-ASCII")\n              s.scan(

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -956,6 +956,7 @@
 4c3cdf6fdb768ce2061972f6724dd416	42	class Foo\n              def initialize(x)\n                @x = x\n  
 4c6323de719d0ad254c106b3de0e1ff1	99	b = binding\n            b.local_variable_set("bar", 99)\n           
 4c66c29f7a10c99487fbb86f19ded61a	false	File.file?("readme.md")
+4c69a613ea757c9eff914b8a29903a61	[7]	$log = []\n        def m\n          d = 7\n          [1].each do |x|\n     
 4c6f323c0ce3159e2b7f0992372dd514	false	/a/.match("xay".b).nil?
 4c7471c063042fa95b957878dbb97a5a	[true, false]	class C < Object\n        end\n        class S < C\n        end\n\n        o
 4c7947408d26ed45ead6a30d7a7c8c21	[42, 42, 42, 42, 42, 42, 42, 42, 84, 84, 84]	class A\n          attr_accessor :w\n        end\n        a = A.new\n      
@@ -2925,6 +2926,7 @@ ec616c74470bcaec129ac19540047a93	["method", "nil", nil, "outer", ["a_file", "10"
 ec6e08886fb1c676139aa0cb92bb4296	["extend_object:C", "hello"]	$res = []\n        module M\n          def self.extend_object(obj)\n      
 ec75362ae6eb794adfccd5ea2fd87a71	["Infinity", "NaN", "Infinity", "-Infinity", true, "-0.314e1", "0.314e1", "0.314e1"]	require "rubygems"\n        require "bigdecimal"\n        res = []\n      
 ec7990294dac7ac2a637929f23760d95	[42, 42, 42, 42, 42, 42, 42, 42, 100, 100, 100]	class A\n                attr_accessor :w\n            end\n          
+ec83d3346e8c3ed3a4ed389e11834860	1.5	def m2\n          out = 0.0\n          [1].each do |x|\n            f = 1.
 ec84a8df82f97b16fdedf56efbc6ad35	"hello"	path = "/tmp/monoruby_test_filewrite_perm_#{Process.pid}_#{rand(100
 ecb0c2530aa824ca3b58cd269e696cd6	"xy"	def m; /(\\w)(\\w)/ =~ "xy"; -> { $~[0] }.call; end; m
 ecf0e0788d956837326285cb5c6fe318	[[0, 1, 2, 3, 4, 5, 6], 7, 8]	def f(*x,a,b)\n          [x,a,b]\n        end\n        \n\n        f(0,1,2,3


### PR DESCRIPTION
Fixes #1179 — and its `return` twin, which was worse.

## What actually happens

#1179's analysis attributed the lost `c += 0.5` to a stale outer-local view (the #1172/#1173 family): the ensure "executed by the VM during the non-local unwind" whose write never reaches the loop unit. Three probes on the x86-64 repro (which reproduces identically there — the issue had not yet verified that) say otherwise:

| probe | CRuby | monoruby JIT | meaning |
|---|---|---|---|
| final `c` | 152.0 | **151.5** | the write itself is missing, not a stale read |
| ensure counter | 300 | **299** | the ensure **never ran** at all |
| lowering probe | — | `BlockBreakSpecialized` | not, as assumed, the generic lowering |

## The defect

`break` out of a block and non-local `return` normally unwind through `handle_error`, which runs each escaped frame's `ensure` on the way out. When the whole chain is inlined into one JIT unit they lower instead to `BlockBreakSpecialized` / `MethodRetSpecialized` — a pure machine-level teardown (`lea rbp += Σ; leave; ret`) that never enters `handle_error`. That is only sound when nothing on the way out needs to run.

The guard, `check_exception_handler`, covers the chain's *suspended* frames, each at its in-progress call site — and nothing else. The frame being compiled is not in that range, so an exit written inside its own `begin`..`ensure` still took the specialized teardown, and the block's own `ensure` silently never ran.

The `return` twin is the same hole through `MethodRetSpecialized`, and measures worse on master: in a 300-call loop the block's `ensure` ran **38 times** — only during warmup, then never again.

## Fix

`JitContext::in_protected_region(bc_pos)` — the current frame at the current instruction, against the same exception table, with the same any-entry conservatism as its companion (leaving a rescue clause also needs its `$!` restore, which is likewise `handle_error`'s job). Both exit arms fall back to the generic lowering when it fires — the path `--no-jit` already proves correct.

These two arms are the only consumers: method-local `return`, loop `break`, and block `next` all get their `ensure` inlined by bytecodegen, and `Raise`/`Retry`/`Redo`/`EnsureEnd` always lower generic.

## Testing

| | result |
|---|---|
| x86-64 plain `--lib --tests` | 68 targets green (lib 2366) |
| x86-64 `stress-spill-pool` | 68 targets green (lib 2366) |
| both repro shapes vs CRuby | match (`23025.0 / 152.0 / 300`, `[42, 300]`) |
| regression tests on **unfixed** sources | fail (verified) |

The fix sits entirely in the arch-neutral front-end, and #1179 reproduced identically on aarch64, so the darwin job doubles as the aarch64 check.

## Relation to #1178

Independent — this reproduces unchanged before/after that fix. #1178's `#[ignore]`d divergence record (`break_running_an_ensure_that_writes_an_outer_local`) is this same break shape: once both land, that test can drop its attribute (whichever merges second picks it up; `tests/nonlocal_exit_ensure.rs` here already covers the shape either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_