### PR TITLE
Scan for equality without a dispatch per element

### DIFF
--- a/monoruby/builtins/array.rb
+++ b/monoruby/builtins/array.rb
@@ -499,7 +499,9 @@ class Array
           i = self.size - 1
           next
         end
-        return i if self[i] == val
+        # rb_equal, not a bare `==`: an element that *is* `val` is found
+        # however its `==` answers (CRuby's identity step).
+        return i if __rb_equal(self[i], val)
         i -= 1
       end
       return nil
@@ -522,10 +524,10 @@ class Array
   def assoc(key)
     each do |elem|
       if elem.is_a?(Array)
-        return elem if elem.size > 0 && elem[0] == key
+        return elem if elem.size > 0 && __rb_equal(elem[0], key)
       elsif elem.respond_to?(:to_ary)
         ary = elem.to_ary
-        return ary if ary.is_a?(Array) && ary.size > 0 && ary[0] == key
+        return ary if ary.is_a?(Array) && ary.size > 0 && __rb_equal(ary[0], key)
       end
     end
     nil
@@ -534,10 +536,10 @@ class Array
   def rassoc(key)
     each do |elem|
       if elem.is_a?(Array)
-        return elem if elem.size > 1 && elem[1] == key
+        return elem if elem.size > 1 && __rb_equal(elem[1], key)
       elsif elem.respond_to?(:to_ary)
         ary = elem.to_ary
