### PR TITLE
Share one Symbol#to_proc frame per symbol, and look up once

### DIFF
--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -3604,6 +3604,17 @@ impl Executor {
         data: &ProcData,
         args: &[Value],
     ) -> Result<Value> {
+        // `&:sym` — dispatch the named method straight at `args[0]`.
+        // Going through the generic path instead means a block frame for
+        // `symbol_to_proc_body` plus, because that body takes `*rest`, a
+        // rest `Array` allocated for every element, which for the shape
+        // this exists to serve (`ary.map(&:to_s)`) is the whole cost.
+        if data.func_id() == Some(SYMBOL_TO_PROC_BODY_FUNCID)
+            && let Some(outer) = data.outer()
+            && let Some(symbol) = outer.self_val().try_symbol()
+        {
+            return self.invoke_symbol_proc(globals, symbol, args, None);
+        }
         (globals.invokers.block)(
             self,
             globals,
@@ -3614,6 +3625,46 @@ impl Executor {
             None,
         )
         .ok_or_else(|| self.take_error())
+    }
+
+    ///
+    /// The body of a `Symbol#to_proc` proc, called directly: `args[0]`
+    /// receives `symbol`, the rest are its arguments. Same visibility
+    /// rule as `public_send` (which is what `&:sym` documents), and the
+    /// same answer as running `symbol_to_proc_body` — only without the
+    /// frame and the rest array that body's `*rest` parameter forces.
+    ///
+    pub(crate) fn invoke_symbol_proc(
+        &mut self,
+        globals: &mut Globals,
+        symbol: IdentId,
+        args: &[Value],
+        bh: Option<BlockHandler>,
+    ) -> Result<Value> {
+        let Some((recv, rest)) = args.split_first() else {
+            return Err(MonorubyErr::wrong_number_of_arg_min(0, 1));
+        };
+        self.dispatch_symbol_proc(globals, symbol, *recv, rest, bh)
+    }
+
+    ///
+    /// `recv.public_send(symbol, *args, &bh)` — the one dispatch behind
+    /// `&:sym`, shared by the block-call fast path above and by
+    /// `symbol_to_proc_body` (the general entry, reached when the proc is
+    /// called as an object). `is_func_call = false` is what makes it
+    /// *public*_send: it restricts the lookup to public methods, which is
+    /// one lookup rather than a visibility probe followed by a second,
+    /// unrestricted one.
+    ///
+    pub(crate) fn dispatch_symbol_proc(
+        &mut self,
+        globals: &mut Globals,
+        symbol: IdentId,
+        recv: Value,
+        args: &[Value],
+        bh: Option<BlockHandler>,
+    ) -> Result<Value> {
+        self.invoke_method_inner_vis(globals, symbol, recv, args, bh, None, false)
     }
 
     // NOTE: there is deliberately no generic Rust-side safepoint helper
@@ -3958,7 +4009,7 @@ impl Executor {
     /// back to method dispatch or raise.
     fn resolve_block_target(
         &self,
-        globals: &Globals,
+        globals: &mut Globals,
         cfp: Cfp,
         bh: BlockHandler,
     ) -> Option<(Lfp, FuncId)> {
@@ -3971,10 +4022,11 @@ impl Executor {
             Some((cfp.lfp(), fid))
         } else if let Some(proc) = bh.try_proc() {
             proc.outer_lfp().map(|outer| (outer, proc.func_id()))
-        } else if bh.try_symbol().is_some() {
-            let fid = SYMBOL_TO_PROC_BODY_FUNCID;
-            let outer = Lfp::heap_frame(bh.0, globals[fid].meta());
-            Some((outer, fid))
+        } else if let Some(symbol) = bh.try_symbol() {
+            // The frame is per-symbol and immutable (`self` is the
+            // symbol, nothing else), so it is built once and shared —
+            // this resolution runs on every yield.
+            Some((globals.symbol_proc_frame(symbol), SYMBOL_TO_PROC_BODY_FUNCID))
         } else {
             None
         }

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -259,6 +259,15 @@ pub(crate) struct Invokers {
 pub struct Globals {
     /// main object (`self`` of toplevel).
     pub main_object: Value,
+    /// One `Symbol#to_proc` outer frame per symbol, built on demand.
+    ///
+    /// A `&:sym` block handler is resolved to `(outer_lfp, func_id)` on
+    /// *every* yield (`Executor::resolve_block_target`), and the frame it
+    /// needs holds nothing but the symbol as `self` — immutable, and the
+    /// same for every resolution of that symbol. Building a fresh one
+    /// each time put a heap-frame allocation on every element of
+    /// `ary.map(&:to_s)`.
+    symbol_proc_frames: HashMap<IdentId, Lfp>,
     /// function and class info.
     pub store: Store,
     /// global variables and special variables.
@@ -382,9 +391,28 @@ impl std::ops::DerefMut for Globals {
     }
 }
 
+impl Globals {
+    ///
+    /// The shared `Symbol#to_proc` outer frame for *symbol* (see
+    /// [`Globals::symbol_proc_frames`]), built on first use.
+    ///
+    pub(crate) fn symbol_proc_frame(&mut self, symbol: IdentId) -> Lfp {
+        if let Some(lfp) = self.symbol_proc_frames.get(&symbol) {
+            return *lfp;
+        }
+        let meta = self.store[SYMBOL_TO_PROC_BODY_FUNCID].meta();
+        let lfp = Lfp::heap_frame(Value::symbol(symbol), meta);
+        self.symbol_proc_frames.insert(symbol, lfp);
+        lfp
+    }
+}
+
 impl alloc::GC<RValue> for Globals {
     fn mark(&self, alloc: &mut alloc::Allocator<RValue>) {
         self.main_object.mark(alloc);
+        for lfp in self.symbol_proc_frames.values() {
+            lfp.mark(alloc);
+        }
         self.load_path.mark(alloc);
         self.loaded_features.mark(alloc);
         self.store.mark(alloc);
@@ -588,6 +616,7 @@ impl Globals {
 
         let mut globals = Self {
             main_object,
+            symbol_proc_frames: HashMap::default(),
             store: Store::new(),
             gvars: GvarTable::new(),
             special_gvars: SpecialGvars::default(),

--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -580,26 +580,10 @@ pub(crate) fn symbol_to_proc_body(
     let recv = lfp.arg(0);
     let rest_val = lfp.arg(1);
     let rest_array = rest_val.as_array();
-    let rest: Vec<Value> = rest_array.iter().cloned().collect();
-    // public_send semantics: reject private and protected methods.
-    let class_id = recv.class();
-    if let Some(entry) = globals.check_method_for_class(class_id, symbol) {
-        match entry.visibility() {
-            Visibility::Private => {
-                return Err(MonorubyErr::private_method_called(
-                    globals, symbol, recv,
-                ));
-            }
-            Visibility::Protected => {
-                return Err(MonorubyErr::protected_method_called(
-                    globals, symbol, recv,
-                ));
-            }
-            _ => {}
-        }
-    }
     let bh = lfp.block();
-    vm.invoke_method_inner(globals, symbol, recv, &rest, bh, None)
+    // The rest array is rooted by this frame, and the collector does not
+    // move objects, so the dispatch can read the arguments in place.
+    vm.dispatch_symbol_proc(globals, symbol, recv, &rest_array[..], bh)
 }
 
 ///

--- a/monoruby/tests/proc_compose.rs
+++ b/monoruby/tests/proc_compose.rs
@@ -62,3 +62,22 @@ fn proc_compose_passes_block_to_first() {
         "#,
     );
 }
+
+/// `&:sym` shares one outer frame per symbol (`Globals::symbol_proc_frame`)
+/// instead of building one per yield. The frame is reachable only from that
+/// cache, so a collection between two uses of the same symbol proc must not
+/// reclaim it — and two different symbols must not share one.
+#[test]
+fn symbol_proc_frames_survive_gc_and_stay_per_symbol() {
+    run_test(
+        r##"
+        a = ["one", "two", "three"]
+        first = a.map(&:size)
+        GC.start
+        second = a.map(&:upcase)
+        GC.start
+        third = a.map(&:size)
+        [first, second, third, [1, 2].inject(&:+), :size.to_proc.call("abcd")]
+        "##,
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -538,6 +538,7 @@
 295ad12a1384e7957740bbfc0e7fc6d3	"1,2,3"	class C; def to_str; ","; end; end; o = C.new\n[1, 2, 3] * o
 296560b4ebd046b6c59327975bb90459	"[2.5, 1.0]"	1.0.coerce("2.5").inspect
 296cb9b677550e04208e94ca484931e0	false	(1 << 100) == Float::NAN
+296cf73e0640c371c2684d2cd90d9e7b	[[3, 3, 5], ["ONE", "TWO", "THREE"], [3, 3, 5], 3, 4]	a = ["one", "two", "three"]\n        first = a.map(&:size)\n        GC.st
 2979daa28cf9e1607e9067bfb20e90ba	true	def p2\n          x = nil\n          [].each { x = 9.9 }\n          x.nil?
 2987a50b02c4a3d9e5927d0cf054efc5	[true, true, false, true, false]	[\n              SystemExit.new.success?,\n              SystemExit.n
 29a4782bad89b05e2a89fbdc04ec694a	[[1, :d, [], 1, nil], [1, 2, [3, 4], 1, nil], [1, 2, [], 9, nil], [1, :d, [], 1, :blk], [10, 20, [30], 1, nil], [5, 6, [7], 2, nil]]	def t(a, b = :d, *r, k: 1, &blk); [a, b, r, k, blk ? blk.call : nil


### PR DESCRIPTION
# Summary

`ary.map(&:to_s)` ran **3.1× slower than CRuby** while the same work written as a block ran at parity, so the whole gap was in the `&:sym` path. Two costs, both **per element**:

**1. A heap frame per yield.** `Executor::resolve_block_target` turns a block handler into `(outer_lfp, func_id)` on *every* yield, and for a Symbol handler it built the outer frame right there. That frame holds nothing but the symbol as `self` — immutable, and identical for every resolution of that symbol. `Globals::symbol_proc_frame` now builds one per symbol on first use and keeps it (marked from `Globals`, so a collection between two uses of the same symbol proc cannot reclaim it).

**2. Two method lookups.** `symbol_to_proc_body` probed the method table for the visibility check and then dispatched by name, which looked it up again. Both halves are `public_send`, which `invoke_method_inner_vis(.., is_func_call = false)` already expresses as a single public-restricted lookup — and it keeps going through `find_method`, so a refinement in the caller's scope is resolved exactly as before (dispatching the probed entry's `FuncId` directly would have bypassed that).

The dispatch is now one function, `Executor::dispatch_symbol_proc`, shared with a new fast path in `Executor::invoke_block`: a Rust-side block call on a symbol proc skips the block frame and the rest `Array` that body's `*rest` parameter forces.

# Benchmarks (6M elements, release, vs CRuby 4.0.2)

| | before | after |
|---|---:|---:|
| `ary.map(&:to_s)` | 2.35s (ratio 3.13) | **1.36s (ratio 1.89)** |
| the same written as a block | 0.73s (ratio 1.04) | unchanged |

What remains is structural: a yield to a symbol proc still builds the native frame and the rest array the general body is declared with, where CRuby has a dedicated symbol-proc call.

# Testing

- Full suite: **3596 passed / 0 failed** (default and `stress-spill-pool`)
- `gc-stress` on the proc and method-call suites; a new test covers a GC between two uses of the same cached frame, and two symbols not sharing one
- `cargo check --target aarch64-unknown-linux-gnu`: clean
- Semantics verified against CRuby: public / private / protected / missing (class **and** message), `method_missing`, multi-argument (`inject(&:+)`), `Proc#call` on a symbol proc, `arity` / `lambda?`, hash and struct receivers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_