### PR TITLE
Sum an Integer range in closed form, and scan min/max without dispatch

### DIFF
--- a/monoruby/builtins/range.rb
+++ b/monoruby/builtins/range.rb
@@ -286,6 +286,20 @@ class Range
   end
   alias member? include?
 
+  # An Integer range without a block is an arithmetic series, which
+  # `__builtin_sum` answers in closed form instead of adding up every term
+  # through Enumerable#sum — the difference between O(1) and O(size), and
+  # between an answer and no answer at all for a range like (1..10**20).
+  # It returns nil when the shape does not apply (non-Integer endpoints or
+  # init), which is never a real sum, so anything else falls back here.
+  def sum(init = 0)
+    unless block_given?
+      res = __builtin_sum(init)
+      return res unless res.nil?
+    end
+    super
+  end
+
   # The n argument of min(n)/max(n): #to_int conversion + validation.
   def __minmax_n(n)
     unless n.is_a?(Integer)

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -106,8 +106,8 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func_with(ARRAY_CLASS, "fetch", fetch, 1, 2, false);
     globals.define_builtin_func(ARRAY_CLASS, "take", take, 1);
     globals.define_builtin_func_with(ARRAY_CLASS, "sum", sum, 0, 1, false);
-    globals.define_builtin_func(ARRAY_CLASS, "min", min, 0);
-    globals.define_builtin_func(ARRAY_CLASS, "max", max, 0);
+    globals.define_builtin_func_with(ARRAY_CLASS, "min", min, 0, 1, false);
+    globals.define_builtin_func_with(ARRAY_CLASS, "max", max, 0, 1, false);
     globals.define_builtin_func(ARRAY_CLASS, "minmax", minmax, 0);
     globals.define_builtin_func(ARRAY_CLASS, "partition", partition, 0);
     globals.define_builtin_funcs(ARRAY_CLASS, "filter", &["select", "find_all"], filter, 0);
@@ -2441,16 +2441,155 @@ fn sum(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 }
 
 ///
+/// The `n` of `min(n)` / `max(n)`: `#to_int` conversion and validation,
+/// matching CRuby's messages (and `Range#__minmax_n` in builtins/range.rb,
+/// the Ruby-side twin of this).
+///
+fn minmax_n(vm: &mut Executor, globals: &mut Globals, n: Value) -> Result<usize> {
+    let n = n.coerce_to_int_i64(vm, globals)?;
+    if n < 0 {
+        // CRuby words this one per class: `Array#min` says "negative size
+        // (-1)", `Range#min` "negative array size (or size too big)".
+        return Err(MonorubyErr::argumenterr(format!("negative size ({n})")));
+    }
+    Ok(n as usize)
+}
+
+///
+/// The `min(n)` / `max(n)` forms: the `n` smallest (ascending) or largest
+/// (descending) elements.
+///
+/// Sorting the whole receiver is more work than CRuby's partial selection,
+/// but it reuses the one sort — including its homogeneous fast path and its
+/// GC-rooted merge buffer — and these forms are called for a *ranking*, on
+/// arrays small enough that the sort is not the cost. The receiver itself is
+/// never touched: the sort runs on a fresh copy.
+///
+fn min_max_n(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    n: Value,
+    take_max: bool,
+) -> Result<Value> {
+    let n = minmax_n(vm, globals, n)?;
+    // The copy is freshly allocated and not yet reachable from any GC root,
+    // and the comparator block can collect — root it for the sort, exactly
+    // as `Array#sort` does with its own copy.
+    let copy = Array::new_from_vec(lfp.self_val().as_array().to_vec());
+    let sorted = vm.with_temp_scope(|vm| {
+        vm.temp_push(copy.into());
+        sort_inner(vm, globals, lfp, copy)
+    })?;
+    let sorted = sorted.as_array();
+    let n = n.min(sorted.len());
+    let res: Vec<Value> = if take_max {
+        sorted[sorted.len() - n..].iter().rev().copied().collect()
+    } else {
+        sorted[..n].to_vec()
+    };
+    Ok(Value::array_from_vec(res))
+}
+
+///
+/// The `min` / `max` / `minmax` scan over a homogeneous receiver: one pass
+/// in Rust, no `compare_values` dispatch per element. `None` when the
+/// elements are not of one class with a known `<=>`.
+///
+/// Ties keep the earliest element, which is what the general path does
+/// (it replaces only on a *strict* improvement) and what CRuby does.
+///
+fn min_max_homogeneous(globals: &Globals, ary: &[Value]) -> Option<(Value, Value)> {
+    use executor::op::{HomogeneousOrd, cmp_redefined, homogeneous_ord};
+    // Numbers are the shape `min`/`max` actually meet, and for those the
+    // key *is* the ordering — so instead of classifying the receiver in one
+    // pass and scanning it in another, extract and compare in a single
+    // fused pass that gives up at the first element of another class. The
+    // first element says which key to try, so nothing is wasted on an
+    // array that has neither shape.
+    if ary[0].is_fixnum() && !cmp_redefined(globals, INTEGER_CLASS) {
+        if let Some(res) = min_max_by_key(ary, |v| v.try_fixnum()) {
+            return Some(res);
+        }
+    }
+    // A `NaN` key is left out, which drops the whole array to the general
+    // path — CRuby raises on the comparison rather than ordering around it.
+    if ary[0].try_float().is_some() && !cmp_redefined(globals, FLOAT_CLASS) {
+        if let Some(res) = min_max_by_key(ary, |v| v.try_float().filter(|f| !f.is_nan())) {
+            return Some(res);
+        }
+    }
+    // Strings order by a comparison, not by an extractable key, so they
+    // keep the classify-then-scan shape.
+    match homogeneous_ord(globals, ary)? {
+        HomogeneousOrd::String => {
+            let (mut min, mut max) = (ary[0], ary[0]);
+            // SAFETY of the unwraps: `homogeneous_ord` proved every element
+            // is a String.
+            let cmp = |a: Value, b: Value| {
+                crate::builtins::string::string_byte_then_encoding_cmp(
+                    a.is_rstring_inner().unwrap(),
+                    b.is_rstring_inner().unwrap(),
+                )
+            };
+            for &v in &ary[1..] {
+                if cmp(v, min) == std::cmp::Ordering::Less {
+                    min = v;
+                } else if cmp(v, max) == std::cmp::Ordering::Greater {
+                    max = v;
+                }
+            }
+            Some((min, max))
+        }
+        // Both key shapes were tried above; reaching here means the
+        // redefinition check turned one down.
+        HomogeneousOrd::Fixnum | HomogeneousOrd::Float => None,
+    }
+}
+
+///
+/// One pass over a non-empty `ary`, keeping the elements with the smallest
+/// and largest key — and, on a tie, the earlier one. `None` as soon as an
+/// element has no key, with nothing else read.
+///
+fn min_max_by_key<K: PartialOrd>(
+    ary: &[Value],
+    key: impl Fn(Value) -> Option<K>,
+) -> Option<(Value, Value)> {
+    let (mut min, mut max) = (ary[0], ary[0]);
+    let mut min_k = key(min)?;
+    let mut max_k = key(max)?;
+    for &v in &ary[1..] {
+        let k = key(v)?;
+        if k < min_k {
+            min_k = k;
+            min = v;
+        } else if k > max_k {
+            max_k = k;
+            max = v;
+        }
+    }
+    Some((min, max))
+}
+
+///
 /// ### Array#min
 ///
 /// - min -> object | nil
 /// - min {|a, b| ... } -> object | nil
