### PR TITLE
Keep an outer frame's Sf float view across a block that writes it

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -3277,6 +3277,26 @@ impl Codegen {
         true
     }
 
+    /// Stage 1' write-through — mirror of x86 `emit_store_outer_fpr_home_f`:
+    /// raw f64 of `src` to `[x29 + disp]` (an outer frame's `Sf` home),
+    /// elided when `None`. d0 carries the value (reserved scratch), x10
+    /// the materialized address.
+    pub(in crate::codegen::jitgen) fn emit_store_outer_fpr_home_f(
+        &mut self,
+        src: FPReg,
+        disp: Option<i64>,
+        base: usize,
+    ) -> bool {
+        let Some(disp) = disp else { return true };
+        self.a64_fpr_load(src, 0, base); // value -> d0 (pool fmov or spill load)
+        monoasm_arm64!(&mut self.jit,
+            mov x10, (disp as u64);
+            add x10, x29, x10;
+            str d0, [x10];
+        );
+        true
+    }
+
     /// A JIT-spliced non-local exit (#1185): build and defer the exit's
     /// unwind (value in the `GP::Rdx`-mapped register) so the following
     /// compiled branch enters the shared `ensure` body directly. A

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -172,6 +172,7 @@ impl Codegen {
             | AsmInst::SpecializedCall { .. }
             | AsmInst::SpecializedYield { .. }
             | AsmInst::LoadDynVarSpecialized { .. }
+            | AsmInst::StoreOuterFprHomeF { .. }
             | AsmInst::StoreDynVarSpecialized { .. }
             | AsmInst::Inline(..)
             | AsmInst::ArrayIndex { .. }
@@ -2724,6 +2725,30 @@ impl Codegen {
             jmp  raise;
         cont:
         };
+        true
+    }
+
+    /// Stage 1' write-through: store the raw f64 in `src` (this frame's
+    /// fpr, pool or spill) to `[rbp + disp]` — an outer frame's `Sf`
+    /// home. `None` elides the store (the binding was widened after
+    /// emission). Goes through rax: a plain 8-byte copy, no boxing.
+    pub(in crate::codegen::jitgen) fn emit_store_outer_fpr_home_f(
+        &mut self,
+        src: FPReg,
+        disp: Option<i64>,
+        base: usize,
+    ) -> bool {
+        let Some(disp) = disp else { return true };
+        let disp = i32::try_from(disp).expect("outer fpr home displacement out of i32 range");
+        match PhysMap::new(base).resolve(src) {
+            FPRegLoc::Xmm(p) => monoasm! { &mut self.jit,
+                movq [rbp + (disp)], xmm(p);
+            },
+            FPRegLoc::Spill(off) => monoasm! { &mut self.jit,
+                movq rax, [rbp - (off)];
+                movq [rbp + (disp)], rax;
+            },
+        }
         true
     }
 

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1300,6 +1300,46 @@ pub(crate) enum SplicedExitKind {
     MethodReturn,
 }
 
