### PR TITLE
Splice a protected non-local exit through its own compiled ensure body

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -3075,21 +3075,110 @@ impl Codegen {
     /// End of an `ensure` clause — runtime::ensure_end(vm) returns a nonzero
     /// value when a pending exception must keep propagating (→ entry_raise);
     /// zero means fall through to the normal continuation.
-    pub(in crate::codegen::jitgen) fn emit_ensure_end(&mut self, loop_jit_spill_bytes: usize) -> bool {
+    pub(in crate::codegen::jitgen) fn emit_ensure_end(
+        &mut self,
+        pc: BytecodePtr,
+        loop_jit_spill_bytes: usize,
+        spliced_break: Option<usize>,
+        spliced_ret: Option<usize>,
+    ) -> bool {
         let raise = self.entry_raise();
         let cont = self.jit.label();
-        let f = runtime::ensure_end as *const () as u64;
+        let pc0 = pc.as_ptr() as u64;
+        if spliced_break.is_none() && spliced_ret.is_none() {
+            let f = runtime::ensure_end as *const () as u64;
+            monoasm_arm64!(&mut self.jit,
+                mov x0, x19;             // vm
+                str x30, [sp, #-16]!;
+                mov x9, (f);
+                blr x9;                  // x0 = 0 (continue) / nonzero (re-raise)
+                ldr x30, [sp], #16;
+                cbz x0, cont;            // continue: stay in the (still-bumped) loop body
+            );
+            // Re-raise path resumes the VM, so undo the loop sp-bump first,
+            // and set PC so `handle_error`'s table lookup is aligned.
+            self.a64_undo_loop_rsp_bump(loop_jit_spill_bytes);
+            monoasm_arm64!(&mut self.jit,
+                mov x21, (pc0);
+                b raise;
+                cont:
+            );
+            return true;
+        }
+        // Spliced form (#1185) — mirrors x86 `emit_ensure_end`: the runtime
+        // dispatch classifies the deferred unwind (x0 = code, x1 = value);
+        // codes 2/3 run the same teardown as `BlockBreakSpecialized` /
+        // `MethodRetSpecialized` with the value moved into the accumulator
+        // first, everything else re-raises. Spliced regions live in
+        // specialized inlined frames (`try_splice_exit` refuses loop roots),
+        // whose `loop_jit_spill_bytes` is 0, so no sp-bump undo is owed on
+        // any arm here — but keep the undo on the re-raise path anyway to
+        // stay exactly equivalent to the plain form.
+        let reraise = self.jit.label();
+        let f = runtime::ensure_end_spliced as *const () as u64;
         monoasm_arm64!(&mut self.jit,
             mov x0, x19;             // vm
             str x30, [sp, #-16]!;
             mov x9, (f);
-            blr x9;                  // x0 = 0 (continue) / nonzero (re-raise)
+            blr x9;                  // x0 = code, x1 = value
             ldr x30, [sp], #16;
-            cbz x0, cont;            // continue: stay in the (still-bumped) loop body
+            cbz x0, cont;
+            cmp x0, #1;
         );
-        // Re-raise path resumes the VM, so undo the loop sp-bump first.
+        self.jit.bcond_label(monoasm::Cond::Eq, &reraise);
+        if let Some(off) = spliced_break {
+            let skip = self.jit.label();
+            monoasm_arm64!(&mut self.jit, cmp x0, #2;);
+            self.jit.bcond_label(monoasm::Cond::Ne, &skip);
+            monoasm_arm64!(&mut self.jit, mov x0, x1;); // value -> accumulator
+            self.method_return_specialized(off);
+            self.jit.bind_label(skip);
+        }
+        if let Some(off) = spliced_ret {
+            let skip = self.jit.label();
+            monoasm_arm64!(&mut self.jit, cmp x0, #3;);
+            self.jit.bcond_label(monoasm::Cond::Ne, &skip);
+            monoasm_arm64!(&mut self.jit, mov x0, x1;);
+            self.method_return_specialized(off);
+            self.jit.bind_label(skip);
+        }
+        self.jit.bind_label(reraise);
         self.a64_undo_loop_rsp_bump(loop_jit_spill_bytes);
         monoasm_arm64!(&mut self.jit,
+            mov x21, (pc0);
+            b raise;
+            cont:
+        );
+        true
+    }
+
+    /// A JIT-spliced non-local exit (#1185): build and defer the exit's
+    /// unwind (value in the `GP::Rdx`-mapped register) so the following
+    /// compiled branch enters the shared `ensure` body directly. A
+    /// degenerate outcome raises generically from the exit's own pc.
+    /// Mirrors x86 `emit_defer_spliced_exit`.
+    pub(in crate::codegen::jitgen) fn emit_defer_spliced_exit(
+        &mut self,
+        kind: SplicedExitKind,
+        pc: BytecodePtr,
+    ) -> bool {
+        let raise = self.entry_raise();
+        let f = match kind {
+            SplicedExitKind::Break => runtime::defer_block_break as *const () as u64,
+            SplicedExitKind::MethodReturn => runtime::defer_method_return as *const () as u64,
+        };
+        let val = GP::Rdx.a64().0;
+        let cont = self.jit.label();
+        monoasm_arm64!(&mut self.jit,
+            mov x2, x(val);          // value
+            mov x0, x19;             // vm
+            mov x1, x20;             // globals
+            str x30, [sp, #-16]!;
+            mov x9, (f);
+            blr x9;                  // 0 = deferred / nonzero = error in-flight
+            ldr x30, [sp], #16;
+            cbz x0, cont;
+            mov x21, (pc.as_ptr() as u64);
             b raise;
             cont:
         );

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -162,7 +162,8 @@ impl Codegen {
             | AsmInst::Raise
             | AsmInst::Retry(..)
             | AsmInst::Redo(..)
-            | AsmInst::EnsureEnd
+            | AsmInst::EnsureEnd { .. }
+            | AsmInst::DeferSplicedExit { .. }
             | AsmInst::Yield { .. }
             | AsmInst::MethodRetSpecialized { .. }
             | AsmInst::BlockBreakSpecialized { .. }
@@ -2637,15 +2638,101 @@ impl Codegen {
 
     pub(in crate::codegen::jitgen) fn emit_ensure_end(
         &mut self,
+        pc: BytecodePtr,
         _loop_jit_spill_bytes: usize,
+        spliced_break: Option<usize>,
+        spliced_ret: Option<usize>,
     ) -> bool {
         let raise = self.entry_raise();
+        if spliced_break.is_none() && spliced_ret.is_none() {
+            let cont = self.jit.label();
+            monoasm! { &mut self.jit,
+                movq rdi, rbx;
+                movq rax, (runtime::ensure_end);
+                call rax;
+                testq rax, rax;
+                jz   cont;
+                movq r13, (pc.as_ptr());
+                jmp  raise;
+            cont:
+            };
+            return true;
+        }
+        // Spliced form (#1185): the runtime dispatch classifies the deferred
+        // unwind — rax = code (0 continue / 1 re-raise / 2 spliced break /
+        // 3 spliced return), rdx = the delivered value. The teardown arms are
+        // the same machine sequence as `BlockBreakSpecialized` /
+        // `MethodRetSpecialized`, with the value moved into rax first. A code
+        // whose arm was not emitted falls through to the re-raise, whose
+        // `entry_raise` surfaces the (error-less) state as a fatal — by
+        // construction the runtime only returns codes for kinds this unit
+        // spliced.
+        let cont = self.jit.label();
+        let reraise = self.jit.label();
         monoasm! { &mut self.jit,
             movq rdi, rbx;
-            movq rax, (runtime::ensure_end);
+            movq rax, (runtime::ensure_end_spliced);
             call rax;
             testq rax, rax;
-            jne  raise;
+            jz   cont;
+            cmpq rax, 1;
+            jeq  reraise;
+        };
+        if let Some(off) = spliced_break {
+            let skip = self.jit.label();
+            monoasm! { &mut self.jit,
+                cmpq rax, 2;
+                jne  skip;
+                movq rax, rdx;
+            };
+            self.method_return_specialized(off);
+            self.jit.bind_label(skip);
+        }
+        if let Some(off) = spliced_ret {
+            let skip = self.jit.label();
+            monoasm! { &mut self.jit,
+                cmpq rax, 3;
+                jne  skip;
+                movq rax, rdx;
+            };
+            self.method_return_specialized(off);
+            self.jit.bind_label(skip);
+        }
+        monoasm! { &mut self.jit,
+        reraise:
+            movq r13, (pc.as_ptr());
+            jmp  raise;
+        cont:
+        };
+        true
+    }
+
+    /// A JIT-spliced non-local exit (#1185): build and defer the exit's
+    /// unwind (value in rdx) so the following compiled branch enters the
+    /// shared `ensure` body directly. A degenerate outcome (the runtime
+    /// helper returns non-zero, error left in-flight) raises generically
+    /// from the exit's own pc.
+    pub(in crate::codegen::jitgen) fn emit_defer_spliced_exit(
+        &mut self,
+        kind: SplicedExitKind,
+        pc: BytecodePtr,
+    ) -> bool {
+        let raise = self.entry_raise();
+        let f = match kind {
+            SplicedExitKind::Break => runtime::defer_block_break as *const u8,
+            SplicedExitKind::MethodReturn => runtime::defer_method_return as *const u8,
+        };
+        let cont = self.jit.label();
+        monoasm! { &mut self.jit,
+            movq rdi, rbx;
+            movq rsi, r12;
+            movq rax, (f);
+            call rax;
+            testq rax, rax;
+            jz   cont;
+            movq r13, (pc.as_ptr());
+            jmp  raise;
+        cont:
         };
         true
     }

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1243,6 +1243,20 @@ impl AsmIr {
 /// `Concrete(sum(map[id]) + extra)`. Code generation asserts
 /// `Concrete(_)` and panics on a stray `Hint`.
 ///
+///
+/// Which non-local exit a JIT splice (issue #1185) is deferring across its
+/// own frame's `ensure` body.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SplicedExitKind {
+    /// `break` out of a block — delivered by `BlockBreakSpecialized`'s
+    /// teardown at the region's `EnsureEnd`.
+    Break,
+    /// Non-local `return` out of a block — delivered by
+    /// `MethodRetSpecialized`'s teardown at the region's `EnsureEnd`.
+    MethodReturn,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) enum DynVarOffset {
     Hint {
@@ -1512,7 +1526,29 @@ pub(super) enum AsmInst {
     Raise,
     Retry(BytecodePtr),
     Redo(BytecodePtr),
-    EnsureEnd,
+    EnsureEnd {
+        /// The `EnsureEnd` instruction's own pc, for the re-raise path's
+        /// exception-table lookup in `handle_error`.
+        pc: BytecodePtr,
+        /// When this region has JIT-spliced non-local exits (issue #1185),
+        /// the teardown chain offsets the dispatch delivers through:
+        /// a spliced `break`'s `BlockBreakSpecialized`-equivalent offset,
+        /// and a spliced `return`'s `MethodRetSpecialized`-equivalent one.
+        /// Both `None` keeps the plain two-way (continue / re-raise) form.
+        spliced_break: Option<DynVarOffset>,
+        spliced_ret: Option<DynVarOffset>,
+    },
+    ///
+    /// A JIT-spliced non-local exit (issue #1185): build and *defer* the
+    /// break / method-return error for the value in rax, so the compiled
+    /// jump that follows (emitted by the driver's `Branch` handling) can
+    /// enter the shared `ensure` body directly. When the error degenerates
+    /// (e.g. `LocalJumpError`), fall back to the generic raise from `pc`.
+    ///
+    DeferSplicedExit {
+        kind: SplicedExitKind,
+        pc: BytecodePtr,
+    },
     ///
     /// Conditional branch
     ///

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -1048,9 +1048,21 @@ impl Codegen {
                 pc,
                 loop_jit_spill_bytes: frame.loop_jit_spill_bytes,
             }),
-            AsmInst::EnsureEnd => self.encode_linst(LInst::EnsureEnd {
+            AsmInst::EnsureEnd {
+                pc,
+                spliced_break,
+                spliced_ret,
+            } => self.encode_linst(LInst::EnsureEnd {
+                pc,
                 loop_jit_spill_bytes: frame.loop_jit_spill_bytes,
+                spliced_break: spliced_break.map(|o| o.unwrap_concrete()),
+                spliced_ret: spliced_ret.map(|o| o.unwrap_concrete()),
             }),
+            // A spliced non-local exit defers its unwind and falls through to
+            // the branch into the shared `ensure` body (#1185).
+            AsmInst::DeferSplicedExit { kind, pc } => {
+                self.encode_linst(LInst::DeferSplicedExit { kind, pc })
+            }
             // Generic `yield` (block target resolved at runtime). aarch64 builds
             // the block frame and calls the funcdata indirectly; both arches
             // record the block call's return address under `evict` for the
@@ -1642,8 +1654,11 @@ impl Codegen {
             LInst::Redo { pc, loop_jit_spill_bytes } => {
                 self.emit_redo(pc, loop_jit_spill_bytes);
             }
-            LInst::EnsureEnd { loop_jit_spill_bytes } => {
-                self.emit_ensure_end(loop_jit_spill_bytes);
+            LInst::EnsureEnd { pc, loop_jit_spill_bytes, spliced_break, spliced_ret } => {
+                self.emit_ensure_end(pc, loop_jit_spill_bytes, spliced_break, spliced_ret);
+            }
+            LInst::DeferSplicedExit { kind, pc } => {
+                self.emit_defer_spliced_exit(kind, pc);
             }
             LInst::Yield { callid, simple, error, evict } => {
                 self.emit_yield(callid, simple, &error, evict);

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -907,7 +907,6 @@ impl<'a> JitContext<'a> {
             TraceIr::MethodRet(ret) => {
                 state.flush_gp(ir);
                 assert!(state.no_capture_guard());
-                state.load(ir, ret, GP::Rax);
                 // A non-local `return` written inside a protected region must
                 // unwind through `handle_error`, which runs this frame's
                 // `ensure` (and restores `$!` when leaving a rescue clause) on
@@ -915,9 +914,22 @@ impl<'a> JitContext<'a> {
                 // frame pop and would skip both. `check_exception_handler`
                 // covers only the *suspended* frames of the chain, so the
                 // exiting instruction's own coverage is checked here (#1179).
-                if !self.in_protected_region(bc_pos)
-                    && let Some((spec_ids, extra)) = self.method_caller_specialized_ids()
-                {
+                let specialized = (!self.in_protected_region(bc_pos))
+                    .then(|| self.method_caller_specialized_ids())
+                    .flatten();
+                if specialized.is_none() {
+                    // Mirror `Raise`: when this frame's own `ensure` covers
+                    // the exit, `handle_error` sends the VM into it straight
+                    // from `entry_raise` — *before* any error side exit has
+                    // run, i.e. before the chain-deopt walk has materialized
+                    // anything — so this frame's locals must be slot-true
+                    // now. (An `ensure` in an *intermediate* frame is safe
+                    // without this: it only runs after that frame's own side
+                    // exit wrote back and escalated.)
+                    state.locals_to_S(ir);
+                }
+                state.load(ir, ret, GP::Rax);
+                if let Some((spec_ids, extra)) = specialized {
                     ir.push(AsmInst::MethodRetSpecialized {
                         rbp_offset: DynVarOffset::Hint {
                             ids: spec_ids,
@@ -934,14 +946,21 @@ impl<'a> JitContext<'a> {
             TraceIr::BlockBreak(ret) => {
                 state.flush_gp(ir);
                 assert!(state.no_capture_guard());
-                state.load(ir, ret, GP::Rax);
                 // Same as `MethodRet` above: a `break` inside a protected
                 // region relies on `handle_error` to run this frame's `ensure`
                 // during the unwind; the specialized teardown would skip it —
-                // observed as issue #1179's silently-lost `c += 0.5`.
-                if !self.in_protected_region(bc_pos)
-                    && let Some((spec_ids, extra)) = self.iter_caller_specialized_ids()
-                {
+                // observed as issue #1179's silently-lost `c += 0.5`. And on
+                // the generic path this frame's locals must be slot-true
+                // before the raise, for the same pre-escalation-`ensure`
+                // reason as in `MethodRet`.
+                let specialized = (!self.in_protected_region(bc_pos))
+                    .then(|| self.iter_caller_specialized_ids())
+                    .flatten();
+                if specialized.is_none() {
+                    state.locals_to_S(ir);
+                }
+                state.load(ir, ret, GP::Rax);
+                if let Some((spec_ids, extra)) = specialized {
                     ir.push(AsmInst::BlockBreakSpecialized {
                         rbp_offset: DynVarOffset::Hint {
                             ids: spec_ids,

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -907,13 +907,37 @@ impl<'a> JitContext<'a> {
             TraceIr::MethodRet(ret) => {
                 state.flush_gp(ir);
                 assert!(state.no_capture_guard());
+                // A non-local `return` inside its own frame's protected region
+                // can be *spliced* (#1185): defer the unwind and jump into the
+                // shared `ensure` body — ordinary compiled code of this frame —
+                // whose `EnsureEnd` delivers it through the specialized
+                // teardown. The region's `ensure` then runs compiled and
+                // state-visible instead of interpreted mid-unwind.
+                if let Some(dest_bb) = self.try_splice_exit(bc_pos, SplicedExitKind::MethodReturn) {
+                    // The degenerate fallback inside `DeferSplicedExit` raises
+                    // generically from this pc, so home the locals exactly as
+                    // the generic arm below does.
+                    state.locals_to_S(ir);
+                    state.load(ir, ret, GP::Rdx);
+                    ir.push(AsmInst::DeferSplicedExit {
+                        kind: SplicedExitKind::MethodReturn,
+                        pc,
+                    });
+                    // Enter the `ensure` body with the temp level its join
+                    // expects.
+                    let dest_sp = self.iseq().get_sp(self.iseq().bb_info[dest_bb].begin);
+                    state.set_next_sp(dest_sp);
+                    state.clear_above_next_sp();
+                    return Ok(CompileResult::Branch(dest_bb));
+                }
                 // A non-local `return` written inside a protected region must
-                // unwind through `handle_error`, which runs this frame's
-                // `ensure` (and restores `$!` when leaving a rescue clause) on
-                // the way out. The specialized teardown is a pure machine-level
-                // frame pop and would skip both. `check_exception_handler`
-                // covers only the *suspended* frames of the chain, so the
-                // exiting instruction's own coverage is checked here (#1179).
+                // otherwise unwind through `handle_error`, which runs this
+                // frame's `ensure` (and restores `$!` when leaving a rescue
+                // clause) on the way out. The specialized teardown is a pure
+                // machine-level frame pop and would skip both.
+                // `check_exception_handler` covers only the *suspended* frames
+                // of the chain, so the exiting instruction's own coverage is
+                // checked here (#1179).
                 let specialized = (!self.in_protected_region(bc_pos))
                     .then(|| self.method_caller_specialized_ids())
                     .flatten();
@@ -946,13 +970,26 @@ impl<'a> JitContext<'a> {
             TraceIr::BlockBreak(ret) => {
                 state.flush_gp(ir);
                 assert!(state.no_capture_guard());
-                // Same as `MethodRet` above: a `break` inside a protected
-                // region relies on `handle_error` to run this frame's `ensure`
-                // during the unwind; the specialized teardown would skip it —
-                // observed as issue #1179's silently-lost `c += 0.5`. And on
-                // the generic path this frame's locals must be slot-true
-                // before the raise, for the same pre-escalation-`ensure`
-                // reason as in `MethodRet`.
+                // Splice first — see `MethodRet` above (#1185).
+                if let Some(dest_bb) = self.try_splice_exit(bc_pos, SplicedExitKind::Break) {
+                    state.locals_to_S(ir);
+                    state.load(ir, ret, GP::Rdx);
+                    ir.push(AsmInst::DeferSplicedExit {
+                        kind: SplicedExitKind::Break,
+                        pc,
+                    });
+                    let dest_sp = self.iseq().get_sp(self.iseq().bb_info[dest_bb].begin);
+                    state.set_next_sp(dest_sp);
+                    state.clear_above_next_sp();
+                    return Ok(CompileResult::Branch(dest_bb));
+                }
+                // Otherwise: a `break` inside a protected region relies on
+                // `handle_error` to run this frame's `ensure` during the
+                // unwind; the specialized teardown would skip it — observed as
+                // issue #1179's silently-lost `c += 0.5`. And on the generic
+                // path this frame's locals must be slot-true before the raise,
+                // for the same pre-escalation-`ensure` reason as in
+                // `MethodRet`.
                 let specialized = (!self.in_protected_region(bc_pos))
                     .then(|| self.iter_caller_specialized_ids())
                     .flatten();
@@ -997,7 +1034,41 @@ impl<'a> JitContext<'a> {
             TraceIr::EnsureEnd => {
                 state.flush_gp(ir);
                 state.locals_to_S(ir);
-                ir.push(AsmInst::EnsureEnd);
+                // When exits spliced into this region (#1185), emit the
+                // specialized-teardown dispatch arms for the recorded kinds,
+                // and register the exit edges they create exactly as the plain
+                // specialized exits would. The chains are the same ones
+                // `try_splice_exit` verified; if they are unexpectedly gone,
+                // the un-emitted arm is covered by the runtime dispatch's
+                // re-raise fallback.
+                let spliced = self.current_frame().spliced_ensures.get(&bc_pos).copied();
+                let (spliced_break, spliced_ret) = match spliced {
+                    Some((brk, mret)) => {
+                        let brk_off = brk
+                            .then(|| self.iter_caller_specialized_ids())
+                            .flatten()
+                            .map(|(ids, extra)| DynVarOffset::Hint { ids, extra });
+                        let ret_off = mret
+                            .then(|| self.method_caller_specialized_ids())
+                            .flatten()
+                            .map(|(ids, extra)| DynVarOffset::Hint { ids, extra });
+                        if brk_off.is_some() {
+                            self.unset_return_context_side_effect_guard();
+                            self.new_break(state.as_return_any());
+                        }
+                        if ret_off.is_some() {
+                            self.unset_return_context_side_effect_guard();
+                            self.new_method_return(state.as_return_any());
+                        }
+                        (brk_off, ret_off)
+                    }
+                    None => (None, None),
+                };
+                ir.push(AsmInst::EnsureEnd {
+                    pc,
+                    spliced_break,
+                    spliced_ret,
+                });
             }
             TraceIr::Br(disp) => {
                 state.flush_gp(ir);

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -908,7 +908,16 @@ impl<'a> JitContext<'a> {
                 state.flush_gp(ir);
                 assert!(state.no_capture_guard());
                 state.load(ir, ret, GP::Rax);
-                if let Some((spec_ids, extra)) = self.method_caller_specialized_ids() {
+                // A non-local `return` written inside a protected region must
+                // unwind through `handle_error`, which runs this frame's
+                // `ensure` (and restores `$!` when leaving a rescue clause) on
+                // the way out. The specialized teardown is a pure machine-level
+                // frame pop and would skip both. `check_exception_handler`
+                // covers only the *suspended* frames of the chain, so the
+                // exiting instruction's own coverage is checked here (#1179).
+                if !self.in_protected_region(bc_pos)
+                    && let Some((spec_ids, extra)) = self.method_caller_specialized_ids()
+                {
                     ir.push(AsmInst::MethodRetSpecialized {
                         rbp_offset: DynVarOffset::Hint {
                             ids: spec_ids,
@@ -926,7 +935,13 @@ impl<'a> JitContext<'a> {
                 state.flush_gp(ir);
                 assert!(state.no_capture_guard());
                 state.load(ir, ret, GP::Rax);
-                if let Some((spec_ids, extra)) = self.iter_caller_specialized_ids() {
+                // Same as `MethodRet` above: a `break` inside a protected
+                // region relies on `handle_error` to run this frame's `ensure`
+                // during the unwind; the specialized teardown would skip it —
+                // observed as issue #1179's silently-lost `c += 0.5`.
+                if !self.in_protected_region(bc_pos)
+                    && let Some((spec_ids, extra)) = self.iter_caller_specialized_ids()
+                {
                     ir.push(AsmInst::BlockBreakSpecialized {
                         rbp_offset: DynVarOffset::Hint {
                             ids: spec_ids,

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -1527,6 +1527,24 @@ impl<'a> JitContext<'a> {
     }
 
     ///
+    /// Whether the *current* frame's instruction at `bc_pos` is covered by
+    /// an entry of its iseq's exception table.
+    ///
+    /// The companion to [`Self::check_exception_handler`], which covers only
+    /// the chain's *suspended* frames (each at its in-progress call site) —
+    /// the frame currently being compiled is not in that range, so a
+    /// non-local exit (`MethodRet` / `BlockBreak`) written inside a
+    /// `begin`..`ensure` region asks this before choosing the specialized
+    /// teardown: that teardown is a pure machine-level frame pop, and only
+    /// the generic path's `handle_error` unwind runs the `ensure` bodies
+    /// (and the `$!` restore on leaving a rescue clause). Conservative like
+    /// its companion: any table entry forces the generic path (#1179).
+    ///
+    pub(super) fn in_protected_region(&self, bc_pos: BcIndex) -> bool {
+        self.iseq().get_exception_dest(bc_pos).is_some()
+    }
+
+    ///
     /// Hint variant of stack-offset computation for `LoadDynVar` /
     /// `StoreDynVar`. Returns the chain of [`SpecializedId`]s for
     /// frames `[outer..current)` together with `extra` — the sum

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -547,6 +547,14 @@ pub(super) struct JitStackFrame {
     /// speculation.
     ///
     pub(super) speculation_poisoned: bool,
+    ///
+    /// `ensure` regions of this frame with JIT-spliced non-local exits
+    /// (issue #1185), keyed by the region's `EnsureEnd` bc index. The
+    /// value records which exit kinds spliced into it, so the `EnsureEnd`
+    /// arm knows which specialized-teardown dispatch arms to emit.
+    /// `(break, method_return)`.
+    ///
+    pub(super) spliced_ensures: HashMap<BcIndex, (bool, bool)>,
 }
 
 impl std::fmt::Debug for JitStackFrame {
@@ -650,6 +658,7 @@ impl JitStackFrame {
             speculated_floats: vec![],
             speculated_using_fpr: UsingFpr::default(),
             speculation_poisoned: false,
+            spliced_ensures: HashMap::default(),
         }
     }
 
@@ -679,6 +688,7 @@ impl JitStackFrame {
             speculated_floats: self.speculated_floats.clone(),
             speculated_using_fpr: self.speculated_using_fpr,
             speculation_poisoned: self.speculation_poisoned,
+            spliced_ensures: self.spliced_ensures.clone(),
         }
     }
 
@@ -1089,7 +1099,7 @@ impl<'a> JitContext<'a> {
     }
 
     // handling frame
-    fn current_frame(&self) -> &JitStackFrame {
+    pub(super) fn current_frame(&self) -> &JitStackFrame {
         self.stack_frame.last().unwrap()
     }
 
@@ -1558,6 +1568,98 @@ impl<'a> JitContext<'a> {
     }
 
     ///
+    /// Try to arrange a JIT-spliced non-local exit (issue #1185): a
+    /// `break` / non-local `return` written inside its own frame's
+    /// `begin`..`ensure` region can *defer* its unwind and jump straight
+    /// into the shared `ensure` body — which is ordinary, already-compiled
+    /// code of this frame — whose `EnsureEnd` then delivers it through the
+    /// specialized teardown. That models the unwind edge in the CFG (the
+    /// `ensure`'s writes become visible to the abstract interpreter) and
+    /// skips the whole generic unwind / chain-deopt / VM stint.
+    ///
+    /// Returns the `ensure` body's entry block on success, after recording
+    /// the region's `EnsureEnd` in the frame's [`JitStackFrame::spliced_ensures`]
+    /// registry. `None` refuses (stage 1 is deliberately narrow) and the
+    /// caller falls back to the generic lowering, which handles every case.
+    ///
+    pub(super) fn try_splice_exit(
+        &mut self,
+        bc_pos: BcIndex,
+        kind: SplicedExitKind,
+    ) -> Option<BasicBlockId> {
+        // A dispatch arm compiles straight-line per-class code at one call
+        // site; it must not spawn branch entries into the frame's CFG.
+        if self.in_dispatch_arm() {
+            return None;
+        }
+        // A loop-rooted frame compiles only the loop's basic blocks, and
+        // the shared `ensure` body may lie outside that range. (The common
+        // case — an exit in a specialized inlined frame — compiles the
+        // whole iseq.)
+        if matches!(self.jit_type(), JitType::Loop(_)) {
+            return None;
+        }
+        // The specialized teardown must exist: an in-unit chain with no
+        // handler in any *suspended* frame. (The current frame's own
+        // handler is the very thing being spliced.)
+        match kind {
+            SplicedExitKind::Break => self.iter_caller_specialized_ids()?,
+            SplicedExitKind::MethodReturn => self.method_caller_specialized_ids()?,
+        };
+        let iseq = self.iseq();
+        // Exactly one covering region, and it has an `ensure`.
+        let ensure_pc = iseq.single_covering_ensure(bc_pos)?;
+        // The shared `ensure` copy practically always heads a basic block
+        // (rescue clauses branch to it; without rescue it coincides with
+        // the `else` join) — but refuse rather than assume.
+        let dest_bb = iseq.bb_info.is_bb_head(ensure_pc)?;
+        // Pair the body with its `EnsureEnd` by forward scan.
+        let mut end = None;
+        // Bound the scan by the sp table (one entry per instruction).
+        let limit = iseq.sp_table_len().min(ensure_pc.to_usize() + 1024);
+        let mut i = ensure_pc;
+        while i.to_usize() < limit {
+            match TraceIr::from_pc(iseq.get_pc(i), self.store) {
+                TraceIr::EnsureEnd => {
+                    end = Some(i);
+                    break;
+                }
+                // The spliced deferral is consumed only by the region's
+                // `EnsureEnd` (or discarded by `handle_error` on a raise).
+                // An exit that leaves the frame *without* raising — a `next`
+                // (`Ret`), another `break` / non-local `return`, `retry` /
+                // `redo` — would tear the frame down with the deferral still
+                // parked, leaking a stale per-lfp entry. The VM path runs
+                // these under `handle_error`, which discards; the compiled
+                // teardowns do not. Refuse the splice for such a body.
+                TraceIr::Ret(..)
+                | TraceIr::MethodRet(..)
+                | TraceIr::BlockBreak(..)
+                | TraceIr::Retry
+                | TraceIr::Redo => return None,
+                _ => {}
+            }
+            i = i + 1;
+        }
+        let end = end?;
+        // A nested handler inside the body would put its own `EnsureEnd`
+        // between the two and break the pairing; refuse.
+        if iseq.any_handler_intersects(ensure_pc..end) {
+            return None;
+        }
+        let entry = self
+            .current_frame_mut()
+            .spliced_ensures
+            .entry(end)
+            .or_insert((false, false));
+        match kind {
+            SplicedExitKind::Break => entry.0 = true,
+            SplicedExitKind::MethodReturn => entry.1 = true,
+        }
+        Some(dest_bb)
+    }
+
+    ///
     /// Hint variant of stack-offset computation for `LoadDynVar` /
     /// `StoreDynVar`. Returns the chain of [`SpecializedId`]s for
     /// frames `[outer..current)` together with `extra` — the sum
@@ -1676,6 +1778,18 @@ impl<'a> JitContext<'a> {
                     // `total - PROLOGUE_OVERHEAD`.
                     let prologue_bytes = sizes.total - PROLOGUE_OVERHEAD;
                     *prologue_offset = PrologueOffset::Concrete(prologue_bytes);
+                }
+            }
+            AsmInst::EnsureEnd {
+                spliced_break,
+                spliced_ret,
+                ..
+            } => {
+                for off in [spliced_break, spliced_ret].into_iter().flatten() {
+                    if let DynVarOffset::Hint { ids, extra } = off {
+                        let resolved = self.resolve_specialized_id_chain(ids) + *extra;
+                        *off = DynVarOffset::Concrete(resolved);
+                    }
                 }
             }
             AsmInst::LoopJitRspBump { offset } => {

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -985,6 +985,13 @@ pub(in crate::codegen) enum LInst {
     LoopJitRspBump {
         offset: LoopRspOffset,
     },
+    /// Defer a spliced non-local exit's unwind before jumping into the
+    /// shared `ensure` body (#1185). The value rides in `GP::Rdx`; the
+    /// degenerate outcome raises generically from `pc`.
+    DeferSplicedExit {
+        kind: SplicedExitKind,
+        pc: BytecodePtr,
+    },
     BlockArgProxy {
         ret: SlotId,
         outer: usize,
@@ -1020,7 +1027,15 @@ pub(in crate::codegen) enum LInst {
         loop_jit_spill_bytes: usize,
     },
     EnsureEnd {
+        /// The instruction's own pc, set before the re-raise path enters
+        /// `entry_raise` so `handle_error`'s table lookup is aligned.
+        pc: BytecodePtr,
         loop_jit_spill_bytes: usize,
+        /// Resolved teardown chain offsets for JIT-spliced exits landing at
+        /// this `EnsureEnd` (#1185); both `None` keeps the plain two-way
+        /// (continue / re-raise) form.
+        spliced_break: Option<usize>,
+        spliced_ret: Option<usize>,
     },
     Yield {
         callid: CallSiteId,

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -341,6 +341,16 @@ impl AbstractFrame {
         }
     }
 
+    /// A return state with no compile-time claim about the value — for an
+    /// exit whose value is produced at runtime (a spliced `EnsureEnd`
+    /// delivering a deferred `break` / `return`, issue #1185).
+    pub(super) fn as_return_any(&self) -> ReturnState {
+        ReturnState {
+            ret: ReturnValue::Value,
+            invariants: self.invariants.clone(),
+        }
+    }
+
     pub(crate) fn def_rax2acc(&mut self, ir: &mut AsmIr, dst: impl Into<Option<SlotId>>) {
         self.def_reg2acc(ir, GP::Rax, dst);
     }

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -2439,6 +2439,82 @@ pub(super) extern "C" fn ensure_end(vm: &mut Executor) -> usize {
     vm.finish_ensure(lfp).into()
 }
 
+///
+/// The two-word result of [`ensure_end_spliced`]: `code` in rax/x0, `val`
+/// in rdx/x1 (the same pair-return convention as `handle_error`'s
+/// `ErrorReturn`). See [`Executor::finish_ensure_spliced`] for the codes.
+///
+#[repr(C)]
+pub(in crate::codegen) struct EnsureEndDispatch {
+    code: u64,
+    val: Value,
+}
+
+///
+/// Compiled-`EnsureEnd` helper for a region with JIT-spliced non-local
+/// exits (issue #1185): like [`ensure_end`], but classifies a deferred
+/// spliced `break` / `return` so the compiled code can run its specialized
+/// teardown instead of re-raising through the generic unwind.
+///
+pub(super) extern "C" fn ensure_end_spliced(vm: &mut Executor) -> EnsureEndDispatch {
+    let lfp = vm.cfp().lfp();
+    let (code, val) = vm.finish_ensure_spliced(lfp);
+    EnsureEndDispatch { code, val }
+}
+
+///
+/// JIT splice of a `break` written inside its own frame's protected
+/// region (issue #1185): build the break error exactly as
+/// [`err_block_break`] would, then *defer* it for this frame — the
+/// compiled code jumps straight into the shared `ensure` body, whose
+/// `EnsureEnd` ([`ensure_end_spliced`]) delivers the break through the
+/// specialized teardown. Returns 0 on success; non-zero when the error
+/// degenerated (e.g. `LocalJumpError` for a proc-escaped block), in which
+/// case the error is left in-flight and the caller must raise generically
+/// from the exit's own pc.
+///
+pub(super) extern "C" fn defer_block_break(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    val: Value,
+) -> usize {
+    err_block_break(vm, globals, val);
+    if matches!(
+        vm.exception().map(|e| e.kind()),
+        Some(MonorubyErrKind::BlockBreak(..))
+    ) {
+        let lfp = vm.cfp().lfp();
+        vm.defer_unwind(lfp);
+        0
+    } else {
+        1
+    }
+}
+
+///
+/// The non-local-`return` twin of [`defer_block_break`]: build the
+/// method-return error as [`err_method_return`] would and defer it. The
+/// degenerate outcomes (`LocalJumpError` across a thread barrier or a
+/// class body) stay in-flight and return non-zero for the generic raise.
+///
+pub(super) extern "C" fn defer_method_return(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    val: Value,
+) -> usize {
+    err_method_return(vm, globals, val);
+    if matches!(
+        vm.exception().map(|e| e.kind()),
+        Some(MonorubyErrKind::MethodReturn(..))
+    ) {
+        let lfp = vm.cfp().lfp();
+        vm.defer_unwind(lfp);
+        0
+    } else {
+        1
+    }
+}
+
 pub(super) extern "C" fn raise_err(vm: &mut Executor, err_val: Value) {
     match err_val.is_exception() {
         Some(ex) => vm.set_error(MonorubyErr::new_from_exception(ex).with_original(err_val)),

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -1615,6 +1615,61 @@ impl Executor {
     }
 
     ///
+    /// [`Self::finish_ensure`] for a compiled `EnsureEnd` whose region has
+    /// JIT-spliced non-local exits (`doc`: issue #1185). Classifies the
+    /// deferred unwind so the compiled code can take its specialized
+    /// teardown instead of re-raising:
+    ///
+    /// - `0`: nothing pending — continue on the normal path.
+    /// - `1`: an error is pending (`ensure` body raised, superseding any
+    ///   deferral; or the deferral is not one the compiled teardown can
+    ///   deliver) — the caller re-enters `entry_raise`.
+    /// - `2`: a spliced `break` — `val` is the break value; the caller runs
+    ///   its `BlockBreakSpecialized` teardown.
+    /// - `3`: a spliced non-local `return` targeting this frame's outermost
+    ///   method frame — `val` is the return value; the caller runs its
+    ///   `MethodRetSpecialized` teardown.
+    ///
+    /// The compiled `EnsureEnd` sees a deferral only when compiled code
+    /// parked it (the splice): a VM-parked deferral means the frame is
+    /// being *interpreted* through the handler, whose `EnsureEnd` is the VM
+    /// opcode. The kind checks below are therefore belt-and-braces — any
+    /// unexpected deferral re-raises through the generic machinery, which
+    /// handles every kind.
+    ///
+    pub(crate) fn finish_ensure_spliced(&mut self, lfp: Lfp) -> (u64, Value) {
+        let top_is_mine = matches!(self.deferred_unwind.last(), Some((l, _)) if *l == lfp);
+        if self.exception.is_some() {
+            // The ensure body raised its own error: it supersedes the
+            // deferred exit (CRuby semantics), exactly as `finish_ensure`.
+            if top_is_mine {
+                self.deferred_unwind.pop();
+            }
+            return (1, Value::nil());
+        }
+        if !top_is_mine {
+            return (0, Value::nil());
+        }
+        let (_, err) = self.deferred_unwind.pop().unwrap();
+        match err.kind() {
+            MonorubyErrKind::BlockBreak(val, _, outer) if Some(*outer) == lfp.outer() => {
+                (2, *val)
+            }
+            // The static teardown returns from this frame's outermost
+            // method frame; a deferred return targeting anything else
+            // (e.g. the block was promoted to a lambda after compile)
+            // must go through the generic unwind.
+            MonorubyErrKind::MethodReturn(val, target) if *target == lfp.outermost().0 => {
+                (3, *val)
+            }
+            _ => {
+                self.set_error(err);
+                (1, Value::nil())
+            }
+        }
+    }
+
+    ///
     /// Drop a deferred unwind belonging to frame *lfp* when the frame is
     /// being left by a different control-flow path (its `EnsureEnd` will
     /// not run to consume it). No-op when the top entry is for another

--- a/monoruby/src/globals/store/iseq.rs
+++ b/monoruby/src/globals/store/iseq.rs
@@ -689,6 +689,12 @@ impl ISeqInfo {
         self.sp[i.to_usize()]
     }
 
+    /// Number of instructions, via the per-instruction sp table (available
+    /// in every build, unlike `bytecode_len`).
+    pub(crate) fn sp_table_len(&self) -> usize {
+        self.sp.len()
+    }
+
     pub(crate) fn get_bb(&self, bc_pos: BcIndex) -> BasicBlockId {
         self.bb_info.is_bb_head(bc_pos).unwrap()
     }
@@ -719,6 +725,42 @@ impl ISeqInfo {
                 }
             })
             .nth(0)
+    }
+
+    ///
+    /// The `ensure` destination for a JIT-spliced non-local exit at *pc*
+    /// (issue #1185): `Some(ensure_pc)` iff **exactly one** exception-table
+    /// entry covers *pc* and it has an `ensure`. More than one covering
+    /// entry means nested protected regions — a spliced exit would have to
+    /// chain through every `ensure`, which the stage-1 splice refuses (the
+    /// generic unwind handles it).
+    ///
+    pub(crate) fn single_covering_ensure(&self, pc: BcIndex) -> Option<BcIndex> {
+        let mut covering = self
+            .exception_map
+            .iter()
+            .filter(|entry| entry.range.contains(&pc));
+        let first = covering.next()?;
+        if covering.next().is_some() {
+            return None;
+        }
+        first.ensure_pc
+    }
+
+    ///
+    /// Whether any exception-table entry's protected range or handler
+    /// destination falls strictly inside `range`. Used by the splice to
+    /// require a nested-region-free `ensure` body: a nested `begin` inside
+    /// the shared `ensure` copy would put its own `EnsureEnd` between the
+    /// body entry and the region's `EnsureEnd`, breaking the forward scan
+    /// that pairs the two.
+    ///
+    pub(crate) fn any_handler_intersects(&self, range: std::ops::Range<BcIndex>) -> bool {
+        self.exception_map.iter().any(|entry| {
+            range.contains(&entry.range.start)
+                || entry.rescue_pc.is_some_and(|p| range.contains(&p))
+                || entry.ensure_pc.is_some_and(|p| range.contains(&p) && p != range.start)
+        })
     }
 
     pub(crate) fn exception_push(

--- a/monoruby/tests/loop_jit_exit_sp.rs
+++ b/monoruby/tests/loop_jit_exit_sp.rs
@@ -98,23 +98,21 @@ fn block_break_out_of_a_loop_jit_unit() {
     );
 }
 
-/// A pre-existing JIT divergence found while building the shapes above,
-/// recorded so it is not lost — filed as issue #1179; removing the
-/// `#[ignore]` below turns this into its regression test once fixed.
-/// **Not** the sp-undo defect: it reproduces
-/// identically before and after that fix, at both FPR pool sizes, and
-/// `--no-jit` agrees with CRuby.
+/// The JIT divergence found while building the shapes above, filed as
+/// issue #1179 and since fixed — this is its regression test (the
+/// `#[ignore]` this carried while open is dropped). **Not** the sp-undo
+/// defect: it reproduced identically before and after that fix, at both
+/// FPR pool sizes, and `--no-jit` agreed with CRuby.
 ///
-/// When a `break` unwinds through an `ensure` that writes an *outer*
-/// local (`c += 0.5` below, a dynvar of the loop-JIT frame), the write
-/// happens in the VM — but the loop unit keeps reading its own stale view
-/// of `c` for the remaining iterations. Measured: monoruby 22975.5 vs
-/// CRuby 23025.0 — short by exactly 0.5 x the 99 iterations after the
-/// `break`, i.e. the breaking iteration's `ensure` increment never
-/// reached the loop's view. Same family as the block-passing-call float
-/// staleness (#1172/#1173), but through the non-local-exit path.
+/// The record above attributed the lost `c += 0.5` to a stale view (the
+/// #1172/#1173 family); probes said otherwise — the breaking iteration's
+/// `ensure` never ran at all. The `break` inside the block's own
+/// `begin`..`ensure` still lowered to `BlockBreakSpecialized`, a pure
+/// machine-level teardown that never enters `handle_error`, because the
+/// specialization check covered only the chain's *suspended* frames, not
+/// the exiting instruction's own coverage. See
+/// `JitContext::in_protected_region` and `tests/nonlocal_exit_ensure.rs`.
 #[test]
-#[ignore = "issue #1179: an ensure run by `break` writes an outer local the loop unit then reads stale"]
 fn break_running_an_ensure_that_writes_an_outer_local() {
     run_test(
         r#"

--- a/monoruby/tests/nonlocal_exit_ensure.rs
+++ b/monoruby/tests/nonlocal_exit_ensure.rs
@@ -50,6 +50,69 @@ fn a_break_through_an_ensure_writing_an_outer_local() {
     );
 }
 
+/// The ordering hazard behind the generic path: an `ensure` covering the
+/// exit *in the raising frame itself* is interpreted by the VM straight
+/// from `entry_raise` — before any error side exit has run, i.e. before
+/// the chain-deopt walk has materialized anything into slots. The
+/// raising frame's own locals must therefore be slot-true at the exit,
+/// exactly as `TraceIr::Raise` already ensures via `locals_to_S`. Here
+/// `f` lives only in an fpr at the `break`; without the homing the
+/// VM-run `ensure` read the frame's nil-filled slot instead
+/// (`NilClass can't be coerced into Float`).
+#[test]
+fn an_ensure_reading_the_raising_frames_own_float() {
+    run_test(
+        r#"
+        def m2
+          out = 0.0
+          [1].each do |x|
+            f = 1.5 * x
+            begin
+              break if x == 1
+            ensure
+              out += f
+            end
+          end
+          out
+        end
+        r = 0
+        300.times { r = m2 }
+        r
+        "#,
+    );
+}
+
+/// An `ensure` in an *intermediate* frame is safe without that homing:
+/// it only runs after that frame's own error side exit has written back
+/// and escalated (the chain-deopt walk converts every suspended frame —
+/// constant claims included — before the VM interprets the handler).
+/// Pinned here so the ordering contract stays observable: `d` is a
+/// constant-claimed outer local, and the `return` raises in the inner
+/// block while the `ensure` reading `d` sits one frame out.
+#[test]
+fn an_intermediate_ensure_reading_an_outer_constant() {
+    run_test(
+        r#"
+        $log = []
+        def m
+          d = 7
+          [1].each do |x|
+            begin
+              [2].each do |y|
+                return 5 if y == 2
+              end
+            ensure
+              $log << d
+            end
+          end
+          99
+        end
+        300.times { m }
+        $log.uniq
+        "#,
+    );
+}
+
 /// The `MethodRet` twin: a non-local `return` out of a block, written
 /// inside the block's `begin`..`ensure`. Hot enough that the whole
 /// chain (method, `each`, block) inlines into one unit, where the

--- a/monoruby/tests/nonlocal_exit_ensure.rs
+++ b/monoruby/tests/nonlocal_exit_ensure.rs
@@ -1,0 +1,78 @@
+//! A non-local exit written inside a protected region must run the
+//! `ensure` bodies it escapes through.
+//!
+//! `break` out of a block and non-local `return` normally unwind through
+//! `handle_error`, which walks the frames and runs each `ensure` on the
+//! way out. But when the whole chain is specialized-inlined into one JIT
+//! unit, the exits lower to `BlockBreakSpecialized` /
+//! `MethodRetSpecialized` — a pure machine-level frame teardown
+//! (`lea rbp += Σ; leave; ret`) that never enters `handle_error`.
+//!
+//! The chain check (`check_exception_handler`) covered only the
+//! *suspended* frames, each at its in-progress call site. The frame being
+//! compiled — the block whose own `begin`..`ensure` contains the exiting
+//! instruction — was not in that range, so the specialized teardown was
+//! chosen and silently skipped the block's own `ensure` (issue #1179):
+//! the break shape below lost exactly one `c += 0.5` (`22975.5` /
+//! `151.5` / `299` against CRuby's `23025.0` / `152.0` / `300`), and the
+//! return shape lost every post-warmup increment (`$m == 38`, not `300`).
+//! `JitContext::in_protected_region` is the missing half of the check.
+extern crate monoruby;
+use monoruby::tests::*;
+
+/// Issue #1179's shape: a `break` unwinding through an `ensure` that
+/// writes an outer local of the enclosing loop-JIT frame. The `ensure`
+/// must run exactly once per iteration — the breaking one included.
+#[test]
+fn a_break_through_an_ensure_writing_an_outer_local() {
+    run_test(
+        r#"
+        $n = 0
+        def g
+          a = 0.0; c = 2.0
+          i = 0
+          while i < 300
+            [1].each do |x|
+              begin
+                a += c
+                break if i == 200
+              ensure
+                c += 0.5
+                $n += 1
+              end
+            end
+            i += 1
+          end
+          [a, c, $n]
+        end
+        g
+        "#,
+    );
+}
+
+/// The `MethodRet` twin: a non-local `return` out of a block, written
+/// inside the block's `begin`..`ensure`. Hot enough that the whole
+/// chain (method, `each`, block) inlines into one unit, where the
+/// specialized teardown used to skip the `ensure` on every post-warmup
+/// call.
+#[test]
+fn a_return_through_an_ensure_in_a_block() {
+    run_test(
+        r#"
+        $m = 0
+        def h
+          [1].each do |x|
+            begin
+              return 42 if x == 1
+            ensure
+              $m += 1
+            end
+          end
+          99
+        end
+        res = 0
+        300.times { res = h }
+        [res, $m]
+        "#,
+    );
+}

--- a/monoruby/tests/nonlocal_exit_ensure.rs
+++ b/monoruby/tests/nonlocal_exit_ensure.rs
@@ -139,3 +139,133 @@ fn a_return_through_an_ensure_in_a_block() {
         "#,
     );
 }
+
+/// From here down: the JIT-spliced exits of issue #1185. A `break` /
+/// non-local `return` inside its own frame's `begin`..`ensure` defers its
+/// unwind and jumps into the shared `ensure` body — ordinary compiled code
+/// — whose `EnsureEnd` delivers it through the specialized teardown
+/// (`Executor::finish_ensure_spliced`). These shapes pin the dispatch and
+/// its guard rails.
+///
+/// The spliced `break` delivers its value to the receiving call, and the
+/// `ensure` (a compiled, state-visible store now) still runs.
+#[test]
+fn a_spliced_break_delivers_its_value() {
+    run_test(
+        r#"
+        def a4
+          v = [1, 2, 3].each do |i|
+            begin
+              break i * 100 if i == 2
+            ensure
+              $keep = i
+            end
+          end
+          [v, $keep]
+        end
+        r = nil
+        300.times { r = a4 }
+        r
+        "#,
+    );
+}
+
+/// The spliced non-local `return` returns the value from the home method.
+#[test]
+fn a_spliced_return_delivers_its_value() {
+    run_test(
+        r#"
+        def a5
+          [5].each do |i|
+            begin
+              return i + 37 if i == 5
+            ensure
+              $keep2 = i
+            end
+          end
+          0
+        end
+        r = nil
+        300.times { r = [a5, $keep2] }
+        r
+        "#,
+    );
+}
+
+/// An `ensure` body that raises supersedes the deferred exit (CRuby: a
+/// `raise` in an `ensure` overrides the in-flight `break`) — the dispatch's
+/// code-1 arm, which re-enters the generic machinery.
+#[test]
+fn an_ensure_raising_over_a_spliced_break() {
+    run_test(
+        r#"
+        def a1
+          x = 0
+          [1].each do |i|
+            begin
+              break if i == 1
+            ensure
+              x += 1
+              raise "boom" if x == 1
+            end
+          end
+          99
+        rescue => e
+          "rescued:" + e.message
+        end
+        r = nil
+        300.times { r = a1 }
+        r
+        "#,
+    );
+}
+
+/// A `break` *inside* the `ensure` body replaces the deferred one (CRuby
+/// override semantics). The splice refuses such a body — its teardown
+/// would leak the parked deferral — so this goes through the generic
+/// unwind, whose `handle_error` discards and redirects correctly.
+#[test]
+fn a_break_inside_the_ensure_overrides_the_deferred_one() {
+    run_test(
+        r#"
+        def a2
+          [1].each do |i|
+            begin
+              break 10 if i == 1
+            ensure
+              break 20
+            end
+          end
+        end
+        r = nil
+        300.times { r = a2 }
+        r
+        "#,
+    );
+}
+
+/// A real `rescue` alongside the `ensure` (not taken by the break): the
+/// spliced exit must still run only the `ensure`.
+#[test]
+fn a_spliced_break_with_a_rescue_present() {
+    run_test(
+        r#"
+        def a6
+          z = 0
+          [1].each do |i|
+            begin
+              break if i == 1
+            rescue
+              z = -1
+            ensure
+              z += 5
+            end
+          end
+          z
+        end
+        r = nil
+        300.times { r = a6 }
+        r
+        "#,
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -2313,6 +2313,7 @@ bba413775b9fdc4e5a5520013caecba6	true	Process.getpriority(Process::PRIO_USER, 0)
 bbb536d6446e4acae479f2a76bbc22b8	[false, true, "payload"]	base = "/tmp/monoruby_test_rename_#{Process.pid}_#{rand(100000)}"\n 
 bbc6b60d27eb5cad82b53e233df0c6e8	280	class Object\n          def tag = 7\n        end\n        \n\n        res = 
 bbf39b957f63dc57cf6be6b238e3322a	"HELLO world"	s = "hello world"; s.bytesplice(0..4, "HELLO WORLD", 0..-7); s
+bbf88be1f5615be8cbe5cfdbb37cd357	[23025.0, 152.0, 300]	$n = 0\n        def g\n          a = 0.0; c = 2.0\n          i = 0\n       
 bc0ccc0a16c986d29598ed69b9038ff8	[false, true, true]	h = {}\n        before = h.compare_by_identity?\n        ret = h.compare_
 bc2025afe3d4e746f87d06a3bac3e3db	[[]]	r = []; Enumerator.new { |y| y.yield }.each { |*a| r << a }; r
 bc2e5f3b4a16256b7dc6b55712d5a785	nil	Encoding.default_internal
@@ -2704,6 +2705,7 @@ da071b966818f27d5bc0ddb0f84eb172	[false, true, true, true, false, true, false, t
 da0f0adcfe40c1b122d44d207d5921fb	[[1, 2], [:scalar, nil], [:pk, :pv], [:s1, :s2], [nil, nil], [4.5, nil]]	def drive(a)\n              acc = []\n              a.each_with_yield
 da20ef8164c16f9d050189c7530ccdda	13	case 4\n        when 0\n          a = 10\n        when 1\n          a = 11\n
 da337801ffb5841d6913419d4806674b	[[1, 2, 3], [1, 2, 3], 1, 3, [1, 3]]	a = [3, 1, 2]\n            [\n              a.sort { |x, y| (x <=> y)
+da4116da4a0b35a76e2faef0a98c7685	[42, 300]	$m = 0\n        def h\n          [1].each do |x|\n            begin\n      
 da424b8ae2f6063fa60766fab8bac34a	false	t = Thread.new { sleep(2**62) }\n            Thread.pass while t.sta
 da5e06d1fe5eed1ee4258f71a99b2332	0	a = "abc".dup.force_encoding("UTF-8")\n              b = "abc".dup
 da64841b8187b9d8951f84703a56f5e9	[true, false]	$x = []\n            path = "/tmp/monoruby_test_mkdir_#{Process.pid}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -2045,6 +2045,7 @@ a6e76941b428102c2ba4a628d8639080	1000	S = Struct.new(:counter)\n            \n\n
 a6f799b2f3bd4b9cbb9608e44dd52dbc	true	Process.warmup
 a6ffb30dedbdb58fc281fe6682f6497c	[3, :first_store_raises]	class Q\n          def fill(i)\n            @a = i\n            @b = i\n   
 a71e54a7d566380aaed8baaea63868be	99	def make_proc\n          Proc.new { yield }\n        end\n        def get_
+a7842c388edf1fd9f074cafd5774cb4e	23025.0	def g\n          a = 0.0; c = 2.0\n          i = 0\n          while i < 30
 a7bbd186c86ac3ce9091503517f8a4c7	[true, true, false]	class Foo\n              def bar; 1; end\n              alias_method 
 a7d85b5b4b74fdccaa32b812610588e7	true	d = +"foo"\n            h = Hash.new(d)\n            h[:any].equal?(d
 a7dfe3e551ac8402163609fb863ca4e0	["US-ASCII"]	s = "abcabc".dup.force_encoding("US-ASCII")\n              s.scan(

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -467,6 +467,7 @@
 24ac5154b60f3f04786ba9edf76cd37f	"HELLO, WORLD!"	"Hello, World!".upcase
 24b3c2a7f0690e6d1eb054021202ed43	:OVERRIDDEN	class TrueClass; def ===(o); :OVERRIDDEN; end; end; true === true
 24b74847655014f460c36e43e73312e8	7	class C\n          define_method(:add) { |a, b| a + b }\n        end\n    
+24e97acf1f40103919be34d2f73353dd	5	def a6\n          z = 0\n          [1].each do |i|\n            begin\n    
 24ede66710b2716183990244c9ec7ce2	-3.0	class Float; alias __orig :-@; def -@; __orig; end; end; -(3.0)
 250640ebb28cec0f360f71495d32f526	[227, 65, 66, 227, 129, 132]	s = "\\xe3\\x81\\x82\\xe3\\x81\\x84".force_encoding("ASCII-8BIT")\n       
 251463e9ea3898eef34264e66a5b59f3	["ok Foo", "ok Bar", "ok Foo", "ok Bar"]	module Foo\n          def a\n            'ok Foo'\n          end\n        e
@@ -1586,6 +1587,7 @@
 823f7b6229174b0da18f59b5a5c7cca0	[1, 2, "constant"]	module QTopA; X = 1; module Inner; Y = 2; end; end\n            [QTo
 82447060301c9a64b3ac42318f460e62	[1, 2, 3]	class C\n          def foo(*x)\n            x\n          end\n        end\n 
 8256e9068f6e136c99b87f2f7f97fdb8	[[ArgumentError, "negative signal name: -HUP"], "negative signal name: -INT"]	[(begin; Signal.trap("-HUP") {}; rescue => e; [e.class, e.message]; end), (begin
+829f48ebfbc6e4030ced77aaec24c37b	[200, 2]	def a4\n          v = [1, 2, 3].each do |i|\n            begin\n          
 82abda467be3a95b2f6d81fbf7dfb3da	"a:a b:{x: 100, y: 200}"	def f(a, b)\n          "a:#{a} b:#{b}"\n        end\n        \n\n        f("
 82afafb55f0b808c4e046dd1d983831d	["ASCII-8BIT", "US-ASCII", "US-ASCII"]	[/\\xc2\\xa1/n.encoding.to_s, /abc/n.encoding.to_s, /\\x7f/n.encoding.to_s]
 82c9966b62ff6ac43f8a7ad749c3fa16	1	p = proc {\n          a = 10\n        }\n        a = 1\n        p.call\n    
@@ -2173,6 +2175,7 @@ afc664b3664dbfb2235fee8c114e24dc	["a\\n", "b\\n", "c"]	path = "/tmp/monoruby_io_
 afe017e12ee32ba781bc419214f2db54	"e\\n\\nCopyright (c) 202"	File.binread("../LICENSE-MIT", 20, 10)
 afecc303354ce360b53ad03479bdb2f0	2	t = Time.utc(1970, 1, 1, 0, 0, 0); def t.succ; self + 1; end\n      
 b017ead69b837578afee4295eb840ed7	"#<Class:Time>"	Time.singleton_class.to_s
+b0210a3ee0e2cc726743dd177d2617fa	"rescued:boom"	def a1\n          x = 0\n          [1].each do |i|\n            begin\n    
 b041b0aaea8a7d40b26a35b251c0f897	[[:req, :a], [:nokey]]	def m(a, **nil); end\n            method(:m).parameters\n            
 b050bdfac1ec47f5eeda5dc5e12bd05a	45.0	def call_block\n      yield\n    end\n    def call_block_twice\n      yield\n   
 b06f00715b283fa26e9acda37466978d	[1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub]	class MyArray < Array\n              def [](i) = :sub\n            en
@@ -2372,6 +2375,7 @@ bfbe34cf61fcca55c3ea92c6839bb454	1	IO.popen(["false"]) { |io| io.read }\n       
 bfdcfc70fda8f2b3db9a8020171aae4b	"AB"	[65, 66].pack("C C")
 bfe630e757e308e4abdf4d36bdcd4969	0	/(?<z>foo)/ =~ "foofoo"
 bffb45c1c4c4bfb1f18ef0093606fbaa	"/tmp"	File.realpath("tmp", "/")
+c00d90d46d88d991d6b335b49097a639	20	def a2\n          [1].each do |i|\n            begin\n              break 
 c01cf4efc12251b52e9bc2c5c0c2d6ec	["x42y", "42", "nil", "é42ü", "x42!", false, false, "template42mut", "template42", "UTF-8", 3, true, "x43y", "43", "nil", "é43ü", "x43!", false, false, "template43mut", "template43", "UTF-8", 3, true, "x44y", "44", "nil", "é44ü", "x44!", false, false, "template44mut", "template44", "UTF-8", 3, true, "x45y", "45", "nil", "é45ü", "x45!", false, false, "template45mut", "template45", "UTF-8", 3, true, "x46y", "46", "nil", "é46ü", "x46!", false, false, "template46mut", "template46", "UTF-8", 3, true, "x47y", "47", "nil", "é47ü", "x47!", false, false, "template47mut", "template47", "UTF-8", 3, true, "x48y", "48", "nil", "é48ü", "x48!", false, false, "template48mut", "template48", "UTF-8", 3, true, "x49y", "49", "nil", "é49ü", "x49!", false, false, "template49mut", "template49", "UTF-8", 3, true, "x50y", "50", "nil", "é50ü", "x50!", false, false, "template50mut", "template50", "UTF-8", 3, true, "x51y", "51", "nil", "é51ü", "x51!", false, false, "template51mut", "template51", "UTF-8", 3, true, "x52y", "52", "nil", "é52ü", "x52!", false, false, "template52mut", "template52", "UTF-8", 3, true, "x53y", "53", "nil", "é53ü", "x53!", false, false, "template53mut", "template53", "UTF-8", 3, true, "x54y", "54", "nil", "é54ü", "x54!", false, false, "template54mut", "template54", "UTF-8", 3, true, "x55y", "55", "nil", "é55ü", "x55!", false, false, "template55mut", "template55", "UTF-8", 3, true, "x56y", "56", "nil", "é56ü", "x56!", false, false, "template56mut", "template56", "UTF-8", 3, true, "x57y", "57", "nil", "é57ü", "x57!", false, false, "template57mut", "template57", "UTF-8", 3, true, "x58y", "58", "nil", "é58ü", "x58!", false, false, "template58mut", "template58", "UTF-8", 3, true, "x59y", "59", "nil", "é59ü", "x59!", false, false, "template59mut", "template59", "UTF-8", 3, true, "x60y", "60", "nil", "é60ü", "x60!", false, false, "template60mut", "template60", "UTF-8", 3, true, "x61y", "61", "nil", "é61ü", "x61!", false, false, "template61mut", "template61", "UTF-8", 3, true]	r = []\n        20.times do |i|\n            a = 42 + i\n            r << 
 c02bfb68f21771671d9a8ba7a101c48d	99	class C; def to_int; 99; end; end; o = C.new\nInteger(o)
 c02dd9efb46f0fbc32fc6404c32838a8	[4, 8, 101, 58, 24, 77, 97, 114, 115, 104, 97, 108, 83, 105, 110, 103, 108, 101, 116, 111, 110, 69, 120, 116, 111, 58, 11, 79, 98, 106, 101, 99, 116, 0]	module MarshalSingletonExt; def hi; end; end\n            o = Object
@@ -2922,6 +2926,7 @@ ebe0ff80bc75796e6952268415562c02	79758732	a = 0\n        20.times do |x|\n      
 ec17cc112d34937041f056e2b23a6485	[10, 20, 30]	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \ns.val
 ec3412505f146b21a6888012a86820f2	[true, ["1", "2"]]	r = ENV.merge!("MONORUBY_ENV_TEST_M1" => "1",\n                     
 ec3b6db701fd7dc4a8aef71dcf7cdc12	[[[1, nil], nil], [[1, nil], nil], [:args, :block], [[1, nil, 2], nil], [1, 2], [[1, 2], nil]]	def m(*args, &block); [args, block]; end\n        res = []\n        args 
+ec4622bb1fc139438ae329ef3155baea	[42, 5]	def a5\n          [5].each do |i|\n            begin\n              return
 ec4849e638b2a7db1b2adfd4bf8183c9	[[1, nil, nil], []]	S = Struct.new(:a, :b, :c)\n            \n\n            s = S.new(1)\n 
 ec4d377c4801643f31efc8302cd3d528	[true, TypeError, ArgumentError]	(h=ENV.to_h{|k,v| [k.to_sym, v.length]}; a=h.keys.all?{|x| x.is_a?(Symbol)}; b=(
 ec4dde8b7008f35b2cfd35d0cd16f7e3	[true, true]	a = 1356\n            id = a.object_id\n            \n\n            [id

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -956,6 +956,7 @@
 4c3cdf6fdb768ce2061972f6724dd416	42	class Foo\n              def initialize(x)\n                @x = x\n  
 4c6323de719d0ad254c106b3de0e1ff1	99	b = binding\n            b.local_variable_set("bar", 99)\n           
 4c66c29f7a10c99487fbb86f19ded61a	false	File.file?("readme.md")
+4c69a613ea757c9eff914b8a29903a61	[7]	$log = []\n        def m\n          d = 7\n          [1].each do |x|\n     
 4c6f323c0ce3159e2b7f0992372dd514	false	/a/.match("xay".b).nil?
 4c7471c063042fa95b957878dbb97a5a	[true, false]	class C < Object\n        end\n        class S < C\n        end\n\n        o
 4c7947408d26ed45ead6a30d7a7c8c21	[42, 42, 42, 42, 42, 42, 42, 42, 84, 84, 84]	class A\n          attr_accessor :w\n        end\n        a = A.new\n      
@@ -2925,6 +2926,7 @@ ec616c74470bcaec129ac19540047a93	["method", "nil", nil, "outer", ["a_file", "10"
 ec6e08886fb1c676139aa0cb92bb4296	["extend_object:C", "hello"]	$res = []\n        module M\n          def self.extend_object(obj)\n      
 ec75362ae6eb794adfccd5ea2fd87a71	["Infinity", "NaN", "Infinity", "-Infinity", true, "-0.314e1", "0.314e1", "0.314e1"]	require "rubygems"\n        require "bigdecimal"\n        res = []\n      
 ec7990294dac7ac2a637929f23760d95	[42, 42, 42, 42, 42, 42, 42, 42, 100, 100, 100]	class A\n                attr_accessor :w\n            end\n          
+ec83d3346e8c3ed3a4ed389e11834860	1.5	def m2\n          out = 0.0\n          [1].each do |x|\n            f = 1.
 ec84a8df82f97b16fdedf56efbc6ad35	"hello"	path = "/tmp/monoruby_test_filewrite_perm_#{Process.pid}_#{rand(100
 ecb0c2530aa824ca3b58cd269e696cd6	"xy"	def m; /(\\w)(\\w)/ =~ "xy"; -> { $~[0] }.call; end; m
 ecf0e0788d956837326285cb5c6fe318	[[0, 1, 2, 3, 4, 5, 6], 7, 8]	def f(*x,a,b)\n          [x,a,b]\n        end\n        \n\n        f(0,1,2,3


### PR DESCRIPTION
Implements #1185 (stage 1). Since #1180, a `break` / non-local `return` inside its own frame's `begin`..`ensure` fell back to the generic exit: the VM interprets the `ensure`, the chain-deopt walk converts the suspended frames, and (for `break`) the defining frame resumes interpreted until the next OSR entry. Correct, but a deopt on a path the compiler fully knows.

## The key observation: no duplication is needed

The issue sketched "splice the ensure bodies at the exit site", which reads like compiling a second copy. Reading bytecodegen's actual layout shows something better: the non-local-unwind route and normal completion already **share one compiled copy** of the ensure body — `handle_error`'s defer path jumps to the same `ensure_label` the normal path falls into, and `EnsureEnd` dynamically re-raises a deferral parked by `Executor::defer_unwind`. (Real exceptions go elsewhere, to the duplicated exception copy ending in `Raise(err_reg)`.) So the splice rides the existing machinery end to end:

- the exit calls `defer_block_break` / `defer_method_return` — the same error construction as `err_block_break` / `err_method_return`, parked via `defer_unwind` instead of raised — and **branches** into the shared ensure body: an ordinary `CompileResult::Branch` edge, aligned to the body's temp level (`get_sp`), merged by the ordinary machinery. The `ensure` now runs *compiled*, its writes visible to the abstract interpreter — the exact blind spot behind #1179's original mis-analysis;
- `EnsureEnd` in a spliced region grows from the two-way check into a four-way dispatch (`Executor::finish_ensure_spliced`, pair-returned like `ErrorReturn`): continue / re-raise (an ensure-body raise supersedes, CRuby semantics) / deliver the deferred `break` / `return` through the same teardown the plain `BlockBreakSpecialized` / `MethodRetSpecialized` lowerings use, registering the same return-context edges.

Soundness rests on two facts. A compiled `EnsureEnd` can only meet a **splice-parked** deferral — a VM-parked one implies the frame is being interpreted through the handler, whose `EnsureEnd` is the VM opcode. And every compile-time refusal or runtime surprise (unexpected kind, lambda-promoted return target, degenerate `LocalJumpError`) lands on the generic path that #1180 proved out.

## Stage-1 refusals (all → today's generic exit)

A dispatch arm; a loop-rooted frame (its compile range may exclude the body); nested covering regions; a body entry that is not a block head; no specialized chain; and — load-bearing — a body containing a non-raising frame exit (`next` / `break` / `return` / `retry` / `redo`): the compiled teardowns do not discard a parked deferral, so such a body would leak it. A raise in the body is fine — `handle_error` discards on every propagation path.

That last refusal is not hypothetical: **the VM itself leaks the deferral** on the `next`-inside-`ensure` shape and misdelivers it to a later frame recycling the same stack address — reproducible on master with `--no-jit`, filed as #1186. The splice deliberately does not widen it.

Also fixed in passing: `EnsureEnd` now carries its own pc and sets it before `entry_raise` — the re-raise path used to rely on whatever stale value r13/x21 happened to hold.

## Testing

| | result |
|---|---|
| x86-64 plain `--lib --tests` | 69 targets green (lib 2366) |
| x86-64 `stress-spill-pool` | 69 targets green (lib 2366) |
| splice activation | probe-verified: #1179's shape compiles Break-spliced (×12), the return twin MethodReturn-spliced (×4), results unchanged, no deopt |
| `cargo check --target aarch64-unknown-linux-gnu` | clean |

Five new regression shapes pin the dispatch (`tests/nonlocal_exit_ensure.rs`, now 9 tests): value-carrying `break` and `return`, an `ensure` raising over a deferred break (supersede), `break`-inside-`ensure` override via the refusal, and a `rescue` alongside the `ensure`. The #1179/#1180 shapes now run through the splice with unchanged results.

The aarch64 lowerings mirror x86 (runtime pair in x0/x1); the darwin job is their execution check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_