### PR TITLE
Answer Symbol#to_proc with one Proc per symbol

### DIFF
--- a/monoruby/src/builtins/proc.rs
+++ b/monoruby/src/builtins/proc.rs
@@ -443,8 +443,14 @@ fn to_s(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 #[monoruby_builtin]
 fn binding_(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let proc = Proc::new(lfp.self_val());
-    // Curry procs have no Ruby-level binding (CRuby raises ArgumentError).
-    if proc.func_id() == PROC_CURRY_BODY_FUNCID {
+    // Curry and symbol procs have no Ruby-level binding (CRuby raises
+    // ArgumentError for both — they are C-level procs there). The symbol
+    // one matters beyond compatibility: its frame is shared by every
+    // `:sym.to_proc`, so a Binding onto it would hand out a handle to
+    // state the next `to_proc` returns as well.
+    if proc.func_id() == PROC_CURRY_BODY_FUNCID
+        || proc.func_id() == SYMBOL_TO_PROC_BODY_FUNCID
+    {
         return Err(MonorubyErr::argumenterr("Can't create Binding from C level Proc"));
     }
     // For a Method#to_proc proc, the outer self is the Method object;

--- a/monoruby/src/builtins/symbol.rs
+++ b/monoruby/src/builtins/symbol.rs
@@ -142,11 +142,9 @@ fn sym_to_proc(
     lfp: Lfp,
     pc: BytecodePtr,
 ) -> Result<Value> {
-    let self_val = lfp.self_val();
-    let body_fid = SYMBOL_TO_PROC_BODY_FUNCID;
-    let outer_lfp = Lfp::heap_frame(self_val, globals[body_fid].meta());
-    let proc = Proc::from_outer(outer_lfp, body_fid, pc);
-    Ok(proc.into())
+    // One Proc per symbol, over that symbol's one frame: `to_proc` on a
+    // symbol answers the same object every time, as CRuby's does.
+    Ok(globals.symbol_proc(lfp.self_val().as_symbol(), pc))
 }
 
 /// Convert the receiver Symbol to its `String` `Value` by invoking

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -268,6 +268,13 @@ pub struct Globals {
     /// each time put a heap-frame allocation on every element of
     /// `ary.map(&:to_s)`.
     symbol_proc_frames: HashMap<IdentId, Lfp>,
+    /// One `Symbol#to_proc` *Proc* per symbol, over that symbol's frame.
+    ///
+    /// CRuby caches these too — `:x.to_proc.equal?(:x.to_proc)` is true —
+    /// so this is compatibility as much as speed: a `Proc` frozen, or
+    /// given an instance variable, through one `to_proc` is the same
+    /// object the next one returns.
+    symbol_procs: HashMap<IdentId, Value>,
     /// function and class info.
     pub store: Store,
     /// global variables and special variables.
@@ -405,6 +412,27 @@ impl Globals {
         self.symbol_proc_frames.insert(symbol, lfp);
         lfp
     }
+
+    ///
+    /// The shared `Symbol#to_proc` Proc for *symbol* (see
+    /// [`Globals::symbol_procs`]), built on first use over that symbol's
+    /// shared frame.
+    ///
+    /// `pc` is the call site of the `to_proc` that built it. A symbol proc
+    /// has no Ruby source — `source_location` is `nil` and `Proc#binding`
+    /// raises, as in CRuby — so the one recorded here is never read back
+    /// as this proc's own position, and the first caller's is as good as
+    /// any later one's.
+    ///
+    pub(crate) fn symbol_proc(&mut self, symbol: IdentId, pc: BytecodePtr) -> Value {
+        if let Some(proc) = self.symbol_procs.get(&symbol) {
+            return *proc;
+        }
+        let outer_lfp = self.symbol_proc_frame(symbol);
+        let proc = Proc::from_outer(outer_lfp, SYMBOL_TO_PROC_BODY_FUNCID, pc).into();
+        self.symbol_procs.insert(symbol, proc);
+        proc
+    }
 }
 
 impl alloc::GC<RValue> for Globals {
@@ -412,6 +440,9 @@ impl alloc::GC<RValue> for Globals {
         self.main_object.mark(alloc);
         for lfp in self.symbol_proc_frames.values() {
             lfp.mark(alloc);
+        }
+        for proc in self.symbol_procs.values() {
+            proc.mark(alloc);
         }
         self.load_path.mark(alloc);
         self.loaded_features.mark(alloc);
@@ -617,6 +648,7 @@ impl Globals {
         let mut globals = Self {
             main_object,
             symbol_proc_frames: HashMap::default(),
+            symbol_procs: HashMap::default(),
             store: Store::new(),
             gvars: GvarTable::new(),
             special_gvars: SpecialGvars::default(),

--- a/monoruby/tests/proc_compose.rs
+++ b/monoruby/tests/proc_compose.rs
@@ -81,3 +81,53 @@ fn symbol_proc_frames_survive_gc_and_stay_per_symbol() {
         "##,
     );
 }
+
+/// `Symbol#to_proc` answers one Proc per symbol, as CRuby does, so the
+/// object identity is observable: state put on the proc through one
+/// `to_proc` is there through the next, and two symbols stay apart.
+#[test]
+fn symbol_to_proc_is_one_proc_per_symbol() {
+    run_test(
+        r##"
+        p1 = :to_s.to_proc
+        [p1.equal?(:to_s.to_proc), p1 == :to_s.to_proc,
+         p1.equal?(:to_i.to_proc), p1 == :to_i.to_proc,
+         :to_s.to_proc.call(12), [1, 2].map(&:to_s),
+         :to_s.to_proc.arity, :to_s.to_proc.lambda?,
+         :to_s.to_proc.source_location]
+        "##,
+    );
+    // Mutating the shared proc is visible through the next `to_proc` —
+    // run once, since the mutation outlives the snippet.
+    run_test_once(
+        r##"
+        p1 = :to_s.to_proc
+        p1.instance_variable_set(:@tag, :seen)
+        tag = :to_s.to_proc.instance_variable_get(:@tag)
+        p1.freeze
+        [tag, :to_s.to_proc.frozen?, :to_s.to_proc.call(12), :to_i.to_proc.frozen?]
+        "##,
+    );
+    // The cache holds the only reference to the Proc, so a collection
+    // between two uses must not reclaim it.
+    run_test(
+        r##"
+        p1 = :size.to_proc.call("abcd")
+        GC.start
+        p2 = :size.to_proc.call("ab")
+        GC.start
+        [p1, p2, :size.to_proc.equal?(:size.to_proc)]
+        "##,
+    );
+    // A symbol proc has no Ruby frame to bind to, and its one frame is
+    // shared — CRuby calls it a C-level proc and raises.
+    run_test(
+        r##"
+        begin
+          :to_s.to_proc.binding
+        rescue => e
+          [e.class, e.message]
+        end
+        "##,
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -273,6 +273,7 @@
 13c09eba52c55ecec3e82b015d3b4f59	[true, true, true]	C = Class.new\n            D = Class.new(C)\n            \n[C.new.clas
 13e499657f84b7c697664ba59ec4b9f4	[true, false, ArgumentError, false, true]	(o=Object.new; a=o.clone(freeze: true).frozen?; b=(x="s".freeze; x.clone(freeze:
 13edcd86f2bff4fcc4b3b29c5635e9f9	"RUBZ"	succ = proc { |s| s.succ }; upcase = proc { |s| s.upcase }; (succ << upcase).cal
+1407b0c899f10c0ed45b96b8b0aa9529	[true, true, false, false, "12", ["1", "2"], -2, true, nil]	p1 = :to_s.to_proc\n        [p1.equal?(:to_s.to_proc), p1 == :to_s.to_pr
 1408dc4e7fb001b397ca65a58a5bb60b	["XXX", "secret"]	class Foo\n          def initialize data\n            @key = data\n       
 142812ded02a16064ed8507c23bc2193	[true, [true, "Addrinfo", "127.0.0.1"]]	require "socket"\n            require "tmpdir"\n            path = Fi
 1438ba7f43337b0f331290b81cfaafb1	true	Random.srand(42)\n        a = Random.random_number\n        b = Random.ra
@@ -544,6 +545,7 @@
 296cb9b677550e04208e94ca484931e0	false	(1 << 100) == Float::NAN
 296cf73e0640c371c2684d2cd90d9e7b	[[3, 3, 5], ["ONE", "TWO", "THREE"], [3, 3, 5], 3, 4]	a = ["one", "two", "three"]\n        first = a.map(&:size)\n        GC.st
 2979daa28cf9e1607e9067bfb20e90ba	true	def p2\n          x = nil\n          [].each { x = 9.9 }\n          x.nil?
+2980a6aca8adce9ffc5525158053d81d	[4, 2, true]	p1 = :size.to_proc.call("abcd")\n        GC.start\n        p2 = :size.to_
 2987a50b02c4a3d9e5927d0cf054efc5	[true, true, false, true, false]	[\n              SystemExit.new.success?,\n              SystemExit.n
 29a4782bad89b05e2a89fbdc04ec694a	[[1, :d, [], 1, nil], [1, 2, [3, 4], 1, nil], [1, 2, [], 9, nil], [1, :d, [], 1, :blk], [10, 20, [30], 1, nil], [5, 6, [7], 2, nil]]	def t(a, b = :d, *r, k: 1, &blk); [a, b, r, k, blk ? blk.call : nil
 29be5fcdba7ed7a8c6ca8dadda30fdde	["Xtail-line\\nXpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpad", ["tail", "line", "padpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpad"], "T-line\\npadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpad", "Ytail-line\\nYpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpad", "if @c  tail-line\\n  padpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadend\\n"]	s = "HEADER-LINE\\nmiddle\\ntail-line\\n" + "pad" * 20\n        s =~ /middl
@@ -1057,6 +1059,7 @@
 532f5d7ba05f7843743de0b52969bba8	["PSubB", :x, 2, 9]	class PSubB < Proc; def initialize(a, b); @a = a; @b = b; end; attr_reader :a, :
 5344f32f5c73af78489308d9a5575a7d	[["TypeError", "1 is not a symbol nor a string"], ["TypeError", "1 is not a symbol nor a string"], ["TypeError", "1 is not a symbol nor a string"]]	def try; yield; rescue => e; [e.class.to_s, e.message]; end\n       
 536366d9b0b405f788174be1f1a39cb3	[true, true, true, "\\e[1mx (\\e[1;4mRuntimeError\\e[m\\e[1m)\\e[m\\n\\e[1my\\e[m"]	res = []\n        begin\n          begin\n            raise "the cause"\n  
+538fe09e5b06e4ccde36d8fd223d3558	[ArgumentError, "Can't create Binding from C level Proc"]	begin\n          :to_s.to_proc.binding\n        rescue => e\n          [e.
 53a0e18814663d90c976b6d913746bc6	[true, :blocked_ok, :locked, :done]	require 'tmpdir'\n            path = File.join(Dir.tmpdir, "mrb_floc
 53c684da33e546973dbfb03625ab4bc6	"Outer::Inner"	module Outer\n          class Inner\n            def self.name_test\n     
 53d9651dadebd1d49dd5ea2484441652	["hello ", "world", ""]	"hello world" =~ /world/\n            [$`, $&, $']\n            
@@ -1891,6 +1894,7 @@
 9839ce942dc6ceffe4fdfca27b091194	{amount: 42, unit: "km"}	M = Data.define(:amount, :unit)\nM.new(42, "km", **{}).to_h
 9839f0f17947005555bee6338f175943	318.75	obj = Object.new\n        acc = 0.0\n        i = 0\n        while i < 30\n 
 98411750aed4bab667c24946e33e5cb0	[100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10]	$a = []\n            C = 100\n            \n            for i in 0..19
+9861856cd9d5f34b618738bf16e9b44c	[:seen, true, "12", false]	p1 = :to_s.to_proc\n        p1.instance_variable_set(:@tag, :seen)\n     
 988c0b8f8c44428ac627b741f329756c	100	# Ret\n            begin\n              100\n            end\n        
 98996233bfa191027494af2f2287502c	[:inner, :early, :late]	def m1\n          obj = Object.new\n          class << obj\n            re
 98bdea24e737b24b5b5e21db74beb80e	[true, 0]	pid = fork { exit 0 }\n            ret = Process.wait(pid)\n         


### PR DESCRIPTION
# Summary

> Independent of #1204 (no overlapping files); both are based on `master`.

`:to_s.to_proc` built a fresh Proc — and a fresh outer frame — on every call, where CRuby caches one per symbol. That is **4.3x slower than CRuby** on a `to_proc` loop, and it is also a compatibility difference, because the identity is observable:

```ruby
:x.to_proc.equal?(:x.to_proc)   # CRuby: true   monoruby: false
```

so a Proc frozen, or given an instance variable, through one `to_proc` was not the object the next one returned.

`Globals::symbol_proc` now caches the Proc beside the frame cache added in #1201, and builds it *over* that frame, so the two share one frame per symbol. It is marked from `Globals`, like the frames, since the cache holds the only reference to it.

`Proc#binding` on a symbol proc now raises ArgumentError, next to the curry case that already did. CRuby raises there too (`"Can't create Binding from C level Proc"` — both are C-level procs there), and with the frame shared it matters beyond compatibility: a Binding onto it would be a handle to state every later `:sym.to_proc` returns as well.

# Benchmark (release, vs CRuby 4.0.2)

| | before | after |
|---|---:|---:|
| `:to_s.to_proc` in a loop | ratio 4.27 | **0.77** |

`ary.map(&:to_s)` is unchanged at 1.7x — that path already shared the frame from #1201, and what remains there is the structural cost noted in that PR (the native frame and the `*rest` array a yield to the general body forces).

# Testing

- Full suite: **3606 passed / 0 failed** (default and `stress-spill-pool`)
- The proc and method-call suites also under `gc-stress`, since the cache is a new GC root — 128 passed / 0 failed
- `cargo check --target aarch64-unknown-linux-gnu`: clean
- New test covers the identity (`equal?`, `==`, two symbols staying apart), state shared through it (ivar, `freeze`), survival across `GC.start`, `binding` raising, and that `arity` / `lambda?` / `source_location` / `call` / `map(&:sym)` are unchanged — all diffed against CRuby.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_