### PR TITLE
Inline-cache the &amp;:sym dispatch, and make String Comparable

### DIFF
--- a/monoruby/builtins/string.rb
+++ b/monoruby/builtins/string.rb
@@ -1,4 +1,11 @@
 class String
+  # CRuby's String is Comparable, and `between?` / `clamp` come from it —
+  # they were simply missing here. The ordering operators stay native
+  # (builtins/string.rs): a method defined on the class wins over the
+  # module's, so including this adds the two methods without moving
+  # `<` / `<=` / `>` / `>=` onto the slower `<=>`-based path.
+  include Comparable
+
   def to_s
     self
   end

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -3678,7 +3678,51 @@ impl Executor {
         bh: Option<BlockHandler>,
         kw: Option<Hashmap>,
     ) -> Result<Value> {
+        // `&:sym` is a *call site*, and like every other call site it
+        // deserves an inline cache: `ary.map(&:to_s)` asks for one symbol
+        // on one class per element, and the lookup was what made it cost
+        // an explicit `public_send` per element rather than a plain call.
+        if let Some(func_id) = self.symbol_proc_method(globals, symbol, recv) {
+            return self.invoke_func_inner(globals, func_id, recv, args, bh, kw);
+        }
         self.invoke_method_inner_vis(globals, symbol, recv, args, bh, kw, false)
+    }
+
+    ///
+    /// The public method `symbol` names on `recv`, from the one-entry
+    /// cache in `Globals` or resolved and recorded there.
+    ///
+    /// `None` whenever the plain path must run instead: a receiver whose
+    /// `symbol` is private, protected or absent (the errors and the
+    /// `method_missing` fallback are `invoke_method_inner_vis`'s to
+    /// produce, and are not worth caching), or an active refinement, which
+    /// makes the resolution depend on the calling scope rather than on the
+    /// receiver's class alone.
+    ///
+    fn symbol_proc_method(
+        &mut self,
+        globals: &mut Globals,
+        symbol: IdentId,
+        recv: Value,
+    ) -> Option<FuncId> {
+        if globals.store.refinements().is_active() {
+            return None;
+        }
+        // The *real* class, not `class_for_ic`: the latter answers
+        // `BOOL_CLASS` for both `true` and `false`, and `find_method` falls
+        // back to a per-class lookup when the two resolve differently — so
+        // a shared key could hand `false` the method it resolved for
+        // `true`.
+        let class_id = recv.class();
+        let class_version = Globals::class_version();
+        if let Some(func_id) = globals.cached_symbol_method(symbol, class_id, class_version) {
+            return Some(func_id);
+        }
+        // `is_func_call = false` is what makes this `public_send`: the
+        // same restricted lookup the uncached path performs.
+        let func_id = self.find_method(globals, recv, symbol, false).ok()?;
+        globals.cache_symbol_method(symbol, class_id, class_version, func_id);
+        Some(func_id)
     }
 
     // NOTE: there is deliberately no generic Rust-side safepoint helper

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -275,6 +275,11 @@ pub struct Globals {
     /// given an instance variable, through one `to_proc` is the same
     /// object the next one returns.
     symbol_procs: HashMap<IdentId, Value>,
+    /// The last method a `&:sym` dispatch resolved — a one-entry inline
+    /// cache, since that is the shape the dispatch meets: `ary.map(&:to_s)`
+    /// asks for the same symbol on the same class for every element, and
+    /// looked it up every time. See [`Globals::cached_symbol_method`].
+    symbol_proc_cache: Option<SymbolProcCache>,
     /// function and class info.
     pub store: Store,
     /// global variables and special variables.
@@ -385,6 +390,18 @@ pub struct Globals {
     dumped_bc: usize,
 }
 
+///
+/// One resolved `&:sym` dispatch: `symbol` called on an instance of
+/// `class_id` resolved to `func_id`, while the class version was
+/// `class_version`.
+///
+struct SymbolProcCache {
+    symbol: IdentId,
+    class_id: ClassId,
+    class_version: u32,
+    func_id: FuncId,
+}
+
 impl std::ops::Deref for Globals {
     type Target = Store;
     fn deref(&self) -> &Self::Target {
@@ -424,6 +441,43 @@ impl Globals {
     /// as this proc's own position, and the first caller's is as good as
     /// any later one's.
     ///
+    ///
+    /// The method `symbol` resolves to on `class_id`, from the one-entry
+    /// cache — or `None`, leaving the caller to resolve it.
+    ///
+    /// The entry is keyed by the class *and* the class version, so a
+    /// definition, a removal or a visibility change anywhere retires it
+    /// (each of those bumps the version).
+    ///
+    pub(crate) fn cached_symbol_method(
+        &self,
+        symbol: IdentId,
+        class_id: ClassId,
+        class_version: u32,
+    ) -> Option<FuncId> {
+        let cache = self.symbol_proc_cache.as_ref()?;
+        (cache.symbol == symbol && cache.class_id == class_id && cache.class_version == class_version)
+            .then_some(cache.func_id)
+    }
+
+    ///
+    /// Record a `&:sym` resolution for [`Globals::cached_symbol_method`].
+    ///
+    pub(crate) fn cache_symbol_method(
+        &mut self,
+        symbol: IdentId,
+        class_id: ClassId,
+        class_version: u32,
+        func_id: FuncId,
+    ) {
+        self.symbol_proc_cache = Some(SymbolProcCache {
+            symbol,
+            class_id,
+            class_version,
+            func_id,
+        });
+    }
+
     pub(crate) fn symbol_proc(&mut self, symbol: IdentId, pc: BytecodePtr) -> Value {
         if let Some(proc) = self.symbol_procs.get(&symbol) {
             return *proc;
@@ -649,6 +703,7 @@ impl Globals {
             main_object,
             symbol_proc_frames: HashMap::default(),
             symbol_procs: HashMap::default(),
+            symbol_proc_cache: None,
             store: Store::new(),
             gvars: GvarTable::new(),
             special_gvars: SpecialGvars::default(),

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -316,6 +316,7 @@
 175d3bf3dc8f6885e9ac87e2c9486453	[6765, 1999000, 6765, 1999000]	def fib(n) = n < 2 ? n : fib(n-1) + fib(n-2)\n            def loopy(
 1763e2c9bc0720402e213cbf885dd569	[5, 5, nil, nil, 5, 5, IOError]	(f="/tmp/mono_sz_#{Process.pid}"; File.write(f,"12345"); io=File.open(f); o=Obje
 176a18e075a2502220b53b0982b7de35	[:singleton_method_added, :foo, :bar]	$res = []\n            class C\n              def self.singleton_meth
+176a4f88e9d3064441c40d65e63991b7	[[:a, :b, :c, :a], ["1", "2.0", "3", "four", "", "true", "false"], [2, 1, 2]]	class A; def tag = :a; end\n        class B; def tag = :b; end\n        c
 176ade062a39fa54620f862c109af764	"US-ASCII"	"abc".dup.force_encoding("US-ASCII").tr("ab", "xy").encoding.to_s
 177267179432c2c7c88151677405f37d	[true, "Process::Status", 0]	pid = fork { exit 0 }\n            ret, status = Process.wait2(pid)\n
 177aa65b5849b4e8af68b7b3b7db3c28	"01AB456789"	path = "/tmp/monoruby_test_binwrite_off_#{Process.pid}_#{rand(10000
@@ -698,6 +699,7 @@
 35c34bacae1f61a4e888e6635ce091cd	[1, 11, 21]	a_r, a_w = IO.pipe\n            b_r, b_w = IO.pipe\n            t = T
 35c59e1cf7ef55a085a02265b5be6363	["abc", 1, "aBc"]	x = "b"\n               r = /a#{x}c/imx\n               [r.source, (r =~ "xABCx"),
 362197c8ba0c107c5b63c4c8b7e930e6	false	t = Thread.new { IO.select(nil, nil, nil, 2**62) }\n            Thre
+3634c56019b496302e0dbaf2bd90cd08	[[:from_true, :from_false, :from_true], [:from_false, :from_true]]	class TrueClass; def which = :from_true; end\n        class FalseClass; 
 366101f3454d9c3ba104d799233170e4	14	class Foo\n              def with_block; yield 7; end\n            en
 367c0b57251ec6d8861445efce15a4a2	[3, 4, 5]	class MyNum; def to_int; 2; end; end\nn = MyNum.new\n[1,2,3,4,5].drop(n)
 369964a9ab023c59c6982e160cd552b5	10770.0	def g\n          a = 0.0; b = 1.0; c = 2.0; d = 3.0\n          i = 0\n    
@@ -820,6 +822,7 @@
 40dbb62b44df59e21da6740b92d1afe6	[4, 8, 91, 7, 85, 58, 13, 77, 68, 80, 114, 111, 116, 111, 50, 105, 6, 64, 6]	class MDProto2\n              def initialize(x); @x = x; end\n       
 40e716c7328738b3fe988089e88cf750	[false, "d"]	File.open("Cargo.toml") do |f|\n              f.read\n              f
 40ec27ae46c638a3a6280b2acf09bfed	["SocketError", true, 0, ["AF_INET", "127.0.0.1", "127.0.0.1"], true, "127.0.0.1"]	require "socket"\n            res = []\n            # unknown host ->
+410e76b670dd81753a10505bf18e9a4e	[true, ["String", "Comparable", "Object", "Kernel", "BasicObject"], true, false, "b", "c", "c", true, true, true, false, true, false, -1, nil, "b", "a"]	[String.include?(Comparable), String.ancestors.map(&:to_s),\n         "b
 4127f9d58f69e19b5bcf5c3c3cefe969	[true, true, false, :fired]	Thread.handle_interrupt(StandardError => :never) do\n              c
 41308fa046142fe3ed9d2bce06bdeb37	[4, 8, 91, 7, 73, 117, 58, 13, 85, 68, 80, 114, 111, 116, 111, 50, 7, 104, 105, 6, 58, 6, 69, 84, 64, 6]	class UDProto2\n              def initialize(s); @s = s; end\n       
 41709673073e0a9bac7681363b4962df	"語本日"	"日本語".reverse
@@ -1247,6 +1250,7 @@
 623b167ed005d1a8a28f3d3a8053c3ed	[:v, :v, :w]	class B\n              def initialize() @h = {} end\n              de
 623c780251b09b2380a85de8d8651972	[true, true, true]	File.write("/tmp/mr_enc2.txt", "")\n            Encoding.default_int
 625ae98b945176f640a4b3585c1acc5f	[:from_rescue, [:ens]]	$log = []\n            def m\n              raise "x"\n            res
+626249dd96d2b17f8fbf2140e3002208	[[1, 2, [], 9, nil], [1, 5, [6], 9, nil], [1, 2, [], 3, nil], [1, 2, [], 9, :block], 3, [1]]	class Args\n          def call_me(a, b = 2, *rest, kw: 9, &blk)\n        
 62825865a591b21dbb6b9d05adb0c05a	["echo hello", true]	def `(cmd); [cmd, cmd.frozen?]; end\n        `echo hello`\n        
 628eaa8bccd2d8c621e49bd30049c6ce	[301.5, [1.5, 98.5, 195.5, 292.5]]	def call_block\n          yield\n        end\n        def bump\n          y
 62abd44369ee4b6cc7e6dbf66a868f1d	[[nil, nil, nil], [1, nil, nil], [1, 2, nil], [1, 2, 3]]	S = Struct.new(:a, :b, :c)\n            \n\n            [S.new.to_a, S
@@ -1559,6 +1563,7 @@
 7b5f68952152e7580c6ab25f3f926de2	[false, false, false, nil, false, false, false, nil, false, false, false, nil, false, false, false, nil, false, false, false, nil]	def f(x)\n          x&.nil?\n        end\n\n        a = [1,2,3,nil] * 5\n   
 7b7476abdf009af6db3f49d35ef4d89d	[]	def g(*a); a; end; g(*nil)
 7b7f468fd7e708b03afd14b1c5882f15	"hELLO, wORLD!"	"Hello, World!".swapcase
+7b8a6623c250c4690f74c23e3bf712f7	[[[:real, nil], [:mm, :poke, []], [:real, nil]], [[:mm, :poke, []]], :raised, [[:real, nil]]]	class MM\n          def method_missing(name, *args) = [:mm, name, args]\n
 7bac2eab198ba99ba15061f668fa67ce	[0, "nil", "nil"]	o = Object.new\n        [o <=> o, (o <=> Object.new).inspect, (o <=> 3.1
 7bd487fc3bae8a806a0ddc5f0394215f	[true, false]	m = Mutex.new\n            slept = false\n            t = Thread.new 
 7bf72e6eb4c2c593bd81eb7b98dcafb0	:OVERRIDDEN	class Integer; def <=>(o); :OVERRIDDEN; end; end; 1 <=> 2
@@ -2058,6 +2063,7 @@ a2e679bc25d5bbcdcffa24d1390f7717	[true, 0, true, true, true, 0]	pid = fork { exi
 a2fe58a4b8970857e7e6bc4daf663e90	[["UTF-8", "EUC-JP", 1, false], ["UTF-8", "EUC-JP", 1, false], ["UTF-8", "EUC-JP"], [true, "ASCII-8BIT", true], 1, [42, []]]	path = "/tmp/monoruby_test_iostate_#{Process.pid}_#{rand(100000)}"\n
 a315e27bdfdf0dfa963d5e510f6c345b	[[2, 3.5, 4, 5.5], [3.5, 5.5, 7.5], 1180591620717411303425, 1.1805916207174113e+21]	def disagree(x) = x + 1\n            def unstable(x, y) = x + y\n    
 a31930a9e915d99cf23e80f66584373b	["m0", 420, 21, "m0", 0, 4, 109, 30, 777, 5, 880, 24, "argerr", "NoMethodError", "m0", 70, 0]	class C\n          def m0; "m0"; end\n          def m1(a); a * 10; end\n  
+a325e684a0135d4aab296b6018ac921e	[true, true]	class Sub < String; end\n        [Sub.new("b").between?("a", "c"), Sub.a
 a32adc46f1bb4ed6ce92840c775bbf19	""	"".upcase
 a32db795d17419028fabd7b655b6becb	"bar"	class Foo\n              def bar; "bar"; end\n              alias :'b
 a32e5a59e048d15bbb352b6fdb7e1699	[0, 0.0, 6, 8.5, 15.25, "abc"]	[[].sum, [].sum(0.0), [1, 2, 3].sum, [3, 5.5].sum, [2.5, 3.0].sum(0.0) {|e| e * 
@@ -2550,6 +2556,7 @@ c6d3dade907fe66184348357856a018e	[2, -2, 1, -1, 0, 3, -3, 1, 3, -2, 3, 6, 16, 0]
 c6eb9b15a65b550251f8bc847a36dd0d	5.955087954701154e+22	r = 0.0\n            for i in 0..50\n              f = i * 1.1\n      
 c6ec882095c32db233297f4e203f6a3b	[1, 2, [5, 6], 7, 8, 3, 4]	def f\n          yield [1,2,3,4,5,6,7,8]\n        end\n        \n\n        f
 c6f097206e76981036cfc465a5190636	true	Process.maxgroups.is_a?(Integer)
+c6f5c8e7ce6b58cb3bb269cae9e14ec3	[:private, :protected, [:ok], :now_private, [:ok]]	class V\n          def open_door = :ok\n          private def secret = :n
 c6fe44f6e625e7833496d0a607b52675	"Xhello"	s = "hello"; s.bytesplice(0..-100, "X"); s
 c7101771745858d945b8e3d5c923d7a5	[{a: 1}, 42]	h = Hash.new(42)\n            h[:a] = 1\n            h[:b] = nil\n    
 c73d8fd4413dceb9e1c357241d5c7060	[1, 1]	def f(a = false); 1; end\n        [f, f(:x)]\n        
@@ -3134,6 +3141,7 @@ f4dbd65859826724c9fb5648c3f84c3a	[:re]	def m\n              re = /(?<matched>foo
 f4e35e264294b3bd8913c077f24dea7a	[{"a" => 10, "b" => 20}, {1 => :a, 2 => :b}, {}]	h = { a: 1, b: 2 }\n            [h.to_h { |k, v| [k.to_s, v * 10] },
 f4ef37c05309c4811b6d78d2a1b7c9ce	[true, true]	S = Struct.new(:a, :b)\n            \n\n            a = S.new(1, "x")\n
 f4f318253ef6eda2bd57d54a445dae64	[1, 2, [3, 4], 5, [6], 7, 8, [9, 10]]	f = ->((a, b, *c, d), (*e, f, g), (*h)) { [a, b, c, d, e, f, g, h] }\n  
+f54339b0ac95ca56fd90790bbbaab021	[[1], [2], :missing, [:hi], :gone]	class R; def v = 1; end\n        first = [R.new].map(&:v)\n        class 
 f54dcd2ea5a345f130209fcaaafe0294	"US-ASCII"	"abc".encode("US-ASCII").center(5).encoding.to_s
 f5694c7e392bbf1dd23065cde514678b	[["plain"], [".", ".dot", "plain"], [".", ".dot", "plain"], ["EUC-JP"], ["plain"]]	(d="/tmp/mono_ge_#{Process.pid}"; Dir.mkdir(d); File.write("#{d}/.dot", ""); Fil
 f57a8409c183d2a681df3ee5b1b1cc9c	true	begin\n              eval("if true", nil, "speccing.rb", 88)\n       

--- a/monoruby/tests/symbol_proc_cache.rs
+++ b/monoruby/tests/symbol_proc_cache.rs
@@ -1,0 +1,155 @@
+//! The `&:sym` dispatch resolves through a one-entry inline cache
+//! (`Globals::cached_symbol_method`). Everything it must still get right:
+//! the method it finds, and every reason a cached entry has to be retired.
+
+extern crate monoruby;
+use monoruby::tests::*;
+
+/// An array of several classes thrashes the one-entry cache, so each
+/// element must still reach its own method.
+#[test]
+fn polymorphic_receivers_each_reach_their_own_method() {
+    run_test(
+        r##"
+        class A; def tag = :a; end
+        class B; def tag = :b; end
+        class C < A; def tag = :c; end
+        [[A.new, B.new, C.new, A.new].map(&:tag),
+         [1, 2.0, "3", :four, nil, true, false].map(&:to_s),
+         [[1, 2], {a: 1}, (1..2)].map(&:size)]
+        "##,
+    );
+}
+
+/// `true` and `false` share one inline-cache class in the VM; the symbol
+/// cache must not, or `false` gets the method resolved for `true`.
+#[test]
+fn true_and_false_do_not_share_a_cache_entry() {
+    run_test(
+        r##"
+        class TrueClass; def which = :from_true; end
+        class FalseClass; def which = :from_false; end
+        [[true, false, true].map(&:which), [false, true].map(&:which)]
+        "##,
+    );
+}
+
+/// A definition made *after* a symbol proc has run must be seen: the
+/// entry is keyed by the class version, which every definition bumps.
+#[test]
+fn a_redefinition_retires_the_entry() {
+    run_test_once(
+        r##"
+        class R; def v = 1; end
+        first = [R.new].map(&:v)
+        class R; def v = 2; end
+        second = [R.new].map(&:v)
+        # A method added to a superclass, and one removed.
+        class Base; end
+        class Sub < Base; end
+        added = begin
+          [Sub.new].map(&:hello)
+        rescue NoMethodError
+          :missing
+        end
+        class Base; def hello = :hi; end
+        after_add = [Sub.new].map(&:hello)
+        class R; undef_method :v; end
+        after_undef = begin
+          [R.new].map(&:v)
+        rescue NoMethodError
+          :gone
+        end
+        [first, second, added, after_add, after_undef]
+        "##,
+    );
+}
+
+/// `&:sym` is `public_send`: a private or protected method is not called,
+/// and making a public one private has to retire the cached entry.
+#[test]
+fn visibility_is_enforced_and_tracked() {
+    run_test_once(
+        r##"
+        class V
+          def open_door = :ok
+          private def secret = :no
+          protected def guarded = :no
+        end
+        priv = begin; [V.new].map(&:secret); rescue NoMethodError => e; :private; end
+        prot = begin; [V.new].map(&:guarded); rescue NoMethodError => e; :protected; end
+        before = [V.new].map(&:open_door)
+        class V; private :open_door; end
+        after = begin; [V.new].map(&:open_door); rescue NoMethodError => e; :now_private; end
+        class V; public :open_door; end
+        again = [V.new].map(&:open_door)
+        [priv, prot, before, after, again]
+        "##,
+    );
+}
+
+/// A receiver with no such method reaches `method_missing`, and one
+/// without that raises — neither is cached, and both must survive a
+/// successful call to the same symbol on another class.
+#[test]
+fn missing_methods_are_not_cached() {
+    run_test(
+        r##"
+        class MM
+          def method_missing(name, *args) = [:mm, name, args]
+          def respond_to_missing?(*) = true
+        end
+        class Real; def poke(x = nil) = [:real, x]; end
+        [[Real.new, MM.new, Real.new].map(&:poke),
+         [MM.new].map(&:poke),
+         (begin; [Object.new].map(&:poke); rescue NoMethodError; :raised; end),
+         [Real.new].map(&:poke)]
+        "##,
+    );
+}
+
+/// The cached entry carries the method, not the arguments: the same
+/// symbol proc reused with arguments, keywords and a block still passes
+/// them through.
+#[test]
+fn arguments_survive_the_cache() {
+    run_test(
+        r##"
+        class Args
+          def call_me(a, b = 2, *rest, kw: 9, &blk)
+            [a, b, rest, kw, blk ? blk.call : nil]
+          end
+        end
+        o = Args.new
+        p1 = :call_me.to_proc
+        [p1.call(o, 1), p1.call(o, 1, 5, 6), p1.call(o, 1, 2, kw: 3),
+         p1.call(o, 1) { :block }, [1, 2].inject(&:+), [[1, 2]].map(&:first)]
+        "##,
+    );
+}
+
+/// `String` is `Comparable`, as in CRuby — `between?` and `clamp` come
+/// from it, while String's own `<=>` / `==` and the native ordering
+/// operators keep answering.
+#[test]
+fn string_is_comparable() {
+    run_test(
+        r##"
+        [String.include?(Comparable), String.ancestors.map(&:to_s),
+         "b".between?("a", "c"), "b".between?("c", "d"),
+         "b".clamp("a", "c"), "b".clamp("c", "d"), "b".clamp("c".."d"),
+         ("a" < "b"), ("a" <= "a"), ("b" > "a"), ("b" >= "c"),
+         ("a" == "a"), ("a" == 1), ("a" <=> "b"), ("a" <=> 1),
+         "b".clamp("a"..), "b".clamp(.."a")]
+        "##,
+    );
+    run_test_error(r#""b".clamp("c", "a")"#);
+    run_test_error(r#""b".between?("a", 1)"#);
+    // A String subclass inherits Comparable through String.
+    run_test(
+        r##"
+        class Sub < String; end
+        [Sub.new("b").between?("a", "c"), Sub.ancestors.include?(Comparable)]
+        "##,
+    );
+}


### PR DESCRIPTION
# Summary

Two independent gaps, measured in the same sweep.

## `&:sym` looked its method up every call

`ary.map(&:to_s)` asks for one symbol on one class per element, so `dispatch_symbol_proc` now consults a one-entry cache in `Globals` keyed by (symbol, receiver class, class version) — an inline cache, for what is a call site like any other.

The entry is skipped when a refinement is active (the resolution then depends on the calling scope, not the receiver's class), and nothing is cached for a private, protected or missing method, so the errors and the `method_missing` fallback stay where they were. The key is the receiver's **real** class rather than `class_for_ic`: the latter answers `BOOL_CLASS` for both booleans, while `find_method` falls back to a per-class lookup when `TrueClass` and `FalseClass` resolve differently — a shared key could hand `false` the method resolved for `true`.

Same-session, release, 100 elements × 20000:

- `ary.map(&:to_s)` — 0.552s → 0.484s (**−12%**)
- `ary.map(&:itself)` — 0.268s → 0.211s (**−21%**)

The cheaper the method, the larger the share the lookup was.

**This does not reach parity with CRuby** (1.71x → 1.51x), and the measurement says why. With the lookup gone, what remains is the generic `invoke_func_inner` frame setup: `&:sym` still costs what an explicit `public_send` costs here (~90ns per element more than the JIT-compiled block form, which is itself 6x faster than CRuby's). Closing that is a Rust-side call fast path — a separate piece of work, not a bigger cache.

## `String` did not include `Comparable`

CRuby's does, and `between?` / `clamp` come from it; here they were simply missing:

```ruby
"b".between?("a", "c")   # CRuby: true   monoruby: NoMethodError
"b".clamp("a", "c")      # CRuby: "b"    monoruby: NoMethodError
String.include?(Comparable)  # CRuby: true   monoruby: false
```

Including it also corrects `String.ancestors`. The ordering operators stay native — a method defined on the class wins over the module's — so nothing moves onto the slower `<=>`-based path.

One residue, left alone: monoruby defines `<` / `<=` / `>` / `>=` on String itself, so `String.instance_methods(false)` lists them where CRuby lists only `<=>` and `==`.

# Testing

- Full suite: **3626 passed / 0 failed** (default and `stress-spill-pool`)
- `cargo check --target aarch64-unknown-linux-gnu`: clean
- `tests/symbol_proc_cache.rs` covers the polymorphic receivers that thrash the entry, `true`/`false` not sharing one, every retirement (a redefinition, a superclass definition, an `undef_method`, a visibility change in both directions), private and protected staying uncalled, `method_missing`, arguments / keywords / blocks passing through a reused proc, and String's Comparable methods alongside its own comparisons.
- Unrelated benchmarks re-checked for regressions; all unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_