### PR TITLE
Order homogeneous arrays without the comparator plumbing

### DIFF
--- a/monoruby/src/builtins.rs
+++ b/monoruby/src/builtins.rs
@@ -42,7 +42,7 @@ mod regexp;
 mod set;
 mod socket;
 pub(crate) mod spawn;
-mod string;
+pub(crate) mod string;
 pub(crate) mod struct_class;
 mod data_class;
 mod symbol;

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -2706,21 +2706,28 @@ fn sort_by_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr)
             // we do not drop the scope holding the underlying Values.
             let keys: Vec<Value> = (0..n).map(|i| vm.temp_at(base + i * 2)).collect();
             let mut indices: Vec<usize> = (0..n).collect();
-            let mut err = None;
-            indices.sort_by(|&a, &b| {
-                if err.is_some() {
-                    return std::cmp::Ordering::Equal;
-                }
-                match Executor::compare_values(vm, globals, keys[a], keys[b]) {
-                    Ok(o) => o,
-                    Err(e) => {
-                        err = Some(e);
-                        std::cmp::Ordering::Equal
+            // Keys of one ordered class — the usual `sort_by { |x| x.foo }`
+            // — order without running Ruby, and without the
+            // error-capturing comparator closure.
+            if !crate::executor::op::sort_indices_by_homogeneous_keys(
+                globals, &keys, &mut indices,
+            ) {
+                let mut err = None;
+                indices.sort_by(|&a, &b| {
+                    if err.is_some() {
+                        return std::cmp::Ordering::Equal;
                     }
+                    match Executor::compare_values(vm, globals, keys[a], keys[b]) {
+                        Ok(o) => o,
+                        Err(e) => {
+                            err = Some(e);
+                            std::cmp::Ordering::Equal
+                        }
+                    }
+                });
+                if let Some(e) = err {
+                    return Err(e);
                 }
-            });
-            if let Some(e) = err {
-                return Err(e);
             }
             // Read elems back in sorted order from the temp_stack (still
             // rooted) and write them to the receiver.
@@ -2798,21 +2805,28 @@ fn sort_by(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) 
             let n = (vm.temp_len() - base) / 2;
             let keys: Vec<Value> = (0..n).map(|i| vm.temp_at(base + i * 2)).collect();
             let mut indices: Vec<usize> = (0..n).collect();
-            let mut err = None;
-            indices.sort_by(|&a, &b| {
-                if err.is_some() {
-                    return std::cmp::Ordering::Equal;
-                }
-                match Executor::compare_values(vm, globals, keys[a], keys[b]) {
-                    Ok(o) => o,
-                    Err(e) => {
-                        err = Some(e);
-                        std::cmp::Ordering::Equal
+            // Keys of one ordered class — the usual `sort_by { |x| x.foo }`
+            // — order without running Ruby, and without the
+            // error-capturing comparator closure.
+            if !crate::executor::op::sort_indices_by_homogeneous_keys(
+                globals, &keys, &mut indices,
+            ) {
+                let mut err = None;
+                indices.sort_by(|&a, &b| {
+                    if err.is_some() {
+                        return std::cmp::Ordering::Equal;
                     }
+                    match Executor::compare_values(vm, globals, keys[a], keys[b]) {
+                        Ok(o) => o,
+                        Err(e) => {
+                            err = Some(e);
+                            std::cmp::Ordering::Equal
+                        }
+                    }
+                });
+                if let Some(e) = err {
+                    return Err(e);
                 }
-            });
-            if let Some(e) = err {
-                return Err(e);
             }
             let sorted_elems: Vec<Value> = indices
                 .iter()

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -548,7 +548,10 @@ fn string_cmp(
 /// is `-1` (CRuby orders by `rb_enc_index`). For 7-bit ASCII content
 /// across distinct encodings the result stays 0 — encoding only
 /// breaks the tie when the strings carry non-ASCII bytes.
-fn string_byte_then_encoding_cmp(lhs: &RStringInner, rhs: &RStringInner) -> std::cmp::Ordering {
+pub(crate) fn string_byte_then_encoding_cmp(
+    lhs: &RStringInner,
+    rhs: &RStringInner,
+) -> std::cmp::Ordering {
     let ord = lhs.cmp(rhs);
     if ord != std::cmp::Ordering::Equal {
         return ord;

--- a/monoruby/src/executor/op.rs
+++ b/monoruby/src/executor/op.rs
@@ -794,6 +794,20 @@ impl Executor {
         rhs: Value,
     ) -> Result<Option<std::cmp::Ordering>> {
         use std::cmp::Ordering;
+        // The arms below answer `<=>` for the immediate/String classes
+        // without a lookup, which is only sound while nobody replaced the
+        // builtin — the `(class, "<=>")` pairs in `BASIC_OP_DEFS` are what
+        // license it. A redefinition anywhere arms the flag; only then is
+        // the receiver's own pair worth checking. (Before this check
+        // `[3,1,2].sort` kept comparing fixnums directly through a
+        // redefined `Integer#<=>`, where CRuby raises.)
+        if globals.store.basic_op_redefined()
+            && globals
+                .store
+                .basic_op_redefined_for(lhs.class(), IdentId::_CMP)
+        {
+            return Ok(self.dispatch_cmp(globals, lhs, rhs)?);
+        }
         let res = match (lhs.unpack(), rhs.unpack()) {
             (RV::Nil, RV::Nil) => Some(Ordering::Equal),
             (RV::Nil, _) => None,
@@ -815,21 +829,39 @@ impl Executor {
             }
             (RV::Float(lhs), RV::Float(rhs)) => lhs.partial_cmp(&rhs),
             (RV::Float(_), _) => None,
-            _ => {
-                if let Some(i) = self
-                    .invoke_method_inner(globals, IdentId::_CMP, lhs, &[rhs], None, None)?
-                    .try_fixnum()
-                {
-                    match i {
-                        -1 => Some(std::cmp::Ordering::Less),
-                        0 => Some(std::cmp::Ordering::Equal),
-                        1 => Some(std::cmp::Ordering::Greater),
-                        _ => None,
-                    }
-                } else {
-                    None
-                }
+            // `String#<=>` is a byte compare with an encoding tie-break —
+            // no Ruby code runs for a String pair, so answering it here
+            // saves the dispatch every comparison of a string sort paid.
+            (RV::String(lhs), RV::String(rhs)) => {
+                Some(crate::builtins::string::string_byte_then_encoding_cmp(lhs, rhs))
             }
+            _ => return Ok(self.dispatch_cmp(globals, lhs, rhs)?),
+        };
+        Ok(res)
+    }
+
+    ///
+    /// `lhs <=> rhs` through a real dispatch, with CRuby's `rb_cmpint`
+    /// reading of the result (anything but -1/0/1 is "not comparable").
+    ///
+    fn dispatch_cmp(
+        &mut self,
+        globals: &mut Globals,
+        lhs: Value,
+        rhs: Value,
+    ) -> Result<Option<std::cmp::Ordering>> {
+        let res = if let Some(i) = self
+            .invoke_method_inner(globals, IdentId::_CMP, lhs, &[rhs], None, None)?
+            .try_fixnum()
+        {
+            match i {
+                -1 => Some(std::cmp::Ordering::Less),
+                0 => Some(std::cmp::Ordering::Equal),
+                1 => Some(std::cmp::Ordering::Greater),
+                _ => None,
+            }
+        } else {
+            None
         };
         Ok(res)
     }

--- a/monoruby/src/executor/op.rs
+++ b/monoruby/src/executor/op.rs
@@ -850,20 +850,25 @@ impl Executor {
         lhs: Value,
         rhs: Value,
     ) -> Result<Option<std::cmp::Ordering>> {
-        let res = if let Some(i) = self
-            .invoke_method_inner(globals, IdentId::_CMP, lhs, &[rhs], None, None)?
-            .try_fixnum()
-        {
-            match i {
-                -1 => Some(std::cmp::Ordering::Less),
-                0 => Some(std::cmp::Ordering::Equal),
-                1 => Some(std::cmp::Ordering::Greater),
-                _ => None,
-            }
-        } else {
-            None
-        };
-        Ok(res)
+        let res = self.invoke_method_inner(globals, IdentId::_CMP, lhs, &[rhs], None, None)?;
+        if res.is_nil() {
+            return Ok(None);
+        }
+        // `rb_cmpint` reads the *sign*, so a comparator returning ±5 (or a
+        // Bignum, or anything that can compare itself with 0) orders just
+        // as one returning ±1 does. Reading only -1/0/1 made
+        // `[W.new(2), W.new(1)].sort` raise where CRuby sorts, whenever
+        // `W#<=>` returned a difference rather than a unit.
+        //
+        // `cmpint` reports "not comparable" as the same `cmperr` the
+        // callers of this function build from `None`, so its error is
+        // theirs; anything else it raises (from dispatching `res <=> 0`)
+        // propagates as it should.
+        match self.cmpint(globals, res, lhs, rhs) {
+            Ok(ord) => Ok(Some(ord)),
+            Err(err) if matches!(err.kind(), MonorubyErrKind::Arguments) => Ok(None),
+            Err(err) => Err(err),
+        }
     }
 }
 

--- a/monoruby/src/executor/op/sort.rs
+++ b/monoruby/src/executor/op/sort.rs
@@ -35,6 +35,9 @@ impl Executor {
         vec: &mut [Value],
         buf: *mut Value,
     ) -> Result<()> {
+        if sort_homogeneous(globals, vec) {
+            return Ok(());
+        }
         let is_less = |a: Value, b: Value| {
             let ord = Executor::compare_values(self, globals, a, b)?;
             Result::Ok(ord == std::cmp::Ordering::Less)
@@ -95,6 +98,129 @@ impl Executor {
         };
         Ok(i.cmp(&0))
     }
+}
+
+
+///
+/// Sort *vec* in place without running any Ruby, when every element is of
+/// one class whose `<=>` answer is fixed (`BASIC_OP_DEFS` licenses the
+/// pairs, and a redefinition of one is checked here). Returns whether it
+/// did.
+///
+/// This is the shape `Array#sort` / `Hash#sort` actually meet — an array
+/// of numbers, or of strings — and the point is not just skipping the
+/// dispatch (`compare_values_inner` already answers those pairs itself)
+/// but skipping the *comparator plumbing*: a `Result`-returning closure
+/// through a generic merge sort, versus a direct key comparison the
+/// compiler can inline into a pattern-defeating quicksort. Ruby's sort is
+/// not stable, so an unstable sort is a valid answer.
+///
+/// A mixed array, a `Float` (whose `NaN` must still raise through the
+/// comparator), or a class with a redefined `<=>` all fall through to the
+/// general path.
+///
+fn sort_homogeneous(globals: &Globals, vec: &mut [Value]) -> bool {
+    if vec.len() < 2 {
+        return true;
+    }
+    let redefined = |class: ClassId| {
+        globals.store.basic_op_redefined()
+            && globals.store.basic_op_redefined_for(class, IdentId::_CMP)
+    };
+    if vec.iter().all(|v| v.is_fixnum()) {
+        if redefined(INTEGER_CLASS) {
+            return false;
+        }
+        // SAFETY of the unwraps: every element was just proven a fixnum.
+        vec.sort_unstable_by_key(|v| v.try_fixnum().unwrap());
+        return true;
+    }
+    if vec.iter().all(|v| v.is_rstring_inner().is_some()) {
+        if redefined(STRING_CLASS) {
+            return false;
+        }
+        vec.sort_unstable_by(|a, b| {
+            crate::builtins::string::string_byte_then_encoding_cmp(
+                a.is_rstring_inner().unwrap(),
+                b.is_rstring_inner().unwrap(),
+            )
+        });
+        return true;
+    }
+    // A `NaN` has no ordering, and CRuby raises on the comparison rather
+    // than sorting around it — leave any array holding one to the general
+    // path, whose comparator reports the failure.
+    if vec
+        .iter()
+        .all(|v| v.try_float().is_some_and(|f| !f.is_nan()))
+    {
+        if redefined(FLOAT_CLASS) {
+            return false;
+        }
+        vec.sort_unstable_by(|a, b| {
+            a.try_float()
+                .unwrap()
+                .partial_cmp(&b.try_float().unwrap())
+                .expect("NaN was excluded above")
+        });
+        return true;
+    }
+    false
+}
+
+///
+/// [`sort_homogeneous`] for a *sort_by*-shaped sort: the values being
+/// ordered are the keys, and what gets permuted is `indices` into them.
+/// Returns whether it sorted.
+///
+pub(crate) fn sort_indices_by_homogeneous_keys(
+    globals: &Globals,
+    keys: &[Value],
+    indices: &mut [usize],
+) -> bool {
+    if indices.len() < 2 {
+        return true;
+    }
+    let redefined = |class: ClassId| {
+        globals.store.basic_op_redefined()
+            && globals.store.basic_op_redefined_for(class, IdentId::_CMP)
+    };
+    if keys.iter().all(|v| v.is_fixnum()) {
+        if redefined(INTEGER_CLASS) {
+            return false;
+        }
+        indices.sort_unstable_by_key(|&i| keys[i].try_fixnum().unwrap());
+        return true;
+    }
+    if keys.iter().all(|v| v.is_rstring_inner().is_some()) {
+        if redefined(STRING_CLASS) {
+            return false;
+        }
+        indices.sort_unstable_by(|&a, &b| {
+            crate::builtins::string::string_byte_then_encoding_cmp(
+                keys[a].is_rstring_inner().unwrap(),
+                keys[b].is_rstring_inner().unwrap(),
+            )
+        });
+        return true;
+    }
+    if keys
+        .iter()
+        .all(|v| v.try_float().is_some_and(|f| !f.is_nan()))
+    {
+        if redefined(FLOAT_CLASS) {
+            return false;
+        }
+        indices.sort_unstable_by(|&a, &b| {
+            keys[a]
+                .try_float()
+                .unwrap()
+                .partial_cmp(&keys[b].try_float().unwrap())
+                .expect("NaN was excluded above")
+        });
+        return true;
+    }
+    false
 }
 
 ///

--- a/monoruby/src/globals/store/basic_op.rs
+++ b/monoruby/src/globals/store/basic_op.rs
@@ -82,6 +82,17 @@ pub(crate) const BASIC_OP_DEFS: &[(ClassId, &str)] = &[
     (TRUE_CLASS, "==="),
     (FALSE_CLASS, "=="),
     (FALSE_CLASS, "==="),
+    // ---- ordering: `Executor::compare_values_inner` (executor/op.rs)
+    // answers `<=>` for these classes without a lookup — the numeric arms
+    // compare through `RV`, and `Array#sort` / `#max` / `#min` and every
+    // other `Comparable`-style builtin that goes through it inherits the
+    // fast path. `Array#sort`'s homogeneous specialization
+    // (`Executor::sort`) rests on the same pairs.
+    (INTEGER_CLASS, "<=>"),
+    (FLOAT_CLASS, "<=>"),
+    (STRING_CLASS, "<=>"),
+    (SYMBOL_CLASS, "<=>"),
+    (NIL_CLASS, "<=>"),
     // ---- unary: `neg_value` / `pos_value` / `bitnot_value` (Integer,
     // Float, Complex) and `not_value`, whose truthiness answer covers every
     // immediate plus String and Complex — a heap object of any other class
@@ -303,6 +314,11 @@ mod tests {
             ("Complex", "%(o)", "Complex(1,2) % Complex(3,4)"),
             ("Complex", "-@", "-(Complex(1,2))"),
             ("Complex", "!", "!(Complex(1,2))"),
+            ("Integer", "<=>(o)", "1 <=> 2"),
+            ("Float", "<=>(o)", "1.0 <=> 2.0"),
+            ("String", "<=>(o)", r#""a" <=> "b""#),
+            ("Symbol", "<=>(o)", ":a <=> :b"),
+            ("NilClass", "<=>(o)", "nil <=> nil"),
             ("Array", "[](i)", "[1,2][0]"),
             ("Hash", "[](k)", "({1=>2})[1]"),
         ];
@@ -320,6 +336,38 @@ mod tests {
                 "class {class}; def {header}; :OVERRIDDEN; end; end; {expr}"
             ));
         }
+    }
+
+    /// The `<=>` pairs license more than the operator itself: every
+    /// builtin that orders values goes through
+    /// `Executor::compare_values_inner`, and `Array#sort` additionally
+    /// specializes a homogeneous array (`sort_homogeneous`). A
+    /// redefinition has to reach both — before the pairs were tracked,
+    /// `[3,1,2].sort` kept comparing fixnums directly and returned a
+    /// sorted array where CRuby raises (the redefined `<=>` returns a
+    /// Symbol, which is not a valid comparison result).
+    #[test]
+    fn sort_honors_redefined_cmp() {
+        run_test_once(
+            r#"
+            class Integer; def <=>(o); :OVERRIDDEN; end; end
+            begin
+              [3, 1, 2].sort
+            rescue => e
+              e.class
+            end
+            "#,
+        );
+        run_test_once(
+            r#"
+            class String; def <=>(o); :OVERRIDDEN; end; end
+            begin
+              ["c", "a", "b"].sort
+            rescue => e
+              e.class
+            end
+            "#,
+        );
     }
 
     /// `Array#[]=` is in the table but cannot be observed through the

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -381,6 +381,7 @@
 1c55df1a2ab9f2b7ce881cce3520b3da	["File::Stat", 8, true, false, true, true, true, true, true, "file", false, 8, true, true, true, true, true]	path = "/tmp/monoruby_test_stat_#{Process.pid}_#{rand(100000)}"\n   
 1c6926fa6e1462140ee74bc77342fcc8	[nil, :nme, true]	module PrivC\n              class Sec; end\n              private_con
 1c6d7d2ee7c5c48ff5b7040293a055f2	[42, 42, 2]	module BopPlus\n              refine(Integer) { def +(o); 42; end }\n
+1c8836b5348269f0d7f2540ee1f50475	:OVERRIDDEN	class NilClass; def <=>(o); :OVERRIDDEN; end; end; nil <=> nil
 1c925daf4080da92af318381f15467e0	[[[:a, 100], [:b, 100], [:c, 100]], :a, :b2, :c, :d]	class Aa; def tag = :a; end\n            class Bb; def tag = :b; end
 1c979897435ff61b3d8ac16af24e1019	[3, 5, 7, nil, 7, 42, 101, :new, {a: 101, b: :new}]	res = []\n        a = 1; a += 2; res << a\n        b = nil; b ||= 5; res 
 1ca7fb21e8495566f40650238bdfc1f6	[false, true, false, true, false, true, false, true, true, false, false, true, true, true, false, true, false, false]	class C\n            include Comparable\n            attr_accessor :x\n 
@@ -1032,6 +1033,7 @@
 50f9e525cff9a725780f19b016aaa8f9	[-2.0, -2.0, 8.0, 999]	$flag = false\n        def fmaybe\n          Integer.class_eval("def +(o)
 5103d830753ac483d2d4c39e44bc03b5	[0, 0, nil]	["‌" =~ /[[:word:]]/, "‍" =~ /[[:word:]]/, "‌" =~ /\\w/]
 511247f2a3b645da0c49c9876a105a9e	[1.687070598505588, 300]	def call_block\n          yield\n        end\n        def w6\n          s =
+5125ae5b4839d2d086156969d67bcc50	ArgumentError	class String; def <=>(o); :OVERRIDDEN; end; end\n            begin\n 
 5153f5263b097f08fb57811bdbdc5aaa	[true, true, true, false, true, true, true, false, false, false, false]	class A\n          def method1; end\n          protected\n          def pr
 5174f3c6fa3195d1fbd047639e4a904d	[[true, {data: 42}], ["async", "ctx"], [[[true, ["both"]], [false, []]], true, "both", false]]	r = []\n            de = Class.new(StandardError) { attr_reader :dat
 51be01e0d292ac0d9c77567390f1d11f	["Bbar", "B[239, 191, 189]", "Bdbar", "Btbar", Encoding::UndefinedConversionError, [ArgumentError, "too big fallback string"], TypeError, Encoding::UndefinedConversionError]	(r=[]; r << "B�".encode(Encoding::US_ASCII, fallback: { "�" => "bar" }); r << "B
@@ -1219,6 +1221,7 @@
 6181677ef04f4ef6305c1971b5503690	true	class MyStr\n              def to_str\n                "hel"\n        
 618dbff5bb318c45c0cbcadad310f756	"pow 3"	class Foo\n              def **(other)\n                "pow #{other}
 61999c6ea193c221146e7ca8536ca661	[1, 0, 7, 8, false, true, false, "File", true, true, "A", "B"]	require 'tmpdir'\n            f1 = File.join(Dir.tmpdir, "argf_t1_#{
+61c0d3358404d8b3ec51225d2fe11ce4	ArgumentError	class Integer; def <=>(o); :OVERRIDDEN; end; end\n            begin\n
 61d6a9b0085afd6c0cbfefe4fc3fe618	[true, true, true, Hash]	klass = Class.new(Hash)\n            [\n              klass[].instanc
 61fdd1242a66df09095c5df145f21012	12	def m(n); eval("BEGIN {return n*3}"); end; m(4)
 6201f6ca2228419027d2e3763e300a6c	:OVERRIDDEN	class Float; def !=(o); :OVERRIDDEN; end; end; 3.0 != 4.0
@@ -1455,6 +1458,7 @@
 74fde25cc190396a4f3751c20850e35f	["SyntaxError", "SyntaxError", "SyntaxError", "SyntaxError", "SyntaxError", "nil"]	res = []\n        obj = Object.new\n        ["class << obj; yield; end",\n
 7535124d760c4c0a785e8ea480beec65	[nil, nil]	r, w = IO.pipe; v = [r.path, w.path]; r.close; w.close; v
 757079451a7218940c5e1548dbf8b7b7	[[:source_buffer_empty, nil, nil, nil, nil], nil, :invalid_byte_sequence, [:invalid_byte_sequence, "UTF-8", "ISO-8859-1", "\\xF1", "a"], Encoding::InvalidByteSequenceError, ["\\xF1", "a", false], :finished, [:finished, nil, nil, nil, nil], nil, :invalid_byte_sequence, ["ef", "abcef"], "d", "", :finished, ["", "abcef"], :invalid_byte_sequence, [:invalid_byte_sequence, [85, 84, 70, 45, 49, 54, 76, 69], [85, 84, 70, 45, 56], [0, 216], [97, 0]], [97, 0], :incomplete_input, [:incomplete_input, "EUC-JP", "UTF-8", "\\xA4", ""], Encoding::InvalidByteSequenceError, true]	(r=[]; ec=Encoding::Converter.new("utf-8","iso-8859-1"); r << ec.primitive_errin
+758a54c7fdfade5f5c9dafad6da98f87	:OVERRIDDEN	class String; def <=>(o); :OVERRIDDEN; end; end; "a" <=> "b"
 7594ef08c00240ce6aa9cc4c8da38186	[UncaughtThrowError, :abc, "uncaught throw :abc"]	begin\n          throw :abc\n        rescue UncaughtThrowError => e\n     
 75aa5279b9de5e0524d3833ce166ea1c	:assigned	class Object\n          def self.const_missing(c); c; end\n        end\n  
 75b113d3b79894812ec54346427be988	[[255], [233], [128], [65], [128], [RangeError, "256 out of char range"], [RangeError, "256 out of char range"], [RangeError, "1286 out of char range"], [65], [177], [130, 160], [ArgumentError, "invalid character"], [ArgumentError, "invalid character"], [ArgumentError, "invalid character"], [65], [142, 177], [164, 162], [143, 161, 161], [ArgumentError, "invalid character"], [ArgumentError, "invalid character"], [ArgumentError, "invalid character"], [ArgumentError, "invalid character"], [ArgumentError, "invalid character"], [130, 160], [164, 162], "A", ""]	def c(enc, v)\n              begin\n                ("%c".dup.force_e
@@ -1480,6 +1484,7 @@
 7766681c09761e7b66d6fdb86feb1bae	[3.2, 1.6, 238.18399999999997, -267770.88, 924.0, -1124.0]	def f(d1, d2, x, y, s, c, p)\n          px = x - 100.0\n          py = y 
 7783137d4cd2c70faf7f01584872ab95	"\\x04\\bo:\\bBar\\b:\\n@nameI\\"\\nhello\\x06:\\x06ET:\\v@valuei/:\\v@items[\\bi\\x06i\\ai\\b"	class Bar\n              def initialize\n                @name = "hel
 778b89eb473f320143b57466fe6c623b	2	[1, 2, 3].each.with_object(:m) { |v, m| break v if v == 2 }
+7790f406d9357f3c834f0766360e44ab	:OVERRIDDEN	class Symbol; def <=>(o); :OVERRIDDEN; end; end; :a <=> :b
 77a7dafab8914bfd337708beb97921b8	[9223372036854774900, 900, 9223372036854774901, 899, 9223372036854774902, 898, 9223372036854774903, 897, 9223372036854774904, 896, 9223372036854774905, 895, 9223372036854774906, 894, 9223372036854774907, 893, 9223372036854774908, 892, 9223372036854774909, 891, 9223372036854774910, 890, 9223372036854774911, 889, 9223372036854774912, 888, 9223372036854774913, 887, 9223372036854774914, 886, 9223372036854774915, 885, 9223372036854774916, 884, 9223372036854774917, 883, 9223372036854774918, 882, 9223372036854774919, 881, 9223372036854774920, 880, 9223372036854774921, 879, 9223372036854774922, 878, 9223372036854774923, 877, 9223372036854774924, 876, 9223372036854774925, 875, 9223372036854774926, 874, 9223372036854774927, 873, 9223372036854774928, 872, 9223372036854774929, 871]	def drive\n              res = []\n              a = 3\n              
 77b00e5257cfe366d9ad6a60194785e2	[true, false, true, false]	x = 1\n            b = binding\n            [\n              b.local_v
 77be5f23f43f53c251e9965e79fe7154	true	class MyStr\n              def to_str\n                "llo"\n        
@@ -1532,6 +1537,7 @@
 7b7f468fd7e708b03afd14b1c5882f15	"hELLO, wORLD!"	"Hello, World!".swapcase
 7bac2eab198ba99ba15061f668fa67ce	[0, "nil", "nil"]	o = Object.new\n        [o <=> o, (o <=> Object.new).inspect, (o <=> 3.1
 7bd487fc3bae8a806a0ddc5f0394215f	[true, false]	m = Mutex.new\n            slept = false\n            t = Thread.new 
+7bf72e6eb4c2c593bd81eb7b98dcafb0	:OVERRIDDEN	class Integer; def <=>(o); :OVERRIDDEN; end; end; 1 <=> 2
 7bfe1905c8cfcd84d8d0ad738c459253	[1, 2, 3, 4, 1, 2]	def f(x,y,a:100,b:200,c:300,d:400)\n              [a,b,c,d,x,y]\n    
 7c1f60d60806a84dcf3a11a88bdef692	TypeError	("a" =~ "b" rescue $!.class)
 7c28dee19aa27309293f956968134d84	"HELLOd"	s = "hello world"; s.bytesplice(0...-1, "HELLO"); s
@@ -1669,6 +1675,7 @@
 87305cab4ce459da4f12b255d2e568a4	true	class Coercible\n              def ==(other); true; end\n            
 873209a668c450584c681b28f3af09f3	7.0	class Float; alias __orig :+; def +(o); __orig(o); end; end; 3.0 + 4.0
 8741050c3a5bc835bcab3cb04b928f9d	"UTF-8"	x = __ENCODING__; x.name
+8741625fdbc8da3229cd34249811a2ea	:OVERRIDDEN	class Float; def <=>(o); :OVERRIDDEN; end; end; 1.0 <=> 2.0
 875df8f0024d1eac090bc7a8e80f17a3	[6, 9, 0, 9, true, false, 9223372036854774000, 8, 16, 0, 12, true, false, 9223372036854774002, 10, 25, 0, 15, true, false, 9223372036854774004, 12, 36, 0, 18, true, false, 9223372036854774006, 14, 49, 0, 21, true, false, 9223372036854774008, 16, 64, 0, 24, true, false, 9223372036854774010, 18, 81, 0, 27, true, false, 9223372036854774012, 20, 100, 0, 30, true, false, 9223372036854774014, 22, 121, 0, 33, true, false, 9223372036854774016, 24, 144, 0, 36, true, false, 9223372036854774018, 26, 169, 0, 39, true, false, 9223372036854774020, 28, 196, 0, 42, true, false, 9223372036854774022, 30, 225, 0, 45, true, false, 9223372036854774024, 32, 256, 0, 48, true, false, 9223372036854774026, 34, 289, 0, 51, true, false, 9223372036854774028, 36, 324, 0, 54, true, false, 9223372036854774030, 38, 361, 0, 57, true, false, 9223372036854774032, 40, 400, 0, 60, true, false, 9223372036854774034, 42, 441, 0, 63, true, false, 9223372036854774036, 44, 484, 0, 66, true, false, 9223372036854774038, 46, 529, 0, 69, true, false, 9223372036854774040, 48, 576, 0, 72, true, false, 9223372036854774042, 50, 625, 0, 75, true, false, 9223372036854774044, 52, 676, 0, 78, true, false, 9223372036854774046, 54, 729, 0, 81, true, false, 9223372036854774048, 56, 784, 0, 84, true, false, 9223372036854774050, 58, 841, 0, 87, true, false, 9223372036854774052, 60, 900, 0, 90, true, false, 9223372036854774054, 62, 961, 0, 93, true, false, 9223372036854774056, 64, 1024, 0, 96, true, false, 9223372036854774058]	def drive\n              res = []\n              j = 0\n              
 876de098296efcddcfbefb47ad345e9d	[1, 0]	module M5; C = nil; end\n        x = 0; y = 0\n        begin\n          (x
 8794978b94a718366bd0ea968a26e48c	"u"	ENV.update("MONORUBY_ENV_TEST_UP" => "u")\n            v = ENV["MONO

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -69,6 +69,7 @@
 0450309ba6608915a161d31a0317403a	["abc", "KwStr", 42, "UTF-8"]	class KwStr < String\n          attr_reader :opt\n          def initializ
 0459d7cb4f158e142736bf52fff36347	[Hash, {x: 1}, false]	sub = Class.new(Hash)\n            o = sub.new\n            o[:x] = 1
 046110996c8a0ca3802aa257c29bd814	["class variable", true]	class DefCV\n              @@v = 1\n              def t; [defined?(@@
+046d94cf4086a6c146dcfd28675f5e90	[ArgumentError, [[1, :a], [2, :b]], [9], []]	a = [1, 2, 3]\n        raised = begin\n          a.sort_by! { |x| x == 2 
 04960a654db6978cf6c1b2b82065abdf	[1, 2, 3, 4, 5, 6, 7, 8]	class C < Array\n          attr_reader :a, :b, :c, :d, :e, :f, :g, :h\n  
 04bc3e73fd691534c5f67d6cff6c0117	true	o = Object.new\n            o.singleton_class\n            Marshal.lo
 04cd443314c532007660c17ebab3d577	[-4, 1, 2, 5, 7, 10, 12]	class Integer\n              alias old_spaceship <=>\n              d
@@ -169,6 +170,7 @@
 0b0604dcfa5aa2a90ccb9b55c158b24e	101	def get_binding\n              x = 100\n              binding\n       
 0b272bc1eee3862ebd5afe122f6530ac	[0, 50, "custom", true, false, false]	def check(x) = x.is_a?(Integer)\n            def fro(x) = x.frozen?\n
 0b360a7151ca4646f547e0ecffd6cf13	[true, true, true, true, true, ArgumentError, ArgumentError, TypeError, TypeError, Hash, false]	(ENV["MONO_T_ZZ"]="hi"; a=ENV["MONO_T_ZZ"].frozen?; b=ENV.method(:has_key?)==ENV
+0b40f53074d9e48c2b4d7383337aaada	[[1, 1, 2, 3], ArgumentError, -2, nil]	class Diff\n          attr_reader :v\n          def initialize(v) = @v = 
 0b45e95b3c2f86584c9598881d58fac9	[42, 90, 15, "1/2", "7:8", "argerr"]	def a0; 42; end\n        def a1(x); x * 10; end\n        def a5(a, b, c, 
 0b56e400524c40599f5741f2c015962d	7	class Foo\n              def method_missing(name, *args)\n           
 0b645df6fa816084c17746fbb8754151	-4	class Integer; alias __orig :~; def ~; __orig; end; end; ~(3)
@@ -533,6 +535,7 @@
 290233524b8c606fdb5063d01de93f38	"UTF-8"	def g; e = __ENCODING__; e.name; end; g
 290acb743144a02340cf3b45e01749b0	[123, 123, 123, 123, 123, 123, 123, 123, 123, 123, -521]	def g(a, b, c) = a * 100 + b * 10 + c\n        def f(...) = g(...)\n     
 2919233f40561782fac125f189ea5af5	[5, "hello"]	path = "/tmp/monoruby_io_syswrite_#{Process.pid}_#{rand(100000)}"\n 
+2922491d6c7f4ad62cce6e62d97a8cac	ArgumentError	class String; def <=>(o); :OVERRIDDEN; end; end\n        begin\n         
 29243ebc3ef776238c9f1ef7f0357bea	["matched", "custom not match"]	class Bar\n              def =~(other)\n                "matched"\n   
 293764b891fd3805a23234c9c9b9bc87	2	def true.bar; 2; end\n            true.bar\n            
 2951da256d6850b5b2b5f1f354032d04	false	File.executable?("../LICENSE-MIT")
@@ -878,6 +881,7 @@
 45e7cd851152ce44323bc881e5d31ae3	["FrozenError", {a: 1}, [[:a, 1], [:b, 2]], "RuntimeError", 2, 99, 2]	def drive(n)\n              r = nil\n              n.times { r = yiel
 45ebe9672e6cb7a979a3e5075d15e40b	[1, true, nil]	require "json"\n            data = JSON.parse('{"a":[1,{"b":true}],"
 4635d4b0d1f2878f1956e4eae990f393	[2, 0, false]	File.open("Cargo.toml") do |f|\n              f.gets; f.gets\n       
+4636a2a9542130c0eed3c834be76e22b	[[-5, 0, 1, 1, 2, 3], [-1.25, 0.0, 2.0, 3.5, 3.5], ["apple", "apple", "fig", "pear"], [-5, 0, 1, 1, 2, 3], [-1.25, 0.0, 2.0, 3.5, 3.5], ["apple", "apple", "fig", "pear"]]	ints = [3, 1, 2, 1, -5, 0]\n        floats = [3.5, -1.25, 2.0, 3.5, 0.0]
 464097b0dec5ef95d2a454202f882ff3	[1, true, false]	idh = {}.compare_by_identity\n        foo = 'foo'\n        idh[foo] = tru
 4646d58775453b5799c1369ea16d3305	true	Thread.new { 42 }.is_a?(Thread)
 46590c38d8a9995223435001dd59bc53	[Regexp, "abc", 1]	bytes = "\\x04\\x08\\x49\\x2f\\x08\\x61\\x62\\x63\\x01\\x06\\x3a\\x06\\x45\\x46"\n
@@ -1047,6 +1051,7 @@
 52e034352601862a8ad528f2c0b53e00	"TEST"	/(?<t>\\w+)/ =~ "TEST"; l = -> { Regexp.last_match(:t) }; l.call
 52e3c4053b6635a9049d6b966fd6af93	["bogus", "bogus", false, false, "wxq.rb", "wxq.rb", "vxq.rb", true]	cls = Class.new do\n              def go\n                autoload :Z
 530edafd9da1b1757a0295e4d18879dd	["RSub", "x"]	class RSub < Regexp; end\n            r = Marshal.load(Marshal.dump(
+531cf8f2ea5a7d4a2006397c77062c09	[[[1, :a], [2, :b], [3, :c]], [[1, 2], [1, 9], [2, 1]], [["a", 2], ["b", 1]]]	h = { 3 => :c, 1 => :a, 2 => :b }\n        [h.sort, [[2, 1], [1, 9], [1,
 5326cacf44528935163ede17463c01c9	1	lambda { |a,| a }.arity\n            
 532f5d7ba05f7843743de0b52969bba8	["PSubB", :x, 2, 9]	class PSubB < Proc; def initialize(a, b); @a = a; @b = b; end; attr_reader :a, :
 5344f32f5c73af78489308d9a5575a7d	[["TypeError", "1 is not a symbol nor a string"], ["TypeError", "1 is not a symbol nor a string"], ["TypeError", "1 is not a symbol nor a string"]]	def try; yield; rescue => e; [e.class.to_s, e.message]; end\n       
@@ -1573,6 +1578,7 @@
 7e7c0b1b6e6693f9e664b1a54dbde111	0	m = Object.new\n        def m.==(x); true; end\n        m <=> Object.new\n
 7e7e4d6aef6bf7266adf4b085dc59d23	[:one, :two]	rec = []\n        one = proc { |&arg| arg.call(:one) if arg }\n        tw
 7e96f5f901b2f6fae7a6ccede1e6bf9c	[true, "a b c"]	s1 = "a b c"\n            s2 = s1.dup\n            ok = false\n       
+7ea4a8b6207a7718a57b9eda8672c800	[[1.5, 2, 3], [1, 1180591620717411303424, 1208925819614629174706176], [:a, :b, :c], ArgumentError, ArgumentError, [], [7]]	mixed = [2, 1.5, 3]\n        bigs = [2**70, 1, 2**80]\n        syms = [:c
 7eb0d4817551a97def8fe2bf1a9f7035	[[0, 2, 4, 6], 106]	class FwdA\n          attr_reader :a\n          def initialize(n)\n       
 7f230ec5e7c81dcb14df9d04bf7eb5df	"raised"	class BadInt\n                  def to_int; "not an integer"; en
 7f2bcf2ec173056f353c8989fad11530	["A==5", "B==5"]	class A; def ==(o); "A==#{o}"; end; end\n        class B; def ==(o); "B=
@@ -1849,6 +1855,7 @@
 955708d09435794eef9b4fbe5edf0451	[100, 200, 300, 250, 400, 100, 200, 300, 250, 400]	class S\n            def f(x, y, z, a:0, c:0)\n                $res << x
 955a8a7c59c1d4329779dff0936455e9	"ういあ"	"あいう".reverse
 95658a05fe2886c4efc933aeee5d5bf5	[nil, 200, "c"]	h1 = { "a" => 100, 75 => 200, :c => "c" }\n            h1.compare_by
+956da81de1e7eb541fb4e466c59a5baa	ArgumentError	class Float; def <=>(o); :OVERRIDDEN; end; end\n        begin\n          
 958801182970b5dfab163fab5d8365b6	[:x, :y, :z]	def m(x, y); z = 3; local_variables.sort; end; m(1, 2)
 95a3dead7a2937d2986a83dfca6ae8fd	:OVERRIDDEN	class Integer; def ==(o); :OVERRIDDEN; end; end; 3 == 4
 95b4760e2f5808caa8e9af258ad11a5a	[[".", "..", "a"], true, true, true]	base = "/tmp/monoruby_dir_inst_#{Process.pid}_#{rand(100000)}"\n    
@@ -2572,6 +2579,7 @@ ca6aea137215ef3580ab386ef7dcb37d	[[1, 2], [1, 2]]	def f(a,b,*)\n              [a
 ca79e057f33cc52f3f630ba69bc2c841	42	x = 42\n            binding.local_variable_get("x")\n            
 ca8e2478f764162473914c7004640057	[10, 20, 30, 40, 50, 60, 70, 80, 1, 2, 3, 4, 5, 6, 7, 8]	class S\n                def initialize\n                    @a = 10\n
 ca928535f52567b7ee925c29e111ffe1	89.75113055617776	def call_block\n          yield\n        end\n        def w8(s, flag)\n    
+ca9a7fe5197626d693b7a2d84780366f	[["a", "cc", "bbb", "dddd"], ["a", "bbb", "cc", "dddd"], ["a", "cc", "bbb", "dddd"], [3, 2, 1], ArgumentError, ["a", "cc", "bbb", "dddd"], [0.5, 1.5], []]	words = ["bbb", "a", "cc", "dddd"]\n        by_int = words.sort_by { |s|
 caa5a428511c21ba4721bdcbbcf8f21e	true	Random.srand(42)\n        a = Random.rand\n        a.is_a?(Float) && a >=
 cacaf13ae02371850924314a3901d3fb	[[9]]	class C\n                 def initialize; @log = []; end\n                 def []=
 cae47d49ae46af5b3807106c9e781864	"BYE"	s = "hello world"; s.bytesplice(0..-1, "BYE"); s
@@ -2612,6 +2620,7 @@ ce3ab0576ab0634aa202676d23eff78c	[2000, true]	parents = Array.new(2000) { [] }\n
 ce3cb44e401aaa8cd3345ff6d95183b6	12	class Integer; alias __orig :*; def *(o); __orig(o); end; end; 3 * 4
 ce4131c8f9a4a5e155b38f61bca917e4	[[100, 2, 3, 100, 200, 70], [100, 2, 3, 100, 200, 70]]	class C\n              def f(a,(b,c),d,e:30,f:40)\n                $r
 ce62ddea72f477fdc9d5919218bb9a1c	"missing keyword: :x"	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; def m(x:)
+ce892b67feb8acd11ebf56f143c5f349	ArgumentError	class Float; def <=>(o); :OVERRIDDEN; end; end\n        begin\n          
 ce89e95320a8ea01740c37250a1966c9	["A1", "\\nA2\\nB1\\nB2\\n", "A1\\nA2\\nB", "1\\nB2\\n", nil, "", ["A1\\n", "A1\\n"], "negative length -1 given", "A1\\nA2\\n", "", "B1\\nB2\\n", "end of file reached", "A1", ["\\nA2\\n", "\\nA2\\n"], "end of file reached"]	require 'tmpdir'\n            f1 = File.join(Dir.tmpdir, "argf_t1_#{
 ce8eab351b5f58169c33634c2db2f744	[[1, 2], [1, 3], [2, 3]]	class MyNum; def to_int; 2; end; end\nn = MyNum.new\nres = []; [1,2,3].combination
 ce93a6b828d04eedc97c81bbb33e90c3	true	m = Module.new\n            m.set_temporary_name("foo").equal?(m)\n  
@@ -2887,6 +2896,7 @@ e44fe0e6159ead6593e9820b1014b08b	[:two_ensure, :three_post, :three_ensure]	class
 e45448fbfd8f7f0f3eff2312a6288466	nil	begin\n              raise "original"\n            rescue => e\n      
 e45816cf8d4aeb4f460e318b767a5882	1	(1..).min
 e469c6a02fb5f97645ad6fbfae3d6cc2	["T", "F"]	class TrueClass; def label_t713; super rescue "T"; end; end\n        cla
+e47239d7cd6ec89f4fe82f6a1a03800e	ArgumentError	class Integer; def <=>(o); :OVERRIDDEN; end; end\n        begin\n        
 e47afc9bea872de2d1e41b256d5d2554	[true, 9, nil]	pid = fork { sleep 5 }\n            Process.kill("SIGKILL", pid)\n   
 e48337ae565a3904f3c01b8e583758d2	["C", "M2", "M1"]	module M1\n          def f\n            $res << "M1"\n          end\n      
 e4a701808e3a93ca91d9df6170eb2110	[["NestA::NestB", "NestA"], ["NestA::NestB", "NestA"], []]	module NestA\n              module NestB\n                def self.f;

--- a/monoruby/tests/sort_fast_path.rs
+++ b/monoruby/tests/sort_fast_path.rs
@@ -1,0 +1,185 @@
+//! Coverage for the homogeneous-array sort specialization
+//! (`Executor::sort` / `sort_indices_by_homogeneous_keys`): each arm it
+//! takes, each reason it declines, and the comparator paths behind it.
+
+extern crate monoruby;
+use monoruby::tests::*;
+
+/// The three specialized element types, sorted and sorted in place.
+#[test]
+fn homogeneous_arrays_sort_by_type() {
+    run_test(
+        r#"
+        ints = [3, 1, 2, 1, -5, 0]
+        floats = [3.5, -1.25, 2.0, 3.5, 0.0]
+        strings = ["pear", "apple", "fig", "apple"]
+        a = ints.dup; a.sort!
+        b = floats.dup; b.sort!
+        c = strings.dup; c.sort!
+        [ints.sort, floats.sort, strings.sort, a, b, c]
+        "#,
+    );
+}
+
+/// Every reason the specialization declines, each of which must still
+/// produce CRuby's answer through the general comparator: a mixed array,
+/// a `NaN` (which raises rather than sorting), Bignums, Symbols, and
+/// arrays too short to sort.
+#[test]
+fn non_specializable_arrays_fall_back() {
+    run_test(
+        r#"
+        mixed = [2, 1.5, 3]
+        bigs = [2**70, 1, 2**80]
+        syms = [:c, :a, :b]
+        nan = begin
+          [Float::NAN, 1.0].sort
+        rescue => e
+          e.class
+        end
+        cross = begin
+          [1, "a"].sort
+        rescue => e
+          e.class
+        end
+        [mixed.sort, bigs.sort, syms.sort, nan, cross, [].sort, [7].sort]
+        "#,
+    );
+}
+
+/// `sort_by` / `sort_by!` order their *keys*, so the same specialization
+/// applies to the key vector — for each type, and declining on mixed keys.
+#[test]
+fn sort_by_specializes_on_its_keys() {
+    run_test(
+        r#"
+        words = ["bbb", "a", "cc", "dddd"]
+        by_int = words.sort_by { |s| s.size }
+        by_str = words.sort_by { |s| s }
+        by_float = words.sort_by { |s| s.size * 1.5 }
+        by_neg = [3, 1, 2].sort_by { |x| -x }
+        mixed_keys = begin
+          [1, 2].sort_by { |x| x.even? ? 1 : "a" }
+        rescue => e
+          e.class
+        end
+        w = words.dup; w.sort_by! { |s| s.size }
+        f = [1.5, 0.5].dup; f.sort_by! { |x| x }
+        [by_int, by_str, by_float, by_neg, mixed_keys, w, f, [].sort_by { |x| x }]
+        "#,
+    );
+}
+
+/// `Hash#sort` orders `[key, value]` pairs — Arrays, so the general
+/// comparator handles them, but the keys inside go through the same
+/// `<=>` answers.
+#[test]
+fn hash_and_nested_arrays_sort() {
+    run_test(
+        r#"
+        h = { 3 => :c, 1 => :a, 2 => :b }
+        [h.sort, [[2, 1], [1, 9], [1, 2]].sort, [["b", 1], ["a", 2]].sort]
+        "#,
+    );
+}
+
+/// A user comparator is read by sign, as CRuby's `rb_cmpint` does: a
+/// `<=>` returning ±5 orders exactly as one returning ±1, and one
+/// returning `nil` reports the pair as incomparable.
+#[test]
+fn user_comparator_is_read_by_sign() {
+    run_test(
+        r#"
+        class Diff
+          attr_reader :v
+          def initialize(v) = @v = v
+          def <=>(o) = v - o.v
+        end
+        class Nope
+          def <=>(o) = nil
+        end
+        by_diff = [Diff.new(2), Diff.new(1), Diff.new(3), Diff.new(1)].sort.map(&:v)
+        incomparable = begin
+          [Nope.new, Nope.new].sort
+        rescue => e
+          e.class
+        end
+        [by_diff, incomparable, (Diff.new(1) <=> Diff.new(3)), (Nope.new <=> 1)]
+        "#,
+    );
+}
+
+/// The `sort_by` family declines the same way `sort` does, and must then
+/// report through the general comparator — including in the destructive
+/// form, whose fallback writes the receiver back.
+#[test]
+fn sort_by_bang_falls_back_on_mixed_keys() {
+    run_test(
+        r#"
+        a = [1, 2, 3]
+        raised = begin
+          a.sort_by! { |x| x == 2 ? "two" : x }
+        rescue => e
+          e.class
+        end
+        b = [[2, :b], [1, :a]]
+        b.sort_by! { |pair| pair }
+        [raised, b, [9].sort_by { |x| x }, [].sort_by! { |x| x }]
+        "#,
+    );
+}
+
+/// A redefined `<=>` reaches the key sort too, for each specialized key
+/// type: the sort must run the redefinition (and report its non-Integer
+/// answer) rather than ordering the keys directly.
+#[test]
+fn sort_by_honors_redefined_cmp() {
+    run_test_once(
+        r#"
+        class Integer; def <=>(o); :OVERRIDDEN; end; end
+        begin
+          ["bbb", "a"].sort_by { |s| s.size }
+        rescue => e
+          e.class
+        end
+        "#,
+    );
+    run_test_once(
+        r#"
+        class String; def <=>(o); :OVERRIDDEN; end; end
+        begin
+          ["bbb", "a"].sort_by { |s| s }
+        rescue => e
+          e.class
+        end
+        "#,
+    );
+    run_test_once(
+        r#"
+        class Float; def <=>(o); :OVERRIDDEN; end; end
+        begin
+          [2.5, 1.5].sort_by { |x| x }
+        rescue => e
+          e.class
+        end
+        "#,
+    );
+}
+
+/// Redefining `Float#<=>` has to reach the specialization, which is why
+/// the `(class, "<=>")` pairs are tracked in `BASIC_OP_DEFS` (the Integer
+/// and String cases live with the rest of that table's coverage, in
+/// `globals::store::basic_op`).
+#[test]
+fn float_cmp_redefinition_reaches_the_sort() {
+    run_test_once(
+        r#"
+        class Float; def <=>(o); :OVERRIDDEN; end; end
+        begin
+          [2.0, 1.0].sort
+        rescue => e
+          e.class
+        end
+        "#,
+    );
+}


### PR DESCRIPTION
# Summary

`Array#sort` was 2.1× slower than CRuby on an Integer array and 4.1× on a String array, and the two had different causes.

**Strings had no arm in `compare_values_inner`**, so every comparison dispatched `String#<=>` into Ruby. They have one now, calling the same byte-then-encoding comparison the builtin does.

**Both then still paid the general machinery**: a `Result`-returning closure through a generic merge sort, where CRuby runs a specialized comparator. `Executor::sort` now recognizes an array that is all-fixnum, all-String or all-Float (a NaN excluded — CRuby raises on that comparison rather than sorting around it) and sorts it directly. `Array#sort_by` / `#sort_by!` do the same for their key vector. Ruby's sort is not stable, so an unstable sort is a valid answer.

# A bug this uncovered

Skipping `<=>` is only sound while nobody replaced it, which is what `BASIC_OP_DEFS` is for — and `<=>` was missing from it. The numeric arms of `compare_values_inner` already answered fixnum pairs directly, so

```ruby
class Integer; def <=>(o); :OVERRIDDEN; end; end
[3, 1, 2].sort     # monoruby: [1, 2, 3]   CRuby: ArgumentError
```

sorted quietly where CRuby raises. The `(class, "<=>")` pairs are now tracked, `compare_values_inner` checks the receiver's pair before taking any fast arm, and both the operator and the sort paths follow a redefinition (`sort_honors_redefined_cmp`).

# Benchmarks (200k elements ×20, release, vs CRuby 4.0.2)

| | before | after | ratio |
|---|---:|---:|---:|
| Integer sort | 0.82s | **0.24s** | 2.16 → **0.65** |
| Float sort | 1.05s | **0.40s** | 1.08 → **0.43** |
| String sort | 4.17s | **1.30s** | 4.09 → **1.27** |
| `sort_by` | 0.66s | **0.24s** | 1.61 → **0.59** |

Block-comparator sorts, aobench, mandelbrot, binarytrees and fib are unchanged.

# Testing

- Full suite: **3596 passed / 0 failed**
- `cargo check --target aarch64-unknown-linux-gnu`: clean
- Semantics sweep against CRuby: mixed types, NaN, Bignum, Symbol, `Hash#sort`, nil, empty, duplicate keys, `sort!` / `sort_by!`, and the redefinition cases above — all identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_