### PR TITLE
JIT: defer outer-float store boxing to the claim's surrender points (stage 1'')

### DIFF
--- a/doc/trace_chain_joins.md
+++ b/doc/trace_chain_joins.md
@@ -137,30 +137,34 @@ constant claims (`outer_const_count`, `adopt_outer_widenings`,
 
 `JitStackFrame.abstract_state` — the frame a compile parks when it
 suspends for a nested compile — is no longer a truth channel for
-cross-frame claims. What remains:
+cross-frame claims. Its one remaining job is **the suspended frame's own
+resume record**: the caller level resumes from it (§3), and subtree
+events that must reach that record do so under strict monotone rules —
+widens (`widen_outer_at_pos`, dual-written with the live chain and
+logged) and capture unsets.
 
-- **The suspended frame's own resume record.** The caller level resumes
-  from it (§3). Subtree events that must reach that record do so under
-  strict monotone rules: widens (`widen_outer_at_pos`, dual-written with
-  the live chain and logged), capture unsets, and the stage-2 `Sf`
-  promotion binding.
-- **The spill-home id space.** A frame's spill-resident FPR ids must be
-  unique across its whole life — its own compile segments and every
-  claim a nested compile makes while it is suspended — and the parked
-  file's allocator is that single id space. Loop-entry adoption reserves
-  ids there without binding (`reserve_spill_home`); stage-2 promotion
-  allocates and binds (`alloc_spill_home`).
-- **The stage-2 gate** (`try_promote_outer_sf` requires the owner's
-  parked mode to still be a plain `S`).
+The two roles that outlived the join unification were retired by the
+**frame-global home ledger** (`JitStackFrame::spill_home_watermark`). A
+persistent raw-f64 home id is a physical resource — a stack slot in the
+owner's frame, baked into callee code as an address — not a per-path
+belief, so its id space cannot live in the per-path-cloned state; the
+parked copy had provided it by accident of being one-per-frame. The
+ledger is context-side (one per frame, never cloned per branch; analysis
+clones inherit the mark and their bumps die with them), promotions and
+adoptions issue `max(ledger, the allocating path's file length)` and
+bind on the live chain only, the stage-2 gate reads the live chain, and
+on resume every frame's file is grown to its ledger mark. That growth —
+together with capping the allocator's vacant-pick and demote-victim
+phases at the physical pool — closes a reuse hazard the parked scheme
+left open: spill-resident values are not saved across calls, and callee
+code that established a home keeps writing it at runtime, so a home id
+that went vacant must never be re-issued to a transient.
 
 Never publish a nested compile's view of a frame *into* its parked slot:
 that replaces the state the suspended frame will resume from with a view
 taken at a different program point, in a different frame's terms — three
 levels of nested blocks segfaulted in generated code when this was
-tried. Retiring the remaining allocator/gate roles would need an
-allocator that lives outside the frame's state (with a resume-time sync
-into the owner's own allocator); that is allocator engineering, distinct
-from the join semantics this document records.
+tried.
 
 ## 8. Rejected alternatives
 
@@ -184,3 +188,20 @@ from the join semantics this document records.
   capture guard (with its tombstone check, §4) already covers ancestor
   promotions, so stage-C adoption gates on the invariant rather than
   poisoning the whole loop.
+- **Dead outer-home store elimination.** A whole-tree use scan at
+  resolve time (collect every home the finished compile reads — chain
+  reads, the owner's own references, exit write-backs — and elide
+  `StoreOuterFprHomeF`s to homes read nowhere) was built and probed,
+  and found no targets: a store to a *constant* never exists (the
+  kept-`C` machinery folds the claim and surrenders per return path,
+  §2), and every surviving non-constant home had migrated to a **pool**
+  register by codegen time — the owner, once resumed as the innermost
+  frame, re-places `Sf(spill)` claims into the pool at its own merges
+  (`allow_fpr`), and pool-home refreshes already ride the save-set
+  channel, whose shrunk-set case elides them. This held even under
+  `stress-spill-pool` (67 spill promotions, zero spill stores emitted,
+  across the outer-float suite). Pool-home dead-store analysis would
+  need binding-sensitive (per-store, flow-sensitive) liveness — pool
+  ids are reused constantly, so id-level liveness says nothing — and
+  was not pursued. The machinery was reverted; this note is what it
+  bought.

--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -3307,6 +3307,29 @@ impl Codegen {
         true
     }
 
+    /// Stage 1'' surrender write — mirror of x86
+    /// `emit_box_outer_home_to_dynvar`: raw f64 at `[x29 + disp]` into d0,
+    /// boxed via `f64_to_val` (absolute call, same page-split reasoning as
+    /// `a64_gen_chain_replay_stub`), and stored to the owner's slot
+    /// through the chain.
+    pub(in crate::codegen::jitgen) fn emit_box_outer_home_to_dynvar(
+        &mut self,
+        disp: i64,
+        offset: usize,
+        reg: SlotId,
+    ) -> bool {
+        let f64_to_val_addr = self.jit.get_label_address(&self.f64_to_val).as_ptr() as u64;
+        monoasm_arm64!(&mut self.jit,
+            mov x10, (disp as u64);
+            add x10, x29, x10;
+            ldr d0, [x10];
+            mov x9, (f64_to_val_addr);
+            blr x9;              // x0 = Value
+        );
+        self.store_dyn_var_specialized(offset, reg, GP::Rax);
+        true
+    }
+
     /// Stage 3a home read — mirror of x86 `emit_load_outer_fpr_home_f`:
     /// raw f64 from `[x29 + disp]` into `dst` via the d0 scratch.
     pub(in crate::codegen::jitgen) fn emit_load_outer_fpr_home_f(

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -175,6 +175,7 @@ impl Codegen {
             | AsmInst::StoreOuterFprHomeF { .. }
             | AsmInst::LoadOuterFprHomeF { .. }
             | AsmInst::GuardFloatToOuterHomeF { .. }
+            | AsmInst::BoxOuterHomeToDynVar { .. }
             | AsmInst::StoreDynVarSpecialized { .. }
             | AsmInst::Inline(..)
             | AsmInst::ArrayIndex { .. }
@@ -2778,6 +2779,28 @@ impl Codegen {
         monoasm! { &mut self.jit,
             movq [rbp + (disp)], xmm0;
         }
+    }
+
+    /// Stage 1'' surrender write: raw f64 at `[rbp + disp]` (the owner's
+    /// spill home) into xmm0, boxed via `f64_to_val`, and stored to the
+    /// owner's slot through the chain (same addressing as
+    /// `store_dyn_var_specialized`).
+    ///
+    /// ### destroy
+    /// - rax, rcx, xmm0
+    pub(in crate::codegen::jitgen) fn emit_box_outer_home_to_dynvar(
+        &mut self,
+        disp: i64,
+        offset: usize,
+        reg: SlotId,
+    ) {
+        let disp = i32::try_from(disp).expect("outer home displacement out of i32 range");
+        let f64_to_val = self.f64_to_val.clone();
+        monoasm! { &mut self.jit,
+            movq xmm0, [rbp + (disp)];
+            call f64_to_val;
+        }
+        self.store_dyn_var_specialized(offset, reg, GP::Rax);
     }
 
     /// Stage 3a home read: raw f64 from `[rbp + disp]` into `dst` (this

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -2653,6 +2653,23 @@ pub(super) enum AsmInst {
         home: OuterFprHome,
         deopt: AsmDeopt,
     },
+    ///
+    /// Stage 1'' (deferred outer boxing), the surrender write: the frame
+    /// *pos* levels down holds a deferred `F(spill home)` claim this path
+    /// is giving up — load the raw f64 from the home, box it
+    /// (`f64_to_val`), and store the Value into the owner's slot through
+    /// the chain. The claim's dual of the kept-`C` surrender: emitted on
+    /// exactly the paths where the join demotes the claim, so every
+    /// resuming path arrives with the slot current.
+    ///
+    /// ### destroy
+    /// - rax, rcx (x86-64) / x0, x9, x10 (aarch64), xmm0/d0
+    ///
+    BoxOuterHomeToDynVar {
+        home: OuterFprHome,
+        offset: DynVarOffset,
+        reg: SlotId,
+    },
     LoadDynVarSpecialized {
         /// Machine stack offset in bytes. Emitted as a
         /// `DynVarOffset::Hint(...)` chain by Pass 1; the pre-codegen
@@ -2896,7 +2913,8 @@ impl AsmInst {
             }
             // Same over-reservation as the two above: the adopted home's
             // id must size the owner's spill region.
-            Self::GuardFloatToOuterHomeF { home, .. } => {
+            Self::GuardFloatToOuterHomeF { home, .. }
+            | Self::BoxOuterHomeToDynVar { home, .. } => {
                 if let OuterFprHome::Hint { fpr, .. } = home {
                     vec![*fpr]
                 } else {

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -1114,6 +1114,13 @@ impl Codegen {
                     base: frame.base_stack_offset,
                 })
             }
+            AsmInst::BoxOuterHomeToDynVar { home, offset, reg } => {
+                let disp = home.unwrap_concrete().expect(
+                    "deferred outer home is always a spill slot — its resolve is unconditional",
+                );
+                let offset = offset.unwrap_concrete();
+                self.encode_linst(LInst::BoxOuterHomeToDynVar { disp, offset, reg });
+            }
             AsmInst::GuardFloatToOuterHomeF { home, deopt } => {
                 let disp = home.unwrap_concrete().expect(
                     "adopted outer home is always a spill slot — its resolve is unconditional",
@@ -1704,6 +1711,9 @@ impl Codegen {
             }
             LInst::GuardFloatToOuterHomeF { src, disp, deopt } => {
                 self.emit_guard_float_to_outer_home_f(src, disp, &deopt);
+            }
+            LInst::BoxOuterHomeToDynVar { disp, offset, reg } => {
+                self.emit_box_outer_home_to_dynvar(disp, offset, reg);
             }
             LInst::Yield { callid, simple, error, evict } => {
                 self.emit_yield(callid, simple, &error, evict);

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -569,17 +569,25 @@ impl<'a> JitContext<'a> {
                 // boundaries); after that a Value use falls back to the
                 // ordinary `F` re-box, which is always sound.
                 if let Some((ids, extra, true)) = self.outer_specialized_ids(state, src.outer)
-                    && let Some(afpr) = state.outer_sf_float(src.outer, src.reg)
+                    && let Some(afpr) = state.outer_float_home(src.outer, src.reg)
                 {
-                    let alias = crate::codegen::jitgen::state::DynVarAliasLoad {
-                        ids: ids.clone(),
-                        extra,
-                        reg: src.reg,
-                    };
+                    // Stage B's slot-reading alias only under `Sf` — a
+                    // stage-1'' deferred `F(home)` leaves the owner's slot
+                    // stale, so a Value use must re-box from the raw f64,
+                    // never load the slot.
+                    let alias = state
+                        .outer_sf_float(src.outer, src.reg)
+                        .map(|_| crate::codegen::jitgen::state::DynVarAliasLoad {
+                            ids: ids.clone(),
+                            extra,
+                            reg: src.reg,
+                        });
                     if let Some(home) = self.outer_fpr_home_hint(ids, extra, src.outer, afpr) {
                         let dfpr = state.def_F_new(dst);
                         ir.push(AsmInst::LoadOuterFprHomeF { dst: dfpr, home });
-                        state.set_dynvar_alias(dst, alias);
+                        if let Some(alias) = alias {
+                            state.set_dynvar_alias(dst, alias);
+                        }
                         self.restore_unfrozen(Some(dst));
                         return Ok(CompileResult::Continue);
                     }

--- a/monoruby/src/codegen/jitgen/compile/dispatch.rs
+++ b/monoruby/src/codegen/jitgen/compile/dispatch.rs
@@ -121,7 +121,7 @@ impl<'a> JitContext<'a> {
         // merge state inherited an empty file from `declare_merge`, so every
         // arm has to pay its own residents back to their stack homes first.
         arm.flush_gp(ir);
-        arm.gen_bridge_all(ir, &m.target.slot_states(), m.pc);
+        arm.gen_bridge_all(ir, &m.target.slot_states(), m.pc, &self.chain_surrender_table());
         if jump {
             ir.push(AsmInst::Br(m.merge));
         }

--- a/monoruby/src/codegen/jitgen/compile/variables.rs
+++ b/monoruby/src/codegen/jitgen/compile/variables.rs
@@ -274,6 +274,7 @@ impl<'a> JitContext<'a> {
         // (chain escalation), and the salvage re-entry case is confirmed
         // after the fact by `drain_kept_outer_views`. The slot store
         // below stays authoritative either way.
+        let mut deferred = false;
         let keep = match &outer_spec {
             Some((ids, extra, true)) => {
                 let fsrc = match state.mode(src) {
@@ -287,12 +288,55 @@ impl<'a> JitContext<'a> {
                     _ => None,
                 };
                 fsrc.and_then(|fsrc| {
-                    if let Some(afpr) = state.outer_sf_float(dst.outer, dst.reg) {
-                        // Stage 1': the owner already holds a Float `Sf`
-                        // view — refresh its existing home.
+                    if let Some(afpr) = state.outer_float_home(dst.outer, dst.reg) {
+                        // Stage 1'' (deferred boxing): a *spill* home is
+                        // addressable from everywhere that may need the
+                        // boxed value later — the surrender bridges, the
+                        // claim barrier, and the deopt write-backs (an
+                        // `F(spill)` entry boxes from its slot natively).
+                        // Weaken the owner to `F(home)` and skip the boxed
+                        // slot store: the per-iteration cost of the store
+                        // becomes one raw movq. Only for an owner already
+                        // holding a *spill* home (a stage-2 promotion in
+                        // this subtree, or the loop-entry `F(home)`
+                        // adoption). A pool `Sf` keeps the stage-1' boxed
+                        // store: migrating it to a fresh spill mid-callee
+                        // was tried, and on shapes where the claim dies at
+                        // every return join (a conditional store) it
+                        // churns the owner through `S -> Sf(pool)`
+                        // re-establishment bridges every iteration — the
+                        // occupied-pool tmp path of that bridge is exactly
+                        // the fragile-under-pressure code the loop
+                        // adoption exists to avoid.
+                        let hfpr = afpr;
+                        if hfpr.0 < crate::codegen::PHYS_FPR_POOL {
+                            let home = self.keep_outer_sf_view(
+                                ids.clone(),
+                                *extra,
+                                dst.outer,
+                                dst.reg,
+                                hfpr,
+                            )?;
+                            return Some((fsrc, home));
+                        }
                         let home = self
-                            .keep_outer_sf_view(ids.clone(), *extra, dst.outer, dst.reg, afpr)?;
-                        Some((fsrc, home))
+                            .keep_outer_sf_view(ids.clone(), *extra, dst.outer, dst.reg, hfpr)?;
+                        deferred = true;
+                        // The live chain carries the claim; the *parked*
+                        // copy — the owner's conservative resume base —
+                        // is widened like any other store: if the claim
+                        // survives every return path, the resume overlay
+                        // re-adopts the joined `F(home)`; if it dies at a
+                        // join, the surrender write on the losing edges
+                        // made the slot current and the owner resumes at
+                        // plain `S`. Leaving the parked view in place
+                        // instead resumed the owner believing its pool
+                        // register still held the value this store just
+                        // changed.
+                        self.widen_outer_slot(dst.outer, dst.reg);
+                        state.defer_outer_boxing_to(dst.outer, dst.reg, hfpr);
+                        ir.push(AsmInst::StoreOuterFprHomeF { src: fsrc, home });
+                        return None; // fully handled — `deferred` skips the rest
                     } else {
                         // Stage 2: the owner holds only `S` — promote it to
                         // `Sf` with a fresh spill home, when this store
@@ -307,6 +351,12 @@ impl<'a> JitContext<'a> {
             }
             _ => None,
         };
+        if deferred {
+            // Stage 1'': the home refresh above is the whole store — the
+            // claim (owner `F(home)`) says so, and every path that has to
+            // give it up boxes from the home there.
+            return;
+        }
         if keep.is_none() {
             // The store invalidates whatever the outer frame's abstract
             // state claimed about this slot — in both places that track

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -1475,7 +1475,7 @@ impl<'a> JitContext<'a> {
         len.checked_sub(1)?.checked_sub(outer)
     }
 
-    fn outer_pos(&self, outer: usize) -> Option<usize> {
+    pub(super) fn outer_pos(&self, outer: usize) -> Option<usize> {
         let mut i = self.stack_frame.len() - 1;
         for _ in 0..outer {
             i -= self.stack_frame[i].outer?;
@@ -1524,7 +1524,7 @@ impl<'a> JitContext<'a> {
     /// loop-entry init whose owner is reachable through a *block's*
     /// lexical chain but not the (method) frame the loop head sits in.
     ///
-    fn specialized_ids_at_pos(&self, pos: usize) -> (Vec<SpecializedId>, usize) {
+    pub(super) fn specialized_ids_at_pos(&self, pos: usize) -> (Vec<SpecializedId>, usize) {
         let end = self.stack_frame.len() - 1;
         let chain = &self.stack_frame[pos..end];
         let ids = chain.iter().map(|f| f.specialized_id).collect();
@@ -1540,7 +1540,7 @@ impl<'a> JitContext<'a> {
     /// stack position *pos* — the pos-addressed sibling of
     /// [`Self::outer_fpr_home_hint`].
     ///
-    fn outer_fpr_home_hint_at_pos(
+    pub(super) fn outer_fpr_home_hint_at_pos(
         &self,
         pos: usize,
         fpr: crate::codegen::FPReg,
@@ -1596,7 +1596,7 @@ impl<'a> JitContext<'a> {
     /// has live; the caller then binds the id on the live chain (which
     /// grows the file past it).
     ///
-    fn alloc_spill_home_at(&mut self, pos: usize, live_len: usize) -> crate::codegen::FPReg {
+    pub(super) fn alloc_spill_home_at(&mut self, pos: usize, live_len: usize) -> crate::codegen::FPReg {
         let frame = &mut self.stack_frame[pos];
         let id = frame.spill_home_watermark.max(live_len);
         frame.spill_home_watermark = id + 1;
@@ -2234,6 +2234,25 @@ impl<'a> JitContext<'a> {
                     }
                 }
             }
+            AsmInst::BoxOuterHomeToDynVar { home, offset, .. } => {
+                if let DynVarOffset::Hint { ids, extra } = offset {
+                    let resolved = self.resolve_specialized_id_chain(ids) + *extra;
+                    *offset = DynVarOffset::Concrete(resolved);
+                }
+                if let OuterFprHome::Hint {
+                    ids, extra, owner, fpr, ..
+                } = home
+                {
+                    debug_assert!(fpr.0 >= crate::codegen::PHYS_FPR_POOL);
+                    let sigma = (self.resolve_specialized_id_chain(ids) + *extra) as i64;
+                    let sizes = self.frame_sizes_or_panic(*owner);
+                    *home = OuterFprHome::Concrete(Some(
+                        sigma
+                            - (sizes.base as i64 - 24
+                                + 8 * (fpr.0 - crate::codegen::PHYS_FPR_POOL) as i64),
+                    ));
+                }
+            }
             AsmInst::StoreOuterFprHomeF { home, .. }
             | AsmInst::LoadOuterFprHomeF { home, .. }
             | AsmInst::GuardFloatToOuterHomeF { home, .. } => {
@@ -2695,6 +2714,28 @@ impl<'a> JitContext<'a> {
     /// captures the live bump, like every other dynvar hint emitted
     /// under the call).
     ///
+    ///
+    /// Per-level chain addressing for the bridge-time stage-1'' surrender
+    /// writes ([`AbstractFrame::bridge_at`]'s deferred-`F` demotion arms):
+    /// for every suspended level, the specialized-id chain that addresses
+    /// its frame from the innermost, plus its unit id (the spill-home
+    /// owner). `None` for the innermost frame (its own bridges box
+    /// through the ordinary own-frame arms).
+    ///
+    pub(super) fn chain_surrender_table(&self) -> crate::codegen::jitgen::state::ChainSurrender {
+        let len = self.stack_frame.len();
+        let per_level = (0..len)
+            .map(|level| {
+                if level + 1 >= len {
+                    return None;
+                }
+                let (ids, extra) = self.specialized_ids_at_pos(level);
+                Some((ids, extra, self.stack_frame[level].specialized_id))
+            })
+            .collect();
+        crate::codegen::jitgen::state::ChainSurrender { per_level }
+    }
+
     fn build_return_segments(
         &mut self,
         frame: &mut JitStackFrame,
@@ -2731,9 +2772,36 @@ impl<'a> JitContext<'a> {
                                 src: GP::Rax,
                             });
                         }
-                        // A suspended frame's `F` is path-invariant (its
-                        // only copy sits in a call-site save area nothing
-                        // here can address); the join must have kept it.
+                        // Stage 1'': this path's deferred-boxing home was
+                        // demoted by the join — box it into the owner's
+                        // slot on this edge, the write-side twin of the
+                        // kept-`C` surrender above.
+                        (LinkMode::F(l), tfm)
+                            if l.0 >= crate::codegen::PHYS_FPR_POOL
+                                && !matches!(tfm, LinkMode::F(r) if l == r) =>
+                        {
+                            let (ids, extra) = ids_extra
+                                .get_or_insert_with(|| self.ids_spanning_from_callee(lvl))
+                                .clone();
+                            let owner = self.stack_frame[lvl].specialized_id;
+                            ir.push(AsmInst::BoxOuterHomeToDynVar {
+                                home: OuterFprHome::Hint {
+                                    ids: ids.clone(),
+                                    extra,
+                                    owner,
+                                    // Unused for a spill home (only the
+                                    // pool save-set branch reads it).
+                                    callee: owner,
+                                    fpr: l,
+                                },
+                                offset: DynVarOffset::Hint { ids, extra },
+                                reg: slot,
+                            });
+                        }
+                        // A suspended pool `F` is path-invariant (its only
+                        // copy sits in a call-site save area nothing here
+                        // can address); the join must have kept it. A kept
+                        // spill `F` matches the join by the arm above.
                         (LinkMode::F(l), tfm) => {
                             debug_assert!(
                                 matches!(tfm, LinkMode::F(r) if l == r),

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -1016,6 +1016,14 @@ pub(in crate::codegen) enum LInst {
         disp: i64,
         deopt: DestLabel,
     },
+    /// Stage 1'' surrender write: load the raw f64 at `[rbp + disp]`
+    /// (the owner's spill home), box it via `f64_to_val`, and store the
+    /// Value to the owner's slot at the pre-resolved chain offset.
+    BoxOuterHomeToDynVar {
+        disp: i64,
+        offset: usize,
+        reg: SlotId,
+    },
     /// Defer a spliced non-local exit's unwind before jumping into the
     /// shared `ensure` body (#1185). The value rides in `GP::Rdx`; the
     /// degenerate outcome raises generically from `pc`.

--- a/monoruby/src/codegen/jitgen/merge.rs
+++ b/monoruby/src/codegen/jitgen/merge.rs
@@ -24,7 +24,7 @@ impl<'a> JitContext<'a> {
                 eprintln!("    {mode:?} src:{src_bb:?}");
 
                 let mut ir = AsmIr::new(self);
-                state.gen_bridge_all(&mut ir, &target, pc);
+                state.gen_bridge_all(&mut ir, &target, pc, &self.chain_surrender_table());
                 match mode {
                     BranchMode::Side { dest } => {
                         self.add_outline_bridge(ir, dest, bbid);
@@ -204,7 +204,20 @@ impl<'a> JitContext<'a> {
                                 || (subtree_read.contains(&i)
                                     && matches!(be.mode(i), LinkMode::S(_)))
                         };
-                        target.keep_backedge_floats(adopt, adopt_sf, promotable);
+                        // Stage 1'': a spill-home view at the back edge is
+                        // store-driven (only `try_promote_outer_sf` and the
+                        // deferring store create one) — adopt it as
+                        // `F(home)` so the deferral holds across the whole
+                        // loop. See `keep_backedge_floats`.
+                        let adopt_deferred = |i| match be.mode(i) {
+                            LinkMode::Sf(h, SfGuarded::Float) | LinkMode::F(h)
+                                if h.0 >= crate::codegen::PHYS_FPR_POOL =>
+                            {
+                                Some(h)
+                            }
+                            _ => None,
+                        };
+                        target.keep_backedge_floats(adopt, adopt_sf, adopt_deferred, promotable);
                     }
                 }
                 // §27.3 Stage-2a: record the loop-carried float set `L` (slots
@@ -311,7 +324,7 @@ impl<'a> JitContext<'a> {
                     deopt,
                 });
             }
-            state.gen_bridge_all(&mut ir, &target, pc);
+            state.gen_bridge_all(&mut ir, &target, pc, &self.chain_surrender_table());
             match mode {
                 BranchMode::Side { dest } => {
                     self.add_outline_bridge(ir, dest, bbid);

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -226,6 +226,7 @@ impl AbstractState {
         ir: &mut AsmIr,
         target: &[SlotState],
         pc: BytecodePtr,
+        sur: &ChainSurrender,
     ) {
         #[cfg(feature = "jit-debug")]
         eprintln!("      from:{:?}", &self);
@@ -251,7 +252,7 @@ impl AbstractState {
                 frame.locals()
             };
             for slot in slots {
-                frame.bridge_at(ir, tgt, slot, pc, outer);
+                frame.bridge_at(ir, tgt, slot, pc, outer, sur, level);
             }
         }
     }
@@ -290,10 +291,30 @@ impl AbstractState {
         let mut widened = vec![];
         for level in (0..depth).rev() {
             let outer = depth - 1 - level;
-            let frame = &mut self.frames[level];
-            for i in frame.locals() {
-                if frame.unbox_to_S_at(ir, i, outer) {
-                    widened.push((level, i));
+            for i in self.frames[level].locals() {
+                match self.frames[level].unbox_to_S_at(ir, i, outer) {
+                    crate::codegen::jitgen::state::slot::OuterBarrier::Kept => {}
+                    crate::codegen::jitgen::state::slot::OuterBarrier::Widened => {
+                        widened.push((level, i));
+                    }
+                    crate::codegen::jitgen::state::slot::OuterBarrier::BoxHome(fpr) => {
+                        // Stage 1'': the deferred home's slot is stale and
+                        // the outgoing block can read it — box the home
+                        // into the slot through the chain, on this (the
+                        // only) path into the call. Addressing is still
+                        // valid here: the claim was created under the
+                        // no-capture invariant, and this site's own unset
+                        // happens after the barrier.
+                        let (ids, extra) = jitctx.specialized_ids_at_pos(level);
+                        if let Some(home) = jitctx.outer_fpr_home_hint_at_pos(level, fpr) {
+                            ir.push(crate::codegen::jitgen::asmir::AsmInst::BoxOuterHomeToDynVar {
+                                home,
+                                offset: crate::codegen::jitgen::DynVarOffset::Hint { ids, extra },
+                                reg: i,
+                            });
+                        }
+                        widened.push((level, i));
+                    }
                 }
             }
         }
@@ -376,6 +397,48 @@ impl AbstractState {
         }
     }
 
+    ///
+    /// The live chain's raw-f64 home of the slot *outer* lexical levels
+    /// out, if it holds one — `Sf(Float)` (home and slot both current) or
+    /// a stage-1'' deferred `F(spill home)` (home current, slot stale).
+    /// Either licenses a home-directed read; only `Sf` licenses the
+    /// slot-reading alias (stage B).
+    ///
+    pub(super) fn outer_float_home(&self, outer: usize, slot: SlotId) -> Option<FPReg> {
+        match self.outer_mode(outer, slot)? {
+            LinkMode::Sf(fpr, SfGuarded::Float) => Some(fpr),
+            LinkMode::F(fpr) if fpr.0 >= crate::codegen::PHYS_FPR_POOL => Some(fpr),
+            _ => None,
+        }
+    }
+
+    ///
+    /// Stage 1'' — defer the boxing of a float store into the frame
+    /// *outer* levels out: the owner's `Sf(spill home)` weakens to
+    /// `F(home)` (home authoritative, slot stale). The caller emits only
+    /// the raw home refresh; the boxed slot store moves to the surrender
+    /// paths (return-join demotions, the claim barrier) and the deopt
+    /// write-backs (an `F` entry boxes from its spill slot natively).
+    ///
+    pub(super) fn defer_outer_boxing_to(&mut self, outer: usize, slot: SlotId, hfpr: FPReg) {
+        debug_assert!(hfpr.0 >= crate::codegen::PHYS_FPR_POOL);
+        if let Some(level) = self.outer_level(outer) {
+            let frame = &mut self.frames[level];
+            match frame.mode(slot) {
+                // Already deferred to this home by an earlier store.
+                LinkMode::F(fpr) if fpr == hfpr => {}
+                // Upgrade (spill `Sf` keeps its home) or migrate (a pool
+                // view moves to the fresh ledger home the caller's store
+                // initializes).
+                LinkMode::Sf(_, SfGuarded::Float) | LinkMode::F(_) => {
+                    frame.grow_fpr_to(hfpr.0 + 1);
+                    frame.set_F(slot, hfpr);
+                }
+                m => debug_assert!(false, "defer_outer_boxing_to on {m:?}"),
+            }
+        }
+    }
+
     pub(super) fn outer_mode(&self, outer: usize, slot: SlotId) -> Option<LinkMode> {
         if outer == 0 {
             return None;
@@ -417,6 +480,54 @@ pub(crate) struct AbstractFrame {
     /// assuming the chain holds only lexical ancestors, which is what
     /// lets the chain grow to the whole trace (join unification).
     lexical_outer: Option<usize>,
+}
+
+///
+/// Per-level chain addressing for bridge-time stage-1'' surrender writes
+/// — built by [`JitContext::chain_surrender_table`], consumed by
+/// [`AbstractFrame::bridge_at`]'s deferred-`F` demotion arms.
+///
+pub(super) struct ChainSurrender {
+    /// `(ids, extra, owner unit)` per chain level; `None` for the
+    /// innermost frame.
+    pub(super) per_level: Vec<Option<(Vec<crate::codegen::jitgen::context::SpecializedId>, usize, crate::codegen::jitgen::context::SpecializedId)>>,
+}
+
+impl ChainSurrender {
+    ///
+    /// Emit the box-from-home surrender write for the deferred `F(spill)`
+    /// claim of *slot* on the frame at chain position *level*. Returns
+    /// false when the table has no addressing for that level (never the
+    /// case for a genuinely suspended frame).
+    ///
+    pub(super) fn emit_box(
+        &self,
+        ir: &mut AsmIr,
+        level: usize,
+        fpr: FPReg,
+        slot: SlotId,
+    ) -> bool {
+        let Some(Some((ids, extra, owner))) = self.per_level.get(level) else {
+            return false;
+        };
+        ir.push(crate::codegen::jitgen::asmir::AsmInst::BoxOuterHomeToDynVar {
+            home: crate::codegen::jitgen::OuterFprHome::Hint {
+                ids: ids.clone(),
+                extra: *extra,
+                owner: *owner,
+                // Unused for a spill home (only the pool save-set branch
+                // reads it at resolve).
+                callee: *owner,
+                fpr,
+            },
+            offset: crate::codegen::jitgen::DynVarOffset::Hint {
+                ids: ids.clone(),
+                extra: *extra,
+            },
+            reg: slot,
+        });
+        true
+    }
 }
 
 impl std::ops::Deref for AbstractFrame {

--- a/monoruby/src/codegen/jitgen/state/join.rs
+++ b/monoruby/src/codegen/jitgen/state/join.rs
@@ -92,7 +92,33 @@ impl AbstractFrame {
             // `apply_join` allocating inline. Behaviour is identical to the old
             // fused per-slot match.
             let mut action = self.decide_join(other, i);
-            if !allow_fpr {
+            if allow_fpr {
+                // Stage 1'', the loop-boundary meet: when one side holds a
+                // *spill-home* `F` and the other a Float view in a
+                // different register, prefer the spill home. The bridge on
+                // the non-F side is then a register move into the home
+                // (once, on that edge); the generic meet would instead
+                // pick the register view and make the F side box at every
+                // arrival — for a loop back edge, a `f64_to_val` per
+                // iteration, the exact cost the deferral removes.
+                action = match (self.mode(i), other.mode(i)) {
+                    (LinkMode::F(x), LinkMode::Sf(y, SfGuarded::Float))
+                    | (LinkMode::Sf(y, SfGuarded::Float), LinkMode::F(x))
+                    | (LinkMode::F(x), LinkMode::F(y))
+                        if x != y && x.0 >= PHYS_FPR_POOL =>
+                    {
+                        JoinAction::SetF(x)
+                    }
+                    (LinkMode::F(y), LinkMode::F(x))
+                        if x != y && y.0 < PHYS_FPR_POOL && x.0 >= PHYS_FPR_POOL =>
+                    {
+                        JoinAction::SetF(x)
+                    }
+                    _ => action,
+                };
+            } else {
+                // `SetF` (the stage-1'' spill-home meet) passes through:
+                // it binds no new register, exactly like `SetSf`.
                 action = action.without_fpr();
             }
             #[cfg(debug_assertions)]
@@ -202,6 +228,11 @@ enum JoinAction {
     TryFreshSfElseS(SfGuarded),
     /// `_ -> S(guarded)`
     SetS(Guarded),
+    /// rebind to `F(x)` with the current fpr `x` — the suspended-frame
+    /// meet of a deferred-boxing claim (stage 1''): `F(h)` against
+    /// `Sf(h, Float)` or `F(h)` weakens the slot-current half and keeps
+    /// the home, emitting nothing (the home is current on both sides).
+    SetF(FPReg),
 }
 
 impl JoinAction {
@@ -248,6 +279,19 @@ impl AbstractFrame {
                 }
             }
             (LinkMode::F(_), LinkMode::C(r)) if r.is_float() => Nop,
+            // Stage 1'' deferred boxing: `F(h)` against the same *spill*
+            // home's `Sf` meets to `F(h)` — the home (the spill slot) is
+            // the canonical copy on both sides, and only the slot-current
+            // half is dropped. Emitting nothing on either edge. The
+            // generic arm below would meet to `Sf`, forcing the F side to
+            // box at every loop boundary — the cost the deferral exists
+            // to remove.
+            (LinkMode::F(x), LinkMode::Sf(y, SfGuarded::Float))
+            | (LinkMode::Sf(x, SfGuarded::Float), LinkMode::F(y))
+                if x == y && x.0 >= PHYS_FPR_POOL =>
+            {
+                SetF(x)
+            }
             (LinkMode::F(x), LinkMode::Sf(_, _))
             | (LinkMode::Sf(x, _), LinkMode::Sf(_, _) | LinkMode::F(_)) => {
                 let mut guarded = match self.mode(i) {
@@ -316,6 +360,13 @@ impl AbstractFrame {
                 }
             }
             JoinAction::SetS(guarded) => self.set_S_with_guard(i, guarded),
+            JoinAction::SetF(x) => {
+                // The fpr may be bound only on the *other* side (a spill
+                // id this branch never allocated) — grow the file so the
+                // rebind resolves; the reverse map stays exact.
+                self.grow_fpr_to(x.0 + 1);
+                self.set_F(i, x);
+            }
         }
     }
 }

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -802,10 +802,28 @@ impl SlotState {
         &mut self,
         adopt: impl Fn(SlotId) -> bool,
         adopt_sf: impl Fn(SlotId) -> bool,
+        adopt_deferred: impl Fn(SlotId) -> Option<FPReg>,
         promotable: impl Fn(SlotId) -> bool,
     ) {
         for i in self.all_regs() {
             if !promotable(i) {
+                continue;
+            }
+            // Stage 1'': the back edge carries a spill-home view of a
+            // slot the loop's subtree *stores* each iteration (the home
+            // came from a store-driven promotion). Adopt `F(home)`
+            // directly — slot stale, home authoritative: the entry
+            // bridge's one guard+unbox establishes the home, the body's
+            // deferring stores refresh it in place, and the back edge
+            // meets `F(h) ⊔ F(h)` with nothing emitted. Adopting an `Sf`
+            // here instead (the pre-deferral behavior) declares the slot
+            // current, which the codegen pass's deferring store then
+            // breaks — re-boxing at the back edge every iteration.
+            if let Some(h) = adopt_deferred(i)
+                && matches!(self.mode(i), LinkMode::S(_))
+            {
+                self.grow_fpr_to(h.0 + 1);
+                self.set_F(i, h);
                 continue;
             }
             // `try_set_new_F` / `try_set_new_Sf` (no phase-2 spill): only
@@ -1297,6 +1315,19 @@ impl SlotState {
                     self.grow_fpr_to(fpr.0 + 1);
                     self.set_Sf(slot, fpr, SfGuarded::Float);
                 }
+                // Stage 1'': the subtree deferred this slot's boxing —
+                // every resuming path either kept the home current (the
+                // claim) or boxed it into the slot on its return segment,
+                // so adopting the joined `F(spill home)` is exactly as
+                // sound as the kept `C` above. The parked mode may be `S`
+                // (the claim began as a stage-2 promotion in the subtree)
+                // or the pre-call `Sf` (the deferral upgraded it).
+                (LinkMode::S(_) | LinkMode::Sf(_, _), LinkMode::F(fpr))
+                    if fpr.0 >= crate::codegen::PHYS_FPR_POOL =>
+                {
+                    self.grow_fpr_to(fpr.0 + 1);
+                    self.set_F(slot, fpr);
+                }
                 _ => {}
             }
         }
@@ -1365,8 +1396,30 @@ impl SlotState {
             // box the store writes is a `Value::float` (the same reasoning
             // as `bridge_at`'s `F -> Sf` arm).
             LinkMode::F(fpr) if keep_claims => {
-                ir.spill(Spill::Fpr(fpr, slot));
-                self.set_Sf(slot, fpr, SfGuarded::Float);
+                // Stage 1'': a spill-resident float's slot may stay stale
+                // across a specialized call. The callee reads the value
+                // through the chain claim (a home read of the spill slot),
+                // a store refreshes the same slot, and any deopt under the
+                // call boxes it from there via the call site's write-back
+                // — boxing here would re-pay, at every call, the store the
+                // deferral removed.
+                if fpr.0 >= PHYS_FPR_POOL {
+                    return;
+                }
+                // A pool `F`'s only copy would sit in the call-site save
+                // area, which neither the callee's chain reads nor the
+                // exits can address. Boxing it here (the old behavior)
+                // costs an `f64_to_val` per call, per iteration in a loop;
+                // moving the raw f64 to a fresh spill slot instead costs
+                // one store and turns the claim into the addressable
+                // `F(spill)` above — the callee reads and refreshes it in
+                // place, and the boxed value is materialized only where a
+                // path actually gives the claim up.
+                let h = self.fpr_alloc.push_spill();
+                self.fpr_remove(slot, fpr);
+                self.fpr_add(slot, h);
+                self.set_mode(slot, LinkMode::F(h));
+                ir.fpr_move(fpr, h);
             }
             LinkMode::F(fpr) => {
                 let guarded = self.guarded(slot);
@@ -1997,6 +2050,21 @@ pub(in crate::codegen::jitgen) enum Placement {
 /// instead of pushing `AsmInst`, and the lowering pass replays them via
 /// [`Spill::emit`].
 ///
+///
+/// What [`SlotState::unbox_to_S_at`] did to an outer-frame claim at the
+/// block-handout barrier.
+///
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(in crate::codegen::jitgen) enum OuterBarrier {
+    /// Nothing given up (no claim, or an unreachable method-caller `F`).
+    Kept,
+    /// A slot-current claim dropped — report the widen, emit nothing.
+    Widened,
+    /// A stage-1'' deferred home dropped — the caller emits the
+    /// box-from-home surrender write, then reports the widen.
+    BoxHome(FPReg),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(in crate::codegen::jitgen) enum Spill {
     None,
@@ -2353,6 +2421,8 @@ impl AbstractFrame {
         slot: SlotId,
         pc: BytecodePtr,
         outer: usize,
+        sur: &crate::codegen::jitgen::state::ChainSurrender,
+        level: usize,
     ) {
         if outer == 0 {
             return self.bridge(ir, target, slot, pc);
@@ -2371,6 +2441,32 @@ impl AbstractFrame {
         match (self.mode(slot), target.mode(slot)) {
             (LinkMode::F(l), LinkMode::F(r)) if l == r => {
                 return;
+            }
+            // Stage 1'' deferred boxing. Weakening `Sf(h)` to the target's
+            // deferred `F(h)` is pure state (both claim the home current;
+            // the slot-current half is dropped)...
+            (LinkMode::Sf(l, _), LinkMode::F(r))
+                if l == r && l.0 >= crate::codegen::PHYS_FPR_POOL =>
+            {
+                self.set_F(slot, l);
+            }
+            // ...while demoting a deferred `F(h)` to anything slot-current
+            // boxes the home into the owner's slot through the chain — the
+            // write-side surrender, mirrored per edge like the kept-`C`
+            // literal write.
+            (LinkMode::F(l), LinkMode::Sf(r, g))
+                if l == r && l.0 >= crate::codegen::PHYS_FPR_POOL =>
+            {
+                let ok = sur.emit_box(ir, level, l, slot);
+                debug_assert!(ok, "no chain addressing for a suspended frame at {level}");
+                self.set_Sf(slot, l, g);
+            }
+            (LinkMode::F(l), LinkMode::S(_))
+                if l.0 >= crate::codegen::PHYS_FPR_POOL =>
+            {
+                let ok = sur.emit_box(ir, level, l, slot);
+                debug_assert!(ok, "no chain addressing for a suspended frame at {level}");
+                self.set_S_with_guard(slot, Guarded::Float);
             }
             (LinkMode::V, LinkMode::V)
             | (LinkMode::None, LinkMode::None)
@@ -2404,8 +2500,11 @@ impl AbstractFrame {
 
     ///
     /// [`Self::unbox_to_S`] for a slot of the frame *outer* levels out:
-    /// give the claim up, emitting nothing, for the reason above. Returns
-    /// whether anything was given up.
+    /// give the claim up, for the reason above. Most claims go with
+    /// nothing emitted; a stage-1'' deferred `F(spill home)` — whose slot
+    /// is genuinely stale — reports [`OuterBarrier::BoxHome`] so the
+    /// caller ([`AbstractState::all_frames_unbox_to_S`]) can emit the
+    /// box-from-home surrender write through the chain.
     ///
     #[allow(non_snake_case)]
     pub(in crate::codegen::jitgen) fn unbox_to_S_at(
@@ -2413,28 +2512,36 @@ impl AbstractFrame {
         ir: &mut AsmIr,
         slot: SlotId,
         outer: usize,
-    ) -> bool {
+    ) -> OuterBarrier {
         if outer == 0 {
             self.unbox_to_S(ir, slot, false);
-            return false;
+            return OuterBarrier::Kept;
         }
         match self.mode(slot) {
             // The slot holds the boxed value; only the read-only view goes.
             LinkMode::Sf(_, _) => {
                 self.set_mode(slot, LinkMode::S(Guarded::Value));
-                true
+                OuterBarrier::Widened
             }
             LinkMode::C(_) => {
                 self.set_mode(slot, LinkMode::S(Guarded::Value));
-                true
+                OuterBarrier::Widened
             }
-            // A suspended *method* caller can hold `F` across its call (the
-            // value lives in its call-site save area). The block handed out
-            // here cannot reach that frame — every frame a block's lexical
-            // chain crosses was homed at its own block-handing call site —
-            // so the stale slot is never read and the binding stays.
-            LinkMode::F(_) => false,
-            _ => false,
+            // Stage 1'': a deferred-boxing home — the slot is stale, and
+            // the block handed out here can reach it, so the barrier must
+            // materialize the boxed value before the call.
+            LinkMode::F(fpr) if fpr.0 >= PHYS_FPR_POOL => {
+                self.set_mode(slot, LinkMode::S(Guarded::Float));
+                OuterBarrier::BoxHome(fpr)
+            }
+            // A suspended *method* caller can hold a pool `F` across its
+            // call (the value lives in its call-site save area). The block
+            // handed out here cannot reach that frame — every frame a
+            // block's lexical chain crosses was homed at its own
+            // block-handing call site — so the stale slot is never read
+            // and the binding stays.
+            LinkMode::F(_) => OuterBarrier::Kept,
+            _ => OuterBarrier::Kept,
         }
     }
 

--- a/monoruby/tests/outer_float_write_through.rs
+++ b/monoruby/tests/outer_float_write_through.rs
@@ -732,3 +732,156 @@ fn a_non_local_return_resumes_from_the_entry_chain() {
         "#,
     );
 }
+
+/// Stage 1'' (deferred outer boxing), the canonical shape: the block
+/// stores a float into the caller's slot every iteration. The owner's
+/// claim rides as `F(spill home)` — slot stale, home authoritative — so
+/// the per-iteration cost is one raw store; boxing happens once, where
+/// the value is finally consumed as a Value.
+#[test]
+fn a_deferred_store_boxes_only_at_the_loop_exit() {
+    run_test(
+        r#"
+        def call_block
+          yield
+        end
+        def w1(a, b)
+          s = 0.0
+          i = 0
+          while i < 300
+            call_block { s = s * a + b }
+            i += 1
+          end
+          s
+        end
+        w1(0.999, 0.5)
+        "#,
+    );
+}
+
+/// Two deferred slots, read and written by the block each iteration —
+/// the home reads and refreshes must stay consistent with each other.
+#[test]
+fn two_deferred_slots_read_and_written_by_the_block() {
+    run_test(
+        r#"
+        def call_block
+          yield
+        end
+        def w2
+          a = 1.0
+          s = 0.0
+          i = 0
+          while i < 300
+            call_block { s += a * 1.000001; a = a * 0.9999999 + 0.0000001 }
+            i += 1
+          end
+          [s, a]
+        end
+        w2
+        "#,
+    );
+}
+
+/// A conditional store inside the block: one path defers, the other
+/// leaves the pre-store claim — the join demotes and the F-side edge
+/// must box the home into the slot (the surrender bridge).
+#[test]
+fn a_conditional_deferred_store_surrenders_on_the_other_path() {
+    run_test(
+        r#"
+        def call_block
+          yield
+        end
+        def w3(q)
+          s = 1.5
+          r = []
+          i = 0
+          while i < 300
+            call_block { s = s * q if i % 3 == 0 }
+            r << s if i % 97 == 0
+            i += 1
+          end
+          [s, r]
+        end
+        w3(1.001)
+        "#,
+    );
+}
+
+/// The claim barrier: after deferring stores, the loop hands a block to
+/// a generic callee — the barrier must box the home into the slot
+/// before the call, since the outgoing block's runtime reads bypass
+/// every compile-time claim.
+#[test]
+fn a_generic_call_materializes_the_deferred_home() {
+    run_test(
+        r#"
+        def call_block
+          yield
+        end
+        def w4(q)
+          s = 0.25
+          t = 0.0
+          i = 0
+          while i < 300
+            call_block { s = s * q + 0.001 }
+            [s].each { |x| t += x } if i % 50 == 0
+            i += 1
+          end
+          [s, t]
+        end
+        w4(1.0001)
+        "#,
+    );
+}
+
+/// Deopt under a deferred claim: the store's operand type flips
+/// mid-run, so the guard deopts while the owner's slot is stale — the
+/// evict write-back must box the value from the spill home before the
+/// interpreter resumes.
+#[test]
+fn a_type_flip_deopt_boxes_from_the_deferred_home() {
+    run_test(
+        r#"
+        def call_block
+          yield
+        end
+        def w5(arr)
+          s = 0.5
+          arr.each do |v|
+            call_block { s = s + v }
+          end
+          s
+        end
+        r = []
+        40.times { r << w5([0.5] * 40) }
+        r << w5([0.25] * 30 + [7])
+        [r.last, r.first]
+        "#,
+    );
+}
+
+/// A break out of the deferring block: the non-local exit leaves the
+/// compiled return paths, so the claim must reach the slot through the
+/// deopt/exit machinery, never read stale.
+#[test]
+fn a_break_under_a_deferred_claim_stays_consistent() {
+    run_test(
+        r#"
+        def call_block
+          yield
+        end
+        def w6
+          s = 1.25
+          i = 0
+          while i < 300
+            call_block { s = s * 1.001; break if s > 2.0 }
+            i += 1
+          end
+          [s, i]
+        end
+        w6
+        "#,
+    );
+}

--- a/monoruby/tests/outer_float_write_through.rs
+++ b/monoruby/tests/outer_float_write_through.rs
@@ -885,3 +885,150 @@ fn a_break_under_a_deferred_claim_stays_consistent() {
         "#,
     );
 }
+
+/// A promote-then-defer pair inside one block, with the second store
+/// conditional: the unconditional store promotes the owner to the
+/// slot-current `Sf(home)` (no loop head adopts it — the owner is
+/// method-compiled), the deferring arm weakens it to `F(home)`, and the
+/// if-merge meets the two claims over the same spill home — keeping the
+/// home and weakening the `Sf` edge in place, with no box on either.
+#[test]
+fn a_conditional_second_store_meets_the_promoted_view() {
+    run_test(
+        r#"
+        def call_block
+          yield
+        end
+        def w7(s, flag)
+          call_block do
+            s = s * 1.001
+            if flag
+              s = s + 0.5
+            end
+            s
+          end
+          s
+        end
+        r = 0.0
+        50.times { |i| r += w7(1.5 + r * 0.001, i % 2 == 0) }
+        r
+        "#,
+    );
+}
+
+/// The mirrored arm order (a reading arm laid out first): the merge
+/// still keeps the shared spill home whichever edge fixes the target.
+#[test]
+fn a_conditional_store_in_the_else_arm_meets_the_promoted_view() {
+    run_test(
+        r#"
+        def call_block
+          yield
+        end
+        def w8(s, flag)
+          t = 0.0
+          call_block do
+            s = s * 1.001
+            if flag
+              t = s + 0.25
+            else
+              s = s + 0.5
+            end
+            s
+          end
+          [s, t]
+        end
+        r = 0.0
+        50.times { |i| r += w8(1.5 + r * 0.001, i % 2 == 0)[0] }
+        r
+        "#,
+    );
+}
+
+/// Two stores to the same slot in one block body: the first store
+/// promotes the owner to a spill-homed `Sf`, and the second defers from
+/// that `Sf` — the upgrade arm that drops only the slot-current half.
+#[test]
+fn a_second_store_defers_from_the_promoted_view() {
+    run_test(
+        r#"
+        def call_block
+          yield
+        end
+        def w9
+          s = 1.5
+          i = 0
+          while i < 300
+            call_block do
+              s = s * 1.001
+              s = s + 0.0005
+            end
+            i += 1
+          end
+          s
+        end
+        w9
+        "#,
+    );
+}
+
+/// A promoted-then-deferred claim where one return segment leaves via
+/// `next` still holding `F(home)` and the fallthrough re-widens the slot
+/// with an integer: the return join demotes to plain `S`, and the
+/// deferring segment boxes the home through the chain on its own edge.
+#[test]
+fn an_early_next_surrenders_per_return_segment() {
+    run_test(
+        r#"
+        def call_block
+          yield
+        end
+        def w10(s, flag)
+          call_block do
+            s = s * 1.001
+            s = s + 0.5
+            if flag
+              next 1
+            end
+            s = 0
+            2
+          end
+          s
+        end
+        r = 0
+        50.times { |i| r = [w10(1.5 + i * 0.001, i % 3 != 0), r].first }
+        r
+        "#,
+    );
+}
+
+/// A suspended *method* caller holding a bare pool float across its call:
+/// the barrier walk for a block handed out deeper in the chain must keep
+/// that binding (the frame is unreachable from the block), not box it.
+#[test]
+fn a_pool_float_in_a_suspended_method_frame_survives_a_barrier() {
+    run_test(
+        r#"
+        def leaf
+          a = [1, 2]
+          a.each { |x| a }
+          a.size
+        end
+        def mid
+          leaf + 1
+        end
+        def w11
+          x = 0.5
+          y = x * 2.0
+          i = 0
+          r = 0
+          while i < 300
+            r = mid
+            i += 1
+          end
+          [x, y, r]
+        end
+        w11
+        "#,
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -456,6 +456,7 @@
 23868e074ac73bfea9c45758469abb55	["0.15e3", "0.15e-1", "0.123e3"]	require "rubygems"\n        require "bigdecimal"\n        res = []\n      
 238dac5c14eb1e5ebc188a5c3d5178b0	[true, true, true, true, "instance of IO needed", nil]	require "stringio"\n\n            res = []\n            # (obj, level) — Integer 2n
 239549c97fe9daba196ffabee457a2e2	[Encoding::UndefinedConversionError, [97, 63, 98]]	(a=(begin; "→".encode("IBM437"); rescue Encoding::UndefinedConversionError => e;
+23a0218d69caec2b834ff308ccc59f36	[1.6576735465811328, [1.5014999999999998, 1.5503002457376653, 1.6006865480747698, 1.6543631658861948]]	def call_block\n          yield\n        end\n        def w3(q)\n          
 23b5c46bdfbd2a1aa2005c0fb1a745ec	[[0, :a, 2], [0, 1, :a, :b, :c, :d, 6, 7, 8, 9], [0, :a, :b, :c, :d, :e, :f, 7, 8, 9], [0, 1, 2], [0, 1, 2, 3, 4, 5, :a, :b, :c, :d], [0, 1, 2, 3, 4, :a, :b, :c, :d, 9], [:a, :b, 4, 5, 6, 7, 8, 9], [:a, :b, :c, :d, :e, :f, 4, 5, 6, 7, 8, 9], [0, 1, 2, 3, 4, 5, 6, 7, :a, :b, :c, :d], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, :a, :b, :c, :d], [0, 1, 42, 6, 7, 8, 9], [0, 1, :x, :y, :z, :w, 6, 7, 8, 9], [0, 1, nil, 6, 7, 8, 9], [0, 1, 0, 1, 2, 3, 4, 5, 6, 7, 6, 7], [:a, :b, :c, :d], IndexError, FrozenError, [0, :a, :b, :c, 4, 5, 6, 7, 8, 9], [0, :a], [0, :a, :b, 3, 4, 5, 6, 7, 8, 9], [0, :a, :b, 3, 4, 5, 6, 7, 8, 9], [0, 1, :a, :b, 6, 7, 8, 9], ArgumentError, IndexError]	class ToAry; def to_ary = [:x, :y, :z, :w]; end\n        def sl0(a, i, v
 23bc3351ce47d94e083999fe38415774	["old+new", "fresh"]	ENV["MONORUBY_ENV_TEST_BLK"] = "old"\n            ENV.merge!("MONORU
 23e6b8b59d2037e9f3b0bae2a98f7d40	true	FileTest.readable?("/bin/sh")
@@ -565,6 +566,7 @@
 2b510e03b79828da0942ba4c9373ce3d	["wrong number of arguments (given 1, expected 2+)", true]	def rq(a, b, *c); end\n            m1 = begin; rq(1); rescue Argumen
 2b5b6ab6b8da93e6db6006879fa273a5	6	x = "wor"; "hello world" =~ /#{x}ld/
 2b64130006b71bbb74c8bb727d06d0ed	[[10, 20, 30], [10, 20, 30]]	class E\n              def initialize(a); @a = a; end\n              
+2b6c13f023cd91b33099b2a063fca4c3	129.64648392195028	def call_block\n          yield\n        end\n        def w1(a, b)\n       
 2b80e35e675c69b12c235aeda04b3512	[true, true, true, false, false, false]	class Object\n              def tp1; 1; end\n              protected 
 2b87eaf9abc9671b3f0ed0a3582bc372	[100, 100, 42]	$res = []\n        class C\n        \tdef f\n        \t\t100\n      
 2b92ff3de3e79725a67adfb4ee7eddd7	1	c = Class.new\n            c.const_set(:FOO, 1)\n            c.send(:
@@ -634,6 +636,7 @@
 32c2b7533445abe2c786addc24166b66	"3/4"	Rational(0.75).to_s
 32dc2c8ce60f570a592f91cf451f6746	99	class C\n          X = 99\n        end\n        \nC.class_eval("X")
 32f8a3ccb6465782cb76e9906981206c	777	class C\n          private\n          def secret; 777; end\n        end\n  
+330c0d9b8d65fb03e7e8ec58a22e4a99	[300.00029999999936, 1.0]	def call_block\n          yield\n        end\n        def w2\n          a =
 3311ccd4cb9cd7e5df6df18d7421cb90	nil	Exception.new.backtrace_locations
 33151d5f5ddac3016b0004900224a63a	["warning: the block passed to 'UBWarn#unused' may be ignored\\n", "", "", "", "", "warn-bg", "", "", "silent-strict"]	def cap\n          saved = $stderr\n          buf = +""\n          io = Ob
 3320b224735f4ca919ccdcccb8c4e5bd	-450.5353775047145	def calc(i)\n          f = i * 1.1; g = i * 0.9; h = i * 1.3; j = i * 0.
@@ -1024,6 +1027,7 @@
 50dc75cab4d7c00e25ec748ffac45bee	"[C2, M, C1, M, Object, Kernel, BasicObject]"	module M\n            end\n            class C1\n            end\n     
 50f9e525cff9a725780f19b016aaa8f9	[-2.0, -2.0, 8.0, 999]	$flag = false\n        def fmaybe\n          Integer.class_eval("def +(o)
 5103d830753ac483d2d4c39e44bc03b5	[0, 0, nil]	["‌" =~ /[[:word:]]/, "‍" =~ /[[:word:]]/, "‌" =~ /\\w/]
+511247f2a3b645da0c49c9876a105a9e	[1.687070598505588, 300]	def call_block\n          yield\n        end\n        def w6\n          s =
 5153f5263b097f08fb57811bdbdc5aaa	[true, true, true, false, true, true, true, false, false, false, false]	class A\n          def method1; end\n          protected\n          def pr
 5174f3c6fa3195d1fbd047639e4a904d	[[true, {data: 42}], ["async", "ctx"], [[[true, ["both"]], [false, []]], true, "both", false]]	r = []\n            de = Class.new(StandardError) { attr_reader :dat
 51be01e0d292ac0d9c77567390f1d11f	["Bbar", "B[239, 191, 189]", "Bdbar", "Btbar", Encoding::UndefinedConversionError, [ArgumentError, "too big fallback string"], TypeError, Encoding::UndefinedConversionError]	(r=[]; r << "B�".encode(Encoding::US_ASCII, fallback: { "�" => "bar" }); r << "B
@@ -1272,6 +1276,7 @@
 66d3a720ccfcd8a4c65aa4a7264f96c3	nil	um = Integer.instance_method(:to_s)\n        um.source_location\n        
 66de5b13ad3146aa31137d2a2a57cbda	[1, 2, 3, 4, 9]	t = Process::Tms.new(1, 2, 3, 4)\n            u = Process::Tms.new\n 
 66ffaa1b0f890b32d4446740cc7383f4	["Struct::MStructA", 1, "two"]	Struct.new("MStructA", :a, :b)\n            \n\n            s = Struct
+670c773e2073e18117a7165d0039c444	[0.5621431308531042, 2.282033618166754]	def call_block\n          yield\n        end\n        def w4(q)\n          
 676948299cc86ad51d988c8190977471	:OVERRIDDEN	class Float; def -(o); :OVERRIDDEN; end; end; 3.0 - 4.0
 676a91e7312a022bcb4dc087ee24de72	["super", nil]	class S\n              def f\n                defined?(super)\n       
 67825914c378828613082b33f1dd81d4	[45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45]	j = 42\n        a = []\n        f = ->(x){x + j}\n        for i in 0..30\n 
@@ -2683,6 +2688,7 @@ d580dc9cae27404632621b762b7de5a8	""	f = File.open("/dev/null")\n            f.re
 d596c9980b2a827151179a99b5e3af5e	{"amount" => 1}	M = Data.define(:amount, :unit)\nM.new(1, "m").deconstruct_keys(["amount"])
 d5af874066319ba603a85fd17d84867b	[1, true, 15, false]	pid = fork { sleep 5 }\n            count = Process.kill("TERM", pid
 d5df22aa40370195aea7d6fbeed48540	[true, 0, false, 1]	IO.popen(["true"]) { |io| io.read }\n            a = [$?.exited?, $?
+d5e09e5c474b635d3ec99416426e1f5d	[15.0, 20.5]	def call_block\n          yield\n        end\n        def w5(arr)\n        
 d5eb36d331547e68e65b5e236315bb2c	false	File.exist?("../LICENCE-MIT")
 d5ec889974c38262d62062c5b088a2ff	"ASCII-8BIT"	"abc".b.reverse.encoding.to_s
 d5f2b019270b0aa4e77071d07cc78f9c	"secret"	class Foo\n          private\n          def secret; "secret"; end\n       

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -76,6 +76,7 @@
 051c6c1a4febd93666a6dd7af8fec314	true	Class.new.method_defined?(:hash)\n            
 052141b09b61ede8409ccea5658c7508	[true, true]	minor = GC.stat(:minor_gc_count)\n            GC.start(full_mark: fa
 0529c3b994259a346f88054c03aff90d	[[Encoding::InvalidByteSequenceError, "\\"\\\\xF1\\" followed by \\"a\\" on UTF-8"], [:invalid_byte_sequence, "UTF-8", "ISO-8859-1", "\\xF1", "a"], Encoding::InvalidByteSequenceError, Encoding::UndefinedConversionError, true, "", [Encoding::InvalidByteSequenceError, "incomplete \\"\\\\xA4\\" on EUC-JP"], [:incomplete_input, "EUC-JP", "UTF-8", "\\xA4", ""], [["US-ASCII", "UTF-8"]], [["US-ASCII", "UTF-8"], ["UTF-8", "Big5"]], "crlf_newline", "crlf_newline", nil]	(t=lambda{|&b| begin; b.call; rescue Exception => e; [e.class, e.message]; end};
+053e5f5a9063fc97e841e63ef86bad82	2.0505489999999997	def call_block\n          yield\n        end\n        def w10(s, flag)\n   
 055f890657b797cbf39b10ff47a602e6	"hello"	class Bar\n              class_variable_set(:@@val, "hello")\n       
 059105186c8c7fcaa5b946c1c71b007a	"hello\\n"	r, w = IO.pipe\n            t = Thread.new { r.gets }\n            w.
 05950871938fb64822a955fd038dac97	["included:C"]	$res = []\n        module M\n          def self.included(base)\n          
@@ -843,6 +844,7 @@
 4433d71bfa1c5cc6691d2dd71800fbe7	[:range, :range, :type]	h = { a: 1, b: 2 }\n            if h.respond_to?(:__key_at)\n        
 443bfeb84d9c2d708f478b4cd0860091	[true, true, false]	r, w = IO.pipe\n            a = [r.close_on_exec?, w.close_on_exec?]
 44528032436bdb6e6e366e913d073a06	"v1\\n"	r, w = IO.pipe\n            Process.wait Process.spawn({"SPAWN_T1" =
+4452ae427b2a0862038f7f2a87830617	89.76394847667156	def call_block\n          yield\n        end\n        def w7(s, flag)\n    
 44559a35406b5a8f1093bcfc268a7dd5	false	File.readable?("nonexistent_file_xyz")
 445fbc5889648d57a0f017eb770cb3aa	[["#<Method:", "#<Method:"], ["#<Method:", "#<Method:"], ["#<Method:", "#<Method:"], ["#<Method:", "#<Method:"], ["#<Method:", "#<Method:"], ["#<Method:", "#<Method:"], ["#<Method:", "#<Method:"], ["#<Method:", "#<Method:"], ["#<Method:", "#<Method:"], ["#<Method:", "#<Method:"], ["#<Method:", "#<Method:"], ["#<UnboundMethod:", "#<UnboundMethod:"], ["#<UnboundMethod:", "#<UnboundMethod:"], ["#<Method:", "#<Method:"]]	module MS\n              module MyMod; def bar; :bar; end; end\n     
 4469cd34806e00d8575f88a69f15e60f	"run"	Thread.current.status
@@ -1342,6 +1344,7 @@
 6c891eca2cb89ba2ef5d9d75c6d8f60f	[20, 20]	def m\n              binding\n            end\n            b1 = m\n    
 6c8f517d749d2dbedcad192eb4098b30	42	module Foo\n                def self.bar; 42; end\n                pr
 6d02db687943a63ad711b5395a933b96	"str"	class C; def to_s; "s"; end; def to_str; "str"; end; end\n[C.new].join
+6d2e4ef244e863673fbdfe58804dce19	[1.7426207497071933, 2.2426207497071933]	def call_block\n          yield\n        end\n        def w7\n          s =
 6d4221cf12759db4700deb70a10b88df	["can't modify frozen Class: #<Class:#<Class:0xX>>", "can't modify frozen Object: #<Object:0xX>"]	res = []\n        c = Class.new\n        sc = c.singleton_class\n        s
 6d4635412b101da73e8aca3b2253868a	nil	m = Module.new\n            m.set_temporary_name("temp")\n           
 6d824bfa55f3dea9e0838ce24c5e5937	[false, true, "SyWMkJRvgNMi", "aff08813c4e4323a", "JfTBauuA", 8, 9, true, true, 36]	before = Random.respond_to?(:alphanumeric)\n        require "random/form
@@ -2216,6 +2219,7 @@ b15052c5abbd93a1a9004be3b57beb9c	[:foo, :bar]	$res = []\n            obj = Objec
 b18169111f27cd344540accc05f616fe	nil	File.open("Cargo.toml") { |f| IO.new(f.fileno, autoclose: false).path }
 b18a80835134d8dffe61ec8e951213f0	["あcba", "あcba", true]	s = "abcあ".dup\n              t = s.reverse!\n              [s, t, 
 b196364f0e469cc01f39c67211d6218a	["abcdef", "abcdef", "abc", ["abcdef", "UTF-8"], "abcdef"]	File.write("/tmp/mr_cr5.txt", "abcdef")\n            r = []\n        
+b1b2cec0e935228e81e569ed82b71df3	2.1993129576089645	def call_block\n          yield\n        end\n        def w9\n          s =
 b1e42cb82ca28ab492397ec61bd6e2b5	[159600, 79800, 159600, 79800]	def osr_mul(n); s = 0; i = 0; while i < n; s = s + (i * 2); i = i + 1; 
 b1e841a013941b44c006b4154587a777	[{a: 1, b: 2}, nil]	T = Struct.new(:a, :b)\n            \n\n            s = T.new({a: 1, b
 b1e95110d8ea3a01a8392d5fcde03380	[true, "nil"]	begin\n              raise RuntimeError, "x"\n            rescue Runt
@@ -2558,6 +2562,7 @@ ca52734c6644d5ea8d449f149120fcc2	[3, -1, :nme]	res = []\n            res << (1 +
 ca6aea137215ef3580ab386ef7dcb37d	[[1, 2], [1, 2]]	def f(a,b,*)\n              [a,b]\n            end\n        \n\n        
 ca79e057f33cc52f3f630ba69bc2c841	42	x = 42\n            binding.local_variable_get("x")\n            
 ca8e2478f764162473914c7004640057	[10, 20, 30, 40, 50, 60, 70, 80, 1, 2, 3, 4, 5, 6, 7, 8]	class S\n                def initialize\n                    @a = 10\n
+ca928535f52567b7ee925c29e111ffe1	89.75113055617776	def call_block\n          yield\n        end\n        def w8(s, flag)\n    
 caa5a428511c21ba4721bdcbbcf8f21e	true	Random.srand(42)\n        a = Random.rand\n        a.is_a?(Float) && a >=
 cacaf13ae02371850924314a3901d3fb	[[9]]	class C\n                 def initialize; @log = []; end\n                 def []=
 cae47d49ae46af5b3807106c9e781864	"BYE"	s = "hello world"; s.bytesplice(0..-1, "BYE"); s
@@ -2676,6 +2681,7 @@ d4349d852cf60f39c3e6adcdc9ab0313	[:bar, [{a: 1, b: 2}]]	class Foo\n             
 d4446ffb96e085f7f76798c18cf331c5	:OVERRIDDEN	class Integer; def >=(o); :OVERRIDDEN; end; end; 3 >= 4
 d4718d9b7f7a7afcf1379197ca836a9a	[IO, true, [ArgumentError, "wrong number of arguments (given 3, expected 1..2)"], [ArgumentError, "wrong number of arguments (given 3, expected 1..2)"], [ArgumentError, "mode specified twice"], [ArgumentError, "invalid access mode "], [Errno::EINVAL, "Invalid argument"], [TypeError, "no implicit conversion of String into Integer"], [TypeError, "no implicit conversion of IO into Integer"], Errno::EBADF, :mode_kw, :int_mode, :toint_kw, ["UTF-8", "ISO-8859-1"], ["UTF-8", "ISO-8859-1"], ["UTF-8", "nil"], "nil", [ArgumentError, "encoding specified twice"], [true, "ASCII-8BIT"], [true, "ASCII-8BIT"], "ISO-8859-1", "ISO-8859-1", [ArgumentError, "binmode specified twice"], [ArgumentError, "both textmode and binmode specified"], [ArgumentError, "both textmode and binmode specified"], [ArgumentError, "both textmode and binmode specified"], false, 3, false, true, IO, :blockval, true, [ArgumentError, "boom"]]	require "tempfile"\n            t = Tempfile.new("mrb_ionew")\n      
 d48868180accf425c1cce5bbb37022fc	:OVERRIDDEN	class FalseClass; def ==(o); :OVERRIDDEN; end; end; false == false
+d49c8d4441da431d63717840fad0ac31	[0.5, 1.0, 3]	def leaf\n          a = [1, 2]\n          a.each { |x| a }\n          a.si
 d4b11df043d7e94411357a9fb1a4b7b9	true	"hello".index(/z/); $~.nil?
 d4b1bfe9eda9533ed079348cdba23ae4	"abcaあ"	"あ".rjust(5, "abc")
 d4e0ae9c56a69c0c332580eb22172e11	[[1, 2, 0], 999]	$flag = false\n        class KwNode\n          attr_reader :v\n          d
@@ -2861,6 +2867,7 @@ e3153e08936de555d02588b7435ba4c8	nil	begin\n              raise "err"\n         
 e358ab5ec7cd3f4599432855b55c2865	[[:ensure_ran], "reraised"]	$log = []\n            def m\n              raise "orig"\n            
 e383349a267c6ca9fda59d2f6df0e56c	[81, true]	require "stringio"\n            old = $stderr\n            begin\n    
 e39fd220262a3610b4d7b6874ada52af	[2.5, 3.0]	class RS1\n          def initialize = (@flag = true)\n          attr_writ
+e3c66bc50ce61dc70f16392dc5d5f22a	[1.6576735465811328, 200]	def call_block\n          yield\n        end\n        def w10\n          s 
 e3d5014354546675123f59bdf2d1daca	104	Const=4\n            Const+=100\n            a = Const\n        \n\n    
 e3dc251c39edf8fca9953b41f0868749	"self"	begin\n              Fiber.current.raise "self"\n            rescue =
 e403909aa1128050ff094c7e45c920db	["1234567890", "12345", "45678", "ASCII-8BIT", "", "ASCII-8BIT", nil, "67890", "1234567890", "ISO-8859-1", "EUC-JP", "US-ASCII", "UTF-8"]	File.write("/tmp/mr_cr.txt", "1234567890")\n            r = []\n     
@@ -2925,6 +2932,7 @@ e8ea755b0d3d65aee46f4cca2a396948	["/root", ArgumentError, true, nil, [Errno::EBA
 e8f73c5ee545fe5b71d1c667d8bec38b	[3, [:gt, :gt]]	class Gt\n              attr_reader :calls\n              def initial
 e8fff433024d62ecc658476201cd2358	[0.0, 750.0]	def call_block\n          yield\n        end\n        def d4(n)\n          
 e90638f8f74350ab109848abe99b3ee9	:from_emit	def emit(tag); throw tag, :from_emit; end\n            catch(:x) { e
+e91f61ddda46d6fb8af4dd6bdef5212a	35.03	def call_block\n          yield\n        end\n        def w8(flag)\n       
 e95108f8dbf4714b38e0e2eeaeef2060	["one x\\n", "two x\\n", 2, 2, "one x\\ntwo x\\n\\n\\n\\nthree\\nfour\\n", "one x\\ntwo x\\n\\n", "three\\nfour\\n", nil, "one x", "\\nt", "one ", "", "x\\n", "one x", "two x", "one ", "\\ntwo x\\n\\n\\n\\nthree\\nfour\\n", "three\\n", "one x", "one x\\n", :eof, "one", " x\\n", :range, :tyerr, "one x\\n", "o", 26, [[230, 156, 157], [230, 151, 165]]]	require "tempfile"\n            t = Tempfile.new("mrb_gets")\n       
 e9579fc0c8b362d6be81fff6d2f5180c	[[1], false]	r = []\n            t = Thread.new { r << 1; Thread.exit; r << 2 }\n 
 e96050e4165f7c4908cc9b521cc96f1c	[255, 49]	"\\xFF#{1}".bytes
@@ -2979,6 +2987,7 @@ ec84a8df82f97b16fdedf56efbc6ad35	"hello"	path = "/tmp/monoruby_test_filewrite_pe
 ecb0c2530aa824ca3b58cd269e696cd6	"xy"	def m; /(\\w)(\\w)/ =~ "xy"; -> { $~[0] }.call; end; m
 ecf0e0788d956837326285cb5c6fe318	[[0, 1, 2, 3, 4, 5, 6], 7, 8]	def f(*x,a,b)\n          [x,a,b]\n        end\n        \n\n        f(0,1,2,3
 ed06e4b3aaaf57db436613d3ad55b04a	[["EUC-JP"], ["ISO-8859-1"], ["ISO-8859-1"], ["ISO-8859-1"], ["UTF-8"]]	(d="/tmp/mono_de_#{Process.pid}"; Dir.mkdir(d); File.write("#{d}/a", ""); a=Dir.
+ed0a174c8759c88d0048f799de692008	[2.0244847182067076, 200]	def call_block\n          yield\n        end\n        def w10\n          s 
 ed0e20c8bb4c374081ab10bd2a0e9853	[31375, [200, 2]]	$flag = true\n        def osr\n          [1].each { return 5 }\n        en
 ed1b9d1127bc95203a639e5a1aec8a0c	false	(0x8000_0000_0000_0000 + 39) == (0x8000_0000_0000_0000 + 39 + 0.0)
 ed21697a03332cf5034e4574459d9bdf	[:ok, [:x, :y]]	A = Struct.new(nil, :x, :y)\n            \n\n            [A.name.nil? 
@@ -3162,6 +3171,7 @@ fb19b9db3ad873510aed81f16b1dbcd9	["ISO-8859-1", "UTF-8"]	(d="/tmp/mono_rpe_あ_#
 fb34f21f962af0c522442f03bd1d5c04	["ab", "ab"]	$/ = "cde"; s = +"abcde"; r = s.chomp!; $/ = "\\n"; [r, s]
 fb39dbdb558be25e38526a8809edbaac	3	->((*, a)) { a }.call([1, 2, 3])
 fb5ca5680002838248335aca3324daec	[true, true]	f = File.open("Cargo.toml")\n            begin\n              [f.set_
+fb6ad4fe010b6af46750af131edde489	[1.7426207497071933, 2.2408798698373564]	def call_block\n          yield\n        end\n        def w8\n          s =
 fb7515015bb0bb626fed9f090adde701	["elefant", 4]	S = Struct.new(:name, :legs, keyword_init: true)\n            \n\n    
 fb83f0f3c5d9a742d3d64fea1049e98f	"abc"	"abc".ljust(3)
 fb85b2dce678ed41a0929ae0e5b0932c	"Kernel"	Kernel.eval("self").to_s
@@ -3191,6 +3201,7 @@ fd3802cafa2a8bb073e7a7b5d24fb307	1	case 9\n        when 0,4,8\n          0\n    
 fd3ef4cb297b9a0b3056de6c29187e1b	[[0, 1], [2, 3, 4], [100, 200], [1, 2], [3, 4, 5], [100, 200], [2, 3], [4, 5, 6], [100, 200], [3, 4], [5, 6, 7], [100, 200], [4, 5], [6, 7, 8], [100, 200], [5, 6], [7, 8, 9], [100, 200], [6, 7], [8, 9, 10], [100, 200], [7, 8], [9, 10, 11], [100, 200], [8, 9], [10, 11, 12], [100, 200], [9, 10], [11, 12, 13], [100, 200], [10, 11], [12, 13, 14], [100, 200], [11, 12], [13, 14, 15], [100, 200], [12, 13], [14, 15, 16], [100, 200], [13, 14], [15, 16, 17], [100, 200], [14, 15], [16, 17, 18], [100, 200], [15, 16], [17, 18, 19], [100, 200], [16, 17], [18, 19, 20], [100, 200], [17, 18], [19, 20, 21], [100, 200], [18, 19], [20, 21, 22], [100, 200], [19, 20], [21, 22, 23], [100, 200], [20, 21], [22, 23, 24], [100, 200], [21, 22], [23, 24, 25], [100, 200], [22, 23], [24, 25, 26], [100, 200], [23, 24], [25, 26, 27], [100, 200], [24, 25], [26, 27, 28], [100, 200], [25, 26], [27, 28, 29], [100, 200], [26, 27], [28, 29, 30], [100, 200], [27, 28], [29, 30, 31], [100, 200], [28, 29], [30, 31, 32], [100, 200], [29, 30], [31, 32, 33], [100, 200], [30, 31], [32, 33, 34], [100, 200], [31, 32], [33, 34, 35], [100, 200], [32, 33], [34, 35, 36], [100, 200], [33, 34], [35, 36, 37], [100, 200], [34, 35], [36, 37, 38], [100, 200], [35, 36], [37, 38, 39], [100, 200], [36, 37], [38, 39, 40], [100, 200], [37, 38], [39, 40, 41], [100, 200], [38, 39], [40, 41, 42], [100, 200], [39, 40], [41, 42, 43], [100, 200], [40, 41], [42, 43, 44], [100, 200], [41, 42], [43, 44, 45], [100, 200], [42, 43], [44, 45, 46], [100, 200], [43, 44], [45, 46, 47], [100, 200], [44, 45], [46, 47, 48], [100, 200], [45, 46], [47, 48, 49], [100, 200], [46, 47], [48, 49, 50], [100, 200], [47, 48], [49, 50, 51], [100, 200], [48, 49], [50, 51, 52], [100, 200], [49, 50], [51, 52, 53], [100, 200]]	def run\n              out = []\n              50.times do |k|\n      
 fd568c0534228d89142ef4754da5cd21	[A, C]	class Recorder\n          RECORDS = []\n        end\n\n        module X\n   
 fd67bec60fd8f1e0e4e27bcd0a3675a3	[100, 200]	def f(&p)\n            g(&p)\n        end\n                \n        def g(
+fd7909da8862ced4ea8f2370dfcf4c11	35.03	def call_block\n          yield\n        end\n        def w7(flag)\n       
 fd92e81c5b7963a2b9abc4898533c1c0	1320	class Object\n          def cgf_probe\n            a = [1, 2]\n           
 fde9c01977b03195091b314bb13afc2f	true	old_stderr = $stderr\n            captured = String.new\n            
 fe1d12a770bcd49e6528c05052a7fe89	[[42], [7]]	$log = []\n            def g(x) = 42\n            def f(...) = g(...)


### PR DESCRIPTION
# Summary

The write side of the outer-float roadmap: a float store into an outer frame's slot paid, every loop iteration, a flonum encode (or heap allocation) plus the chain slot store. When the owner already holds a spill-resident raw-f64 home of the slot — a stage-2 promotion made in this subtree, or the new loop-entry adoption — the store now weakens the owner's claim to `F(home)` (slot stale, home authoritative) and emits only the raw home refresh: **one `movq` per iteration**.

Boxing moves to the points where a path actually gives the claim up:

- **Return joins, per edge** — a new `AsmInst::BoxOuterHomeToDynVar` (load the home, `f64_to_val`, store through the chain; both backends) is emitted on exactly the return segments whose join demotes the claim — the write-side twin of the kept-`C` surrender. `bridge_at` gains the same demotion arms for merges, addressed through a per-level chain table (`ChainSurrender`) threaded into `gen_bridge_all`.
- **Deopt exits** — the caller resumes holding `F(spill)`, so the call site's evict write-back boxes it from the spill slot natively. The deferring store also widens the owner's *parked* copy (the conservative resume base): a claim that dies at a join resumes as plain `S` with the surrender-written slot, and one that survives is re-adopted by the resume overlay. This fixes a real bug found during stress testing — a resumed owner otherwise kept believing its pool register still held the value the callee had just changed.
- **The claim barrier** — handing a block out of the unit materializes a deferred home into the slot (`unbox_to_S_at` reports `BoxHome`; the barrier emits the box through the chain).

Three placement decisions keep the steady state at zero overhead:

1. `locals_unbox_to_S_keeping_claims` no longer boxes a spill-resident `F` at specialized call boundaries — the callee reads and refreshes the home in place.
2. Joins meet `F(h)` against the same spill home's `Sf` (and a mismatched `Float` view) to `F(h)` (`JoinAction::SetF`), so a loop back edge emits nothing instead of a box per arrival.
3. The loop-entry float adoption adopts a back-edge spill home as `F(home)` directly (`adopt_deferred`), establishing the home once on the entry edges. The analysis pass never defers (each fixpoint walk re-promotes from `S`), so without this arm the codegen pass's deferral fought a pool-`Sf` loop target at every back edge.

Deferral is deliberately **upgrade-only**: an owner holding a pool `Sf` keeps the stage-1' boxed store. Migrating the pool view to a fresh spill mid-callee was built and reverted — on shapes where the claim dies at every return join (a conditional store) it churned the owner through `S → Sf(pool)` re-establishment bridges whose occupied-pool tmp path miscompiled under `stress-spill-pool`.

Also includes a design-doc entry recording the dead-outer-home-store investigation (negative result).

# Benchmarks (vs master, best of 3)

| benchmark | delta |
|---|---|
| outer-float multi-store loop | **−55%** |
| outer-float read-heavy loop | **−43%** |
| outer-float read/write loop | **−17%** |
| outer-float store-only loop | **−12%** |
| so_mandelbrot | **−8%** |
| pure-read loop | −3% |
| so_nbody / app_fib / app_aobench / stage-C timings | flat |

# Testing

- Full suite, default features: **3584 passed / 0 failed**
- Full suite, `stress-spill-pool`: **3584 passed / 0 failed**
- `gc-stress` targeted float suites (`outer_float_write_through`, `float_across_block_call`, `method_call`): **163 passed / 0 failed**
- `cargo check --target aarch64-unknown-linux-gnu` clean (both backends lower the new AsmInst)
- Six new regression tests: the canonical deferred shape, two-slot read/write blocks, the conditional-store surrender, the generic-call barrier, a type-flip deopt boxing from the home, and `break` under a deferred claim
- Adversarial probes (conditional stores, re-entry, deopt-in-block, coverage probes) bit-identical vs CRuby

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_