### PR TITLE
Port the class-version recovery jump-back to aarch64

### DIFF
--- a/doc/arch_difference.md
+++ b/doc/arch_difference.md
@@ -163,12 +163,15 @@ storing the current version into that word (`Codegen::set_class_version`). An
 earlier revision of this document quoted an aarch64 comment saying *"we do not
 recompile on miss yet — just deopt"*; that text is gone.
 
-What is still x86-only is the **recovery jump-back**: `gen_recompile`'s
-`with_recovery` parameter and `jit_recompile_method_with_recovery` are both
-`#[cfg(target_arch = "x86_64")]`. On x86, a non-specialized class-version miss
-whose salvage succeeds resumes straight back into the compiled body; on aarch64
-the same miss deopts to the VM once and the healed code is entered on the next
-call. Correctness is identical — only the transition cost differs.
+The **recovery jump-back** is ported too: both arches now have a
+`jit_recompile_method_with_recovery` (the aarch64 one returns a tri-state —
+salvaged / recompiled / recompile-panicked — since aarch64 surfaces a
+recompile panic as a Ruby `FatalError`, which x86 does not). On either arch a
+non-specialized class-version miss whose salvage succeeds jumps straight back
+into the compiled body; only a genuine change pays the deopt. The aarch64
+call helper saves the full x86 `save_registers` equivalent (x1-x8 + d2-d7;
+d8-d15/x19-x28 are callee-saved under AAPCS64, and x0 is the return register
+and dead at a guard, like rax on x86).
 
 **Specialized frames are symmetric:** the specialized class-version guard
 recompiles on both arches. x86 uses `guard_class_version_specialized` /
@@ -203,7 +206,7 @@ stack alone — no code is patched, on either arch. See `doc/chain_deopt.md`
 | `guard_array_ty`              | yes (`ObjTy::ARRAY` at `RVALUE_OFFSET_TY`)                        | yes                                                                    |
 | `guard_capture`               | yes (`branch_if_captured`)                                       | yes                                                                    |
 | `float_to_f64` unbox          | yes (flonum / heap-Float, 0.0 sign-bit trick)                    | yes (mirrored)                                                         |
-| class-version guard           | unit snapshot word + **recovery jump-back** (§4.1)                | unit snapshot word, **no recovery** — salvaged miss deopts once (§4.1)  |
+| class-version guard           | unit snapshot word + recovery jump-back (§4.1)                    | same — recovery jump-back ported (§4.1)                                 |
 | eviction on BOP redefinition  | arch-neutral chain-deopt walk, no code patching (§4.2)          | identical (§4.2)                                                        |
 
 Both `a64_guard_class` and `a64_guard_rvalue` always emit (they return a `bool`
@@ -277,11 +280,9 @@ prologue and only the latter has already reserved the unit's spill region.
 - **Correctness is equal.** Both backends produce correct results.
 - **Coverage is equal.** Both backends JIT every method/loop the front-end
   produces; aarch64 no longer falls back to the VM for any instruction shape.
-- **Steady-state recompile behavior differs** in one narrow, non-specialized
-  case (§4.1): after a class-version change whose salvage succeeds, x86 jumps
-  back into the compiled body while aarch64 deopts to the VM once and re-enters
-  the healed code on the next call. Both reach the same steady state; the
-  difference is the transition cost.
+- **Recompile behavior is symmetric** (§4.1): a salvaged class-version miss
+  resumes compiled code in place on both arches; a genuine change recompiles
+  and pays one deopt.
 - **A very large loop body may stay interpreted on aarch64** (§5c, branch
   range). x86 has no such limit.
 
@@ -290,9 +291,8 @@ prologue and only the latter has already reserved the unit's spill region.
 > x86-64 and aarch64 share the entire AsmIR front-end *and* full AsmInst
 > coverage — aarch64 lowers everything (large immediates via scratch
 > registers), so the `bool` bail return is vestigial. What remains is
-> non-coverage: the x86-only **recovery jump-back** after a salvaged
-> non-specialized class-version miss (§4.1), different **code-installation**
-> mechanisms (branch patching vs indirect slots) and **cold-code placement**
-> (page 1 vs inline, which buys aarch64 the `as_pure_deopt` collapse), and
-> aarch64's **branch-range** ceiling on very large loop bodies (§5c). Guards,
+> non-coverage: different **code-installation** mechanisms (branch patching
+> vs indirect slots) and **cold-code placement** (page 1 vs inline, which
+> buys aarch64 the `as_pure_deopt` collapse), and aarch64's **branch-range**
+> ceiling on very large loop bodies (§5c). Guards, the recovery jump-back,
 > BOP eviction, block/method inlining and the GP pool are all symmetric.

--- a/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
@@ -1182,6 +1182,53 @@ impl Codegen {
         );
     }
 