+///
+/// Where an *outer* frame's `Sf` float view lives while the current frame
+/// runs — the raw-f64 home a write-through store refreshes (outer-F
+/// roadmap, stage 1'). A pool-resident fpr was saved into the owner's
+/// in-progress call-site FP save area; a spilled one stayed in the
+/// owner's own spill slot. Emitted as `Hint` (the callee's save layout is
+/// recorded only when the call site is emitted, after this instruction);
+/// the pre-codegen resolve pass turns it into a single rbp-relative
+/// displacement — or `Concrete(None)` when the binding was widened after
+/// emission (the recorded layout no longer saves the fpr), which elides
+/// the now-dead store.
+///
+#[derive(Debug, Clone)]
+pub(crate) enum OuterFprHome {
+    Hint {
+        /// Chain to the owner frame's rbp (same encoding as [`DynVarOffset`]).
+        ids: Vec<super::context::SpecializedId>,
+        extra: usize,
+        /// The owner frame (`ids[0]`), for the frame-size lookup.
+        owner: super::context::SpecializedId,
+        /// The owner's direct-callee instance — the call site whose FP
+        /// save area holds the owner's pool registers.
+        callee: super::context::SpecializedId,
+        /// The owner-file fpr whose home is refreshed.
+        fpr: crate::codegen::FPReg,
+    },
+    Concrete(Option<i64>),
+}
+
+impl OuterFprHome {
+    pub(crate) fn unwrap_concrete(&self) -> Option<i64> {
+        match self {
+            OuterFprHome::Concrete(o) => *o,
+            OuterFprHome::Hint { .. } => panic!(
+                "OuterFprHome::Hint reached code generation — resolve pass did not run"
+            ),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) enum DynVarOffset {
     Hint {
@@ -2562,6 +2602,18 @@ pub(super) enum AsmInst {
         src: DynVar,
     },
     /// rax = DynVar(src)
+    ///
+    /// Write-through refresh (outer-F roadmap, stage 1'): store the raw
+    /// f64 in `src` (a current-frame fpr) into an outer frame's `Sf`
+    /// home, so the owner's kept register view is current when its
+    /// `fpr_restore_cont` reloads it after this call chain returns. The
+    /// boxed slot store (`StoreDynVarSpecialized`) stays authoritative
+    /// and precedes this.
+    ///
+    StoreOuterFprHomeF {
+        src: FPReg,
+        home: OuterFprHome,
+    },
     LoadDynVarSpecialized {
         /// Machine stack offset in bytes. Emitted as a
         /// `DynVarOffset::Hint(...)` chain by Pass 1; the pre-codegen
@@ -2782,6 +2834,7 @@ impl AsmInst {
             Self::F64ToFpr(_, x) => vec![*x],
             Self::I64ToBoth(_, _, x) => vec![*x],
             Self::FprToStack(x, _) => vec![*x],
+            Self::StoreOuterFprHomeF { src, .. } => vec![*src],
             Self::FixnumToFpr(_, x) => vec![*x],
             Self::FloatToFpr(_, x, _) => vec![*x],
             Self::CFunc_F_F { src, dst, .. } => vec![*src, *dst],

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -1095,6 +1095,14 @@ impl Codegen {
                 });
             }
             // Outer-scope local access at a pre-resolved frame offset.
+            AsmInst::StoreOuterFprHomeF { src, home } => {
+                let disp = home.unwrap_concrete();
+                self.encode_linst(LInst::StoreOuterFprHomeF {
+                    src,
+                    disp,
+                    base: frame.base_stack_offset,
+                })
+            }
             AsmInst::LoadDynVarSpecialized { offset, reg } => {
                 let off = offset.unwrap_concrete();
                 self.lower_via_inline(store, labels, frame.base_stack_offset, move |cg, _, _, _| {
@@ -1665,6 +1673,9 @@ impl Codegen {
             }
             LInst::DeferSplicedExit { kind, pc } => {
                 self.emit_defer_spliced_exit(kind, pc);
+            }
+            LInst::StoreOuterFprHomeF { src, disp, base } => {
+                self.emit_store_outer_fpr_home_f(src, disp, base);
             }
             LInst::Yield { callid, simple, error, evict } => {
                 self.emit_yield(callid, simple, &error, evict);

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -1011,6 +1011,7 @@ impl<'a> JitContext<'a> {
             needs_rest_array: _,
             had_deopt: _,
             generic_yield: _,
+            spec_id,
         } = self.compile_specialized_func(
             state,
             iseq,
@@ -1025,6 +1026,9 @@ impl<'a> JitContext<'a> {
         // `InitMethod` entry poll, so no call-site GC poll is needed.
         state.check_stack(ir);
         let using_fpr = state.get_using_fpr(ir);
+        // Stage 1': the resolve pass places write-through refreshes into
+        // this site's save area by this record.
+        self.record_call_site_fpr_save(spec_id, using_fpr);
         // stack pointer adjustment
         // -using_fpr.offset()
         ir.fpr_save_cont(using_fpr);
@@ -1414,6 +1418,7 @@ impl<'a> JitContext<'a> {
             needs_rest_array,
             had_deopt,
             generic_yield,
+            spec_id,
         } = compiled;
         // The call site passes a block literal: if the callee heapifies
         // its *own* frame during the call (`Proc.new` / `lambda` /
@@ -1447,6 +1452,10 @@ impl<'a> JitContext<'a> {
             }
         }
         let evict = ir.new_evict();
+        // Snapshot the save set here (it is what `fpr_save_cont` below
+        // will emit) and record it for the resolve pass — stage 1'.
+        let using_fpr = state.get_using_fpr(ir);
+        self.record_call_site_fpr_save(spec_id, using_fpr);
         state.send_specialized(
             ir,
             &self.store,
@@ -1458,6 +1467,7 @@ impl<'a> JitContext<'a> {
             deferred_rest,
             needs_rest_array,
             bmethod_outer,
+            using_fpr,
         );
         let res = state.def_rax2acc_return(ir, dst, return_state);
         state.immediate_evict(ir, evict);
@@ -1481,6 +1491,9 @@ pub(super) struct SpecializedCompileResult {
     pub needs_rest_array: bool,
     /// The compiled subtree contains a deopt-able side exit.
     pub had_deopt: bool,
+    /// The compiled callee instance, keying its call site's recorded FP
+    /// save layout (stage 1' write-through).
+    pub spec_id: context::SpecializedId,
     /// A `yield` in the compiled subtree was not inlined — see
     /// [`JitStackFrame::generic_yield`].
     pub generic_yield: bool,
@@ -1595,6 +1608,10 @@ impl<'a> JitContext<'a> {
             frame.set_bmethod_home();
         }
 
+        // Stage 1' bet-confirmation mark: write-through keeps recorded by
+        // this call's subtree are drained below if the subtree turns out
+        // to contain a deopt-able exit or a generic yield.
+        let kept_mark = self.kept_outer_views_mark();
         let mut frame = self.specialized_compile(state, callid, frame)?;
         // we must unset no_capture_guard for all state frames if no_capture_guard of the current frame became false.
         if !state.no_capture_guard() {
@@ -1606,6 +1623,7 @@ impl<'a> JitContext<'a> {
         let return_state = return_context.remove(&pos);
         self.merge_return_context(return_context);
         // Capture before `frame.asm_info` is moved below.
+        let spec_id = frame.asm_info.specialized_id;
         let frame_had_deopt = frame.had_deopt;
         let frame_deferred_rest = frame.deferred_rest;
         let frame_needs_rest_array = frame.needs_rest_array;
@@ -1680,6 +1698,21 @@ impl<'a> JitContext<'a> {
         if frame_generic_yield {
             self.current_frame_mut().generic_yield = true;
         }
+        // Stage 1' bet confirmation. Unlike the kept constants below,
+        // `had_deopt` does NOT surrender a write-through keep: the claim
+        // is consumed only by the owner's *compiled* continuation, and —
+        // exactly as the return-state comment further down establishes —
+        // that continuation never runs on a deopt path (side-exit
+        // escalation is unconditional, §8.6; the salvage re-entries
+        // resume compiled in place, so every store on a path that reaches
+        // the continuation performed its write-through). The boxed slot
+        // store is emitted on every path either way, so the VM always
+        // reads truth. `generic_yield` is kept as a belt: an out-of-unit
+        // block's runtime stores bypass the compile-time widen hooks.
+        if frame_generic_yield {
+            self.drain_kept_outer_views(kept_mark, state);
+        }
+        let _ = kept_mark;
         Ok(SpecializedCompileResult {
             entry,
             return_state,
@@ -1687,6 +1720,7 @@ impl<'a> JitContext<'a> {
             needs_rest_array: frame_needs_rest_array,
             had_deopt: frame_had_deopt,
             generic_yield: frame_generic_yield,
+            spec_id,
         })
     }
 
@@ -1878,6 +1912,10 @@ impl AbstractState {
         deferred_rest: bool,
         needs_rest_array: bool,
         bmethod_outer: Option<Option<Lfp>>,
+        // The caller-computed `get_using_fpr` snapshot, taken there so it
+        // can also be recorded for the resolve pass (stage 1' — the
+        // recorded set must be exactly what `fpr_save_cont` emits).
+        using_fpr: UsingFpr,
     ) {
         // D1: skip the caller-side `create_array` only when at least
         // one forwarding consume was source-routed AND no forwarding
@@ -1886,7 +1924,6 @@ impl AbstractState {
         // Stack check only: the specialized callee body compiles its own
         // `InitMethod` entry poll.
         self.check_stack(ir);
-        let using_fpr = self.get_using_fpr(ir);
         // stack pointer adjustment
         // -using_fpr.offset()
         ir.fpr_save_cont(using_fpr);

--- a/monoruby/src/codegen/jitgen/compile/variables.rs
+++ b/monoruby/src/codegen/jitgen/compile/variables.rs
@@ -260,15 +260,48 @@ impl<'a> JitContext<'a> {
         dst: DynVar,
         src: SlotId,
     ) {
-        // The store invalidates whatever the outer frame's abstract state
-        // claimed about this slot — in both places that track it: the live
-        // chain this compile is reasoning about, and the context's copy,
-        // which is what the *caller* will read back when we are done.
-        self.widen_outer_slot(dst.outer, dst.reg);
-        state.widen_outer_slot(dst.outer, dst.reg);
+        let outer_spec = self.outer_specialized_ids(state, dst.outer);
+        // Write-through keep (outer-F roadmap, stage 1'): when the outer
+        // frame still holds a Float-guarded `Sf` view of the target and
+        // the stored value is provably a float in one of this frame's
+        // fprs, refresh the view's raw-f64 home alongside the boxed slot
+        // store and *keep* the binding instead of widening it — the
+        // owner's `fpr_restore_cont` then reloads the current value and
+        // its continuation reads the float without re-unboxing. Sound
+        // under the same umbrella as the kept constants: on any deopt
+        // under the call the owner's compiled continuation never runs
+        // (chain escalation), and the salvage re-entry case is confirmed
+        // after the fact by `drain_kept_outer_views`. The slot store
+        // below stays authoritative either way.
+        let keep = match &outer_spec {
+            Some((ids, extra, true)) => self
+                .outer_parked_sf_float(dst.outer, dst.reg)
+                .and_then(|afpr| {
+                    let bfpr = match state.mode(src) {
+                        LinkMode::F(fpr) => Some(fpr),
+                        LinkMode::Sf(fpr, crate::codegen::jitgen::state::SfGuarded::Float) => {
+                            Some(fpr)
+                        }
+                        _ => None,
+                    }?;
+                    let home =
+                        self.keep_outer_sf_view(ids.clone(), *extra, dst.outer, dst.reg, afpr)?;
+                    Some((bfpr, home))
+                }),
+            _ => None,
+        };
+        if keep.is_none() {
+            // The store invalidates whatever the outer frame's abstract
+            // state claimed about this slot — in both places that track
+            // it: the live chain this compile is reasoning about, and the
+            // context's copy, which is what the *caller* will read back
+            // when we are done.
+            self.widen_outer_slot(dst.outer, dst.reg);
+            state.widen_outer_slot(dst.outer, dst.reg);
+        }
         let r = GP::Rdi;
         state.load(ir, src, r);
-        if let Some((spec_ids, extra, not_captured)) = self.outer_specialized_ids(state, dst.outer)
+        if let Some((spec_ids, extra, not_captured)) = outer_spec
             && not_captured
         {
             assert!(not_captured);
@@ -281,7 +314,11 @@ impl<'a> JitContext<'a> {
                 src: r,
             });
         } else {
+            debug_assert!(keep.is_none());
             ir.push(AsmInst::StoreDynVar { dst, src: r });
+        }
+        if let Some((bfpr, home)) = keep {
+            ir.push(AsmInst::StoreOuterFprHomeF { src: bfpr, home });
         }
     }
 }

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -854,6 +854,20 @@ pub(crate) struct JitContext<'a> {
     /// prologues, `total - base` resolves Loop-JIT rsp bumps.
     ///
     specialized_frame_sizes: HashMap<SpecializedId, FrameSizes>,
+    ///
+    /// The final `UsingFpr` each specialized call site saved (keyed by the
+    /// *callee instance*), recorded when the call is emitted. The resolve
+    /// pass reads it to place a write-through refresh
+    /// (`AsmInst::StoreOuterFprHomeF`) into the owner's save area.
+    call_site_fpr_saves: HashMap<SpecializedId, UsingFpr>,
+    ///
+    /// Outer-frame `Sf` views kept alive by write-through stores
+    /// (stage 1'), as `(stack position, slot)`. A specialized call whose
+    /// subtree had a deopt-able exit or a generic yield drains its marks
+    /// and re-widens them — the same bet-confirmation the kept constants
+    /// go through (#1140), for the same reason: a salvage re-entry runs
+    /// compiled continuations without a chain conversion.
+    kept_outer_views: Vec<(usize, SlotId)>,
 }
 
 impl<'a> JitContext<'a> {
@@ -883,6 +897,8 @@ impl<'a> JitContext<'a> {
             stack_frame,
             next_specialized_id: 0,
             specialized_frame_sizes: HashMap::default(),
+            call_site_fpr_saves: HashMap::default(),
+            kept_outer_views: vec![],
         }
     }
 
@@ -902,6 +918,8 @@ impl<'a> JitContext<'a> {
             store: self.store,
             codegen_mode: false,
             fused_skip: None,
+            call_site_fpr_saves: HashMap::default(),
+            kept_outer_views: vec![],
             unfrozen_slots: Vec::new(),
             instr_unfrozen: Vec::new(),
             capture_events: 0,
@@ -1693,6 +1711,89 @@ impl<'a> JitContext<'a> {
     }
 
     ///
+    /// Record the `UsingFpr` a specialized call site's `fpr_save_cont`
+    /// will save, keyed by the callee instance (stage 1' write-through).
+    ///
+    pub(super) fn record_call_site_fpr_save(&mut self, callee: SpecializedId, using: UsingFpr) {
+        self.call_site_fpr_saves.insert(callee, using);
+    }
+
+    ///
+    /// The *parked* mode an outer frame holds for `slot`: `Some(fpr)` iff
+    /// it is a Float-guarded `Sf` view — the only shape the write-through
+    /// keep applies to.
+    ///
+    pub(super) fn outer_parked_sf_float(&self, outer: usize, slot: SlotId) -> Option<crate::codegen::FPReg> {
+        let pos = self.outer_pos(outer)?;
+        let st = self.stack_frame[pos].abstract_state.as_ref()?;
+        match st.mode(slot) {
+            LinkMode::Sf(fpr, crate::codegen::jitgen::state::SfGuarded::Float) => Some(fpr),
+            _ => None,
+        }
+    }
+
+    ///
+    /// Build the [`OuterFprHome`] hint for a write-through refresh of the
+    /// frame `outer` levels out, and record the kept view for the
+    /// bet-confirmation drain.
+    ///
+    pub(super) fn keep_outer_sf_view(
+        &mut self,
+        ids: Vec<SpecializedId>,
+        extra: usize,
+        outer: usize,
+        slot: SlotId,
+        fpr: crate::codegen::FPReg,
+    ) -> Option<OuterFprHome> {
+        let pos = self.outer_pos(outer)?;
+        let owner = self.stack_frame[pos].specialized_id;
+        let callee = self.stack_frame.get(pos + 1)?.specialized_id;
+        self.kept_outer_views.push((pos, slot));
+        Some(OuterFprHome::Hint {
+            ids,
+            extra,
+            owner,
+            callee,
+            fpr,
+        })
+    }
+
+    /// Mark for [`Self::drain_kept_outer_views`].
+    pub(super) fn kept_outer_views_mark(&self) -> usize {
+        self.kept_outer_views.len()
+    }
+
+    ///
+    /// Bet-confirmation for the write-through keeps a call's subtree made
+    /// (stage 1'): the subtree had a deopt-able exit or a generic yield,
+    /// so a salvage re-entry can run its compiled remainder — or the VM
+    /// can run it outright — writing the kept slots with nothing
+    /// refreshing the raw homes. Re-widen every view the subtree kept:
+    /// the boxed slot stores were emitted either way, so the slots are
+    /// current and `S` is sound; the emitted refreshes go dead (their
+    /// resolve keeps the store — it targets the owner's save area or
+    /// spill slot, both dead once nothing reads the view).
+    ///
+    pub(super) fn drain_kept_outer_views(&mut self, mark: usize, state: &mut AbstractState) {
+        let current = self.stack_frame.len() - 1;
+        for (pos, slot) in self.kept_outer_views.split_off(mark) {
+            if pos > current {
+                // The target frame was popped with its subtree; its state
+                // died with it.
+                continue;
+            }
+            if pos == current {
+                state.invalidate_innermost(slot);
+            } else {
+                if let Some(frame) = self.stack_frame[pos].abstract_state.as_mut() {
+                    frame.invalidate_slot(slot);
+                }
+                state.widen_outer_slot(current - pos, slot);
+            }
+        }
+    }
+
+    ///
     /// Resolve a `DynVarOffset::Hint` chain: the distance from the current
     /// frame's `rbp`/`x29` out to the target frame's, summed frame by
     /// frame. Used by [`Self::resolve_dyn_var_offsets`].
@@ -1797,6 +1898,47 @@ impl<'a> JitContext<'a> {
                         let resolved = self.resolve_specialized_id_chain(ids) + *extra;
                         *off = DynVarOffset::Concrete(resolved);
                     }
+                }
+            }
+            AsmInst::StoreOuterFprHomeF { home, .. } => {
+                if let OuterFprHome::Hint {
+                    ids,
+                    extra,
+                    owner,
+                    callee,
+                    fpr,
+                } = home
+                {
+                    let sigma = (self.resolve_specialized_id_chain(ids) + *extra) as i64;
+                    let disp = if fpr.0 < crate::codegen::PHYS_FPR_POOL {
+                        // Pool-resident: the home is the owner's call-site
+                        // save slot — present only if the emitted save still
+                        // covers the fpr (a later widen may have shrunk the
+                        // set; the refresh is then dead and elided).
+                        match self.call_site_fpr_saves.get(callee) {
+                            Some(using) if using[fpr.0] => {
+                                let rank = using[..fpr.0].count_ones() as i64;
+                                let sizes = self.frame_sizes_or_panic(*owner);
+                                Some(
+                                    sigma
+                                        - (sizes.total as i64 - PROLOGUE_OVERHEAD as i64)
+                                        - using.offset() as i64
+                                        + 8 * rank,
+                                )
+                            }
+                            _ => None,
+                        }
+                    } else {
+                        // Spilled: the home is the owner's own spill slot,
+                        // valid regardless of the save set.
+                        let sizes = self.frame_sizes_or_panic(*owner);
+                        Some(
+                            sigma
+                                - (sizes.base as i64 - 24
+                                    + 8 * (fpr.0 - crate::codegen::PHYS_FPR_POOL) as i64),
+                        )
+                    };
+                    *home = OuterFprHome::Concrete(disp);
                 }
             }
             AsmInst::LoopJitRspBump { offset } => {

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -1774,6 +1774,12 @@ impl<'a> JitContext<'a> {
     /// resolve keeps the store — it targets the owner's save area or
     /// spill slot, both dead once nothing reads the view).
     ///
+    // Dormant by construction today, verified by probe: a compiled
+    // generic `yield` cannot currently appear *inside* a specialized
+    // subtree — a call site passing `&blk` refuses specialization, and
+    // the given-block resolver only fails at a unit root, which is not a
+    // subtree. The belt exists for the day the specializer widens.
+    #[coverage(off)]
     pub(super) fn drain_kept_outer_views(&mut self, mark: usize, state: &mut AbstractState) {
         let current = self.stack_frame.len() - 1;
         for (pos, slot) in self.kept_outer_views.split_off(mark) {

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -989,6 +989,16 @@ pub(in crate::codegen) enum LInst {
     LoopJitRspBump {
         offset: LoopRspOffset,
     },
+    /// Write-through refresh of an outer frame's `Sf` float home
+    /// (outer-F roadmap, stage 1'): a raw-f64 store of `src` to
+    /// `[rbp + disp]`; `None` elides it (the binding was widened after
+    /// emission).
+    StoreOuterFprHomeF {
+        src: FPReg,
+        disp: Option<i64>,
+        /// The emitting frame's `base_stack_offset`, for resolving `src`.
+        base: usize,
+    },
     /// Defer a spliced non-local exit's unwind before jumping into the
     /// shared `ensure` body (#1185). The value rides in `GP::Rdx`; the
     /// degenerate outcome raises generically from `pc`.

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -63,6 +63,7 @@ impl AbstractState {
     ///
     /// Widen the innermost frame's `slot` to `S` (stage 1' drain: the
     /// boxed slot store made the slot current, so `S` is sound).
+    #[coverage(off)] // only called from the dormant drain — see `drain_kept_outer_views`
     pub(super) fn invalidate_innermost(&mut self, slot: SlotId) {
         self.frames.last_mut().unwrap().invalidate_slot(slot);
     }

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -10,7 +10,7 @@ mod slot;
 use liveness::IsUsed;
 pub(super) use liveness::Liveness;
 pub(super) use read_slot::DeoptPoint;
-use slot::SfGuarded;
+pub(in crate::codegen::jitgen) use slot::SfGuarded;
 pub(super) use slot::{Guarded, LinkMode, SlotState};
 
 #[derive(Debug, Clone)]
@@ -61,6 +61,12 @@ impl AbstractState {
     /// *outer* levels out — the live half of
     /// [`JitContext::widen_outer_slot`].
     ///
+    /// Widen the innermost frame's `slot` to `S` (stage 1' drain: the
+    /// boxed slot store made the slot current, so `S` is sound).
+    pub(super) fn invalidate_innermost(&mut self, slot: SlotId) {
+        self.frames.last_mut().unwrap().invalidate_slot(slot);
+    }
+
     pub(super) fn widen_outer_slot(&mut self, outer: usize, slot: SlotId) {
         if outer > 0 && outer < self.frames.len() {
             let level = self.frames.len() - 1 - outer;

--- a/monoruby/tests/outer_float_write_through.rs
+++ b/monoruby/tests/outer_float_write_through.rs
@@ -1,0 +1,139 @@
+//! Write-through keep: an outer frame's `Sf` float view survives a block
+//! that *writes* it (outer-F roadmap, stage 1').
+//!
+//! At a block-passing call every unboxed local is boxed into its slot and
+//! lands on `Sf` — slot current, register view kept (see
+//! `tests/float_across_block_call.rs`). A store *into* that slot from the
+//! inlined block used to widen the binding to `S`, so the owner re-read
+//! and re-unboxed the float after every call. Now such a store refreshes
+//! the view's raw-f64 home too — the owner's in-progress call-site FP
+//! save slot for a pool-resident fpr, the owner's own spill slot for a
+//! spilled one (`AsmInst::StoreOuterFprHomeF`, chain-addressed, resolved
+//! against the recorded save layout) — and keeps the binding: the owner's
+//! `fpr_restore_cont` reloads the current value and its continuation uses
+//! the float with no guard and no unbox.
+//!
+//! The boxed slot store stays authoritative on every path, which is what
+//! makes the keep path-insensitive; a deopt anywhere under the call
+//! abandons the owner's compiled continuation (unconditional side-exit
+//! escalation), so only fully-compiled paths ever consume the view. The
+//! floats below accumulate over hundreds of iterations, so any staleness
+//! or a wrong home displacement diverges from the CRuby oracle loudly.
+extern crate monoruby;
+use monoruby::tests::*;
+
+/// The motivating shape: a loop-carried float written by the block every
+/// iteration. The owner's `s += a` consumes the kept view right after
+/// each call.
+#[test]
+fn a_block_writing_a_kept_float_every_iteration() {
+    run_test(
+        r#"
+        def call_block
+          yield
+        end
+        def f(n)
+          a = n * 1.5
+          s = 0.0
+          i = 0
+          while i < 300
+            call_block { a *= 1.001 }
+            s += a
+            i += 1
+          end
+          [s, a]
+        end
+        f(3)
+        "#,
+    );
+}
+
+/// A type flip on one path: the block writes an `Integer` at one
+/// iteration, which must widen the binding (only Float-typed stores
+/// refresh the raw home).
+#[test]
+fn a_type_flip_widens_the_kept_view() {
+    run_test(
+        r#"
+        def t1
+          a = 1.5
+          s = 0.0
+          i = 0
+          while i < 300
+            [1].each { |x| if i == 150 then a = 7 else a = a.to_f * 1.001 end }
+            s += a.to_f
+            i += 1
+          end
+          [s.round(6), a]
+        end
+        t1
+        "#,
+    );
+}
+
+/// Two levels of nesting: the inner block writes a local two frames out.
+/// The chain part of the home displacement crosses both frames.
+#[test]
+fn a_write_through_two_outer_levels() {
+    run_test(
+        r#"
+        def t2
+          a = 2.0
+          s = 0.0
+          i = 0
+          while i < 300
+            [1].each { [2].each { a *= 1.001 } }
+            s += a
+            i += 1
+          end
+          [s.round(6), a.round(6)]
+        end
+        t2
+        "#,
+    );
+}
+
+/// Interaction with the spliced non-local exits (#1185): the `ensure`
+/// writes the kept slot and a `break` unwinds through it mid-loop.
+#[test]
+fn a_kept_float_across_a_spliced_break() {
+    run_test(
+        r#"
+        def t4
+          a = 0.0; c = 2.0
+          i = 0
+          while i < 300
+            [1].each do |x|
+              begin
+                a += c
+                break if i == 200
+              ensure
+                c += 0.5
+              end
+            end
+            i += 1
+          end
+          [a, c]
+        end
+        t4
+        "#,
+    );
+}
+
+/// Reads mixed with writes inside the block: the slot store stays
+/// authoritative, so the block's own re-reads see its writes.
+#[test]
+fn reads_after_writes_inside_the_block() {
+    run_test(
+        r#"
+        def t3
+          a = 1.0
+          [5].each { a += 2.5; a *= 2.0 }
+          a + 1.0
+        end
+        r = 0
+        300.times { r = t3 }
+        r
+        "#,
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -434,6 +434,7 @@
 21715255d5b7d1640238dce91ff9244f	1	case 9\n        when 0,4,8\n          0\n        when 1,5,9\n          1\n  
 21978a61b3437a37e4576edf77547099	1	def nil.foo; 1; end\n            nil.foo\n            
 21c9333fc83d8b5a0cca96f269070205	["1", "2", "3"]	def forward(&b); [1,2,3].map(&b); end\n              forward(&:to_
+21eb0e9527b038ca28ca7c0660efdabb	8.0	def t3\n          a = 1.0\n          [5].each { a += 2.5; a *= 2.0 }\n    
 21f8e47a45fd8696940d39593814b503	["hello", "world"]	require "stringio"\n\n            res = []\n            ret = StringIO.open("hello"
 21ff5a76d37a266f84d3f0dce8947ed7	[:bar, [], {a: 1, b: 2}]	class C\n          def method_missing(name, *args, **kwargs)\n           
 220d3fe1c05b2950f05bfe53024be3aa	[false, false]	m = Mutex.new\n            cv = ConditionVariable.new\n            t 
@@ -853,6 +854,7 @@
 454539e2b45442d94b7989495b4563ef	["UTF-8", [227, 129, 130]]	File.binwrite("/tmp/mr_gc2.txt", [164, 162].pack("C*"))\n           
 454e2e87849398aff023ffd47ce0568a	"hello"	c = Class.new\n            c.class_exec do\n              def hello\n 
 4578bd5fa7148d23a652a1a92eb517df	false	Enumerator.new { |y| y << caller.empty? }.first
+457f6a743618e9a691a1720e9d5b31b0	[1575.0276087749185, 6.073454154620117]	def call_block\n          yield\n        end\n        def f(n)\n          a
 45c219e430e29dc7ecd467638b65c70b	[true, true, true]	pid = spawn("true")\n            t = Process.detach(pid)\n           
 45c9b7ea3cba52cd428385897c67b953	[true, false, false, false, true, false, true, false, true, false]	S = Struct.new(:a, :b)\n        T = Struct.new(:a, :b)\n        \n\n       
 45ca7b6809a873de22eb68bc015aef5c	["abc", "abcd"]	s = +"abc"; t = s.dup; t << "d"; [s, t]
@@ -1915,6 +1917,7 @@
 9d3a8273d76bab638959e38cd8c0a68c	[[:woke], true]	r = []\n            t = Thread.new { sleep 0.05; r << :woke }\n      
 9d4ee118279609a4658649ce219050c0	"a:1 b:{x: 100, y: 200} c:"	def f\n          yield 1,x:100,y:200\n        end\n        \n\n        f do 
 9d6d362d02ec388b6d9235b807fc78d2	5	class C\n              private def f; 5; end\n              def g; f;
+9d83806180901caed6f54effcdcb82d5	[1375.093536, 8.124106059241]	def t1\n          a = 1.5\n          s = 0.0\n          i = 0\n          wh
 9d90ba7627480755e747fc4a1045f51e	[2, 1]	[1, 2, 3].each.with_index { |v, i| break [v, i] if i == 1 }
 9dad3fcfbb4f15771bbac751e3869047	42	module A\n          module B\n            module C\n              VAL = 42
 9dbc194b1b0f6de59813ff04a2e9663a	[20, 20, 100, 2, 2]	Bar = 100\n            class Foo\n              autoload :Bar, "./c"\n
@@ -2209,6 +2212,7 @@ b2d8d3b6539361a8364045da7cfbfa9e	false	a=Object.new; a.instance_variable_set("@i
 b2ec3518315b390f605929160559793b	6	eval("1 + 2 + 3")\n        
 b316ba0b3d3db4c006c0ecfa80fb0c6a	[227, 129, 130, 55]	eval(%Q{# encoding: ascii-8bit\\nx = 7\\n"\\\\u3042\\#{x}".bytes})
 b3426882a7540443a327be9a9da66f26	[10, 20, 30]	res = []\n        [10, 20, 30].each do\n            res << it\n        end
+b37435debc202e7b4697b162437ea121	[23025.0, 152.0]	def t4\n          a = 0.0; c = 2.0\n          i = 0\n          while i < 3
 b37a18c27e0a579600146a5c3a6aea5e	[:wait_readable, "hello"]	r, w = IO.pipe\n            a = r.read_nonblock(1, exception: false)
 b37c44d8c2e41bb2c540d40ee9f7ad20	[11, 220, 11, 220, 11, 220, 220, 11, 220, 11, 220]	class S\n              def g\n                x = 0\n                f
 b38e37a07c9700ce3f2acd61ef3076fa	[1, true]	base = "/tmp/monoruby_test_lutime_#{Process.pid}_#{rand(100000)}"\n 
@@ -2823,6 +2827,7 @@ e2aabc9156279396c43d9f464d256920	[-1, 1]	a = [0xFF].pack("C").force_encoding("UT
 e2b38a39e691cb690c90a70e6ffc1baf	["inner", "outer", "nil"]	log = []\n            begin\n              raise "outer"\n            
 e2c2808fdcfd4ffc06759284fa444bc6	[:a, :b]	S = Struct.new(:a, :b)\nClass.new(S).members
 e2f1f22033c587332b6550fbf0ad525b	42	__ENCODING__; 42
+e2f631ba3fe2cfe362b742fe8ef597f9	[700.012271, 2.699313]	def t2\n          a = 2.0\n          s = 0.0\n          i = 0\n          wh
 e2f7855c9efc89267cc4efaf17ca2b83	[true, true]	[Thread.current == Thread.main, Thread.current.alive?]
 e30802fc039d0a7dafc2afa6978a2fd8	[true, true]	stop = false\n            t = Thread.new { stop = true }\n           
 e3153e08936de555d02588b7435ba4c8	nil	begin\n              raise "err"\n            rescue\n            end\n


### PR DESCRIPTION
First increment of the outer-frame register roadmap discussed after #1185 ("外側のスコープのレジスタの抽象状態も現在のフレームのレジスタ同様に変更できるようにしたい"): letting a nested compile *strengthen* an outer frame's register state, starting with the one shape whose soundness needs no path analysis — the write-through keep.

## What changes

At a block-passing call every unboxed local is boxed into its slot and lands on `Sf` — slot current, register view kept (#1172/#1173). A store *into* that slot from the inlined block used to widen the binding to `S`, so the owner re-read and guard-re-unboxed the float after every call. The accumulate loop

```ruby
while i < 300
  call_block { a *= 1.001 }
  s += a          # guard + unbox, every iteration
  i += 1
end
```

paid a box and an unbox per iteration at its hottest edge.

Now a Float-typed store into a Float-guarded outer `Sf` refreshes the view's raw-f64 **home** alongside the boxed slot store, and keeps the binding:

- **pool-resident fpr** → the owner's in-progress call-site FP save slot — the very word its `fpr_restore_cont` reloads on the way back, so the owner resumes with the current value already in its register;
- **spilled fpr** → the owner's own spill slot, valid unconditionally.

One new chain-addressed instruction (`AsmInst::StoreOuterFprHomeF`) carries an `OuterFprHome::Hint`: the callee's save layout exists only once the call site is emitted (after the callee's body), so `send_specialized` / the specialized-yield site record their final `UsingFpr` per callee instance, and the pre-codegen resolve pass folds the chain distance, the owner's frame sizes and the save rank into a single rbp-relative displacement — or `Concrete(None)` when a later widen shrank the save set, which elides the now-dead store.

## Why it needs no dominance analysis

The nested compile's only channel back to the owner's parked state is path-insensitive, so a strengthening write is sound only if it holds on *every* compiled path. Two invariants make it so:

- the boxed slot store is emitted on every path either way, so slot-level truth is unconditional — the VM, deopt write-backs and chain conversions never see anything stale;
- the raw home is refreshed by every Float store on whatever paths run, and a path with no store leaves the call-time save, which equals the slot.

The kept view is consumed only by the owner's **compiled** continuation — and, exactly as the return-state comment in `compile_specialized_func` already establishes, that continuation never runs on a deopt path: side-exit escalation is unconditional (`doc/chain_deopt.md` §8.6), and the salvage re-entries resume compiled in place, having performed every write-through. `had_deopt` therefore does **not** surrender these keeps. That is a deliberate departure from the kept-constants gate one screen below, and a measured one: an earlier draft mirrored that gate, and a probe showed every keep drained (any float op's guard sets `had_deopt`), making the feature a no-op. `generic_yield` still surrenders (`drain_kept_outer_views`, mark/drain per call subtree, re-widening both the parked and live copies) — an out-of-unit block's runtime stores bypass the compile-time widen hooks. Non-Float stores and non-Float-guarded targets widen exactly as before.

## Testing

| | result |
|---|---|
| x86-64 plain `--lib --tests` | 72 targets green (lib 2366) |
| x86-64 `stress-spill-pool` | 72 targets green (lib 2366) — the spill-home arm of the resolve |
| `tests/outer_float_write_through.rs` (new, 5 shapes) | bit-exact vs the CRuby oracle |
| `cargo check --target aarch64-unknown-linux-gnu` | clean |

The shapes — the accumulate loop, a type flip (Integer store must widen), two nesting levels, interaction with #1185's spliced exits, reads-after-writes inside the block — all accumulate floats over hundreds of iterations, so a wrong home displacement or a stale view diverges from the oracle loudly rather than plausibly. Keep survival (not just correctness-via-drain) was probe-verified on the accumulate shape.

The aarch64 lowering mirrors x86 (`a64_fpr_load` into d0 + materialized-address store); the darwin job is its execution check.

## Roadmap position

Stage 1' of the plan: stage 2 is full `S → F` promotion (a store creating a *new* outer-frame spill home, which needs the entry-region dominance argument), stage 3 the `speculated_floats` save-area redirection for pool-resident outer F. The `OuterFprHome` hint and the per-call-site `UsingFpr` recording built here are the addressing substrate both reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_