### PR TITLE
Pin the CI toolchain install to rust-toolchain.toml's nightly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,13 @@ jobs:
           ruby-version: "4.0.2"
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
+          # Keep in sync with rust-toolchain.toml. A floating `nightly` here
+          # made the job die whenever that day's nightly was missing for the
+          # runner's target (aarch64-apple-darwin gaps are routine): the
+          # toolchain the build actually uses is the pinned one anyway —
+          # rustup auto-fetches it from rust-toolchain.toml — so install
+          # exactly that and nothing else.
+          toolchain: nightly-2026-05-18
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: taiki-e/install-action@nextest
 
@@ -111,7 +117,13 @@ jobs:
           echo "PKG_CONFIG_PATH=$(brew --prefix libffi)/lib/pkgconfig" >> "$GITHUB_ENV"
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
+          # Keep in sync with rust-toolchain.toml. A floating `nightly` here
+          # made the job die whenever that day's nightly was missing for the
+          # runner's target (aarch64-apple-darwin gaps are routine): the
+          # toolchain the build actually uses is the pinned one anyway —
+          # rustup auto-fetches it from rust-toolchain.toml — so install
+          # exactly that and nothing else.
+          toolchain: nightly-2026-05-18
       - uses: taiki-e/install-action@nextest
 
       - name: Clone optcarrot


### PR DESCRIPTION
The darwin leg of #1183's CI run died in toolchain setup:

```
error: toolchain 'nightly-aarch64-apple-darwin' is not installable
```

Both jobs install a **floating** `nightly` via `dtolnay/rust-toolchain`, so any day upstream skips (or lags) publishing a nightly for the runner's target kills the job before it builds anything — aarch64-apple-darwin gaps are routine. The build doesn't even use that toolchain: rustup auto-fetches the `rust-toolchain.toml` pin (`nightly-2026-05-18`).

Install exactly the pin instead, with a keep-in-sync comment. Bumping the pin now means touching `rust-toolchain.toml` and this file together, which is the right coupling — the pin exists so builds are reproducible, and CI should build what's pinned.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
