### PR TITLE
JIT: fold the F -> Sf demote bridge arm into the shared surrender leg

### DIFF
--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -2453,20 +2453,24 @@ impl AbstractFrame {
             // ...while demoting a deferred `F(h)` to anything slot-current
             // boxes the home into the owner's slot through the chain — the
             // write-side surrender, mirrored per edge like the kept-`C`
-            // literal write.
-            (LinkMode::F(l), LinkMode::Sf(r, g))
-                if l == r && l.0 >= crate::codegen::PHYS_FPR_POOL =>
+            // literal write. The `Sf` leg is defensive: today every join
+            // meets a same-home `F`/`Sf` pair to `F` (`JoinAction::SetF`)
+            // and loop targets adopt a back-edge spill home as `F`
+            // (`adopt_deferred`), so no known shape presents an `F(h)`
+            // edge against a still-`Sf(h)` target — but the demotion is
+            // sound if one ever does, and falling through to the
+            // `unreachable!` below would turn that shape into a panic.
+            (LinkMode::F(l), tfm @ (LinkMode::Sf(_, _) | LinkMode::S(_)))
+                if l.0 >= crate::codegen::PHYS_FPR_POOL
+                    && !matches!(tfm, LinkMode::Sf(r, _) if r != l) =>
             {
                 let ok = sur.emit_box(ir, level, l, slot);
                 debug_assert!(ok, "no chain addressing for a suspended frame at {level}");
-                self.set_Sf(slot, l, g);
-            }
-            (LinkMode::F(l), LinkMode::S(_))
-                if l.0 >= crate::codegen::PHYS_FPR_POOL =>
-            {
-                let ok = sur.emit_box(ir, level, l, slot);
-                debug_assert!(ok, "no chain addressing for a suspended frame at {level}");
-                self.set_S_with_guard(slot, Guarded::Float);
+                if let LinkMode::Sf(_, g) = tfm {
+                    self.set_Sf(slot, l, g);
+                } else {
+                    self.set_S_with_guard(slot, Guarded::Float);
+                }
             }
             (LinkMode::V, LinkMode::V)
             | (LinkMode::None, LinkMode::None)

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -2453,24 +2453,22 @@ impl AbstractFrame {
             // ...while demoting a deferred `F(h)` to anything slot-current
             // boxes the home into the owner's slot through the chain — the
             // write-side surrender, mirrored per edge like the kept-`C`
-            // literal write. The `Sf` leg is defensive: today every join
-            // meets a same-home `F`/`Sf` pair to `F` (`JoinAction::SetF`)
-            // and loop targets adopt a back-edge spill home as `F`
-            // (`adopt_deferred`), so no known shape presents an `F(h)`
-            // edge against a still-`Sf(h)` target — but the demotion is
-            // sound if one ever does, and falling through to the
-            // `unreachable!` below would turn that shape into a panic.
-            (LinkMode::F(l), tfm @ (LinkMode::Sf(_, _) | LinkMode::S(_)))
-                if l.0 >= crate::codegen::PHYS_FPR_POOL
-                    && !matches!(tfm, LinkMode::Sf(r, _) if r != l) =>
+            // literal write. Boxing *is* the `F(h) -> Sf(h, Float)`
+            // transition (the home stays bound, the slot becomes current),
+            // so this arm emits the surrender, records exactly that, and
+            // re-enters for the remaining `Sf -> target` step — the
+            // ordinary arms below, which every kind of slot-current target
+            // already handles: `Sf -> S` drops the view, a same-home
+            // `Sf -> Sf` is a no-op, and a *different* home stays the
+            // `unreachable!` it was. Re-entry terminates: the second pass
+            // starts from `Sf`, and no `Sf` arm re-enters.
+            (LinkMode::F(l), LinkMode::Sf(_, _) | LinkMode::S(_))
+                if l.0 >= crate::codegen::PHYS_FPR_POOL =>
             {
                 let ok = sur.emit_box(ir, level, l, slot);
                 debug_assert!(ok, "no chain addressing for a suspended frame at {level}");
-                if let LinkMode::Sf(_, g) = tfm {
-                    self.set_Sf(slot, l, g);
-                } else {
-                    self.set_S_with_guard(slot, Guarded::Float);
-                }
+                self.set_Sf(slot, l, SfGuarded::Float);
+                self.bridge_at(ir, target, slot, pc, outer, sur, level);
             }
             (LinkMode::V, LinkMode::V)
             | (LinkMode::None, LinkMode::None)


### PR DESCRIPTION
# Summary

Follow-up cleanup to #1196. The stage-1'' demotion in the suspended-frame bridge (`AbstractFrame::bridge_at`) had grown two bespoke arms — a deferred `F(home)` meeting an `Sf(home)` target, and one meeting a plain-`S` target — that duplicated the same chain surrender (`ChainSurrender::emit_box`) and differed only in the state they left behind. They collapse into one arm that reuses the bridge's ordinary machinery.

The observation that makes it collapse: **boxing the home *is* the `F(h) -> Sf(h, Float)` transition** — the home stays bound and the slot becomes current. So the arm emits the surrender, records exactly that, and re-enters the bridge for the remaining `Sf -> target` step, which the ordinary arms below already handle:

- `Sf -> S` drops the view,
- a same-home `Sf -> Sf` is a no-op,
- a *different* home stays the `unreachable!` it always was.

Re-entry terminates: the second pass starts from `Sf`, and no `Sf` arm re-enters. Normalizing the guard to `Float` is not observable — `gen_bridge_all` consumes the bridged state, and the successor runs on the target's.

# Why not just delete the unreachable leg

Coverage on #1196 flagged the `F -> Sf` leg as unexercised, so I probed for a shape that reaches it rather than assuming: an entry-`Sf` loop head, a block-internal loop over an already-promoted slot, and both arm orders of a conditional store. None reach it, and the mechanism explains why — every join meets a same-home `F`/`Sf` pair to `F` (`JoinAction::SetF`), and loop targets adopt a back-edge spill home as `F` directly (`adopt_deferred`).

Deleting it outright would have converted a case the code handles soundly today into a `unreachable!` panic, on the strength of an argument about shapes rather than a proof. Keeping it as a bespoke defensive leg was no better: untested code in a JIT state machine that would silently emit machine code if it ever ran. Delegating to the ordinary `Sf` arms resolves both — the case stays handled, by code the suite actually exercises.

# Testing

- Float suites (`outer_float_write_through`, `float_across_block_call`, `method_call`), default and `stress-spill-pool`: green
- Full suite, default and `stress-spill-pool`: green
- `cargo check --target aarch64-unknown-linux-gnu`: clean

No behavior change — the surrender emitted and the resulting state are identical on every path that runs today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM