### PR TITLE
Relax BB-edge branches and inline OptCase tables past the Imm19 reach

### DIFF
--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -877,6 +877,23 @@ pub struct Codegen {
     pub(crate) switch_to_scheduler: extern "C" fn(*mut Executor, Value) -> Option<Value>,
     pub(crate) scheduler_resume: extern "C" fn(*mut Executor, u64) -> Option<Value>,
     pub(crate) startup_flag: bool,
+    /// aarch64 branch relaxation: set while emitting a frame so large that
+    /// an Imm19 (`b.cond`/`cbz`, ±1 MiB) or Adr (±1 MiB) reference between
+    /// basic blocks might not reach. BB-edge branches then emit their long
+    /// form (inverted short branch over an unconditional `b`, ±128 MiB) and
+    /// `OptCase` inlines its jump table next to the `adr`. Normal frames
+    /// never pay anything. Saved/restored around `gen_machine_code`'s
+    /// recursion into inlined callees (the flag is per frame).
+    #[cfg(target_arch = "aarch64")]
+    pub(in crate::codegen) far_branch_mode: bool,
+    /// aarch64 far frames: inline `OptCase` jump tables to patch at the end
+    /// of the current frame — `(table start, dests)`. In `far_branch_mode`
+    /// the const-area table may be past `adr`'s ±1 MiB, so the table is
+    /// laid inline (nop-reserved) and its entries written once the dest
+    /// labels — same-frame BB labels, all bound by then — resolve. Emptied
+    /// by `a64_patch_jump_tables` before the frame ends.
+    #[cfg(target_arch = "aarch64")]
+    pub(in crate::codegen) pending_jump_tables: Vec<(DestLabel, Box<[DestLabel]>)>,
     /// Set by [`Self::set_bop_redefine`], consumed by the next
     /// [`Self::check_bop_redefine`]. On-stack eviction has to happen for the
     /// definition that *made* a basic op stale, not for every definition that
@@ -1228,6 +1245,10 @@ impl Codegen {
             switch_to_scheduler,
             scheduler_resume,
             startup_flag: false,
+            #[cfg(target_arch = "aarch64")]
+            far_branch_mode: false,
+            #[cfg(target_arch = "aarch64")]
+            pending_jump_tables: Vec::new(),
             bop_eviction_pending: false,
             lir_buf: None,
             #[cfg(any(feature = "jit-log", feature = "jit-debug"))]

--- a/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
@@ -1064,26 +1064,55 @@ impl Codegen {
         else_dest: DestLabel,
         branch_dests: Box<[DestLabel]>,
     ) {
-        let jump_table = self.jit.const_align8();
-        for dest_label in branch_dests.iter() {
-            self.jit.abs_address(dest_label.clone());
-        }
+        // In a far frame (see `Codegen::far_branch_mode`) the const-area
+        // table may end up past `adr`'s ±1 MiB reach (constants are emitted
+        // at finalize, after the whole body), so inline the table right
+        // here instead — this op ends the block with an indirect `br`, so
+        // the table sits in dead space behind it and `adr` spans a few
+        // instructions at most. The compares also switch to the relaxed
+        // BB-edge form.
+        let inline_table = self.far_branch_mode;
+        let jump_table = if inline_table {
+            self.jit.label()
+        } else {
+            let table = self.jit.const_align8();
+            for dest_label in branch_dests.iter() {
+                self.jit.abs_address(dest_label.clone());
+            }
+            table
+        };
         let cond = GP::Rdi.a64().0; // x4
         monoasm_arm64!(&mut self.jit,
             asr x(cond), x(cond), #1;   // untag fixnum: x4 = n
             cmp x(cond), #(max as u32);
         );
-        self.jit.bcond_label(monoasm::Cond::Gt, &else_dest); // n > max -> else
+        self.a64_bcond_bb(monoasm::Cond::Gt, &else_dest); // n > max -> else
         monoasm_arm64!(&mut self.jit,
             cmp x(cond), #(min as u32);
         );
-        self.jit.bcond_label(monoasm::Cond::Lt, &else_dest); // n < min -> else
+        self.a64_bcond_bb(monoasm::Cond::Lt, &else_dest); // n < min -> else
         monoasm_arm64!(&mut self.jit,
             sub x(cond), x(cond), #(min as u32);     // index = n - min
             adr x10, jump_table;                     // table base (PC-relative)
             ldr x10, [x10, x(cond), lsl #3];         // table[n - min]
             br x10;
         );
+        if inline_table {
+            // `abs_address` queues its quad for the *const* area (emitted at
+            // finalize, at the page's end) — useless for an inline table. So
+            // reserve the table bytes here with nops and record the dests;
+            // `a64_patch_jump_tables` writes the absolute addresses at the
+            // end of this frame, when the dest labels (same-frame BB labels)
+            // are all bound.
+            if self.jit.get_current() % 8 != 0 {
+                monoasm_arm64!(&mut self.jit, nop;);
+            }
+            self.jit.bind_label(jump_table.clone());
+            for _ in 0..(branch_dests.len() * 2) {
+                monoasm_arm64!(&mut self.jit, nop;);
+            }
+            self.pending_jump_tables.push((jump_table, branch_dests));
+        }
     }
 
     /// Record `return_addr` — the address the callee will `ret` to — under

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -98,13 +98,16 @@ fn a64_float_cond_for_cmp(kind: CmpKind, brkind: BrKind) -> monoasm::Cond {
 }
 
 
-/// Hot-run length (bytes) that forces a mid-stream side-exit island. Half
-/// the `TBZ`/`TBNZ` imm14 reach (±32 KiB): the guards emitted *after* the
-/// island still have to span their own distance to the next island plus
-/// that island's body, and handler bodies are small (a write-back plus a
-/// tail branch), so 16 KiB keeps every direct tbz comfortably in range
-/// without a range-extension thunk.
-const SIDE_EXIT_DRAIN_THRESHOLD: usize = 16 * 1024;
+/// Hot-run length (bytes) that forces a mid-stream side-exit thunk island.
+/// The invariant is that a reference to a still-unbound handler label is
+/// never further than the `TBZ`/`TBNZ` imm14 reach (±32 KiB) from where the
+/// label gets bound. References live at or after `side_exit_watermark`; a
+/// thunk island binds only the labels referenced since then (`touched`),
+/// so its size is at most 8 bytes per referencing instruction — bounded by
+/// the hot run itself. With an 8 KiB trigger the worst case is
+/// 8 KiB (run) + 16 KiB (island of one two-word thunk per instruction)
+/// ≈ 24 KiB, comfortably inside imm14.
+const SIDE_EXIT_DRAIN_THRESHOLD: usize = 8 * 1024;
 
 impl Codegen {
     /// Emit the frame's accumulated side-exit handlers as one outlined
@@ -133,13 +136,20 @@ impl Codegen {
         // re-thunks its own remainder whenever the run since the watermark
         // grows past the threshold — same trick as the mid-block pass, one
         // extra taken `b` per crossing, cold path only.
-        let mut pending: std::collections::VecDeque<_> =
-            std::mem::take(&mut frame.pending_side_exits).into();
-        while let Some(inst) = pending.pop_front() {
+        let mut pending: Vec<Option<LInst>> = std::mem::take(&mut frame.pending_side_exits)
+            .into_iter()
+            .map(Some)
+            .collect();
+        for i in 0..pending.len() {
             if self.jit.get_current() - frame.side_exit_watermark > SIDE_EXIT_DRAIN_THRESHOLD {
-                for inst in pending.iter_mut() {
-                    let LInst::SideExit { entry, .. } = inst else {
-                        unreachable!("pending_side_exits holds only LInst::SideExit");
+                // The island is outgrowing the range invariant; re-thunk the
+                // *referenced* remainder (same selection as the mid-stream
+                // pass) so their outstanding references resolve here, and
+                // let the bodies keep flowing below.
+                for idx in std::mem::take(&mut frame.touched_side_exits) {
+                    let Some(LInst::SideExit { entry, .. }) = pending[idx].as_mut() else {
+                        // Already emitted below — its label was bound then.
+                        continue;
                     };
                     let succ = self.jit.label();
                     self.jit.bind_label(entry.clone());
@@ -148,12 +158,64 @@ impl Codegen {
                 }
                 frame.side_exit_watermark = self.jit.get_current();
             }
+            let inst = pending[i].take().unwrap();
             self.encode_linst(inst);
         }
         if fallthrough_in {
             self.jit.bind_label(skip);
         }
         frame.side_exit_watermark = self.jit.get_current();
+    }
+
+    /// Write the absolute dest addresses into the frame's inline `OptCase`
+    /// jump tables (see `emit_opt_case`'s far arm). Runs at the frame's end,
+    /// when every dest — a same-frame BB label — is bound; the JIT region is
+    /// still writable (we are mid-compile), and `mark_dirty` records the
+    /// bytes for the I-cache flush at the next `set_executable`.
+    pub(in crate::codegen::jitgen) fn a64_patch_jump_tables(&mut self) {
+        for (table, dests) in std::mem::take(&mut self.pending_jump_tables) {
+            let base = self.jit.get_label_address(&table).as_ptr() as *mut u64;
+            for (i, dest) in dests.iter().enumerate() {
+                let addr = self.jit.get_label_address(dest).as_ptr() as u64;
+                let slot = unsafe { base.add(i) };
+                self.jit.mark_dirty(slot as *const u8, 8);
+                // SAFETY: `slot` is inside the nop-reserved table this frame
+                // emitted, still writable during compilation.
+                unsafe { slot.write(addr) };
+            }
+        }
+    }
+
+    /// BB-edge conditional branch, branch-relaxed: the short Imm19 form
+    /// (±1 MiB) normally, or — in `far_branch_mode`, i.e. a frame so large
+    /// the target may be out of Imm19 reach — the *same* condition taken to
+    /// a local trampoline that continues with an unconditional `b`
+    /// (±128 MiB). The condition is deliberately NOT inverted: several of
+    /// these branches follow an `fcmp`, where each condition encodes its
+    /// own NaN (unordered) behaviour — e.g. `gt` is "greater AND ordered"
+    /// while `le` is "less-equal OR unordered" — so a mechanical inversion
+    /// flips which way an unordered compare branches. Keeping the condition
+    /// costs the not-taken path one extra `b` in far mode only.
+    ///
+    /// Only BB-edge branches route through here; side-exit references are
+    /// bounded by the island watermark (`a64_thunk_side_exits`) and stay
+    /// short.
+    pub(in crate::codegen::jitgen) fn a64_bcond_bb(
+        &mut self,
+        cond: monoasm::Cond,
+        target: &DestLabel,
+    ) {
+        if self.far_branch_mode {
+            let taken = self.jit.label();
+            let skip = self.jit.label();
+            self.jit.bcond_label(cond, &taken);
+            monoasm_arm64!(&mut self.jit, b skip;);
+            self.jit.bind_label(taken);
+            monoasm_arm64!(&mut self.jit, b target;);
+            self.jit.bind_label(skip);
+        } else {
+            self.jit.bcond_label(cond, target);
+        }
     }
 
     /// Range-extension thunks (mid-block): when the hot run since the last
@@ -172,14 +234,20 @@ impl Codegen {
         labels: &mut SideExitLabels,
         links: &[(usize, usize)],
     ) {
-        if frame.pending_side_exits.is_empty() {
+        frame.touched_side_exits.extend(labels.take_touched());
+        if frame.touched_side_exits.is_empty() {
             frame.side_exit_watermark = self.jit.get_current();
             return;
         }
         let skip = self.jit.label();
         monoasm_arm64!(&mut self.jit, b skip;);
-        for inst in frame.pending_side_exits.iter_mut() {
-            let LInst::SideExit { entry, .. } = inst else {
+        // Bind only the labels actually referenced since their last thunk:
+        // a handler-heavy frame accumulates tens of thousands of pending
+        // handlers, and binding them all made the island itself outgrow the
+        // imm14 reach. A label with no new reference has nothing measuring
+        // a distance to it and can wait for the final island.
+        for idx in std::mem::take(&mut frame.touched_side_exits) {
+            let LInst::SideExit { entry, .. } = &mut frame.pending_side_exits[idx] else {
                 unreachable!("pending_side_exits holds only LInst::SideExit");
             };
             let succ = self.jit.label();
@@ -187,6 +255,8 @@ impl Codegen {
             monoasm_arm64!(&mut self.jit, b succ;);
             *entry = succ;
         }
+        // Re-point the current block's entries at the (possibly fresh)
+        // successor labels so later references measure from here.
         for (pending_idx, label_idx) in links {
             let LInst::SideExit { entry, .. } = &frame.pending_side_exits[*pending_idx] else {
                 unreachable!();
@@ -405,6 +475,12 @@ impl Codegen {
                 #[cfg(feature = "deopt")]
                 created_at,
             );
+            // `links` records (pending, labels) index pairs in push order;
+            // mirror the pending index onto the labels side too, so
+            // `raw_deopt` can note which handler a lowering referenced
+            // (the thunk pass binds only those).
+            let (pending_idx, _) = links.last().copied().unwrap();
+            labels.note_pending_idx(pending_idx);
         }
         frame.pending_side_exits.extend(lir.into_insts());
 
@@ -425,6 +501,9 @@ impl Codegen {
             let exit = frame.resolve_bb_label(&mut self.jit, exit);
             monoasm_arm64!(&mut self.jit, b exit;);
         }
+        // Carry this block's outstanding references over to the frame set —
+        // the next thunk (possibly in a later block) must bind them.
+        frame.touched_side_exits.extend(labels.take_touched());
     }
 
     /// Release the spill region the loop-JIT entry pinned sp below
@@ -1216,7 +1295,7 @@ impl Codegen {
                     LCond::Gt => monoasm::Cond::Gt,
                     LCond::Ge => monoasm::Cond::Ge,
                 };
-                self.jit.bcond_label(c, &target);
+                self.a64_bcond_bb(c, &target);
             }
             // Ruby-truthiness branch: `orr 0x10` folds nil(0x04)/false(0x14) to
             // FALSE_VALUE; truthy (!= FALSE) takes Ne, falsy takes Eq.
@@ -1232,16 +1311,25 @@ impl Codegen {
                 } else {
                     monoasm::Cond::Ne
                 };
-                self.jit.bcond_label(cond, &target);
+                self.a64_bcond_bb(cond, &target);
             }
             LInst::BranchIfNil { target } => {
                 let rax = GP::Rax.a64().0;
                 monoasm_arm64!(&mut self.jit, cmp x(rax), #(NIL_VALUE as u32););
-                self.jit.bcond_label(monoasm::Cond::Eq, &target);
+                self.a64_bcond_bb(monoasm::Cond::Eq, &target);
             }
             LInst::BranchIfNonzero { target } => {
                 let rax = GP::Rax.a64().0;
-                monoasm_arm64!(&mut self.jit, cbnz x(rax), target;);
+                if self.far_branch_mode {
+                    let skip = self.jit.label();
+                    monoasm_arm64!(&mut self.jit,
+                        cbz x(rax), skip;
+                        b target;
+                    );
+                    self.jit.bind_label(skip);
+                } else {
+                    monoasm_arm64!(&mut self.jit, cbnz x(rax), target;);
+                }
             }
             // GC write barrier (aarch64 takes the parent register explicitly).
             LInst::WriteBarrier { parent, value } => {
@@ -1266,7 +1354,20 @@ impl Codegen {
             // here — the ops stay distinct so the distinction survives if
             // aarch64 grows the recorder.
             LInst::BrClassNe { reg, class, target } => {
-                self.a64_guard_class(reg, class, &target);
+                if self.far_branch_mode {
+                    // `a64_guard_class` may reference its fail label with a
+                    // `tbz` (Test14, ±32 KiB); in a far frame route the miss
+                    // through a local veneer.
+                    let miss = self.jit.label();
+                    let hit = self.jit.label();
+                    self.a64_guard_class(reg, class, &miss);
+                    monoasm_arm64!(&mut self.jit, b hit;);
+                    self.jit.bind_label(miss);
+                    monoasm_arm64!(&mut self.jit, b target;);
+                    self.jit.bind_label(hit);
+                } else {
+                    self.a64_guard_class(reg, class, &target);
+                }
             }
             // Class-set guard: membership chain built from the single-class
             // guard — each class's check falls through on match (branch to
@@ -1289,6 +1390,13 @@ impl Codegen {
                             b ok;
                         );
                         self.jit.bind_label(next);
+                    } else if self.far_branch_mode {
+                        // See `BrClassNe`: veneer the far miss.
+                        let miss = self.jit.label();
+                        self.a64_guard_class(reg, *class, &miss);
+                        monoasm_arm64!(&mut self.jit, b ok;);
+                        self.jit.bind_label(miss);
+                        monoasm_arm64!(&mut self.jit, b target;);
                     } else {
                         self.a64_guard_class(reg, *class, &target);
                     }
@@ -1603,7 +1711,7 @@ impl Codegen {
                 let rp = self.a64_fpr_read(rhs, 1, base);
                 monoasm_arm64!(&mut self.jit, fcmp d(lp), d(rp););
                 let cond = a64_float_cond_for_cmp(kind, brkind);
-                self.jit.bcond_label(cond, &dest);
+                self.a64_bcond_bb(cond, &dest);
             }
             // ---- FP pool save/restore + FP C-calls ---------------------------
             LInst::FprSave { using_fpr, cont } => {

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -747,6 +747,30 @@ impl Codegen {
 
         let mut ir_vec = frame.detach_ir();
 
+        // aarch64 branch relaxation (see `Codegen::far_branch_mode`): decide
+        // from the frame's total AsmIr instruction count whether a BB-edge
+        // Imm19/Adr reference could exceed its ±1 MiB reach. 64 bytes per
+        // AsmInst is a generous per-instruction bound, so 8192 instructions
+        // stays comfortably inside 1 MiB even doubled by the long forms;
+        // anything larger emits BB edges in long form. The flag is saved and
+        // restored around this frame because `gen_machine_code` recursed into
+        // the inlined callees above — each frame decides for itself.
+        #[cfg(target_arch = "aarch64")]
+        let far_branch_saved = {
+            let total: usize = ir_vec.iter().map(|(_, ir)| ir.inst_len()).sum::<usize>()
+                + frame
+                    .iter_outline_bridges_mut()
+                    .map(|(ir, _, _)| ir.inst_len())
+                    .sum::<usize>()
+                + frame
+                    .iter_inline_bridges_mut()
+                    .map(|(ir, _)| ir.inst_len())
+                    .sum::<usize>();
+            let saved = self.far_branch_mode;
+            self.far_branch_mode = total > 8192;
+            saved
+        };
+
         // §21 — AsmIR optimization seam (Path 2). `inst` is the ordered,
         // replayable instruction stream; this is the arch-neutral layer where
         // peephole/optimization passes run, between AsmIR construction
@@ -852,6 +876,11 @@ impl Codegen {
         // decides.
         #[cfg(target_arch = "aarch64")]
         self.a64_drain_side_exits(&mut frame, !had_outline_bridges && fallthrough_in);
+        #[cfg(target_arch = "aarch64")]
+        {
+            self.a64_patch_jump_tables();
+            self.far_branch_mode = far_branch_saved;
+        }
         #[cfg(not(target_arch = "aarch64"))]
         let _ = had_outline_bridges;
 

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -74,6 +74,17 @@ pub(crate) struct SideExitLabels {
     exit_id: Vec<u32>,
     #[cfg(feature = "deopt")]
     created_at: Vec<Option<&'static std::panic::Location<'static>>>,
+    /// aarch64: parallel to `labels` — the index of each handler in the
+    /// frame's `pending_side_exits` accumulator, recorded by `gen_asm` right
+    /// after `push`. Lets [`Self::raw_deopt`] note *which* handler a lowering
+    /// just referenced.
+    #[cfg(target_arch = "aarch64")]
+    pending_idx: Vec<usize>,
+    /// aarch64: pending indices referenced since the last drain by the
+    /// thunk pass (`Codegen::a64_thunk_side_exits`). Interior-mutable
+    /// because `raw_deopt` runs under a shared borrow.
+    #[cfg(target_arch = "aarch64")]
+    touched: std::cell::RefCell<Vec<usize>>,
 }
 
 impl SideExitLabels {
@@ -99,6 +110,10 @@ impl SideExitLabels {
             exit_id: vec![],
             #[cfg(feature = "deopt")]
             created_at: vec![],
+            #[cfg(target_arch = "aarch64")]
+            pending_idx: vec![],
+            #[cfg(target_arch = "aarch64")]
+            touched: std::cell::RefCell::new(vec![]),
         }
     }
 
@@ -127,7 +142,23 @@ impl SideExitLabels {
     /// [`DeoptCause`].
     ///
     pub(crate) fn raw_deopt(&self, index: AsmDeopt) -> &DestLabel {
+        #[cfg(target_arch = "aarch64")]
+        self.touched.borrow_mut().push(self.pending_idx[index.0]);
         &self.labels[index.0]
+    }
+
+    /// aarch64: record the accumulator index of the handler just pushed —
+    /// see the `pending_idx` field.
+    #[cfg(target_arch = "aarch64")]
+    pub(in crate::codegen) fn note_pending_idx(&mut self, idx: usize) {
+        self.pending_idx.push(idx);
+        debug_assert_eq!(self.pending_idx.len(), self.labels.len());
+    }
+
+    /// aarch64: drain the handler indices referenced since the last call.
+    #[cfg(target_arch = "aarch64")]
+    pub(in crate::codegen) fn take_touched(&self) -> Vec<usize> {
+        std::mem::take(&mut *self.touched.borrow_mut())
     }
 
     #[cfg(feature = "deopt")]
@@ -143,6 +174,10 @@ impl std::ops::Index<AsmError> for SideExitLabels {
     type Output = DestLabel;
 
     fn index(&self, index: AsmError) -> &Self::Output {
+        // Every fetch is a (potential) reference — record it for the
+        // aarch64 thunk pass, like `raw_deopt`.
+        #[cfg(target_arch = "aarch64")]
+        self.touched.borrow_mut().push(self.pending_idx[index.0]);
         &self.labels[index.0]
     }
 }
@@ -151,6 +186,8 @@ impl std::ops::Index<AsmEvict> for SideExitLabels {
     type Output = DestLabel;
 
     fn index(&self, index: AsmEvict) -> &Self::Output {
+        #[cfg(target_arch = "aarch64")]
+        self.touched.borrow_mut().push(self.pending_idx[index.0]);
         &self.labels[index.0]
     }
 }
@@ -281,6 +318,12 @@ impl AsmIr {
         if self.codegen_mode {
             self.inst.push(inst);
         }
+    }
+
+    /// Number of `AsmInst`s in the stream — the frame-size estimate the
+    /// aarch64 branch-relaxation decision reads (`Codegen::far_branch_mode`).
+    pub(super) fn inst_len(&self) -> usize {
+        self.inst.len()
     }
 
     pub(super) fn inst_iter_mut(&mut self) -> std::slice::IterMut<'_, AsmInst> {

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -266,6 +266,11 @@ pub(super) struct AsmInfo {
     /// aarch64: code position of the last side-exit island (or the frame
     /// start), the base the hot-run length is measured from.
     pub(in crate::codegen) side_exit_watermark: usize,
+    /// aarch64: indices into `pending_side_exits` whose labels have been
+    /// referenced since their last thunk — the only ones a thunk island has
+    /// to bind (binding all of them made the island itself outgrow the
+    /// `TBZ` reach on handler-heavy frames).
+    pub(in crate::codegen) touched_side_exits: std::collections::HashSet<usize>,
 }
 
 impl AsmInfo {
@@ -291,6 +296,7 @@ impl AsmInfo {
             start_codepos: 0,
             pending_side_exits: Vec::new(),
             side_exit_watermark: 0,
+            touched_side_exits: std::collections::HashSet::default(),
         }
     }
 
@@ -629,6 +635,7 @@ impl JitStackFrame {
                 start_codepos: 0,
                 pending_side_exits: Vec::new(),
                 side_exit_watermark: 0,
+                touched_side_exits: std::collections::HashSet::default(),
             },
             outer,
             callid: None,

--- a/monoruby/tests/far_branch_relaxation.rs
+++ b/monoruby/tests/far_branch_relaxation.rs
@@ -1,0 +1,66 @@
+//! Branch relaxation for frames past the Imm19 / Adr reach (aarch64).
+//!
+//! A frame whose AsmIr exceeds the `far_branch_mode` threshold emits its
+//! BB-edge conditional branches in a long form (same condition taken to a
+//! local trampoline that continues with `b`, ±128 MiB — the condition is
+//! never inverted, because after an `fcmp` each condition encodes its own
+//! NaN behaviour), routes class-dispatch misses through a local veneer
+//! (their guards may use `TBZ`, ±32 KiB), and lays `OptCase` jump tables
+//! inline, nop-reserved and patched with absolute dest addresses at the
+//! frame's end (`a64_patch_jump_tables`) — the const-area table `adr`
+//! normally reaches sits past ±1 MiB in such frames.
+//!
+//! The shapes below build methods big enough to cross the threshold by
+//! `eval`ing generated source. Before the relaxation they either failed to
+//! compile (a caught panic parking the loop in the interpreter — or, through
+//! the double-panic in the recovery path, an outright abort) or could not
+//! exist at all: the pre-#1183 layout overflowed `TBZ`'s reach first.
+//!
+//! On x86-64 the same shapes compile through the ordinary path (its ±2 GiB
+//! branches need no relaxation) and simply pin the results.
+extern crate monoruby;
+use monoruby::tests::*;
+
+/// A while-loop body of ~18k AsmInsts with an if/else split: the `condbr`
+/// across each arm spans megabytes of code, and every `a + k` carries an
+/// overflow deopt, so the side-exit accumulator sees thousands of handlers
+/// (the touched-only thunk selection keeps the islands within imm14).
+#[test]
+fn a_frame_past_the_imm19_reach() {
+    run_test(
+        r#"
+        add = (0...9000).map { |k| "a = a + #{k % 7 + 1}" }.join("\n")
+        sub = (0...9000).map { |k| "a = a - #{k % 5 + 1}" }.join("\n")
+        eval "def big\n a = 0\n i = 0\n while i < 200\n if i.odd?\n #{add}\n else\n #{sub}\n end\n i += 1\n end\n a\nend"
+        big
+        "#,
+    );
+}
+
+/// The same scale with a `case`/`when` in the loop: in a far frame the
+/// dispatch's jump table is laid inline and patched at frame end, since
+/// the const-area copy would sit past `adr`'s reach.
+#[test]
+fn an_opt_case_in_a_far_frame() {
+    run_test(
+        r#"
+        add = (0...9000).map { |k| "a = a + #{k % 7 + 1}" }.join("\n")
+        eval "def big(v)\n a = 0\n i = 0\n while i < 200\n #{add}\n case v\n when 1 then a += 10\n when 2 then a += 20\n when 3 then a += 30\n else a += 1\n end\n i += 1\n end\n a\nend"
+        big(2) + big(9)
+        "#,
+    );
+}
+
+/// Floats across the far split: the long form keeps the original fcmp
+/// condition (an inverted one flips the unordered/NaN direction), so the
+/// float compares must behave identically at either scale.
+#[test]
+fn float_compares_in_a_far_frame() {
+    run_test(
+        r#"
+        add = (0...9000).map { |k| "a = a + #{k % 7 + 1}" }.join("\n")
+        eval "def big(x)\n a = 0\n f = 0.0\n i = 0\n while i < 200\n if x > 0.5\n #{add}\n f += 0.25\n else\n a -= 1\n end\n f = 0.0 / 0.0 if i == 100\n i += 1\n end\n [a, f.nan?]\nend"
+        big(1.5)
+        "#,
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -648,6 +648,7 @@
 345a39619ec82fcc2a065326ea5fa6b0	[:a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d, :a, :b, :c, :d]	def c(x)\n              case x\n              when 1 then :a\n        
 346c3ccb2630b081d1268d76b216f8cf	{amount: 4, unit: "km"}	M = Data.define(:amount, :unit)\nm = M.new(42, "km"); m.with(amount: 4).to_h
 3470de4e4871882a3fbb89a9ee3709e3	["MyArr2", [1, 2]]	class MyArr2 < Array; end\n            r = Marshal.load(Marshal.dump
+34773bd7d6db99036167ac66da4a57ad	899500	add = (0...9000).map { |k| "a = a + #{k % 7 + 1}" }.join("\\n")\n        
 347cffbb4c975e8f7aba48cffa253e3a	"a-b"	path = "/tmp/monoruby_test_io_open_#{Process.pid}_#{rand(100000)}"\n
 3491bb9ea3ef0d8e8dc6e9d966784850	[true, true, false]	klass = Class.new\n            Class.new do\n              klass.send
 349f590d26b1d8c968d1a0e8cbacad45	"Hash"	(GC.compact if GC.respond_to?(:compact)).class.to_s
@@ -1664,6 +1665,7 @@
 88b402e7fdaa8b2f9583d10a43b30b83	[true, false, true, false, true]	class C\n          def pub_method; end\n          private\n          def p
 88b74eaedd70ab6521c45c598a99a423	:OVERRIDDEN	class Float; def <=(o); :OVERRIDDEN; end; end; 3.0 <= 4.0
 88babe728a4927abe5d2e25cd6b25a80	:OVERRIDDEN	class TrueClass; def ==(o); :OVERRIDDEN; end; end; true == true
+88bd39fde3bf31060646706246e601d5	[7199000, true]	add = (0...9000).map { |k| "a = a + #{k % 7 + 1}" }.join("\\n")\n        
 88c361bca62c3fbea0462a14aedadf27	[15, 11, 3, [77, 2], [:key, :key, :side, :side]]	class C\n          def initialize; @h = {}; @w = nil; end\n          def 
 88d4180cc8261b799934c513e7ea401c	13	def f(a,b)\n          a + b\n        end\n        f(5,7)\n        f(4,9)\n  
 88f8e9f112097e82f8a521e470848673	["<1>", "'x'"]	module AncInner\n              refine(Integer) { def wrap; "<#{to_s}
@@ -2668,6 +2670,7 @@ d6b954fc5289ea6d95ff086bc292725e	[1, 2, 3]	class A < Array; end\nA[1, 2, 3]
 d6bfe4296b93f2e640133c89a4ab8e47	false	def g; proc{ 1 }; end; g == g
 d6c0eb29e576b66ef1234e2d00a6f0b7	[[1, 0], [2, 1]]	r = []; [1, 2].each.with_index(nil) { |v, i| r << [v, i] }; r
 d6fd88af713f62b2a7bf0032d40dad05	6	def inner(&)\n          yield 1, 2, 3\n        end\n\n        def middle(&)
+d705cb7de3a9fef3b407db97ac6df6e0	14402200	add = (0...9000).map { |k| "a = a + #{k % 7 + 1}" }.join("\\n")\n        
 d70bea4dbbc6846f998b44f536138c16	[60, true, true, "AAA", "A"]	def bapp(s, n)\n          i = 0\n          while i < n\n            s << 6
 d711a3f5a6c7df97c22c300e85978f40	nil	m = method(:gets)\n        m.source_location\n        
 d7156f31d5e84b048bcf0448feec0463	[2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, :nome]	class Priv\n              def initialize = (@a = [1, 2, 3])\n        


### PR DESCRIPTION
Follow-up to #1183, extending the range-safety work from cold side-exit references to **every** branch kind a frame can outgrow. #1183 bounded the `TBZ` (±32 KiB) references by construction, which moved the large-frame ceiling up to the BB-edge branches' Imm19 (`b.cond`/`cbz`, ±1 MiB) and `OptCase`'s `Adr` (±1 MiB). A synthetic if/else body of 20k statements per arm crossed that: the compile panicked, and the recovery path's `finalize()` re-panicked on the leftovers — an outright process abort (pre-existing; reachable on master via `TBZ` at smaller sizes).

## Design

Frames whose AsmIr exceeds **8192 instructions** set `far_branch_mode`; ordinary frames emit **byte-identically** to #1183.

| what | far form |
|---|---|
| BB-edge conditionals (`CondBr`, `BranchTruthy`, `BranchIfNil`, `BranchIfNonzero`, `FloatCmpBr`) | the **same** condition taken to a local trampoline continuing with `b` (±128 MiB) |
| class-dispatch misses (`BrClassNe` / `BrClassNotIn`) | local veneer (their guards may `TBZ` to the miss) |
| `OptCase` | jump table **nop-reserved inline** and patched with absolute dest addresses at frame end (`a64_patch_jump_tables`, under `mark_dirty`) |

Three traps found and fixed on the way — each is a comment in the code now:

1. **Never invert an `fcmp` condition.** `gt` is "greater *and ordered*", `le` is "less-equal *or unordered*": mechanical inversion flips which way a NaN compare branches. The first cut inverted; the integer-only giants passed while float-heavy optcarrot `--opt` crashed wordlessly. The long form keeps the condition and pays one extra `b` on the not-taken path, in far frames only.
2. **The thunk islands themselves can outgrow imm14.** A handler-heavy frame accumulates 20k+ pending side exits; binding them all made the island ~160 KiB. `SideExitLabels` now records which handlers were actually referenced since their last thunk (both fetch paths — `raw_deopt` *and* the `Index` impls), and islands bind only those, bounding the island by the hot run preceding it. Threshold halved to 8 KiB: run + island ≤ 24 KiB < ±32 KiB.
3. **`abs_address` queues for the const area** (emitted at finalize, page end) — useless for an inline table; the bound label ends up naming the *following instructions*, which the dispatch then loads as a pointer (the wordless crash above, take two). The far form reserves the table with nops and writes the absolute dests at frame end, when the same-frame BB labels are all bound.

## Measurements (arm64-apple-darwin native, release)

| | result |
|---|---|
| optcarrot | 283.5 fps — parity with #1183 |
| optcarrot `--opt` | 1118 fps — parity; exercises far mode + inline tables |
| 20k / 60k-stmt-per-arm giants | compile and match CRuby (previously: process abort) |

## Testing

- aarch64 native: **3328 passed at both pool sizes** (three new far-frame regression tests: the Imm19 crosser, the far `OptCase`, and the NaN-carrying float-compare shape), full `SKIP_COV=1 bin/test` green.
- x86-64 untouched: ±2 GiB branches need none of this; shared changes (frame-size count, `SideExitLabels` reference-noting) are cfg-gated or no-ops there.

## Out of scope, recorded

The recovery double-panic (`finalize()` re-panicking on an aborted emit's unresolved relocations → process abort instead of falling back to the interpreter) is a pre-existing, now-harder-to-reach defect; a clean fix wants a `discard_unresolved`-style API on the monoasm side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