-        return ary if ary.is_a?(Array) && ary.size > 1 && ary[1] == key
+        return ary if ary.is_a?(Array) && ary.size > 1 && __rb_equal(ary[1], key)
       end
     end
     nil

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -30,6 +30,10 @@ pub(super) fn init(globals: &mut Globals) {
     // suite), and a future pre-load `Array.new(n)` fails loudly through
     // `Object#initialize`'s arity check rather than silently diverging.
     // Native legs of the Ruby `initialize` (private, `__`-prefixed).
+    // `rb_equal` for the Ruby-level searches in builtins/array.rb
+    // (`rindex`, `assoc`, `rassoc`), which need the identity step a bare
+    // `==` does not have.
+    globals.define_private_builtin_func(ARRAY_CLASS, "__rb_equal", rb_equal_, 2);
     globals.define_private_builtin_func(ARRAY_CLASS, "__init_fill", init_fill, 2);
     globals.define_private_builtin_func(ARRAY_CLASS, "__init_from", init_from, 1);
     globals.define_private_builtin_func(ARRAY_CLASS, "__size_to_int", size_to_int, 1);
@@ -479,10 +483,14 @@ fn count(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> 
         }
         let mut count = 0;
         let ary = lfp.self_val();
+        // `rb_equal(element, argument)`, like `include?` — element as the
+        // receiver, and an element that *is* the argument counted whatever
+        // its `==` says.
+        let mut search = executor::op::EqSearch::new(globals, arg0);
         let mut i = 0;
         while i < ary.as_array().len() {
             let elem = ary.as_array()[i];
-            if vm.invoke_eq(globals, arg0, elem)? {
+            if vm.rb_equal_search(globals, &mut search, elem)? {
                 count += 1;
             }
             i += 1;
@@ -3638,15 +3646,31 @@ fn grep(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 ///
 /// - include?(val) -> bool
 ///
+/// `rb_equal(element, needle)` for the Ruby-level searches: `element ==
+/// needle`, except that an element which *is* the needle is equal however
+/// its `==` answers. Private; see the registration above.
+///
+#[monoruby_builtin]
+fn rb_equal_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(Value::bool(vm.rb_equal(globals, lfp.arg(0), lfp.arg(1))?))
+}
+
+///
+/// #### Array#include?
+///
+/// - include?(val) -> bool
+///
 /// [https://docs.ruby-lang.org/ja/latest/method/Array/i/include=3f.html]
 #[monoruby_builtin]
 fn include_(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
-    let rhs = lfp.arg(0);
+    let mut search = executor::op::EqSearch::new(globals, lfp.arg(0));
     let mut i = 0;
+    // The length is re-read every step: an element's `==` runs Ruby, which
+    // may resize the receiver.
     while i < self_val.as_array().len() {
-        let lhs = self_val.as_array()[i];
-        if vm.eq_values_bool(globals, lhs, rhs)? {
+        let elem = self_val.as_array()[i];
+        if vm.rb_equal_search(globals, &mut search, elem)? {
             return Ok(Value::bool(true));
         };
         i += 1;
@@ -4803,9 +4827,10 @@ fn delete(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     let recv = lfp.self_val();
     let mut ary = recv.as_array();
     let arg0 = lfp.arg(0);
+    let mut search = executor::op::EqSearch::new(globals, arg0);
     let mut has_match = false;
     for i in 0..ary.len() {
-        if vm.eq_values_bool(globals, ary[i], arg0)? {
+        if vm.rb_equal_search(globals, &mut search, ary[i])? {
             has_match = true;
             break;
         }
@@ -4818,7 +4843,7 @@ fn delete(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
         };
     }
     recv.ensure_not_frozen(&globals.store)?;
-    let f = |v: &Value| Ok(!vm.eq_values_bool(globals, *v, arg0)?);
+    let f = |v: &Value| Ok(!vm.rb_equal_search(globals, &mut search, *v)?);
     Ok(ary.retain(f)?.unwrap_or(Value::nil()))
 }
 
@@ -4869,14 +4894,15 @@ fn find_index(
         if lfp.block().is_some() {
             vm.ruby_warn_caller(globals, "warning: given block not used")?;
         }
-        let func_id = vm.find_method(globals, arg0, IdentId::_EQ, false)?;
+        // `rb_equal(element, argument)` — the *element* is the receiver of
+        // `==`, as in CRuby. This used to look `==` up on the argument and
+        // call it the other way round, which answers differently for any
+        // asymmetric `==`.
+        let mut search = executor::op::EqSearch::new(globals, arg0);
         let mut i = 0;
         while i < self_val.as_array().len() {
-            let v = self_val.as_array()[i];
-            if vm
-                .invoke_func_inner(globals, func_id, arg0, &[v], None, None)?
-                .as_bool()
-            {
+            let elem = self_val.as_array()[i];
+            if vm.rb_equal_search(globals, &mut search, elem)? {
                 return Ok(Value::integer(i as i64));
             }
             i += 1;

--- a/monoruby/src/executor/op.rs
+++ b/monoruby/src/executor/op.rs
@@ -54,6 +54,158 @@ pub extern "C" fn i64_to_value(i: i64) -> Value {
     Value::integer(i)
 }
 
+///
+/// A needle for a linear `rb_equal` search (`Array#include?`, `#index`,
+/// `#count`, `#delete`), prepared once so the scan itself can skip work.
+///
+/// The scan always answers "same object" from the bits. What this adds is
+/// the rest of the answer for the needle classes worth naming: for an
+/// Integer, a Symbol, `nil`, `true` or `false`, an element of that same
+/// class with different bits is *unequal*, and for a String the contents
+/// settle it either way. Neither needs an `==` to run. That is the whole
+/// of `[1, 2, 3].include?(9)` and `%w[a b].include?("b")`, which otherwise
+/// dispatch once per element.
+///
+/// `None` means every element goes through the dispatch, which is also
+/// what a redefined `==` on the needle's class produces: `BASIC_OP_DEFS`
+/// tracks these pairs, so the redefinition is visible here.
+///
+pub(crate) struct EqSearch {
+    needle: Value,
+    decided: Option<EqDecided>,
+    /// Monomorphic cache of `==` for the elements that do reach a
+    /// dispatch: an array is nearly always of one class, so the lookup is
+    /// done for the first such element and reused while that class — and
+    /// the class version the lookup was valid at — still holds.
+    ///
+    /// `Array#index` used to hoist one lookup out of the loop by asking
+    /// the *argument* for its `==`, which is the wrong receiver; this
+    /// keeps the saving with the right one.
+    cached_eq: Option<(ClassId, u32, ResolvedEq)>,
+}
+
+///
+/// What `==` resolved to for one element class.
+///
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum ResolvedEq {
+    /// The inherited `BasicObject#==`, which *is* the identity test the
+    /// scan already made — so an element of this class that is not the
+    /// needle is unequal, and the call can be skipped entirely. This is
+    /// the ordinary object: a class that defines no `==` of its own.
+    Identity,
+    /// A real `==` to call.
+    Method(FuncId),
+}
+
+///
+/// The class of element an [`EqSearch`] can rule out from the bits alone.
+///
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum EqDecided {
+    /// Two Fixnums are equal exactly when their bits are. (A Float
+    /// element is *not* decided — `1 == 1.0` is true — so it dispatches.)
+    Fixnum,
+    /// Two Symbols likewise.
+    Symbol,
+    /// `nil` / `true` / `false`, each equal only to itself.
+    NilBool,
+    /// Two Strings compare by content, and by encoding compatibility —
+    /// the answer `String#==` itself gives, reached here without the
+    /// dispatch.
+    String,
+}
+
+impl EqSearch {
+    pub(crate) fn new(globals: &Globals, needle: Value) -> Self {
+        let eq_redefined = |class: ClassId| {
+            globals.store.basic_op_redefined()
+                && globals.store.basic_op_redefined_for(class, IdentId::_EQ)
+        };
+        let decided = if needle.is_fixnum() {
+            (!eq_redefined(INTEGER_CLASS)).then_some(EqDecided::Fixnum)
+        } else if needle.try_symbol().is_some() {
+            (!eq_redefined(SYMBOL_CLASS)).then_some(EqDecided::Symbol)
+        } else if is_nil_or_bool(needle) {
+            // Three classes answer for this one shape, so all three have
+            // to still be the builtin.
+            (!eq_redefined(NIL_CLASS) && !eq_redefined(TRUE_CLASS) && !eq_redefined(FALSE_CLASS))
+                .then_some(EqDecided::NilBool)
+        } else if needle.is_rstring_inner().is_some() && needle.class() == STRING_CLASS {
+            // A String *subclass* is left out: its `==` is the builtin
+            // only until the subclass defines one, which this check does
+            // not track.
+            (!eq_redefined(STRING_CLASS)).then_some(EqDecided::String)
+        } else {
+            None
+        };
+        Self {
+            needle,
+            decided,
+            cached_eq: None,
+        }
+    }
+
+    ///
+    /// The answer for `elem`, when the needle's class decides it — the
+    /// identity test having already failed, so the immediate classes
+    /// answer `false` and only a String has content left to compare.
+    ///
+    #[inline]
+    fn decide(&self, elem: Value) -> Option<bool> {
+        match self.decided {
+            Some(EqDecided::Fixnum) => elem.is_fixnum().then_some(false),
+            Some(EqDecided::Symbol) => elem.try_symbol().is_some().then_some(false),
+            Some(EqDecided::NilBool) => is_nil_or_bool(elem).then_some(false),
+            Some(EqDecided::String) => {
+                // Only an exact String: a subclass may define its own
+                // `==`, and CRuby runs it (`SubString.new("z") == "q"` is
+                // whatever the subclass says). Such an element falls
+                // through to the dispatch below, which resolves it.
+                if elem.class() != STRING_CLASS {
+                    return None;
+                }
+                let needle = self.needle.is_rstring_inner()?;
+                let elem = elem.is_rstring_inner()?;
+                // `String#==`: same bytes *and* compatible encodings.
+                Some(elem.eq(needle) && elem.compatible_encoding(needle).is_some())
+            }
+            None => None,
+        }
+    }
+}
+
+fn is_nil_or_bool(v: Value) -> bool {
+    let bits = v.id();
+    v.is_nil() || bits == TRUE_VALUE || bits == FALSE_VALUE
+}
+
+///
+/// The class to look `==` up on for an element that `eq_values_vis_raw`
+/// does *not* answer from its own arms, or `None` for one it does.
+///
+/// Purely a routing question — either answer is correct, since the two
+/// paths agree — so the arms listed here need only track
+/// `eq_values_vis_raw` closely enough to be worth caching for.
+///
+fn dispatched_eq_class(elem: Value) -> Option<ClassId> {
+    if elem.is_packed_value() {
+        // nil / booleans / Integer / Float / Symbol as immediates.
+        return None;
+    }
+    let class = elem.class();
+    // The heap ones: a Bignum, a boxed Float, a String.
+    (class != INTEGER_CLASS && class != FLOAT_CLASS && class != STRING_CLASS).then_some(class)
+}
+
+/// The `FuncId` of the inherited `BasicObject#==` — the identity test.
+fn basic_object_eq(globals: &Globals) -> Option<FuncId> {
+    globals
+        .store
+        .check_method_for_class(BASIC_OBJECT_CLASS, IdentId::_EQ)
+        .and_then(|entry| entry.func_id())
+}
+
 macro_rules! cmp_values {
     (($op:ident, $op_str:expr)) => {
         paste! {
@@ -311,6 +463,94 @@ impl Executor {
         rhs: Value,
     ) -> Result<bool> {
         Ok(self.eq_values(globals, lhs, rhs)?.as_bool())
+    }
+
+    ///
+    /// CRuby's `rb_equal`: an object is equal to *itself* without `==`
+    /// being asked at all, and only otherwise is `elem == needle`
+    /// dispatched.
+    ///
+    /// The identity step is not an optimization — it is observable, and
+    /// its absence was a bug. `Array#include?` and friends go through
+    /// `rb_equal`, so an element that *is* the argument is found however
+    /// its `==` answers: a class whose `==` returns false is still found
+    /// in an array holding it, and `n = Float::NAN; [n].include?(n)` is
+    /// true even though `n == n` is false. Both answered wrongly here.
+    ///
+    /// Operand order matters as much: the *element* is the receiver.
+    ///
+    pub(crate) fn rb_equal(
+        &mut self,
+        globals: &mut Globals,
+        elem: Value,
+        needle: Value,
+    ) -> Result<bool> {
+        if elem.id() == needle.id() {
+            return Ok(true);
+        }
+        self.eq_values_bool(globals, elem, needle)
+    }
+
+    ///
+    /// [`Executor::rb_equal`] against a needle prepared by
+    /// [`EqSearch::new`], for a linear search: the same answer, with no
+    /// dispatch for the elements the needle's class decides by itself.
+    ///
+    #[inline]
+    pub(crate) fn rb_equal_search(
+        &mut self,
+        globals: &mut Globals,
+        search: &mut EqSearch,
+        elem: Value,
+    ) -> Result<bool> {
+        if elem.id() == search.needle.id() {
+            return Ok(true);
+        }
+        if let Some(answer) = search.decide(elem) {
+            // The needle's class settles it against this element, with no
+            // `==` to run.
+            return Ok(answer);
+        }
+        // Kept out of line so the two tests above — the whole of a scan
+        // over one class — inline into the caller's loop.
+        self.rb_equal_search_slow(globals, search, elem)
+    }
+
+    fn rb_equal_search_slow(
+        &mut self,
+        globals: &mut Globals,
+        search: &mut EqSearch,
+        elem: Value,
+    ) -> Result<bool> {
+        let Some(class) = dispatched_eq_class(elem) else {
+            // A class `eq_values_bool` answers from its own arms, with no
+            // lookup and no frame — cheaper than any dispatch.
+            return self.eq_values_bool(globals, elem, search.needle);
+        };
+        let version = Globals::class_version();
+        let resolved = match search.cached_eq {
+            Some((cached_class, cached_version, resolved))
+                if cached_class == class && cached_version == version =>
+            {
+                resolved
+            }
+            _ => {
+                let func_id = self.find_method(globals, elem, IdentId::_EQ, true)?;
+                let resolved = if Some(func_id) == basic_object_eq(globals) {
+                    ResolvedEq::Identity
+                } else {
+                    ResolvedEq::Method(func_id)
+                };
+                search.cached_eq = Some((class, version, resolved));
+                resolved
+            }
+        };
+        match resolved {
+            ResolvedEq::Identity => Ok(false),
+            ResolvedEq::Method(func_id) => Ok(self
+                .invoke_func_inner(globals, func_id, elem, &[search.needle], None, None)?
+                .as_bool()),
+        }
     }
 
     ///

--- a/monoruby/tests/eq_search.rs
+++ b/monoruby/tests/eq_search.rs
@@ -1,0 +1,186 @@
+//! Coverage for the `rb_equal` scan behind `Array#include?` / `#index` /
+//! `#count` / `#delete` (and the Ruby-level `#rindex` / `#assoc` /
+//! `#rassoc`): the identity step, the operand order, the needle classes it
+//! answers without a dispatch, and every reason it declines.
+
+extern crate monoruby;
+use monoruby::tests::*;
+
+/// The identity step of `rb_equal`: an element that *is* the argument is
+/// found however its `==` answers, and a `NaN` needle finds itself for the
+/// same reason even though `NaN == NaN` is false.
+#[test]
+fn an_element_that_is_the_argument_is_found() {
+    run_test(
+        r##"
+        class Never
+          def ==(o) = false
+        end
+        n = Never.new
+        nan = Float::NAN
+        # Results are reduced to identity/shape, never inspected: an
+        # object's `inspect` carries its address.
+        [[n, 1].include?(n), [n, 1].index(n), [n, n].count(n),
+         [n, 1].dup.delete(n).equal?(n), [n, 1].rindex(n),
+         [[n, 1]].assoc(n)&.last, [[1, n]].rassoc(n)&.first,
+         [nan].include?(nan), [nan].index(nan), [nan].count(nan),
+         [nan].rindex(nan), [nan].dup.delete(nan)]
+        "##,
+    );
+}
+
+/// The *element* is the receiver of `==`, as in CRuby — `index` used to
+/// ask the argument instead, which answers differently for an asymmetric
+/// `==`.
+#[test]
+fn the_element_is_the_receiver() {
+    run_test(
+        r##"
+        class Always
+          def ==(o) = true
+        end
+        class Only1
+          def ==(o) = o == 1
+        end
+        a = Always.new
+        [[1, 2].index(a), [1, 2].include?(a), [1, 2].count(a),
+         [a, 2].index(1), [a, 2].include?(1), [a, 2].count(1),
+         [Only1.new, 2].index(1), [1, 2].index(Only1.new),
+         [2, 3].index(Only1.new)]
+        "##,
+    );
+}
+
+/// Each needle class the scan answers from the value itself, matching and
+/// missing, over every method that scans.
+#[test]
+fn decided_needle_classes() {
+    run_test(
+        r##"
+        ints = [1, 2, 3]
+        syms = [:a, :b]
+        flags = [nil, true, false]
+        strs = ["a", "b", "a"]
+        [ints.include?(3), ints.include?(9), ints.index(2), ints.index(9),
+         ints.count(2), ints.dup.delete(2), ints.rindex(2),
+         syms.include?(:b), syms.include?(:c), syms.index(:b), syms.count(:c),
+         flags.index(nil), flags.index(false), flags.index(true),
+         flags.count(nil), flags.include?(0),
+         strs.include?("b"), strs.include?("c"), strs.index("a"),
+         strs.rindex("a"), strs.count("a"), strs.dup.delete("a"),
+         [].include?(1), [].index(1), [].count(1)]
+        "##,
+    );
+}
+
+/// A String needle is answered by content *and* encoding compatibility,
+/// exactly as `String#==` would — including the empty-string case, where
+/// incompatible encodings still compare equal.
+#[test]
+fn string_needle_matches_string_semantics() {
+    run_test(
+        r##"
+        [["abc".b].include?("abc"),
+         ["あ".encode("UTF-8")].include?("あ".encode("UTF-16BE")),
+         ["".encode("UTF-16BE")].include?(""),
+         ["a".freeze].index("a"),
+         [:a].include?("a"), ["a"].include?(:a),
+         ["a"].include?(1), [1].include?("a")]
+        "##,
+    );
+}
+
+/// Every reason the value-side answer does not apply, each of which must
+/// still give CRuby's result through the dispatch: a needle whose class is
+/// not one of them, a numeric pair that is equal across classes, a Bignum,
+/// and a String *subclass* element, whose own `==` CRuby runs.
+#[test]
+fn undecided_shapes_fall_back_to_dispatch() {
+    run_test(
+        r##"
+        class SubStr < String
+          def ==(o) = true
+        end
+        [[1.0, 2].count(1), [1, 2].count(1.0), [1, 2].index(1.0),
+         [2**70, 1].index(2**70), [1].include?(2**70),
+         [2**70].include?(2**70 + 0),
+         [SubStr.new("zzz")].include?("q"),
+         ["q"].include?(SubStr.new("zzz")),
+         [[1, 2], [3]].index([3]), [[1, 2]].include?([1, 2]),
+         [{a: 1}].include?({a: 1})]
+        "##,
+    );
+}
+
+/// The element side is dispatched through a cache keyed by class, so an
+/// array of several classes must still ask each one's own `==`.
+#[test]
+fn polymorphic_elements_each_use_their_own_eq() {
+    run_test(
+        r##"
+        class Yes
+          def ==(o) = true
+        end
+        class No
+          def ==(o) = false
+        end
+        class Plain
+        end
+        mixed = [No.new, Plain.new, Yes.new, No.new]
+        [mixed.index(:anything), mixed.count(:anything),
+         mixed.include?(:anything), mixed.rindex(:anything),
+         [Plain.new, Plain.new].index(:anything)]
+        "##,
+    );
+}
+
+/// A redefined `==` on the needle's class takes the scan off the
+/// value-side answer, for each class that has one.
+#[test]
+fn redefined_eq_reaches_the_scan() {
+    run_test_once(
+        r#"
+        class Integer; def ==(o) = true; end
+        [[1, 2].index(9), [1, 2].include?(9), [1, 2].count(9)]
+        "#,
+    );
+    run_test_once(
+        r#"
+        class Symbol; def ==(o) = true; end
+        [[:a, :b].index(:z), [:a, :b].include?(:z)]
+        "#,
+    );
+    run_test_once(
+        r#"
+        class String; def ==(o) = true; end
+        [["a", "b"].index("z"), ["a", "b"].include?("z")]
+        "#,
+    );
+    run_test_once(
+        r#"
+        class NilClass; def ==(o) = true; end
+        [[nil, 1].index(false), [nil].include?(false)]
+        "#,
+    );
+}
+
+/// `delete` scans twice — once to find a match, then to filter — and both
+/// must agree; the block form runs only when nothing matched.
+#[test]
+fn delete_scans_agree() {
+    run_test(
+        r##"
+        class Never
+          def ==(o) = false
+        end
+        n = Never.new
+        a = [1, 2, 1, 3]
+        deleted = a.delete(1)
+        b = [n, 1, n]
+        b.delete(n)
+        [deleted, a, b.size, [1, 2].delete(9), [1, 2].delete(9) { :none },
+         ["x", "y"].tap { |s| s.delete("x") }]
+        "##,
+    );
+    run_test_error("[1, 2].freeze.delete(1)");
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -495,6 +495,7 @@
 25f0534564d801243342b23debebc6f2	[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19], true, [0, 1, 2, 3, 4, 5, 6], [[0, "s0"], [1, "s1"], [2, "s2"], [3, "s3"], [4, "s4"], [5, "s5"]], [0, 1, 2], FrozenError]	def app(a, v) = a << v\n        def app_blk(a, v, &b) = a.<<(v, &b)\n    
 25f7204942eba1042f12b5429463ecc6	1	Rational(0.5).numerator
 260aadbc1eafcac4daf5a56eb84558cd	true	$/.frozen?
+260b6583e5dde4f43cbcd1c33fb20174	[true, false, 1, nil, 1, 2, 1, true, false, 1, 0, 0, 2, 1, 1, false, true, false, 0, 2, 2, "a", false, nil, 0]	ints = [1, 2, 3]\n        syms = [:a, :b]\n        flags = [nil, true, fa
 2635fffd46a3e17a2174ca9ccb6fc7a3	["-", "A"]	module UsingA\n              refine(String) { def tag; "A"; end }\n  
 264b0263d3d2c06bbb4abdb266123919	[:missing_constant, "test message"]	e = NameError.new("test message", :missing_constant)\n            [e
 266e77b9e0f7c96253fed71dffed0fc7	:type_error	class BadAry\n          def to_ary; 42; end\n        end\n        begin\n  
@@ -803,6 +804,7 @@
 3f6f1c23deee61068ec39f5295c45a16	[[], [:f]]	class S\n              def f; end\n            end\n            class 
 3f839e4337603d2011e09f2f712091a4	[:bar, :foo]	class A\n              def foo; end\n              def bar; end\n     
 3f92dae4c5bb5d0850bb428a743f7317	[4, 5]	r = []\n        10.times { |i| r << i if (i == 4)...(i == 5) }\n        r
+3fb8c0c6f9028a8a1d17e01958b4d1f5	[0, true, 2, 0, true, 1, 0, 0, nil]	class Always\n          def ==(o) = true\n        end\n        class Only1
 3fcbc9935b035dee352be56a30398754	"world"	IO.popen("echo world") { |io| io.read.chomp }\n            
 3fef9f42692341177896868638c71b46	[["v1", "v2"], [nil, nil, "new"]]	ENV["MONORUBY_ENV_TEST_MN1"] = "v1"\n            ENV["MONORUBY_ENV_T
 3ff02e23d910a4fb58eb4a1180f7d75c	"\\\\u{61}"	Regexp.new(/\\u{61}/).source
@@ -1095,6 +1097,7 @@
 5625d0e94e4d1bc9b84e2742fce64c08	true	class Foo\n              def initialize\n                @a = 1\n     
 565141a1ed8e896232b365303c5ac4d4	:OVERRIDDEN	class Integer; def ===(o); :OVERRIDDEN; end; end; 3 === 4
 56568fdc7f4e0b46c94d29cb9def4ec2	["renudged-to-main", 0]	r, w = IO.pipe\n            pid = fork do\n              r.close\n    
+5667fbe0e0218a0e00101f5832e7fa6e	[2, 1, true, 2, nil]	class Yes\n          def ==(o) = true\n        end\n        class No\n     
 5674c6743eb1f8cb3c5480370147f096	[10, 20]	class A\n          def initialize(x)\n            @x = x\n          end\n  
 5682fe3035100385f60effc866827604	[false, false]	def foo; end\n            def bar; end\n            public [:foo, :ba
 569d1753aae6166485a592748257a963	[[[:a, 1], [:b, 2], [:c, 3]]]	class C\n          def f(**kw)\n            $res << kw.sort\n          end
@@ -1335,6 +1338,7 @@
 69b168e7d0ad487fc9118309039d2192	"HELLOworld"	s = "hello world"; s.bytesplice(0..-6, "HELLO"); s
 69c5968b4eb20ac66bb1a05cf40e9cd8	[:dup, :clone]	class CH\n                 attr_accessor :tag\n                 def initialize_dup
 69d8601366cb9c364194ec7f9a90b959	25200	o = Object.new; def o.to_int; 7*3600; end\n               Time.new(2000,1,1,0,0,0
+69e5aa480a677f8260e98b949407011b	[0, true, 2]	class Integer; def ==(o) = true; end\n        [[1, 2].index(9), [1, 2].i
 69f49ce287605942316b64a3f0b0f5f9	12	class S\n          def f(x,y,z)\n            x + y + z\n          end\n    
 6a0c184b3e4f1cbf73f4c3924d6f92e6	1	x = 1 until x\n            x\n        
 6a0e2ea7d7a981bac74e9d7198383c7a	[1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995, 1001, 993, 1001, 1073742823, 1073742824, -1073740824, 995]	def drive\n              res = []\n              x = 1000\n           
@@ -1346,6 +1350,7 @@
 6a746985c7bc6408f83085340479fbf6	[1.0, NaN]	[1.0, 0.0 / 0.0]
 6a8c9e9a6d23a92d8a98ff382b620742	[["", 0], ["", 1], ["", 2], ["", 2], ["", 2], ["", 1], ["", 0], nil, nil, "b", true, false, true, false]	r = []\n        [0, 1, 2, 3, 9, -1, -2, -3].each do |i|\n            m = 
 6aafe015c3410b6ae65d66f8f67d1dd5	["boom", nil, [:done, "TypeError"], "b199"]	class T; attr_accessor :e; end\n\n        res = []\n        t = T.new\n        begin
+6ab691ea9d97f4c04bf963dc81c69487	[true, 0, 2, true, 0, 1, 1, true, 0, 1, 0, NaN]	class Never\n          def ==(o) = false\n        end\n        n = Never.n
 6adba7a52d188043ac47d2a6ceae5508	42	class C\n              def bar\n                42\n              end\n
 6aff68386825a6831642fe95c7e580e7	:raised	r = nil\n            100.times do\n              begin\n              
 6b0b243416e0d106d617e4ad489ecdf7	42	class C\n          attr_writer :x\n          def get_x; @x; end\n        e
@@ -1438,6 +1443,7 @@
 728b693008cde91b8e668b5188312960	"stream closed in another thread"	require "socket"\n            s = TCPServer.new("127.0.0.1", 0)\n    
 72974cf937f6e974bf3d810fa2d06cb0	15	SystemExit.new(15, "woo").status\n        
 729af1cd6bd675bb594030ffacbd8561	[true, "fifo"]	path = "/tmp/monoruby_test_mkfifo_#{Process.pid}_#{rand(100000)}"\n 
+72adb4f9d1509cf9e728948040205592	[0, true]	class String; def ==(o) = true; end\n        [["a", "b"].index("z"), ["a
 72c671a8d35d91c187dcae14e7d6acfa	true	"abc".force_encoding("ISO-8859-15").encoding == Encoding::ISO_8859_15
 72e5566a1bbca4743ca6172eaaed27c4	["hello", nil]	ENV["MONORUBY_ENV_TEST_BASIC"] = "hello"\n            v = ENV["MONOR
 72f2a3b4b542af05e8ddd39460142cfe	"through"	r, w = IO.pipe\n            w.write("through")\n            res = r.r
@@ -1490,6 +1496,7 @@
 76d3c5429fdfa8af5370245762d7d60e	7	inc = proc { |n| n + 1 }; mul = proc { |n, m| n * m }; (inc << mul).call(2, 3)
 76d509e8caeda190c6d7f40c93ccd441	["can't convert nil into Rational", "can't convert nil into Rational", nil, "3/4", "3/2", "can't convert 1+2i into Rational", "7/1"]	[\n              (begin; Rational(nil); rescue TypeError => e; e.mes
 76e48600c83896fad83372ad16b233b6	[2, 1, ["dup", "dup"]]	h = {}.compare_by_identity\n        a = "dup"\n        h[a] = 1\n        h
+76eb6b35bb134acea1b9c5fdfc968f0f	[1, 1, 0, 0, false, true, true, false, 1, true, true]	class SubStr < String\n          def ==(o) = true\n        end\n        [[
 76f23d253bc9500bc54883b3fca2396f	[Array, :rb, true, true]	res = $LOAD_PATH.resolve_feature_path("pp")\n              [res.cl
 76f39b244a1c5e6d61a888dd4e103f5b	:OVERRIDDEN	class Float; def ===(o); :OVERRIDDEN; end; end; 3.0 === 4.0
 770025e2293750c0989f11bccedf3d21	"US-ASCII"	"abc".dup.force_encoding("US-ASCII").sub(/a/) { "Z" }.encoding.to_s
@@ -2068,6 +2075,7 @@ a4149a238fc4b1eb2b5d83d5a3a1df6e	[1, [2, 3, 4], 5]	->((a, *b, c)) { [a, b, c] }.
 a41897885873df2832ff2e4ca224faf4	true	class Foo\n              def initialize\n                @a = 1\n     
 a438a5b6095e3a044e9fc3a4b29764a8	[false, true, true, false, false, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true]	class StrMock\n          def to_str; "abc"; end\n          def ==(o); o =
 a46413028c2e82be019705a623976977	[1, 2, [], 4, 5, 3, 12]	def f\n          yield [1,2,3,4,5]\n        end\n        \n\n        f { |a,
+a46cded2c6b6ee08a3f22bc6e16ba8d2	[1, [2, 3], 1, nil, :none, ["y"]]	class Never\n          def ==(o) = false\n        end\n        n = Never.n
 a4739bf8ad36ba60eb568b2316e72ec9	[99, false]	c = Class.new\n            c.class_variable_set(:@@x, 99)\n          
 a4748dc92361b8ec397bdcc7a0edea32	[4000, [0, 0, nil, nil, nil, 3999, nil]]	h = { 0 => [0, 0, nil, nil, nil, 0, nil], 1 => [0, 0, nil, nil, nil, 1, nil], 2 
 a476fbd8b3d5aa7065ffc4804ce4f8f2	[0, 3, true]	f = File.open("Cargo.toml")\n            begin\n              [f.syss
@@ -2662,6 +2670,7 @@ cffe2bea88b632377cf81196a0f5adbc	:OVERRIDDEN	class Integer; def %(o); :OVERRIDDE
 d005def98ec838cc7d6f37a7bdf0aaa0	[1, 2, 42, 12]	def f(x,y,z=42,w=12)\n            [x,y,z,w]\n        end\n        \n\n      
 d00a59254916621fa57745491676e04c	[true, false]	m = Module.new\n            m.freeze\n            ok = false\n        
 d01f7af924363a6dde43e88de3de59d1	nil	"hello".byteindex("x")
+d03f3da52be16a5382075d9aea65e40c	[0, true]	class Symbol; def ==(o) = true; end\n        [[:a, :b].index(:z), [:a, :
 d044b1d1eedcdda6f15b67ec84350344	4	"hello".byteindex("o")
 d05976bbfb14033f00937939ab90a32c	36000000	class Lib; def twice(n); n + n; end; end\n        $lib = Lib.new\n       
 d07ee4e87e21212dcf67ec14eaa4fbbc	Object	include Math\n        
@@ -2819,6 +2828,7 @@ dca1fe10428b94607119699e4536affd	77	module Foo\n          def self.Bar; yield; e
 dcb299cee36b3bcad2f0615af4c007af	true	File.exist?("../LICENSE-MIT")
 dcc86ed827f6b6845b9c7cf7a78c4c2f	"ababxababa"	"x".center(10, "ab")
 dce9ecd5cb55866eac9f8003fbb5343b	"UTF-8"	/#{"あ"}/.encoding.to_s
+dcf8f9800ca36fc1d761f06b3e651f75	[true, false, true, 0, false, false, false, false]	[["abc".b].include?("abc"),\n         ["あ".encode("UTF-8")].include?("あ"
 dcfeee4a0f36c226b961d97eee897e9b	true	(require "stringio"; old=$VERBOSE; $VERBOSE=true; s1=StringIO.new; $stderr=s1; f
 dd3c071c4a6f6953708de611a7d532e1	true	d = Dir.new("/tmp")\n            begin\n              fd = d.fileno\n 
 dd59ae7dd4e6777883a269edec790eb4	[[195], 2]	s = "\\303\\251\\303".dup.force_encoding(Encoding::Windows_31J)\n               m = 
@@ -3204,6 +3214,7 @@ fac9bf918d6cefc7590454e6cac04dc2	"abc"	"abc".ljust(-5)
 faf2d0672d70ae819b5f4e530350f3ce	[["a\\n", "b\\n", "c\\n"], ["ISO-8859-1"], ["a\\nb\\nc\\n"], ["a\\n", "b\\n", "c\\n"], "EUC-JP", [["a\\n", "ISO-8859-1"], ["b\\n", "ISO-8859-1"], ["c\\n", "ISO-8859-1"]], ["UTF-16LE"]]	File.write("/tmp/mr_rlf.txt", "a\\nb\\nc\\n")\n            r = []\n     
 fafb2306f5998b1a5d3fd37189e39235	"hello"	class HasToS; def to_s; "hello"; end; end\n            sprintf("%s",
 fb19b9db3ad873510aed81f16b1dbcd9	["ISO-8859-1", "UTF-8"]	(d="/tmp/mono_rpe_あ_#{Process.pid}"; Dir.mkdir(d); a=File.realpath(".".encode(En
+fb27a658425b604c46ae6e1895b2637d	[0, true]	class NilClass; def ==(o) = true; end\n        [[nil, 1].index(false), [
 fb34f21f962af0c522442f03bd1d5c04	["ab", "ab"]	$/ = "cde"; s = +"abcde"; r = s.chomp!; $/ = "\\n"; [r, s]
 fb39dbdb558be25e38526a8809edbaac	3	->((*, a)) { a }.call([1, 2, 3])
 fb5ca5680002838248335aca3324daec	[true, true]	f = File.open("Cargo.toml")\n            begin\n              [f.set_


### PR DESCRIPTION
# Summary

`[1, 2, 3].include?(9)` and `#index` dispatched `==` once per element — **2.5x and 3.7x slower than CRuby**. Both now go through one shared scan, `Executor::rb_equal_search`, prepared per call by `EqSearch`.

The scan is CRuby's `rb_equal`, and writing it out turned up two things monoruby was getting wrong:

**The identity step was missing.** `rb_equal` answers "the same object" *before* asking `==`, and that is observable:

```ruby
class Never; def ==(o) = false; end
n = Never.new
[n, 1].include?(n)          # CRuby: true   monoruby: false
nan = Float::NAN
[nan].include?(nan)         # CRuby: true   monoruby: false   (nan == nan is false)
```

**`index` asked the wrong receiver.** It looked `==` up on the *argument* and called `argument == element`, where CRuby calls `element == argument` — a different answer for any asymmetric `==`. `count` did the same.

# The fast path

With identity in hand, the fast path is the rest of the answer for a needle whose class monoruby knows: an Integer, a Symbol, `nil`, `true` or `false` is unequal to any other value of its class (the bits already said so), and a String is settled by content and encoding compatibility — `String#==`'s own answer, reached without the call. `BASIC_OP_DEFS` tracks these pairs, so a redefined `==` takes them off it, and a String *subclass* element is left to its own `==` (which CRuby runs, and the old shared `==` path did not).

Elements that do reach a dispatch keep the saving `index` used to get from hoisting: a monomorphic cache of `==` per element class, validated by the class version. When the lookup lands on the inherited `BasicObject#==` — an ordinary object, defining no `==` — the answer is the identity test already made, so **no call happens at all**.

Applied to `include?`, `index` / `find_index`, `count(obj)` and `delete` in Rust, and to `rindex` / `assoc` / `rassoc` in builtins/array.rb through a private `__rb_equal`, so the family does not disagree with itself.

# Benchmarks (release, vs CRuby 4.0.2, same-run, best of 3)

| | before | after |
|---|---:|---:|
| `include?`, Integer array | 2.53 | **0.84** |
| `index`, Integer array | 3.66 | **0.99** |
| `delete` | 1.46 | **0.89** |
| `include?`, array of plain objects | 3.20 | **0.77** |
| `include?` / `index`, Strings | 1.63 / 1.38 | **1.27 / 1.29** |
| `index`, elements with a user `==` | — | **0.19** |

# Testing

- Full suite: **3619 passed / 0 failed** (default and `stress-spill-pool`)
- `cargo check --target aarch64-unknown-linux-gnu`: clean
- `tests/eq_search.rs` covers the identity step and the operand order across all seven methods, each decided needle class matching and missing, the String encoding cases (binary vs UTF-8, incompatible non-ASCII, the empty-string exception, frozen), every reason the scan declines (cross-class numerics, Bignum, String subclass, arrays and hashes), a polymorphic array through the element cache, a redefined `==` per class, and both of `delete`'s scans.
- Every case diffed against CRuby 4.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_