### PR TITLE
JIT: move the spill-home id space to a frame-global ledger

### DIFF
--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -470,6 +470,22 @@ pub(super) struct JitStackFrame {
     ///
     return_edges: Vec<(JitLabel, Vec<AbstractFrame>, AbstractFrame, SlotId, BasicBlockId)>,
     ///
+    /// The frame-global ledger of persistent spill-home ids: one past the
+    /// highest id ever issued as a raw-f64 *home* in this frame's file
+    /// (stage-2 promotions and loop-entry adoptions, both made while the
+    /// frame is suspended). Context-side — a `JitStackFrame` exists once
+    /// per frame and is never cloned per branch — because a home id is a
+    /// physical resource (a stack slot in the frame, baked into callee
+    /// code as an address), not a per-path belief: two branches handing
+    /// out the same id to different homes could never be repaired by a
+    /// join. Issued ids stay reserved for the life of the frame: on
+    /// resume the frame's file is grown to this mark, so a home whose
+    /// claim was dropped at a join is never re-issued to a transient —
+    /// spill-resident values are not saved across calls, and the callee
+    /// code that established the home still writes it at runtime.
+    ///
+    spill_home_watermark: usize,
+    ///
     /// Nested loop count.
     ///
     loop_count: usize,
@@ -679,6 +695,7 @@ impl JitStackFrame {
             loop_info: indexmap::IndexMap::default(),
             loop_outer_reads: HashMap::default(),
             return_edges: vec![],
+            spill_home_watermark: 0,
             loop_count: 0,
             branch_map: HashMap::default(),
             backedge_map: HashMap::default(),
@@ -708,6 +725,10 @@ impl JitStackFrame {
             loop_info: indexmap::IndexMap::default(),
             loop_outer_reads: HashMap::default(),
             return_edges: vec![],
+            // Analysis walks allocate home ids too; starting from the
+            // live mark keeps their ids consistent with what codegen
+            // will issue, and the clone's bumps die with it.
+            spill_home_watermark: self.spill_home_watermark,
             loop_count: 0,
             branch_map: HashMap::default(),
             backedge_map: HashMap::default(),
@@ -1328,6 +1349,15 @@ impl<'a> JitContext<'a> {
                 state.invalidate_at(pos, slot);
             }
         }
+        // Sync every frame's file with its home ledger: ids issued while
+        // the frame was suspended stay reserved even when the claim they
+        // carried was dropped at a join — the callee code that
+        // established such a home still writes it at runtime, so a
+        // transient re-issued into it would be clobbered across the next
+        // call (spill-resident values are not saved at call boundaries).
+        for pos in 0..self.stack_frame.len() {
+            state.grow_frame_fpr_to(pos, self.stack_frame[pos].spill_home_watermark);
+        }
         Ok(frame)
     }
 
@@ -1558,6 +1588,22 @@ impl<'a> JitContext<'a> {
     }
 
     ///
+    /// Issue a persistent spill-home id for the frame at stack position
+    /// *pos*, from its frame-global ledger (see
+    /// [`JitStackFrame::spill_home_watermark`]). *live_len* is the
+    /// allocating path's current view of that frame's file length —
+    /// taking the max keeps the id clear of every transient the path
+    /// has live; the caller then binds the id on the live chain (which
+    /// grows the file past it).
+    ///
+    fn alloc_spill_home_at(&mut self, pos: usize, live_len: usize) -> crate::codegen::FPReg {
+        let frame = &mut self.stack_frame[pos];
+        let id = frame.spill_home_watermark.max(live_len);
+        frame.spill_home_watermark = id + 1;
+        crate::codegen::FPReg(id)
+    }
+
+    ///
     /// Stage-C loop adoption, the decision itself (called from the
     /// loop-entry merge, codegen pass only): for every outer-frame slot
     /// the loop's subtree read as a raw f64 — read straight off the back
@@ -1567,8 +1613,9 @@ impl<'a> JitContext<'a> {
     /// state*. The entry edges establish the home (chain load, Float
     /// guard, unbox, store); the claim's scope is handled by the joins
     /// themselves — a path that bypassed the head meets it back to `S`.
-    /// The owner's (parked) file only reserves the id, keeping the
-    /// owner's own later allocations from colliding with the home.
+    /// The id comes from the owner's frame-global ledger
+    /// ([`JitStackFrame::spill_home_watermark`]), which keeps it clear
+    /// of the owner's own allocations for the life of the frame.
     ///
     pub(super) fn adopt_outer_loop_views(
         &mut self,
@@ -1615,10 +1662,7 @@ impl<'a> JitContext<'a> {
                 {
                     continue;
                 }
-                let Some(parked) = self.stack_frame[pos].abstract_state.as_mut() else {
-                    continue;
-                };
-                let fpr = parked.reserve_spill_home();
+                let fpr = self.alloc_spill_home_at(pos, target[pos].fpr_len());
                 let Some(home) = self.outer_fpr_home_hint_at_pos(pos, fpr) else {
                     continue;
                 };
@@ -2021,17 +2065,14 @@ impl<'a> JitContext<'a> {
                 return None;
             }
         }
-        {
-            let parked = self.stack_frame[pos].abstract_state.as_ref()?;
-            if !matches!(parked.mode(slot), LinkMode::S(_)) {
-                return None;
-            }
+        // Only a plain boxed slot promotes — checked on the live chain,
+        // the same truth the read decisions consult (a sibling call's
+        // earlier promotion arrives here through the threaded chain).
+        let level = state.outer_level(outer)?;
+        if !matches!(state[level].mode(slot), LinkMode::S(_)) {
+            return None;
         }
-        let fpr = self.stack_frame[pos]
-            .abstract_state
-            .as_mut()
-            .unwrap()
-            .alloc_spill_home(slot);
+        let fpr = self.alloc_spill_home_at(pos, state[level].fpr_len());
         state.promote_outer_sf(outer, slot, fpr);
         let home = self.keep_outer_sf_view(ids.to_vec(), extra, outer, slot, fpr)?;
         Some((fpr, home))

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -78,7 +78,7 @@ impl AbstractState {
     /// twin of [`JitContext::outer_pos`]. `outer == 0` is the innermost
     /// frame itself; a link leaving the chain answers `None`.
     ///
-    fn outer_level(&self, outer: usize) -> Option<usize> {
+    pub(super) fn outer_level(&self, outer: usize) -> Option<usize> {
         let mut level = self.frames.len().checked_sub(1)?;
         for _ in 0..outer {
             level = level.checked_sub(self.frames[level].lexical_outer()?)?;
@@ -109,6 +109,17 @@ impl AbstractState {
 
     pub(super) fn depth(&self) -> usize {
         self.frames.len()
+    }
+
+    ///
+    /// Grow the file of the frame at chain position *pos* to *len* —
+    /// the resume-time sync with the frame's home ledger
+    /// (`JitStackFrame::spill_home_watermark`): every id the ledger has
+    /// issued stays reserved in the file, so a home whose claim was
+    /// dropped at a join is never re-issued to a transient.
+    ///
+    pub(super) fn grow_frame_fpr_to(&mut self, pos: usize, len: usize) {
+        self.frames[pos].grow_fpr_to(len);
     }
 
     ///
@@ -143,11 +154,11 @@ impl AbstractState {
     /// [`JitContext::widen_outer_slot`].
     ///
     ///
-    /// Stage 2: mirror an outer-frame `S -> Sf` promotion into the live
-    /// chain (the context's parked copy was promoted by the caller). The
-    /// clone's file may be shorter than the parked one it diverged from —
-    /// grow it so the id resolves; the merge machinery already reconciles
-    /// differing lengths between sibling clones (`grow_fpr_to`).
+    /// Stage 2: bind an outer-frame `S -> Sf` promotion on the live
+    /// chain. The id comes from the owner's frame-global ledger and may
+    /// lie past this file's length — grow it so the id resolves; the
+    /// merge machinery already reconciles differing lengths between
+    /// sibling clones (`grow_fpr_to`).
     ///
     pub(super) fn promote_outer_sf(&mut self, outer: usize, slot: SlotId, fpr: FPReg) {
         if outer == 0 {

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -55,9 +55,19 @@ mod alloc_policy {
         /// path (it is the original Phase-0 scan).
         ///
         fn pick_vacant(&self, state: &SlotState) -> Option<FPReg> {
-            (0..state.fpr_alloc.len()).map(FPReg).find(|&fpr| {
-                !state.fpr_alloc.is_pinned(fpr) && state.fpr_alloc.is_vacant(fpr)
-            })
+            // Pool registers only, per this phase's contract ("vacant
+            // phys"). A vacant *spill* id must not be re-issued: it may
+            // be a persistent raw-f64 home whose binding this path does
+            // not carry (issued from the frame's home ledger while the
+            // frame was suspended, or dropped at a join) — and homes are
+            // written by callee code at runtime, while spill-resident
+            // values are not saved across calls. Retired transient spill
+            // ids are also skipped; that only costs frame bytes.
+            (0..state.fpr_alloc.len().min(PHYS_FPR_POOL))
+                .map(FPReg)
+                .find(|&fpr| {
+                    !state.fpr_alloc.is_pinned(fpr) && state.fpr_alloc.is_vacant(fpr)
+                })
         }
 
         ///
@@ -99,7 +109,11 @@ mod alloc_policy {
         // the stack is canonical. The default `victim_rank` is the pool index, so
         // `min_by_key` selects the same register the prior `for 0..len { return
         // first }` scan did.
-        let victim = (0..state.fpr_alloc.len())
+        // Pool registers only, like phase 0: "freeing" a spill id gains
+        // nothing over a fresh phase-2 spill (both are stack slots), and
+        // demoting a spill-resident raw-f64 *home* would re-issue an id
+        // that callee code still writes at runtime.
+        let victim = (0..state.fpr_alloc.len().min(PHYS_FPR_POOL))
             .map(FPReg)
             .filter(|&fpr| !state.fpr_alloc.is_pinned(fpr) && !state.fpr_alloc.is_vacant(fpr))
             .filter(|&fpr| {
@@ -606,7 +620,7 @@ impl SlotState {
     /// Used by `gen_bridge` so the source state can grow its own
     /// `fpr` vec up to the target's width before merge bridging.
     ///
-    pub(super) fn fpr_len(&self) -> usize {
+    pub(in crate::codegen::jitgen) fn fpr_len(&self) -> usize {
         self.fpr_alloc.len()
     }
 
@@ -815,29 +829,6 @@ impl SlotState {
         self.clear(slot);
         self.set_mode(slot, LinkMode::F(fpr));
         self.fpr_add(slot, fpr);
-    }
-
-    ///
-    /// Stage 2 outer promotion: allocate a fresh spill-resident fpr as the
-    /// raw-f64 home of *slot* and bind it `Sf(Float)`. Force-spill (never a
-    /// pool register): the home must survive arbitrarily many callee
-    /// frames, and a spill slot of this frame does so unconditionally.
-    ///
-    pub(in crate::codegen::jitgen) fn alloc_spill_home(&mut self, slot: SlotId) -> FPReg {
-        let fpr = self.fpr_alloc.push_spill();
-        self.set_Sf(slot, fpr, SfGuarded::Float);
-        fpr
-    }
-
-    ///
-    /// Reserve a spill-resident home id in this (the owner's) file
-    /// without binding any slot — for a promotion whose binding lives on
-    /// the live chain only (the loop-entry adoption). The file is the
-    /// single id space for the owner, so the reservation keeps the
-    /// owner's own later allocations from colliding with the home.
-    ///
-    pub(in crate::codegen::jitgen) fn reserve_spill_home(&mut self) -> FPReg {
-        self.fpr_alloc.push_spill()
     }
 
     ///


### PR DESCRIPTION
Follow-up to #1194, retiring the parked frame copies' last cross-frame role. A persistent raw-f64 home id is a physical resource — a stack slot in the owner's frame, baked into callee code as an address — not a per-path belief: two branches handing the same id to different homes could never be repaired by a join. The parked copies provided the un-forked id space by accident of being one-per-frame; this PR gives that ledger an explicit, honest home.

## What changed

**`JitStackFrame::spill_home_watermark`** — one past the highest home id ever issued in the frame's file. Context-side, because a `JitStackFrame` exists once per frame and is never cloned per branch; analysis clones inherit the mark and their bumps die with them, so analysis and codegen issue identical id sequences. Stage-2 promotions and loop-entry adoptions now issue ids as `max(ledger, the allocating path's file length)`, bind on the live chain only, and never touch the parked copy. The stage-2 gate reads the live chain too (a sibling call's earlier promotion arrives through the threaded chain). On resume, every frame's file is grown to its ledger mark. `SlotState::{alloc_spill_home, reserve_spill_home}` are deleted.

**A hazard the old scheme left open, closed.** The investigation surfaced that spill-resident values are not saved across calls (only pool registers are — `using_fpr_offset` skips spills since they "already live on the stack"), while callee code that established a home keeps writing it at runtime. So a home id that went vacant — a loop-adoption reservation, which never bound the owner's file, or a claim dropped at a join — must never be re-issued to a transient: the transient's spill slot would be clobbered across the next call into that callee. Accordingly, `pick_vacant` (phase 0) and the phase-1 victim scan are capped at the physical pool. This is pure safety at zero cost: re-issuing a vacant spill id, or demoting an all-`Sf` spill resident, gains nothing over a fresh phase-2 spill — both are stack slots — and is exactly the unsafe reuse. Frame sizing is unaffected either way: it scans the emitted IR (`max_virt_fpreg_id`), recursively through nested units, so every referenced id is covered regardless of who issued it.

With this, the parked copies' cross-frame roles are fully retired. What remains is the suspended frame's own resume record — park/take, widen invalidations, the capture mirror — which is its legitimate job.

## Verification

- Full default and `stress-spill-pool` suites: **3578/0 each** (the stress pool of 2 exercises the capped phases hard).
- aarch64 `cargo check` clean.
- Ledger allocation probe-verified firing on stage-2 and loop-adoption shapes, with consistent ids between the analysis and codegen passes.
- Benchmarks flat vs master, including the stage-C loop-adoption shapes (`stagec_times`, `stagec_readheavy_times`, `pureread_times`); mandelbrot / nbody bit-identical vs CRuby.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_