### PR TITLE
Route Proc#call on a symbol proc through the shared dispatch

### DIFF
--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -332,33 +332,20 @@ fn call(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
     // block passed to Proc#call is forwarded to the invoked method. The
     // regular invoke_proc/block_invoker path currently drops block handlers.
     if proc.func_id() == SYMBOL_TO_PROC_BODY_FUNCID {
-        let symbol = proc.self_val();
-        let symbol_id = symbol
+        let symbol_id = proc
+            .self_val()
             .try_symbol()
             .expect("symbol-to-proc outer self is not a Symbol");
         let args_val = lfp.arg(0);
         let args = args_val.as_array();
-        if args.is_empty() {
+        let Some((recv, rest)) = args.split_first() else {
             return Err(MonorubyErr::argumenterr("no receiver given"));
-        }
-        let recv = args[0];
-        let rest: Vec<Value> = args[1..].to_vec();
-        let class_id = recv.class();
-        if let Some(entry) = globals.check_method_for_class(class_id, symbol_id) {
-            match entry.visibility() {
-                Visibility::Private => {
-                    return Err(MonorubyErr::private_method_called(globals, symbol_id, recv));
-                }
-                Visibility::Protected => {
-                    return Err(MonorubyErr::protected_method_called(
-                        globals, symbol_id, recv,
-                    ));
-                }
-                _ => {}
-            }
-        }
+        };
         let bh = lfp.block();
-        return vm.invoke_method_inner(globals, symbol_id, recv, &rest, bh, kw);
+        // Same dispatch as a yield to this proc — one public-restricted
+        // lookup, and the arguments read in place (the array is rooted by
+        // this frame, and the collector does not move objects).
+        return vm.dispatch_symbol_proc_kw(globals, symbol_id, *recv, rest, bh, kw);
     }
     let bh = lfp.block();
     vm.invoke_proc_with_block(globals, &proc, &lfp.arg(0).as_array(), bh, kw)

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -3664,7 +3664,21 @@ impl Executor {
         args: &[Value],
         bh: Option<BlockHandler>,
     ) -> Result<Value> {
-        self.invoke_method_inner_vis(globals, symbol, recv, args, bh, None, false)
+        self.dispatch_symbol_proc_kw(globals, symbol, recv, args, bh, None)
+    }
+
+    /// [`Self::dispatch_symbol_proc`] with keyword arguments — `Proc#call`
+    /// on a symbol proc forwards the keywords it was given.
+    pub(crate) fn dispatch_symbol_proc_kw(
+        &mut self,
+        globals: &mut Globals,
+        symbol: IdentId,
+        recv: Value,
+        args: &[Value],
+        bh: Option<BlockHandler>,
+        kw: Option<Hashmap>,
+    ) -> Result<Value> {
+        self.invoke_method_inner_vis(globals, symbol, recv, args, bh, kw, false)
     }
 
     // NOTE: there is deliberately no generic Rust-side safepoint helper


### PR DESCRIPTION
# Summary

> Re-opens #1202, which GitHub auto-closed unmerged when its base branch (`claude/symbol-proc-frame`, #1201) was deleted on merge. Same change, rebased onto `master`.

`Proc#call`'s own fast path for `Symbol#to_proc` procs was the third copy of the same dispatch: it collected the arguments into a fresh `Vec`, probed the method table for the visibility check, and then dispatched by name — a second lookup. It now calls `Executor::dispatch_symbol_proc` (keywords forwarded), the one the yield path and the Rust-side block call already share: one public-restricted lookup, arguments read in place.

# What is left of the `&b` / `b.call` gap, and why

`b.call(x)` runs 2.1× slower than `yield x` (which is at parity with CRuby). This PR takes the part that is not structural. The rest is:

- reading a block parameter materializes the Proc, which promotes the frame, and
- `Proc#call` is a native method declared with `*rest`, so each call allocates the rest array.

Compiling `b.call(x)` as a yield when the block parameter's only uses are calls would remove both, but it is **not a pure rewrite**: `yield` with no block raises `LocalJumpError` where `b.call` raises `NoMethodError` on nil, and `break` differs. It needs its own bytecode instruction carrying the call-form semantics, not a redirect to `Yield` — left for a separate change.

# Testing

- Full suite on the rebased branch: **3605 passed / 0 failed**
- `cargo check --target aarch64-unknown-linux-gnu`: clean
- Semantics verified against CRuby for `Proc#call` in every form (`call` / `.()` / `[]` / `yield`), arity mismatches on proc vs lambda, keyword forwarding through a symbol proc, and block-parameter forwarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_