### PR TITLE
Run the ensure on a non-local exit out of a specialized chain

### DIFF
--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -907,8 +907,8 @@ impl<'a> JitContext<'a> {
             TraceIr::MethodRet(ret) => {
                 state.flush_gp(ir);
                 assert!(state.no_capture_guard());
-                state.load(ir, ret, GP::Rax);
-                if let Some((spec_ids, extra)) = self.method_caller_specialized_ids() {
+                if let Some((spec_ids, extra)) = self.method_caller_specialized_ids(pc) {
+                    state.load(ir, ret, GP::Rax);
                     ir.push(AsmInst::MethodRetSpecialized {
                         rbp_offset: DynVarOffset::Hint {
                             ids: spec_ids,
@@ -916,6 +916,14 @@ impl<'a> JitContext<'a> {
                         },
                     });
                 } else {
+                    // The non-specialized path goes through `handle_error`,
+                    // which may resume *this* frame in the interpreter (an
+                    // ensure body protecting the `return`) — so every local
+                    // must be materialized in its slot first, exactly like
+                    // `Raise`. The specialized teardown above never resumes
+                    // the frame and skips this.
+                    state.locals_to_S(ir);
+                    state.load(ir, ret, GP::Rax);
                     ir.push(AsmInst::MethodRet(pc));
                 }
                 let result = state.as_return(ret);
@@ -925,8 +933,8 @@ impl<'a> JitContext<'a> {
             TraceIr::BlockBreak(ret) => {
                 state.flush_gp(ir);
                 assert!(state.no_capture_guard());
-                state.load(ir, ret, GP::Rax);
-                if let Some((spec_ids, extra)) = self.iter_caller_specialized_ids() {
+                if let Some((spec_ids, extra)) = self.iter_caller_specialized_ids(pc) {
+                    state.load(ir, ret, GP::Rax);
                     ir.push(AsmInst::BlockBreakSpecialized {
                         rbp_offset: DynVarOffset::Hint {
                             ids: spec_ids,
@@ -934,6 +942,10 @@ impl<'a> JitContext<'a> {
                         },
                     });
                 } else {
+                    // Same as `MethodRet`: `handle_error` may resume this
+                    // frame at its ensure body, which reads the slots.
+                    state.locals_to_S(ir);
+                    state.load(ir, ret, GP::Rax);
                     ir.push(AsmInst::BlockBreak(pc));
                 }
                 let result = state.as_return(ret);

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -1517,6 +1517,16 @@ impl<'a> JitContext<'a> {
     }
 
 
+    /// Whether *pc* (an absolute bytecode address of the frame currently
+    /// being compiled) sits inside one of that frame's exception-handler
+    /// regions. The non-local exits use it to refuse the specialized
+    /// static-teardown lowering, which cannot run handler bodies.
+    fn pc_in_handler_region(&self, pc: BytecodePtr) -> bool {
+        let iseq = self.iseq();
+        let idx = iseq.get_pc_index(Some(pc));
+        iseq.get_exception_dest(idx).is_some()
+    }
+
     fn check_exception_handler(&self, begin: usize, end: usize) -> bool {
         self.stack_frame[begin..end].iter().any(|f| {
             let iseq_id = f.iseq_id();
@@ -1672,7 +1682,22 @@ impl<'a> JitContext<'a> {
     /// captured at AsmIr emission time — see
     /// [`Self::outer_specialized_ids`] for the rationale.
     ///
-    pub(super) fn method_caller_specialized_ids(&self) -> Option<(Vec<SpecializedId>, usize)> {
+    pub(super) fn method_caller_specialized_ids(
+        &self,
+        pc: BytecodePtr,
+    ) -> Option<(Vec<SpecializedId>, usize)> {
+        // The static teardown leaves every frame between here and the home
+        // without ever consulting an exception table — including *this*
+        // one. A `return` written inside a begin/ensure must run the
+        // ensure body on the way out (`handle_error` does, via
+        // `defer_unwind`), so when the return site itself sits in a
+        // handler region the only correct lowering is the non-specialized
+        // `MethodRet` -> `err_method_return` path. `check_exception_handler`
+        // below covers the *suspended* frames (by their call-site pc), but
+        // not the frame the instruction is in.
+        if self.pc_in_handler_region(pc) {
+            return None;
+        }
         // Method specialization is lowered on both arches now, so the caller
         // chain is encoded for `MethodRetSpecialized` on aarch64 too — as is
         // block inlining, see `iter_caller_specialized_ids`.
@@ -1711,7 +1736,19 @@ impl<'a> JitContext<'a> {
     /// and the current frame. Returns `(ids, extra)` — see
     /// [`Self::method_caller_specialized_ids`].
     ///
-    pub(super) fn iter_caller_specialized_ids(&self) -> Option<(Vec<SpecializedId>, usize)> {
+    pub(super) fn iter_caller_specialized_ids(
+        &self,
+        pc: BytecodePtr,
+    ) -> Option<(Vec<SpecializedId>, usize)> {
+        // Same current-frame test as `method_caller_specialized_ids`: a
+        // `break` inside a begin/ensure must run this frame's ensure on
+        // the way out, which only the non-specialized `BlockBreak` ->
+        // `err_block_break` -> `handle_error` path does. Without it the
+        // static teardown skipped the ensure entirely (issue #1179: every
+        // post-OSR `break` lost its `ensure` write).
+        if self.pc_in_handler_region(pc) {
+            return None;
+        }
         // Block inlining is lowered on aarch64 now, so `break` out of an inlined
         // block can encode its caller chain for `BlockBreakSpecialized` too.
         let caller = self.iter_caller_pos()?;

--- a/monoruby/tests/loop_jit_exit_sp.rs
+++ b/monoruby/tests/loop_jit_exit_sp.rs
@@ -98,23 +98,21 @@ fn block_break_out_of_a_loop_jit_unit() {
     );
 }
 
-/// A pre-existing JIT divergence found while building the shapes above,
-/// recorded so it is not lost — filed as issue #1179; removing the
-/// `#[ignore]` below turns this into its regression test once fixed.
-/// **Not** the sp-undo defect: it reproduces
-/// identically before and after that fix, at both FPR pool sizes, and
-/// `--no-jit` agrees with CRuby.
-///
-/// When a `break` unwinds through an `ensure` that writes an *outer*
-/// local (`c += 0.5` below, a dynvar of the loop-JIT frame), the write
-/// happens in the VM — but the loop unit keeps reading its own stale view
-/// of `c` for the remaining iterations. Measured: monoruby 22975.5 vs
-/// CRuby 23025.0 — short by exactly 0.5 x the 99 iterations after the
-/// `break`, i.e. the breaking iteration's `ensure` increment never
-/// reached the loop's view. Same family as the block-passing-call float
-/// staleness (#1172/#1173), but through the non-local-exit path.
+/// Issue #1179's original shape. The first analysis ("the ensure's write
+/// happens in the VM but the loop unit reads a stale view") was wrong:
+/// counting the `ensure` executions showed the ensure **never ran** for a
+/// post-OSR `break`. The break site sat inside a begin/ensure, but
+/// `iter_caller_specialized_ids` only checked the *suspended* frames of
+/// the chain for handler regions — never the frame the `break` itself is
+/// in — so the loop unit compiled the exit as `BlockBreakSpecialized`, a
+/// static teardown that consults no exception table. Every `break` taken
+/// from the compiled loop skipped its `ensure` (measured on a
+/// break-every-iteration variant: 99 of 300 ensures ran — exactly the
+/// pre-OSR interpreted ones). Fixed by `pc_in_handler_region`: a
+/// non-local exit inside a handler region refuses the specialized
+/// lowering and goes through `err_block_break` -> `handle_error`, which
+/// runs the ensure.
 #[test]
-#[ignore = "issue #1179: an ensure run by `break` writes an outer local the loop unit then reads stale"]
 fn break_running_an_ensure_that_writes_an_outer_local() {
     run_test(
         r#"
@@ -133,6 +131,64 @@ fn break_running_an_ensure_that_writes_an_outer_local() {
             i += 1
           end
           a
+        end
+        g
+        "#,
+    );
+}
+
+/// The sharpest form of issue #1179: `break` on *every* iteration, with
+/// the `ensure` counting its own executions through a global. Before the
+/// fix only the pre-OSR (interpreted) iterations ran their ensure — 99 of
+/// 300 — because every `break` compiled into the loop unit took the
+/// specialized static teardown past the exception table.
+#[test]
+fn every_break_runs_its_ensure() {
+    run_test(
+        r#"
+        $n = 0
+        def g
+          i = 0
+          while i < 300
+            [1].each do |x|
+              begin
+                break if true
+              ensure
+                $n += 1
+              end
+            end
+            i += 1
+          end
+          $n
+        end
+        g
+        "#,
+    );
+}
+
+/// The integer variant: rules out any float/register-file involvement —
+/// integer locals are always slot-resident (the GP pool is empty), and
+/// the deficit was identical, which is what disproved the stale-view
+/// analysis and pointed at the ensure never running.
+#[test]
+fn break_ensure_writing_an_outer_integer() {
+    run_test(
+        r#"
+        def g
+          a = 0; c = 2
+          i = 0
+          while i < 300
+            [1].each do |x|
+              begin
+                a += c
+                break if i == 200
+              ensure
+                c += 1
+              end
+            end
+            i += 1
+          end
+          [a, c]
         end
         g
         "#,

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -421,6 +421,7 @@
 20246e0e0b12cd595e31cd7c277fa443	{life: 42}	fiber = Fiber.new(storage: {life: 42}) do\n              Thread.new 
 20354b8af635160a503c14b0bc910c4d	["pack length too big", "pack length too big", "pack length too big", "pack length too big", ["b"]]	r = []\n            [["@99999999999999999999999999", :unpack],\n     
 205e65e2298e3b75f7ddf8cf3f3495c6	[false, true, "z", :nme]	res = []\n        30.times { res << ("abc" !~ /b/) << ("abc" !~ /z/) << 
+2063bfa810947588ebf2d2b7ff4741a3	[45450, 302]	def g\n          a = 0; c = 2\n          i = 0\n          while i < 300\n  
 206652bec5b6b36846721ea87b2a4280	[true, true, true, true]	b = binding\n        sl = b.source_location\n        [sl.is_a?(Array), sl
 207dfdc3a331dc3a9bd12c35a3e92870	["pv\\n", "pv2\\n", "pv3\\n", "/tmp\\n", "/tmp\\n", true, "ISO-8859-1", ["UTF-8", "ISO-8859-1"]]	r = []\n            IO.popen([{"PV" => "pv"}, "sh", "-c", "echo $PV"
 209dfca7e20d5b08fbea7e352067e47e	1	begin\n          abort("test")\n        rescue SystemExit => e\n          
@@ -2044,6 +2045,7 @@ a6e76941b428102c2ba4a628d8639080	1000	S = Struct.new(:counter)\n            \n\n
 a6f799b2f3bd4b9cbb9608e44dd52dbc	true	Process.warmup
 a6ffb30dedbdb58fc281fe6682f6497c	[3, :first_store_raises]	class Q\n          def fill(i)\n            @a = i\n            @b = i\n   
 a71e54a7d566380aaed8baaea63868be	99	def make_proc\n          Proc.new { yield }\n        end\n        def get_
+a7842c388edf1fd9f074cafd5774cb4e	23025.0	def g\n          a = 0.0; c = 2.0\n          i = 0\n          while i < 30
 a7bbd186c86ac3ce9091503517f8a4c7	[true, true, false]	class Foo\n              def bar; 1; end\n              alias_method 
 a7d85b5b4b74fdccaa32b812610588e7	true	d = +"foo"\n            h = Hash.new(d)\n            h[:any].equal?(d
 a7dfe3e551ac8402163609fb863ca4e0	["US-ASCII"]	s = "abcabc".dup.force_encoding("US-ASCII")\n              s.scan(
@@ -2387,6 +2389,7 @@ c09d6cb41615f95536118d7f2c2d3ac5	"UTF-8"	-> { e = __ENCODING__; e.name }.call
 c0bd20c1f72134f81f9605cb0369bad4	["hello", "helloworld", "helloworld"]	path = "/tmp/mr_buf_rw.txt"\n            res = []\n            f = Fi
 c0ccecf51a28d34a9407d29cd759ff8a	[:f, :f]	class C; def f; 1; end; end\n            \n\n            m = C.new.met
 c0d486ae823c1add3b9717cbf806e267	54	[2, 3, 4, 5].inject(0) {|result, item| result + item ** 2 }
+c0da8cb417f12c88e38ff252f456992d	300	$n = 0\n        def g\n          i = 0\n          while i < 300\n          
 c0ddaa891fb7a63e6690683fe1ec0f3d	[["a"], ["abc"], ["1"]]	[/\\p{Word}/.match("a").to_a, /\\p{Alpha}+/.match("abc").to_a, /\\p{^L}/.match("1")
 c0f28d6a8eec92ebb24ada71d093ae08	[:from_proc, :nope]	class FwdH\n          def check = block_given? ? yield : :nope\n        e
 c0f4d9f562f9dd0bd39e836e62a9886e	[:rescued]	def boom; raise "no"; end\n            def test; [1].map { begin; bo


### PR DESCRIPTION
Fixes #1179 — and corrects its analysis.

## The reported theory was wrong

The issue blamed a stale view: the `break`'s `ensure` writes an outer local in the VM, and the loop unit keeps reading the old value. Counting the ensure executions through a global disproved that — **the ensure never ran**:

```ruby
[1].each do |x|
  begin
    break if true
  ensure
    $n += 1        # 99 of 300 executions — exactly the pre-OSR, interpreted ones
  end
end
```

`handle_error` (instrumented) was never entered for a post-OSR `break`. The integer variant reproduced with an identical deficit, ruling the FPR file out entirely.

## Two defects, one path

**1. The specialized teardown never asks whether the exit itself sits in a handler region.**

`iter_caller_specialized_ids` / `method_caller_specialized_ids` check only the *suspended* frames of the chain (by call-site pc, `check_exception_handler`). Nothing tested the `break` / `return` instruction's own pc — so the loop unit lowered the exit to `BlockBreakSpecialized`, a static `lea rbp += Σ; leave; ret` that consults no exception table, and every `break` compiled into the OSR unit skipped its `ensure`.

Fix: `pc_in_handler_region` — a non-local exit inside a begin/ensure refuses the specialized lowering and takes `err_block_break` / `err_method_return` → `handle_error`, which runs the ensure (`defer_unwind`).

**2. Exposed immediately: the non-specialized lowerings don't materialize locals.**

`Raise` / `Retry` / `Redo` all do `locals_to_S` before leaving, because `handle_error` may resume *this frame* in the interpreter at its ensure body — which reads slots. `MethodRet` / `BlockBreak` did not, so a block-local held in a register (or folded as a constant) was nil when the ensure read it: `undefined method '+' for nil`. Fix: the same `locals_to_S`, on the non-specialized arm only — the specialized teardown never resumes the frame.

## Tests

- The #1178 `#[ignore]` divergence record is un-ignored and its doc comment rewritten with the corrected analysis.
- Two sharper shapes join it: the ensure-count-via-global variant (the 99/300 measurement), and the all-integer variant that disproved the stale-view theory.

| | result |
|---|---|
| aarch64 native, `stress-spill-pool` | 3323 passed, 1 skipped |
| aarch64 native, default pool | 3323 passed, 1 skipped |

The change is arch-neutral (TraceIr → AsmIr selection in `jitgen/compile.rs` + `context.rs`); an x86-64 run is needed before merge. x86 has the same two defects structurally — `BlockBreakSpecialized`'s teardown is shared — so the amd64 CI leg is a real check, not a formality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