+    /// Call `jit_recompile_method_with_recovery` for a class-version-guard
+    /// miss, leaving its tri-state (2 salvaged / 1 recompiled / 0 panic) in
+    /// x0.
+    ///
+    /// Unlike [`Self::a64_call_recompile`] — whose save set (d2-d7, x5-x8)
+    /// only feeds the deopt write-back that always follows — this returns
+    /// to *compiled* code on the salvage arm, so every abstract scratch the
+    /// guard site may hold live must survive the call: the x86 twin's
+    /// `save_registers` set (caller-saved except rax) maps here to x1-x8
+    /// plus d2-d7. d8-d15 and x19-x28 are callee-saved under AAPCS64, and
+    /// x0 (`Rax`) is the return register and, as on x86, dead at a guard.
+    pub(super) fn a64_call_recompile_with_recovery(&mut self, reason: RecompileReason) {
+        let f = crate::codegen::compiler::jit_recompile_method_with_recovery as *const () as u64;
+        monoasm_arm64!(&mut self.jit,
+            sub sp, sp, #(112);
+            str d2, [sp, #(0)];
+            str d3, [sp, #(8)];
+            str d4, [sp, #(16)];
+            str d5, [sp, #(24)];
+            str d6, [sp, #(32)];
+            str d7, [sp, #(40)];
+            stp x1, x2, [sp, #(48)];
+            stp x3, x4, [sp, #(64)];
+            stp x5, x6, [sp, #(80)];
+            stp x7, x8, [sp, #(96)];
+            mov x0, x19;                  // vm (Executor)
+            mov x1, x20;                  // globals
+            mov x2, x22;                  // lfp
+            mov x3, (reason as u64);
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;                       // x0: 2 salvaged / 1 recompiled / 0 panic
+            ldr x30, [sp], #16;
+            ldr d2, [sp, #(0)];
+            ldr d3, [sp, #(8)];
+            ldr d4, [sp, #(16)];
+            ldr d5, [sp, #(24)];
+            ldr d6, [sp, #(32)];
+            ldr d7, [sp, #(40)];
+            ldp x1, x2, [sp, #(48)];
+            ldp x3, x4, [sp, #(64)];
+            ldp x5, x6, [sp, #(80)];
+            ldp x7, x8, [sp, #(96)];
+            add sp, sp, #(112);
+        );
+    }
+
     ///
     /// Salvage-only miss handler for a constant-version guard
     /// (`ConstMiss::Salvage`) — the aarch64 counterpart of

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -2536,7 +2536,7 @@ impl Codegen {
         &mut self,
         class_version: DestLabel,
         position: Option<BytecodePtr>,
-        _with_recovery: bool,
+        with_recovery: bool,
         deopt: DestLabel,
     ) {
         // On a class-version miss, recompile (loop → `jit_recompile_loop`,
@@ -2546,20 +2546,31 @@ impl Codegen {
         // is stranded in the interpreter for the rest of the process after any
         // unrelated method definition. Mirrors x86 `guard_class_version` and the
         // aarch64 `GuardClassVersionSpecialized` twin; no counter — the
-        // recompile bakes in the new version, so the guard won't re-fire. The
-        // cheap x86 `with_recovery` path (an in-place inline-cache re-bake that
-        // resumes in JIT without recompiling) is not ported —
-        // `jit_recompile_method_with_recovery` is x86-only — so `_with_recovery`
-        // is ignored and this always full-recompiles. On a recompile panic the
-        // helper leaves a FatalError set and x0 == 0; we still branch to the
-        // deopt, which resumes at the guarded call where the interpreter
-        // propagates the fatal (matching the specialized twin).
+        // recompile bakes in the new version, so the guard won't re-fire.
+        //
+        // With `with_recovery` (a method-entry guard, `position == None`) the
+        // miss goes through `jit_recompile_method_with_recovery`, whose
+        // salvage arm re-validates the unit's assumptions and re-stamps its
+        // version word without recompiling; on that arm (x0 == 2) control
+        // jumps straight back to the guarded fall-through and the invocation
+        // continues in compiled code — the x86 `with_recovery` jump-back.
+        // Otherwise (recompiled, x0 == 1; or a recompile panic, x0 == 0 with
+        // a FatalError set on vm) fall to the deopt, where the interpreter
+        // resumes — or propagates the fatal — exactly as before.
         let miss = self.jit.label();
         let done = self.jit.label();
         self.a64_guard_class_version(&class_version, &miss); // version mismatch -> miss
         monoasm_arm64!(&mut self.jit, b done;); // match -> continue in JIT
         self.jit.bind_label(miss);
-        self.a64_call_recompile(position, RecompileReason::ClassVersionGuardFailed);
+        if with_recovery && position.is_none() {
+            self.a64_call_recompile_with_recovery(RecompileReason::ClassVersionGuardFailed);
+            monoasm_arm64!(&mut self.jit,
+                cmp x0, #2;
+            );
+            self.jit.bcond_label(monoasm::Cond::Eq, &done); // salvaged -> resume in place
+        } else {
+            self.a64_call_recompile(position, RecompileReason::ClassVersionGuardFailed);
+        }
         monoasm_arm64!(&mut self.jit, b deopt;); // recompiled -> resume via deopt
         self.jit.bind_label(done);
     }

--- a/monoruby/src/codegen/compiler.rs
+++ b/monoruby/src/codegen/compiler.rs
@@ -1004,6 +1004,49 @@ pub(in crate::codegen) extern "C" fn jit_recompile_method(
     Some(Value::nil())
 }
 
+/// aarch64 twin of the x86 `jit_recompile_method_with_recovery`: the
+/// class-version-guard miss handler that distinguishes a successful salvage
+/// from a full recompile, so the emitted guard can resume compiled code in
+/// place instead of paying a deopt-to-VM for the rest of the invocation.
+///
+/// Returns a tri-state (the x86 version's `u64` grown by the panic case,
+/// which x86 does not surface):
+/// - `2` — salvaged: every assumption re-validated, the unit's version word
+///   re-stamped. The caller jumps straight back to the guarded fall-through.
+/// - `1` — recompiled (or the recompile found real changes): deopt once and
+///   enter the new code on the next call, as before.
+/// - `0` — the recompile panicked; a Ruby `FatalError` is set on `vm` and
+///   the caller deopts, where the interpreter propagates it (same contract
+///   as [`jit_recompile_method`]).
+#[cfg(target_arch = "aarch64")]
+pub(in crate::codegen) extern "C" fn jit_recompile_method_with_recovery(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    reason: RecompileReason,
+) -> u64 {
+    #[cfg(feature = "jit-log")]
+    crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::RECOVERY_ATTEMPT);
+    if globals.store.update_inline_cache(lfp) {
+        #[cfg(feature = "jit-log")]
+        crate::codegen::jit_stats::bump(&crate::codegen::jit_stats::SALVAGE_OK);
+        return 2;
+    }
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        CODEGEN.with(|codegen| {
+            codegen.borrow_mut().recompile_method(globals, lfp, reason);
+        });
+    }));
+    if result.is_err() {
+        CODEGEN.with(|codegen| codegen.borrow_mut().jit.finalize());
+        vm.set_error(MonorubyErr::fatal(
+            "internal error: JIT method recompilation panicked.",
+        ));
+        return 0;
+    }
+    1
+}
+
 /// aarch64 loop recompile, called from the `RecompileDeopt` lowering
 /// (`arch/aarch64/compile.rs`) when `position` is the loop pc. Re-runs `compile_partial`
 /// for the loop body and rewrites the loop's codeptr at `[pc + 8]`, so the next


### PR DESCRIPTION
Closes the last optimization asymmetry between the two JIT backends identified in the arch-difference audit (#1177): the **class-version recovery jump-back** was x86-64-only. On a non-specialized class-version-guard miss whose salvage succeeds, x86 jumps straight back into the compiled body; aarch64 always paid a deopt-to-VM for the rest of the invocation and only entered the healed code on the next call.

## What

Three pieces, mirroring the x86 structure:

- **`jit_recompile_method_with_recovery` (aarch64)** — tri-state `u64`: `2` salvaged (resume in place), `1` recompiled (deopt once), `0` recompile panicked (`FatalError` set on `vm`; the deopt propagates it). The x86 twin's return is binary because x86 does not surface recompile panics.
- **`a64_call_recompile_with_recovery`** — unlike `a64_call_recompile`, whose save set (d2–d7, x5–x8) only feeds the deopt write-back that always follows, this returns to *compiled* code on the salvage arm, so it saves the full x86 `save_registers` equivalent: **x1–x8 + d2–d7**. d8–d15/x19–x28 are callee-saved under AAPCS64; x0 (`Rax`) is the return register and dead at a guard, exactly like rax on x86 (whose `save_registers` also excludes it).
- **`emit_guard_class_version`** — honours the `with_recovery` flag the shared IR already carried (method-entry guards, `position == None`): miss → recovery call; `x0 == 2` branches back to the guarded fall-through; otherwise fall to the deopt as before. Loop-position guards keep the existing path, mirroring x86 (whose recovery also applies only to the `position == None` arm).

## Verification

- Probe on the new salvage arm, on the salvage shape (hot loop over an inline-cached call, `def` bumping the class version between runs): **20 salvage-resumes**, results identical to CRuby — i.e. every one of those was previously a deopt plus interpreted remainder.
- aarch64 native: **3325 passed at both pool sizes**, plus a full `SKIP_COV=1 bin/test` (benchmarks / optcarrot / ruby-bench / ruby-spec diffs all clean, exit 0).
- x86-64 untouched: the new runtime fn and call helper are `cfg(aarch64)`; the shared lowering already carried `with_recovery`.

`doc/arch_difference.md` updated: the class-version-guard row and the summary now read symmetric — what remains arch-specific is installation mechanics (patching vs indirect slots), cold-code placement (page 1 vs inline + `as_pure_deopt`), and the aarch64 branch-range ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