-/// - [NOT SUPPORTED] min(n) -> Array
-/// - [NOT SUPPORTED] min(n) {|a, b| ... } -> Array
+/// - min(n) -> Array
+/// - min(n) {|a, b| ... } -> Array
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Array/i/min.html]
 #[monoruby_builtin]
 pub(crate) fn min(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    // An explicit `nil` for `n` means "no n" — `[3,1,2].min(nil)` is 1,
+    // not a TypeError.
+    if let Some(n) = lfp.try_arg(0)
+        && !n.is_nil()
+    {
+        return min_max_n(vm, globals, lfp, n, false);
+    }
     let ary = lfp.self_val().as_array();
     if ary.len() == 0 {
         return Ok(Value::nil());
@@ -2466,9 +2605,15 @@ pub(crate) fn min(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecod
         }
         Ok(min)
     } else {
+        if let Some((min, _)) = min_max_homogeneous(globals, &ary) {
+            return Ok(min);
+        }
         let mut min = ary[0];
         for v in &ary[1..] {
-            if vm.compare_values(globals, min, *v)? == std::cmp::Ordering::Greater {
+            // The element is the receiver of `<=>`, as in CRuby, so an
+            // incomparable pair is reported the way CRuby reports it:
+            // `[1, "a"].min` names the String, not the Integer.
+            if vm.compare_values(globals, *v, min)? == std::cmp::Ordering::Less {
                 min = *v;
             }
         }
@@ -2481,12 +2626,17 @@ pub(crate) fn min(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecod
 ///
 /// - max -> object | nil
 /// - max {|a, b| ... } -> object | nil
-/// - [NOT SUPPORTED] max(n) -> Array
-/// - [NOT SUPPORTED] max(n) {|a, b| ... } -> Array
+/// - max(n) -> Array
+/// - max(n) {|a, b| ... } -> Array
 ///
 /// [https://docs.ruby-lang.org/ja/latest/method/Array/i/max.html]
 #[monoruby_builtin]
 pub(crate) fn max(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    if let Some(n) = lfp.try_arg(0)
+        && !n.is_nil()
+    {
+        return min_max_n(vm, globals, lfp, n, true);
+    }
     let ary = lfp.self_val().as_array();
     if ary.len() == 0 {
         return Ok(Value::nil());
@@ -2502,9 +2652,13 @@ pub(crate) fn max(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecod
         }
         Ok(max)
     } else {
+        if let Some((_, max)) = min_max_homogeneous(globals, &ary) {
+            return Ok(max);
+        }
         let mut max = ary[0];
         for v in &ary[1..] {
-            if vm.compare_values(globals, max, *v)? == std::cmp::Ordering::Less {
+            // Element as receiver, as in `min` above.
+            if vm.compare_values(globals, *v, max)? == std::cmp::Ordering::Greater {
                 max = *v;
             }
         }
@@ -2539,22 +2693,8 @@ fn minmax(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
                 max = *v;
             }
         }
-    } else if let Some(first_i) = ary[0].try_fixnum()
-        && ary.iter().all(|v| v.try_fixnum().is_some())
-    {
-        // All-Fixnum fast path: tight i64 loop, no Ruby-level dispatch.
-        let mut min_i = first_i;
-        let mut max_i = first_i;
-        for v in &ary[1..] {
-            // SAFETY: pre-checked above that every element is a Fixnum.
-            let x = unsafe { v.try_fixnum().unwrap_unchecked() };
-            if x < min_i {
-                min_i = x;
-            } else if x > max_i {
-                max_i = x;
-            }
-        }
-        return Ok(Value::array2(Value::integer(min_i), Value::integer(max_i)));
+    } else if let Some((min, max)) = min_max_homogeneous(globals, &ary) {
+        return Ok(Value::array2(min, max));
     } else {
         for v in &ary[1..] {
             if vm.compare_values(globals, min, *v)? == std::cmp::Ordering::Greater {
@@ -7841,6 +7981,104 @@ mod tests {
         ]);
         // error for out-of-range without block
         run_test_error("[10, 20, 30].fetch_values(0, 5)");
+    }
+
+    #[test]
+    fn min_max_homogeneous_fast_path() {
+        run_tests(&[
+            // Each class the fast path takes, and each it declines.
+            "[3, 1, 2].min",
+            "[3, 1, 2].max",
+            "[3, 1, 2].minmax",
+            "[3.5, 1.5, 2.5].min",
+            "[3.5, 1.5, 2.5].max",
+            "[3.5, 1.5, 2.5].minmax",
+            r#"["b", "a", "c"].min"#,
+            r#"["b", "a", "c"].max"#,
+            r#"["b", "a", "c"].minmax"#,
+            // Declined: mixed numerics (still ordered, by the general path),
+            // a Bignum, a Symbol, one element, none.
+            "[1, 2.5, 0].min",
+            "[1, 2.5, 0].max",
+            "[10**20, 1].min",
+            "[10**20, 1].max",
+            "[:b, :a].min",
+            "[:b, :a].minmax",
+            "[7].min",
+            "[7].minmax",
+            "[].min",
+            "[].max",
+            "[].minmax",
+            // Ties keep the first equal element, which `equal?` can see.
+            r#"a = "x"; b = "x"; [a, b].min.equal?(a)"#,
+            r#"a = "x"; b = "x"; [a, b].max.equal?(a)"#,
+        ]);
+        // A NaN has no ordering: the general path raises, as CRuby does,
+        // rather than the fast path ordering around it.
+        run_test_error("[3.0, Float::NAN, 2.0].min");
+        run_test_error("[3.0, Float::NAN, 2.0].max");
+        run_test_error("[3.0, Float::NAN].minmax");
+        // Incomparable elements raise, and name the operands CRuby's way.
+        run_test_error(r#"[1, "a"].min"#);
+        run_test_error(r#"[1, "a"].max"#);
+        run_test_error(r#"[1, "a"].minmax"#);
+    }
+
+    #[test]
+    fn min_max_redefined_cmp() {
+        // A redefined `<=>` takes the receiver off the fast path — every
+        // one of min / max / minmax must go through the redefinition.
+        for m in ["min", "max", "minmax"] {
+            run_test_with_prelude(
+                &format!("[3, 1, 2].{m}"),
+                "class Integer; def <=>(o) = (o.to_i - to_i); end",
+            );
+            run_test_with_prelude(
+                &format!("[3.0, 1.0, 2.0].{m}"),
+                "class Float; def <=>(o) = (o.to_f - to_f); end",
+            );
+            run_test_with_prelude(
+                &format!(r#"["b", "a", "c"].{m}"#),
+                "class String; def <=>(o) = (o.length - length); end",
+            );
+        }
+    }
+
+    #[test]
+    fn min_max_n() {
+        run_tests(&[
+            "[3, 1, 2].min(2)",
+            "[3, 1, 2].max(2)",
+            // n at and past the edges, and the no-op forms.
+            "[3, 1, 2].min(0)",
+            "[3, 1, 2].max(0)",
+            "[3, 1, 2].min(99)",
+            "[3, 1, 2].max(99)",
+            "[].min(2)",
+            "[].max(2)",
+            // An explicit nil for n means "no n", not a TypeError.
+            "[3, 1, 2].min(nil)",
+            "[3, 1, 2].max(nil)",
+            "[3, 1, 2].min(nil) {|a, b| b <=> a}",
+            // n is #to_int-converted.
+            "[3, 1, 2].min(2.0)",
+            r#"[3, 1, 2].min(Object.new.tap {|o| def o.to_int = 2 })"#,
+            // With a comparator block, and over the other element types.
+            "[3, 1, 2].min(2) {|a, b| b <=> a}",
+            "[3, 1, 2].max(2) {|a, b| b <=> a}",
+            r#"["b", "a", "c"].min(2)"#,
+            r#"["b", "a", "c"].max(2)"#,
+            "[3.5, 1.5, 2.5].min(2)",
+            "[3.5, 1.5, 2.5].max(2)",
+            // The receiver is not reordered by the ranking.
+            "a = [3, 1, 2]; a.min(2); a",
+            "a = [3, 1, 2]; a.max(2); a",
+        ]);
+        run_test_error("[3, 1, 2].min(-1)");
+        run_test_error("[3, 1, 2].max(-2)");
+        run_test_error(r#"[3, 1, 2].min("a")"#);
+        run_test_error("[3, 1, 2].min(2**70)");
+        run_test_error(r#"[1, "a"].min(2)"#);
     }
 
     #[test]

--- a/monoruby/src/builtins/range.rs
+++ b/monoruby/src/builtins/range.rs
@@ -1,5 +1,6 @@
 use super::*;
 use jitgen::{AbstractState, JitContext};
+use num::BigInt;
 
 //
 // Range class
@@ -49,6 +50,9 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(RANGE_CLASS, "__builtin_min", min, 0);
     globals.define_builtin_func(RANGE_CLASS, "__builtin_max", max, 0);
     globals.define_builtin_func(RANGE_CLASS, "count", count, 0);
+    // Reached from `Range#sum` (builtins/range.rb), which owns the
+    // block / fallback decision.
+    globals.define_builtin_func(RANGE_CLASS, "__builtin_sum", int_sum, 1);
     globals.define_builtin_func(RANGE_CLASS, "minmax", minmax, 0);
 }
 
@@ -933,6 +937,89 @@ fn count(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
 }
 
 ///
+/// An Integer `Value` (Fixnum or Bignum) as one of the two, or `None` for
+/// anything else.
+///
+enum IntVal {
+    Fix(i64),
+    Big(BigInt),
+}
+
+fn int_val(v: Value) -> Option<IntVal> {
+    match v.unpack() {
+        RV::Fixnum(i) => Some(IntVal::Fix(i)),
+        RV::BigInt(b) => Some(IntVal::Big(b.clone())),
+        _ => None,
+    }
+}
+
+impl IntVal {
+    fn to_bigint(&self) -> BigInt {
+        match self {
+            Self::Fix(i) => BigInt::from(*i),
+            Self::Big(b) => b.clone(),
+        }
+    }
+}
+
+///
+/// ### Range#sum — the Integer closed form
+///
+/// The arithmetic series `init + beg + (beg+1) + ... + end`, computed as
+/// `init + (beg + end) * (end - beg + 1) / 2` instead of iterating, which
+/// is what CRuby's `int_range_sum` does.
+///
+/// Called only from `Range#sum` in builtins/range.rb, and only when no
+/// block was given. `nil` means the shape did not apply — the endpoints or
+/// `init` are not all Integers — and tells the caller to fall back to
+/// `Enumerable#sum`. That is never a real result here: a sum of Integers
+/// is an Integer, and an empty range answers `init`, which this path is
+/// only reached with when it is one too.
+///
+/// Beyond the speed, this is what makes `(1..10**20).sum` answer at all:
+/// summing term by term never finishes.
+///
+#[monoruby_builtin]
+fn int_sum(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_ = lfp.self_val();
+    let range = self_.as_range();
+    let (Some(beg), Some(end), Some(init)) = (
+        int_val(range.start()),
+        int_val(range.end()),
+        int_val(lfp.arg(0)),
+    ) else {
+        return Ok(Value::nil());
+    };
+    let excl = range.exclude_end();
+    // Fixnums are i63, so `beg + end` and `end - beg + 1` each fit in i64
+    // and their product in i128 — no overflow check needed, and the
+    // division by 2 is exact because one of the two factors is even.
+    if let (IntVal::Fix(beg), IntVal::Fix(end), IntVal::Fix(init)) = (&beg, &end, &init) {
+        let (beg, mut end, init) = (*beg as i128, *end as i128, *init as i128);
+        if excl {
+            end -= 1;
+        }
+        if end < beg {
+            return Ok(Value::integer(init as i64));
+        }
+        let sum = init + (beg + end) * (end - beg + 1) / 2;
+        return Ok(match i64::try_from(sum) {
+            Ok(i) => Value::integer(i),
+            Err(_) => Value::bigint(BigInt::from(sum)),
+        });
+    }
+    let (beg, mut end, init) = (beg.to_bigint(), end.to_bigint(), init.to_bigint());
+    if excl {
+        end -= 1u32;
+    }
+    if end < beg {
+        return Ok(Value::bigint(init));
+    }
+    let sum = init + (&beg + &end) * (&end - &beg + 1u32) / 2u32;
+    Ok(Value::bigint(sum))
+}
+
+///
 /// ### Range#minmax
 ///
 /// - minmax -> [object, object]
@@ -1562,6 +1649,43 @@ mod tests {
             (1..5).max {|a, b| z }
             "#,
         );
+    }
+
+    #[test]
+    fn sum() {
+        run_tests(&[
+            // The closed form: inclusive / exclusive, empty, negative,
+            // single element, and an Integer init.
+            "(1..10).sum",
+            "(1...10).sum",
+            "(1..1).sum",
+            "(1...1).sum",
+            "(10..1).sum",
+            "(10...1).sum",
+            "(-5..5).sum",
+            "(-10..-5).sum",
+            "(1..10).sum(100)",
+            "(10..1).sum(100)",
+            "(1..10).sum(-100)",
+            // Results and endpoints past Fixnum range.
+            "(1..10**10).sum",
+            "(1...10**10).sum",
+            "(10**20..10**20 + 2).sum",
+            "(1..10**20).sum",
+            "(-10**20..10**20).sum",
+            "(1..10).sum(10**30)",
+            // Shapes that fall back to Enumerable#sum: a block, and
+            // endpoints that are not both Integers.
+            "(1..10).sum { |x| x * 2 }",
+            "(1..10).sum(100) { |x| x * 2 }",
+            r#"("a".."e").sum("")"#,
+            "(1..10).step(2).sum",
+        ]);
+        // A Float range has no `succ` to iterate, so once the closed form
+        // declines it, Enumerable#sum raises — with or without a block,
+        // exactly as CRuby does.
+        run_test_error("(1.0..3.0).sum");
+        run_test_error("(1.0..3.0).sum { |x| x }");
     }
 
     #[test]

--- a/monoruby/src/executor/op.rs
+++ b/monoruby/src/executor/op.rs
@@ -780,11 +780,11 @@ impl Executor {
         rhs: Value,
     ) -> Result<std::cmp::Ordering> {
         self.compare_values_inner(globals, lhs, rhs)?
-            .ok_or_else(|| {
-                let lhs = lhs.get_real_class_name(&globals.store);
-                let rhs = rhs.to_s(&globals.store);
-                MonorubyErr::argumenterr(format!("comparison of {lhs} with {rhs} failed"))
-            })
+            // `cmperr` is CRuby's `rb_cmperr`, which names the argument by
+            // class unless it is an immediate or a Float: `[1, "a"].min`
+            // reports "comparison of String with 1 failed", not the
+            // argument's `to_s` (which read as an unquoted `a`).
+            .ok_or_else(|| cmperr(&globals.store, lhs, rhs))
     }
 
     pub(crate) fn compare_values_inner(
@@ -860,15 +860,14 @@ impl Executor {
         // `[W.new(2), W.new(1)].sort` raise where CRuby sorts, whenever
         // `W#<=>` returned a difference rather than a unit.
         //
-        // `cmpint` reports "not comparable" as the same `cmperr` the
-        // callers of this function build from `None`, so its error is
-        // theirs; anything else it raises (from dispatching `res <=> 0`)
-        // propagates as it should.
-        match self.cmpint(globals, res, lhs, rhs) {
-            Ok(ord) => Ok(Some(ord)),
-            Err(err) if matches!(err.kind(), MonorubyErrKind::Arguments) => Ok(None),
-            Err(err) => Err(err),
-        }
+        // A `nil` answer — the "these two are not comparable" one, which
+        // `<=>` reports as `nil` rather than by raising — was returned
+        // above, so anything `cmpint` raises while reading the sign of a
+        // non-`nil` result is a real error and propagates. CRuby does the
+        // same: a comparator returning a String raises from the `res > 0`
+        // inside `rb_cmpint` ("comparison of String with 0 failed"), and
+        // that error is what the caller sees.
+        Ok(Some(self.cmpint(globals, res, lhs, rhs)?))
     }
 }
 

--- a/monoruby/src/executor/op/sort.rs
+++ b/monoruby/src/executor/op/sort.rs
@@ -84,16 +84,33 @@ impl Executor {
                         num::bigint::Sign::Plus => std::cmp::Ordering::Greater,
                     });
                 }
+                // Anything else is asked for its sign the way rb_cmpint
+                // asks — `res > 0`, then `res < 0` — and *not* through
+                // `res <=> 0`. The difference shows whenever the program
+                // redefined the `<=>` of the very class the comparator
+                // returns: with `class Float; def <=>(o) = o - self; end`,
+                // `[3.0, 1.0].sort` re-entered that method to read the sign
+                // of its own result and got it backwards. A Float result
+                // also has no exact Integer to coerce to — reading
+                // `Float::MAX - 1.0` as an integer raised RangeError, where
+                // CRuby just sees a positive number.
+                //
+                // A class that answers neither comparison — a String
+                // comparator result, say — reaches the same ArgumentError
+                // CRuby reaches, and by the same route: `String#>` comes
+                // from Comparable, which reports
+                // "comparison of String with 0 failed".
                 let zero = Value::integer(0);
-                let cmp =
-                    self.invoke_method_inner(globals, IdentId::_CMP, res, &[zero], None, None)?;
-                if cmp.is_nil() {
-                    // CRuby reaches the same place through `res > 0`, and
-                    // names the comparator's own result: e.g. a String
-                    // comparator gives "comparison of String with 0 failed".
-                    return Err(cmperr(&globals.store, res, zero));
+                let gt = self.invoke_method_inner(globals, IdentId::_GT, res, &[zero], None, None)?;
+                if gt.as_bool() {
+                    return Ok(std::cmp::Ordering::Greater);
                 }
-                cmp.coerce_to_int_i64(self, globals)?
+                let lt = self.invoke_method_inner(globals, IdentId::_LT, res, &[zero], None, None)?;
+                return Ok(if lt.as_bool() {
+                    std::cmp::Ordering::Less
+                } else {
+                    std::cmp::Ordering::Equal
+                });
             }
         };
         Ok(i.cmp(&0))
@@ -102,70 +119,101 @@ impl Executor {
 
 
 ///
-/// Sort *vec* in place without running any Ruby, when every element is of
-/// one class whose `<=>` answer is fixed (`BASIC_OP_DEFS` licenses the
-/// pairs, and a redefinition of one is checked here). Returns whether it
-/// did.
+/// A class of element whose `<=>` answer is fixed, so an ordering over a
+/// slice of them can be computed in Rust without running any Ruby.
 ///
-/// This is the shape `Array#sort` / `Hash#sort` actually meet — an array
-/// of numbers, or of strings — and the point is not just skipping the
-/// dispatch (`compare_values_inner` already answers those pairs itself)
-/// but skipping the *comparator plumbing*: a `Result`-returning closure
-/// through a generic merge sort, versus a direct key comparison the
-/// compiler can inline into a pattern-defeating quicksort. Ruby's sort is
-/// not stable, so an unstable sort is a valid answer.
+/// Produced by [`homogeneous_ord`], which is what licenses the assumption:
+/// every element is of the class, and the class's `<=>` is not redefined.
+/// Callers then write the comparison for that one class directly — a
+/// monomorphic loop that inlines, rather than a dispatch per comparison —
+/// so the `unwrap`s they use are safe only for values that passed the
+/// check.
 ///
-/// A mixed array, a `Float` (whose `NaN` must still raise through the
-/// comparator), or a class with a redefined `<=>` all fall through to the
-/// general path.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum HomogeneousOrd {
+    Fixnum,
+    String,
+    Float,
+}
+
+///
+/// Classify `vals` as all-of-one-class with a known `<=>` (`BASIC_OP_DEFS`
+/// licenses the pairs, and a redefinition of the class's own `<=>` is
+/// checked here), or `None` when no such shape applies.
+///
+/// These are the shapes `sort` / `min` / `max` actually meet — a slice of
+/// numbers, or of strings — and the point is not just skipping the dispatch
+/// (`compare_values_inner` already answers those pairs itself) but skipping
+/// the *comparator plumbing*: a `Result`-returning closure through a generic
+/// merge sort, or a `compare_values` call per element, versus a direct
+/// comparison the compiler can inline.
+///
+/// A mixed slice, a `Float` slice holding a `NaN` (which has no ordering —
+/// CRuby raises on the comparison rather than ordering around it, so it is
+/// left to the general path to report), or a class with a redefined `<=>`
+/// all give `None`.
+///
+/// An empty or single-element slice classifies as `Fixnum` vacuously; every
+/// caller has already handled those lengths, and no comparison is made.
+///
+pub(crate) fn homogeneous_ord(globals: &Globals, vals: &[Value]) -> Option<HomogeneousOrd> {
+    if vals.iter().all(|v| v.is_fixnum()) {
+        return (!cmp_redefined(globals, INTEGER_CLASS)).then_some(HomogeneousOrd::Fixnum);
+    }
+    if vals.iter().all(|v| v.is_rstring_inner().is_some()) {
+        return (!cmp_redefined(globals, STRING_CLASS)).then_some(HomogeneousOrd::String);
+    }
+    if vals
+        .iter()
+        .all(|v| v.try_float().is_some_and(|f| !f.is_nan()))
+    {
+        return (!cmp_redefined(globals, FLOAT_CLASS)).then_some(HomogeneousOrd::Float);
+    }
+    None
+}
+
+///
+/// Whether `class` had its `<=>` redefined, which takes the ordering of its
+/// instances away from the fast paths above. The global flag is checked
+/// first: until *something* redefines a basic operation, no per-class
+/// lookup is worth doing.
+///
+pub(crate) fn cmp_redefined(globals: &Globals, class: ClassId) -> bool {
+    globals.store.basic_op_redefined()
+        && globals.store.basic_op_redefined_for(class, IdentId::_CMP)
+}
+
+///
+/// Sort *vec* in place without running any Ruby, when [`homogeneous_ord`]
+/// classifies it. Returns whether it did.
+///
+/// Ruby's sort is not stable, so an unstable sort is a valid answer. Each
+/// class gets its own `sort_unstable_by*` call rather than one call through
+/// a shared comparator, so the key extraction is monomorphic and inlines.
 ///
 fn sort_homogeneous(globals: &Globals, vec: &mut [Value]) -> bool {
     if vec.len() < 2 {
         return true;
     }
-    let redefined = |class: ClassId| {
-        globals.store.basic_op_redefined()
-            && globals.store.basic_op_redefined_for(class, IdentId::_CMP)
-    };
-    if vec.iter().all(|v| v.is_fixnum()) {
-        if redefined(INTEGER_CLASS) {
-            return false;
-        }
-        // SAFETY of the unwraps: every element was just proven a fixnum.
-        vec.sort_unstable_by_key(|v| v.try_fixnum().unwrap());
-        return true;
-    }
-    if vec.iter().all(|v| v.is_rstring_inner().is_some()) {
-        if redefined(STRING_CLASS) {
-            return false;
-        }
-        vec.sort_unstable_by(|a, b| {
+    match homogeneous_ord(globals, vec) {
+        // SAFETY of the unwraps here and below: `homogeneous_ord` proved
+        // every element is of the class.
+        Some(HomogeneousOrd::Fixnum) => vec.sort_unstable_by_key(|v| v.try_fixnum().unwrap()),
+        Some(HomogeneousOrd::String) => vec.sort_unstable_by(|a, b| {
             crate::builtins::string::string_byte_then_encoding_cmp(
                 a.is_rstring_inner().unwrap(),
                 b.is_rstring_inner().unwrap(),
             )
-        });
-        return true;
-    }
-    // A `NaN` has no ordering, and CRuby raises on the comparison rather
-    // than sorting around it — leave any array holding one to the general
-    // path, whose comparator reports the failure.
-    if vec
-        .iter()
-        .all(|v| v.try_float().is_some_and(|f| !f.is_nan()))
-    {
-        if redefined(FLOAT_CLASS) {
-            return false;
-        }
-        vec.sort_unstable_by(|a, b| {
+        }),
+        Some(HomogeneousOrd::Float) => vec.sort_unstable_by(|a, b| {
             a.try_float()
                 .unwrap()
                 .partial_cmp(&b.try_float().unwrap())
                 .expect("NaN was excluded above")
-        });
-        return true;
+        }),
+        None => return false,
     }
-    false
+    true
 }
 
 ///
@@ -181,46 +229,26 @@ pub(crate) fn sort_indices_by_homogeneous_keys(
     if indices.len() < 2 {
         return true;
     }
-    let redefined = |class: ClassId| {
-        globals.store.basic_op_redefined()
-            && globals.store.basic_op_redefined_for(class, IdentId::_CMP)
-    };
-    if keys.iter().all(|v| v.is_fixnum()) {
-        if redefined(INTEGER_CLASS) {
-            return false;
+    match homogeneous_ord(globals, keys) {
+        Some(HomogeneousOrd::Fixnum) => {
+            indices.sort_unstable_by_key(|&i| keys[i].try_fixnum().unwrap())
         }
-        indices.sort_unstable_by_key(|&i| keys[i].try_fixnum().unwrap());
-        return true;
-    }
-    if keys.iter().all(|v| v.is_rstring_inner().is_some()) {
-        if redefined(STRING_CLASS) {
-            return false;
-        }
-        indices.sort_unstable_by(|&a, &b| {
+        Some(HomogeneousOrd::String) => indices.sort_unstable_by(|&a, &b| {
             crate::builtins::string::string_byte_then_encoding_cmp(
                 keys[a].is_rstring_inner().unwrap(),
                 keys[b].is_rstring_inner().unwrap(),
             )
-        });
-        return true;
-    }
-    if keys
-        .iter()
-        .all(|v| v.try_float().is_some_and(|f| !f.is_nan()))
-    {
-        if redefined(FLOAT_CLASS) {
-            return false;
-        }
-        indices.sort_unstable_by(|&a, &b| {
+        }),
+        Some(HomogeneousOrd::Float) => indices.sort_unstable_by(|&a, &b| {
             keys[a]
                 .try_float()
                 .unwrap()
                 .partial_cmp(&keys[b].try_float().unwrap())
                 .expect("NaN was excluded above")
-        });
-        return true;
+        }),
+        None => return false,
     }
-    false
+    true
 }
 
 ///

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -19,6 +19,7 @@
 011e3a767663769a41763822af96c4c2	"foo"	def m\n              a = 42\n              1.times { /(?<a>foo)/ =~ "
 01285d5502da85e38cd005e70dcfe4ac	["hello Fred", "bye Fred"]	def get_binding(str)\n            binding\n        end\n        str = "hel
 013365e50f318e63be4522e4d94c3ff4	nil	puts 100\n        
+0139110b899540a213795ab6a404e305	"b"	class String; def <=>(o) = (o.length - length); end\n["b", "a", "c"].max
 0142f6a78c90261818a919df5e34508a	true	define_method(:boom) { :bam }\n            Object.method_defined?(:b
 01443549f3178fa419efc8dfabeb3d03	[1, 4, 5]	class MyAry; def to_ary; [4,5]; end; end\nobj = MyAry.new\na = [1]; a.concat(obj);
 0157b6a817ac1fed2a62196ed525d722	["a.rb:1: Some runtime error (RuntimeError)\\n\\tfrom b.rb:2\\n", "Traceback (most recent call last):\\n\\t1: from b.rb:2\\na.rb:1: Some runtime error (RuntimeError)\\n", "a.rb:1: \\e[1mSome runtime error (\\e[1;4mRuntimeError\\e[m\\e[1m)\\e[m\\n\\tfrom b.rb:2\\n", "\\e[1mTraceback\\e[m (most recent call last):\\n\\t1: from b.rb:2\\na.rb:1: \\e[1mSome runtime error (\\e[1;4mRuntimeError\\e[m\\e[1m)\\e[m\\n"]	e = RuntimeError.new("Some runtime error")\n        e.set_backtrace(["a.
@@ -323,7 +324,9 @@
 181190488544c9b5c85380245eaff93b	["B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 1|[2, 3, 4]", "B->A 9|[]"]	class A\n          def m(a, *r) = "A #{a}|#{r.inspect}"\n        end\n    
 1821c10c6ad04de6330183a77e1e0216	["Binding", 41, 42, 41]	x = 41\n            b = binding\n            b2 = b.dup\n            b
 182caa69fa07777b5c852ab6d6cd523b	[:@b]	class Foo\n              def initialize\n                @a = 1\n     
+1838df795bd9fd01b3bfa47259229043	1.0	class Float; def <=>(o) = (o.to_f - to_f); end\n[3.0, 1.0, 2.0].max
 185001d9a1904b3f91e65a1932e2bf0b	[11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11]	def g(a) = yield(a * 2)\n        def f(...) = g(...)\n        \n\n        $
+18507817da0f9cab02fe974f7701f74a	[[3.0, 2.0, 1.0], 3.0, 1.0, [3.0, 1.0], [1.7976931348623157e+308, 1.0]]	class Float; def <=>(o) = (o.to_f - to_f); end\n        [[3.0, 1.0, 2.0]
 186a15eac97b7392435d31cc9d7e59de	70	class Coercible\n              def to_proc\n                proc { |x
 18a7283ed1dcb3c87a0a51c2be6ebeca	[111, 111]	def add_fold; 5 + 3; end\n        def add_dyn(a, b); a + b; end\n        
 18b3f31c36b0241cca4cd3e50f3ef25a	"hi world"	class Foo\n              def hello(x); "hi #{x}"; end\n            en
@@ -548,6 +551,7 @@
 29a4782bad89b05e2a89fbdc04ec694a	[[1, :d, [], 1, nil], [1, 2, [3, 4], 1, nil], [1, 2, [], 9, nil], [1, :d, [], 1, :blk], [10, 20, [30], 1, nil], [5, 6, [7], 2, nil]]	def t(a, b = :d, *r, k: 1, &blk); [a, b, r, k, blk ? blk.call : nil
 29be5fcdba7ed7a8c6ca8dadda30fdde	["Xtail-line\\nXpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpad", ["tail", "line", "padpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpad"], "T-line\\npadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpad", "Ytail-line\\nYpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpad", "if @c  tail-line\\n  padpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadend\\n"]	s = "HEADER-LINE\\nmiddle\\ntail-line\\n" + "pad" * 20\n        s =~ /middl
 29c1437316aed84311f490aa6a4532d1	["C", "B", "A", "M3", "M2", "M1"]	module M1; end\n        module M2\n          include M1\n        end\n     
+2a0125843d4ab599f9e3f4ec2c1ca1c3	["b", "b"]	class String; def <=>(o) = (o.length - length); end\n["b", "a", "c"].minmax
 2a04e0b26f5843b7982d5765e50f29cf	[[:c1, :c2], [:c1, :c2]]	class S\n              def s; end\n            end\n            class 
 2a054f41f0ebb76b11549882f920add6	[]	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \ns.val
 2a25d512f1f2e7b492c0615e3eebe7e4	[:hi, true, false, :hi, true, false]	module CrefMixin\n          BLK = proc do\n            module DefinedInBl
@@ -657,6 +661,7 @@
 33cc5f4be417d616ecd8eb208e890c90	[3, 3, 4]	def f(x, y = x, z = y + 1); [x, y, z]; end; f(3)
 33cd8b36724499dce5c02aaf1ed6ba18	nil	$LOAD_PATH.resolve_feature_path("zzzz")
 33d265b1410d2d73366d85d5914634a0	:bar	class Foo\n              def bar; end\n            end\n            \n\n
+33d815d902d4f407cf435eb0d28d1208	3	class Integer; def <=>(o) = (o.to_i - to_i); end\n[3, 1, 2].min
 33f240174e1b4ed412a41494df988007	true	rng = Random.new(42)\n        a = rng.rand(0.0)\n        a.is_a?(Float) &
 3412cc41d6de3781c63ffde8aa5321ad	3	class MyNum; def to_int; 2; end; end\nn = MyNum.new\n[1,2,3,4,5].fetch(n)
 34185ec344beed72368ad045d6e8444c	[false, false]	require "tempfile"\n            t = Tempfile.new("mrb_sec")\n        
@@ -787,6 +792,7 @@
 3ea714d00ab18c02ddeeeac4648d3d50	"hello\\n"	io = IO.popen("echo hello")\n            s = io.read\n            io.
 3ec757fa265aa412b3b36ba1f96c0f14	["1234", "567", true, "12345", "1234567890", 2, "12XY567890", true]	path = "/tmp/monoruby_io_prw_#{Process.pid}_#{rand(100000)}"\n      
 3edda3e10e05dd7d22ab125a3f3fc747	[true, true, true, true, true, true, true, true, true, true, true, true, true, true]	GC.start\n            s = GC.stat\n            [\n              s[:hea
+3ee5dc8ce5dbe36171c4972cfc8a4911	[3.0, 1.0]	class Float; def <=>(o) = (o.to_f - to_f); end\n[3.0, 1.0, 2.0].minmax
 3f05b99cbc38adbfbc473b701ac03671	[:solo, :solo, 42]	obj = Object.new\n            def obj.solo; 42; end\n            m = 
 3f11838333fcfd0c716211da92e940b8	[[1, 2], [true, nil], [true, nil], [42, nil], [0, 1, 2], [1, 2], [true, nil], [1, [2]]]	class Ary;  def to_ary; [1, 2]; end; end\n        class Nily; def to_ary
 3f1b46f2be220ff7e899b8081439a046	true	"abc".force_encoding("ISO-8859-16").encoding == Encoding::ISO_8859_16
@@ -1350,6 +1356,7 @@
 6bab7203c03f2793f901298b3357f169	true	"abc".force_encoding("ISO-8859-5").encoding == Encoding::ISO_8859_5
 6bc256a131cd947b4c256d4afa639789	["y", Encoding::ConverterNotFoundError, Encoding::ConverterNotFoundError, [254, 255, 0, 97, 0, 10, 0, 98], "UTF-16", [[254, 255, 0, 97, 0, 10, 0, 98]], true, Encoding::ConverterNotFoundError]	(a="\\x79".dup.force_encoding(Encoding::BINARY).encode(Encoding::Emacs_Mule); b=(
 6c331f471496111694ecb08afb04cab9	[1, 2, 3]	v = []\n            t = Thread.new { v << 1; sleep; v << 3 }\n       
+6c6bac9e1206b463f412a2b2d96f020e	[3, 1]	class Integer; def <=>(o) = (o.to_i - to_i); end\n[3, 1, 2].minmax
 6c8169ed67889ab883af159b5e32ee14	[[:reader_splat, 2, :struct_reader_arg, 3], 3]	class AccCov\n          attr_reader :x\n          attr_writer :y\n        
 6c858418f8d579a73265ea125ceceeeb	1.5	class C; def to_f; 1.5; end; end; o = C.new\nFloat(o)
 6c891eca2cb89ba2ef5d9d75c6d8f60f	[20, 20]	def m\n              binding\n            end\n            b1 = m\n    
@@ -1380,6 +1387,7 @@
 6f24de5d11a542e7e8ae8c08bd85f5b7	[true, TypeError, IOError, Errno::ENOENT, Time]	(f="/tmp/mono_ep_#{Process.pid}"; File.write(f,"abc"); base=Object.new; def base
 6f2c032bb56f206798d710670edd906e	"Ruby on Railsd"	a = "Ruby"\n            a << " on Rails"\n            a << 100\n      
 6f3586689788165519257e6a0519ec54	"false"	require "tmpdir"\n            Dir.mktmpdir do |d|\n              out 
+6f412c98f8a121e54dda47768d00dcc0	[[1.5, 2.5, 3.5], [-1.7976931348623157e+308, 1.0, 1.7976931348623157e+308], -1.7976931348623157e+308, 1.7976931348623157e+308]	class Wide\n          attr_reader :v\n          def initialize(v) = @v = 
 6f48a4a001fdd1b6d3fd9bc7a12ae5fe	[true, "directory"]	[File.stat("/tmp").directory?, File.stat("/tmp").ftype]
 6f6180f86272a5e7760efeac4c2a956e	"abcああ"	"abc".ljust(5, "あ")
 6f89c5db7683986a9e61229515e918a3	"[] {a: 42, 100 => 100, c: 5}"	class C\n          def foo(*x, **y)\n            $res << x.inspect + " " 
@@ -1907,6 +1915,7 @@
 99bb34801d29ed3f9e2aa19ad41e3e16	true	proc{ 1 + 1 }.hash.is_a?(Integer)
 99c86d200493ccc2ea42e7d9e6990a3e	true	r, w = IO.pipe\n            begin\n              writers = IO.select(
 99c9a2df91f9cf9273cac10f6bf9fdd4	[[2, 4, 6], 6, 6, 42]	module BopLeak\n              refine(Integer) { def +(o); 42; end }\n
+99cf4152d5e0d0caa19da467722dd24b	"b"	class String; def <=>(o) = (o.length - length); end\n["b", "a", "c"].min
 99cfc04650144986127f45b7743e69aa	[900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900]	class A\n          def m(a, *r) = yield(a + r.sum)\n        end\n        c
 99d9f00bc752fd756d973756cc553768	:OVERRIDDEN	class Hash; def [](k); :OVERRIDDEN; end; end; ({1=>2})[1]
 99ecbfe1c60911aafcec1d108ca89493	[false, true, true]	path = "/tmp/monoruby_io_eof_#{Process.pid}_#{rand(100000)}"\n      
@@ -2311,6 +2320,7 @@ b7091d188869013ccaa15480c8f7b154	["Block isn't given.", "Block is given."]	def c
 b72e139f9584a1a1c990a63100a2e98c	[["NoMemoryError", nil, true], ["ScriptError", nil, true], ["SecurityError", nil, true], ["SignalException", nil, true], ["SystemStackError", nil, true], ["LoadError", nil, true], ["SyntaxError", nil, true], ["NotImplementedError", nil, true]]	[\n              NoMemoryError, ScriptError, SecurityError, SignalEx
 b76b635413644a9ee6cb10accbfe88d1	false	class Float; alias __orig :>=; def >=(o); __orig(o); end; end; 3.0 >= 4.0
 b76d6e4320dd94711348a48796e6ef33	[42, 100]	$res = []\n        class S\n          class C\n            def f\n         
+b7b526853ed3aa9d81b2dda6dbba1cf2	1	class Integer; def <=>(o) = (o.to_i - to_i); end\n[3, 1, 2].max
 b7b791ae9b8a5b32ebb0e713566b57b5	[:foo, [1], {x: 10, y: 20}]	class C\n          def method_missing(name, *args, **kwargs)\n           
 b7cb35744fdfaa984b6e9aa7ca2b4447	[4000, 3999]	n = 0; a = [n, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
 b7d68f9088d3f3aed2ab62dc9d949be5	[true, true]	class Foo\n              def bar; 42; end\n            end\n          
@@ -2503,6 +2513,7 @@ c541a3e07294eab4a4d213c945171c7a	[[99, 198, 99.0], [Sub, 99], [99, 100, 101], [n
 c55e6248eb41c6e540c40b61f2e992ed	420	class C\n          def f\n            x = 0\n            10.times { x += y
 c56c19f790a407710bd65fa095a58592	[3, 3]	from = 1\n        to = 2\n        [(from..to ? 3 : 4), (from...to ? 3 : 4
 c57f3073a34696e272a4c621e59717cf	false	"a".index(/a/); $~.nil?
+c5a28c5f978023ef4ce7e9a6bcff4faf	[ArgumentError, "comparison of String with 0 failed"]	class Str\n          def <=>(o) = "not a number"\n        end\n        beg
 c5a9ac24fee6ccfc26954a34f012d3d1	"UTF-8"	"\\xFF#{1}".encoding.to_s
 c5f5ea4d7ccb33511960c242704f06f0	[[195], [169], 3, [195, 169], [195]]	s = "\\303\\251\\303".dup.force_encoding(Encoding::Windows_31J)\n               m = 
 c60883d6df2480fbe9ec2ae4e169130c	[200, 300, 250, 60, 200, 300, 250, 60]	class S\n            def f(x, y, a:10, b:20)\n                $res << x\n
@@ -2904,6 +2915,7 @@ e4a701808e3a93ca91d9df6170eb2110	[["NestA::NestB", "NestA"], ["NestA::NestB", "N
 e4b07dfb345d9091378925364fd0c790	[8, [1, 3, 5], 50, 3, 10]	def first_even(a); a.each { |x| break x if x % 2 == 0 }; end\n        de
 e4c3805b5eda733c2c3b305a068dc955	"Cargo.toml"	File.open("Cargo.toml") { |f| f.path }
 e4e344de107f90e3a04f591c1d83fb9a	nil	Inner = Struct.new(:b)\n        Outer = Struct.new(:a)\n        o = Outer
+e4e47b16c304d24fa7f1fd62c39e35e0	3.0	class Float; def <=>(o) = (o.to_f - to_f); end\n[3.0, 1.0, 2.0].min
 e4f68a2f5af719f7806b8131e1468888	[1, 2, 3]	def f(x,y,z=42)\n            [x,y,z]\n        end\n        \n\n        f(1,2
 e5006c1032b8867e3476898f3a7987dd	"not match (?-mix:regex)"	class Foo\n              def !~(other)\n                "not match #{
 e5100caa80d4f4b7d03f697cc77e1758	1	(0x8000_0000_0000_0000 + 39) <=> (0x8000_0000_0000_0000 + 39 + 0.0)

--- a/monoruby/tests/sort_fast_path.rs
+++ b/monoruby/tests/sort_fast_path.rs
@@ -109,6 +109,53 @@ fn user_comparator_is_read_by_sign() {
     );
 }
 
+/// The sign of a *non-Integer* comparator result is read the way
+/// `rb_cmpint` reads it — `res > 0`, then `res < 0` — never by asking
+/// `res <=> 0`.
+///
+/// Asking `<=>` re-enters the redefinition when the comparator returns an
+/// instance of the very class the program redefined `<=>` on, which read
+/// the sign backwards; and it has no Integer to convert a Float result to,
+/// so a difference as large as `Float::MAX` raised RangeError where CRuby
+/// simply sees a positive number.
+#[test]
+fn comparator_result_sign_is_read_without_cmp() {
+    run_test_once(
+        r#"
+        class Float; def <=>(o) = (o.to_f - to_f); end
+        [[3.0, 1.0, 2.0].sort, [3.0, 1.0].min, [3.0, 1.0].max,
+         [3.0, 1.0].minmax, [Float::MAX, 1.0].sort]
+        "#,
+    );
+    run_test(
+        r#"
+        class Wide
+          attr_reader :v
+          def initialize(v) = @v = v
+          # A Float difference, one of them past every Integer conversion.
+          def <=>(o) = (v - o.v).to_f
+        end
+        huge = [Wide.new(Float::MAX), Wide.new(1.0), Wide.new(-Float::MAX)]
+        by_float = [Wide.new(2.5), Wide.new(1.5), Wide.new(3.5)].sort.map(&:v)
+        [by_float, huge.sort.map(&:v), huge.min.v, huge.max.v]
+        "#,
+    );
+    // A comparator whose result answers neither `>` nor `<` against 0 is
+    // the incomparable case, reported as CRuby reports it.
+    run_test(
+        r#"
+        class Str
+          def <=>(o) = "not a number"
+        end
+        begin
+          [Str.new, Str.new].sort
+        rescue => e
+          [e.class, e.message]
+        end
+        "#,
+    );
+}
+
 /// The `sort_by` family declines the same way `sort` does, and must then
 /// report through the general comparator — including in the destructive
 /// form, whose fallback writes the receiver back.


### PR DESCRIPTION
# Summary

A 162-case microbenchmark sweep against CRuby 4.0.2 put two shapes at the top of the gap. Both are now answered in Rust.

| | before | after |
|---|---:|---:|
| `(1..100).sum` | ratio **139.8** | **0.67** |
| `[..].min` (100 Integers) | ratio **8.6** | **1.00** |

**`Range#sum`** had no Rust implementation, so it fell through to `Enumerable#sum` — which builds a lambda per call and invokes it per element. `Range#sum` (builtins/range.rb) now hands an Integer range with no block to `__builtin_sum`, the arithmetic series in closed form, exactly as CRuby's `int_range_sum` does; every other shape still falls back with `super`. Beyond the speed, this is what makes `(1..10**20).sum` **answer at all** — summing term by term never finishes.

**`Array#min` / `#max`** called `compare_values` per element. `minmax` already had a Fixnum-only fast path, so the three disagreed on what they could specialize and on whether a redefined `<=>` reached them. `homogeneous_ord` now names the one classification (Integer / Float / String, no redefined `<=>`, no NaN) that `sort`, `sort_by` and all three of min/max/minmax share, and each writes its own monomorphic loop over it. `min`/`max` fuse classification into the scan — one pass that gives up at the first element of another class, which is what took them from 2.1x to parity.

# Compatibility gaps the tests turned up

- **`min(n)` / `max(n)` did not exist** — `[3,1,2].min(2)` raised ArgumentError. Implemented (ranking by the shared sort), including `n = nil` meaning "no n", `#to_int` conversion, and CRuby's `"negative size (-1)"` wording (`Range#min` words the same error differently, and keeps its own).

- **A redefined `Float#<=>` reached none of them** — `[3.0, 1.0].sort` ignored it (on master too). The classification declined correctly; the bug was one layer down, in `cmpint`. Reading the sign of a non-Integer comparator result by asking `res <=> 0` **re-enters the very method the program redefined**, so the sort read its own comparator's sign backwards — and a `Float::MAX` difference raised RangeError trying to become an Integer. `rb_cmpint` asks `res > 0` then `res < 0`; monoruby now does too. That also stops `dispatch_cmp` swallowing the ArgumentError those raise for a comparator whose result answers neither: a String result now reports `"comparison of String with 0 failed"`, CRuby's message, instead of being relabelled with the two elements.

- **`compare_values` named the failing operand by `to_s`**, so `[1, "a"].min` read `"comparison of Integer with a failed"`. It now goes through `cmperr` (`rb_cmperr`) like the rest, and compares the element against the running best in CRuby's operand order, giving CRuby's `"comparison of String with 1 failed"`.

# Left alone (pre-existing, out of scope)

- `sort` compares its operands in the opposite order from CRuby, so an incomparable pair is named the other way round; `min(n)` is built on sort and inherits it.
- A non-Integer `init` to `Range#sum` still takes the Enumerable path, where `(1..3).sum(2r)` answers `(8/1)` to CRuby's `8.0`.

# Testing

- Full suite: **3610 passed / 0 failed** (default and `stress-spill-pool`)
- `cargo check --target aarch64-unknown-linux-gnu`: clean
- New tests: each element class the min/max fast path takes and each it declines (mixed, Bignum, Symbol, NaN, empty, one element, ties by `equal?`), a redefined `<=>` per class reaching min/max/minmax, every `min(n)`/`max(n)` form and error, the `Range#sum` closed form (inclusive/exclusive/empty/negative/init/Bignum/past-Fixnum) and each fallback, and the comparator-sign fix (Float result, `Float::MAX` difference, String result).
- Semantics diffed against CRuby 4.0.2 case by case for all of the above.
- Every other benchmark in the sweep is unchanged within run-to-run noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_