### PR TITLE
Answer container equality from identity first

### DIFF
--- a/monoruby/builtins/hash.rb
+++ b/monoruby/builtins/hash.rb
@@ -281,6 +281,12 @@ class Hash
     h
   end
 
+  # Kept in Ruby on purpose. A Rust `dig` used to be registered here and
+  # was shadowed by this one; reviving it measured *slower* (0.133s vs
+  # 0.118s for three levels x 300k, CRuby 0.037s), because this body is
+  # JIT-compiled and inlined while a builtin is an opaque native call that
+  # allocates a rest Array per level. Without the JIT the Rust one does
+  # win (0.158s vs 0.245s), which is what made the swap look attractive.
   def dig(key, *rest)
     val = self[key]
     return val if rest.empty? || val.nil?

--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -1103,6 +1103,10 @@ fn pop(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 fn eql(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let arg = lfp.arg(0);
+    // Identity first, as in `==` below.
+    if self_val.id() == arg.id() {
+        return Ok(Value::bool(true));
+    }
     let lhs = self_val.as_array();
     let rhs = if let Some(rhs) = arg.try_array_ty() {
         rhs
@@ -1137,6 +1141,11 @@ fn eql(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 fn eq(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let arg = lfp.arg(0);
+    // An Array equals itself without any element being looked at, which is
+    // where `rb_ary_equal` starts too.
+    if self_val.id() == arg.id() {
+        return Ok(Value::bool(true));
+    }
     let lhs = self_val.as_array();
     let rhs = if let Some(rhs) = arg.try_array_ty() {
         rhs

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -211,7 +211,6 @@ pub(super) fn init(globals: &mut Globals) {
         0,
     );
     globals.define_builtin_func_rest(HASH_CLASS, "values_at", values_at);
-    globals.define_builtin_func_rest(HASH_CLASS, "dig", dig);
     globals.define_builtin_func(HASH_CLASS, "to_h", to_h, 0);
 
     let mut env_map = RubyMap::default();
@@ -673,6 +672,13 @@ fn size(_vm: &mut Executor, _globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
 fn eq(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let rhs_v = lfp.arg(0);
+    // A Hash equals itself, whatever it holds — `rb_hash_equal` answers
+    // that before looking at a single entry, and it is not only a
+    // shortcut: `h = { x: Float::NAN }; h == h` is true in CRuby, and was
+    // false here.
+    if self_val.id() == rhs_v.id() {
+        return Ok(Value::bool(true));
+    }
     let lhs = self_val.as_hash();
     let rhs = if let Some(rhs) = rhs_v.try_hash_ty() {
         rhs
@@ -690,8 +696,11 @@ fn eq(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
     }
     crate::value::exec_recursive_paired(self_val.id(), rhs_v.id(), || {
         for (k, lhs_value) in lhs.iter() {
+            // `rb_equal` per value, identity included: that is what makes
+            // `{ x: Float::NAN } == { x: Float::NAN }` true, since both
+            // hold the same NaN.
             if let Some(rhs_value) = rhs.get(k, vm, globals)?
-                && vm.eq_values_bool(globals, lhs_value, rhs_value)?
+                && vm.rb_equal(globals, lhs_value, rhs_value)?
             {
                 continue;
             } else {
@@ -714,6 +723,10 @@ fn eq(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Res
 fn eql(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let rhs_v = lfp.arg(0);
+    // Identity first, as in `==` above.
+    if self_val.id() == rhs_v.id() {
+        return Ok(Value::bool(true));
+    }
     let lhs = self_val.as_hash();
     let rhs = if let Some(rhs) = rhs_v.try_hash_ty() {
         rhs
@@ -735,6 +748,11 @@ fn eql(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
             let Some(rhs_value) = rhs.get(k, vm, globals)? else {
                 return Ok(Value::bool(false));
             };
+            // `rb_eql` checks identity before dispatching, so a value that
+            // is not `eql?` to itself (a NaN) still matches itself.
+            if lhs_value.id() == rhs_value.id() {
+                continue;
+            }
             let result = vm.invoke_method_inner(
                 globals,
                 eql_id,
@@ -2349,32 +2367,6 @@ fn values_at(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
         res.push(v);
     }
     Ok(Value::array_from_vec(res))
-}
-
-/// ### Hash#dig
-#[monoruby_builtin]
-fn dig(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    let args = lfp.arg(0).as_array();
-    if args.is_empty() {
-        return Err(MonorubyErr::argumenterr(
-            "wrong number of arguments (given 0, expected 1+)",
-        ));
-    }
-    let hash = lfp.self_val().as_hash();
-    let first_key = args[0];
-    let mut val = if let Some(v) = hash.get(first_key, vm, globals)? {
-        v
-    } else {
-        return Ok(Value::nil());
-    };
-    for i in 1..args.len() {
-        if val.is_nil() {
-            return Ok(Value::nil());
-        }
-        val =
-            vm.invoke_method_inner(globals, IdentId::get_id("dig"), val, &[args[i]], None, None)?;
-    }
-    Ok(val)
 }
 
 /// ### Hash#to_h

--- a/monoruby/src/builtins/set.rs
+++ b/monoruby/src/builtins/set.rs
@@ -630,6 +630,11 @@ fn symmetric_difference(
 #[monoruby_builtin]
 fn eq(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let other = lfp.arg(0);
+    // A Set equals itself without a membership probe per element, which is
+    // where `Set#==` starts in CRuby too.
+    if lfp.self_val().id() == other.id() {
+        return Ok(Value::bool(true));
+    }
     if !is_set(other, &globals.store) {
         return Ok(Value::bool(false));
     }

--- a/monoruby/src/builtins/struct_class.rs
+++ b/monoruby/src/builtins/struct_class.rs
@@ -529,6 +529,11 @@ pub(super) fn qualified_real_class_name(store: &Store, class_id: ClassId) -> Opt
 pub(super) fn eq(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let other = lfp.arg(0);
+    // A Struct equals itself without comparing a member, as in
+    // `rb_struct_equal`.
+    if self_val.id() == other.id() {
+        return Ok(Value::bool(true));
+    }
     if self_val.class() != other.class() {
         return Ok(Value::bool(false));
     }
@@ -574,6 +579,11 @@ pub(super) fn eq(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecode
 pub(super) fn eql(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_val = lfp.self_val();
     let other = lfp.arg(0);
+    // A Struct equals itself without comparing a member, as in
+    // `rb_struct_equal`.
+    if self_val.id() == other.id() {
+        return Ok(Value::bool(true));
+    }
     if self_val.class() != other.class() {
         return Ok(Value::bool(false));
     }

--- a/monoruby/tests/equal_identity.rs
+++ b/monoruby/tests/equal_identity.rs
@@ -1,0 +1,97 @@
+//! Container equality starts from identity, as CRuby's `rb_ary_equal`,
+//! `rb_hash_equal`, `rb_struct_equal` and `Set#==` all do: an object
+//! equals itself before anything inside it is looked at, and a value
+//! equals itself before its `==` is asked.
+//!
+//! Not only a shortcut. Without it a Hash holding a `NaN` — or anything
+//! whose `==` answers false — was not equal to itself.
+
+extern crate monoruby;
+use monoruby::tests::*;
+
+/// Every container answers `true` for itself, whatever it holds.
+#[test]
+fn a_container_equals_itself() {
+    run_test(
+        r##"
+        require "set"
+        class Never
+          def ==(o) = false
+          def eql?(o) = false
+        end
+        n = Never.new
+        nan = Float::NAN
+        ary = [nan, n]
+        hash = { a: nan, b: n }
+        set = Set.new([1, 2])
+        st = Struct.new(:x, :y).new(nan, n)
+        [ary == ary, ary.eql?(ary), ary === ary,
+         hash == hash, hash.eql?(hash), hash === hash,
+         set == set, st == st, st.eql?(st),
+         [] == [], {} == {}, Set.new == Set.new]
+        "##,
+    );
+}
+
+/// A value equals itself inside two *different* containers too — the
+/// per-element step, which Array had and Hash did not.
+#[test]
+fn a_value_equals_itself_across_containers() {
+    run_test(
+        r##"
+        class Never
+          def ==(o) = false
+          def eql?(o) = false
+        end
+        n = Never.new
+        nan = Float::NAN
+        [[nan] == [nan], [n] == [n],
+         { x: nan } == { x: nan }, { x: n } == { x: n },
+         { x: nan }.eql?({ x: nan }), { x: n }.eql?({ x: n }),
+         [[nan]] == [[nan]], { a: { b: nan } } == { a: { b: nan } }]
+        "##,
+    );
+}
+
+/// Everything the identity step must *not* swallow: containers that
+/// really differ, and the class / flag mismatches each `==` checks.
+#[test]
+fn unequal_containers_stay_unequal() {
+    run_test(
+        r##"
+        require "set"
+        S1 = Struct.new(:x)
+        S2 = Struct.new(:x)
+        h = { a: 1 }
+        [[1, 2] == [1, 3], [1] == [1, 2], [1] == 1, [1] == nil,
+         { a: 1 } == { a: 2 }, { a: 1 } == { b: 1 }, { a: 1 } == { a: 1, b: 2 },
+         { a: 1 } == 1, { a: 1 } == nil,
+         h == h.dup, h.dup == h.dup,
+         h == {}.compare_by_identity.merge(a: 1),
+         Set.new([1]) == Set.new([1]), Set.new([1]) == Set.new([2]),
+         Set.new([1]) == [1],
+         S1.new(1) == S1.new(1), S1.new(1) == S2.new(1), S1.new(1) == S1.new(2),
+         [1].eql?([1.0]), ({ a: 1 }).eql?({ a: 1.0 })]
+        "##,
+    );
+}
+
+/// A container that holds itself: the identity step must not hide the
+/// recursion guard that was already there.
+#[test]
+fn self_referential_containers() {
+    run_test(
+        r##"
+        a = []
+        a << a
+        b = []
+        b << b
+        h = {}
+        h[:x] = h
+        g = {}
+        g[:x] = g
+        [a == a, a == b, a == a.dup, a.eql?(a),
+         h == h, h == g, h.eql?(h), a.inspect, h.inspect]
+        "##,
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -996,6 +996,7 @@
 4c1c6f6c3f836877abf737896a925b9d	[true, true, true]	S = Struct.new(:a, :b, :c)\n            \n\n            s = S.new(1, 2
 4c2abed4507b2755e1ec53fe8226c80f	[true, true, :done, :finished]	(a=loop.instance_of?(Enumerator); b=(loop.size == Float::INFINITY); sub=Class.ne
 4c3cdf6fdb768ce2061972f6724dd416	42	class Foo\n              def initialize(x)\n                @x = x\n  
+4c417c7d5c4ca0cfc5e0182ee4cb0ce0	[true, true, true, true, true, true, true, "[[...]]", "{x: {...}}"]	a = []\n        a << a\n        b = []\n        b << b\n        h = {}\n    
 4c6323de719d0ad254c106b3de0e1ff1	99	b = binding\n            b.local_variable_set("bar", 99)\n           
 4c66c29f7a10c99487fbb86f19ded61a	false	File.file?("readme.md")
 4c69a613ea757c9eff914b8a29903a61	[7]	$log = []\n        def m\n          d = 7\n          [1].each do |x|\n     
@@ -1107,6 +1108,7 @@
 5674c6743eb1f8cb3c5480370147f096	[10, 20]	class A\n          def initialize(x)\n            @x = x\n          end\n  
 5682fe3035100385f60effc866827604	[false, false]	def foo; end\n            def bar; end\n            public [:foo, :ba
 569d1753aae6166485a592748257a963	[[[:a, 1], [:b, 2], [:c, 3]]]	class C\n          def f(**kw)\n            $res << kw.sort\n          end
+56af07030ff71ab320bc5fad3b4906c4	[false, false, false, false, false, false, false, false, false, true, true, false, true, false, false, true, false, false, false, false]	require "set"\n        S1 = Struct.new(:x)\n        S2 = Struct.new(:x)\n 
 56b85c950efd2cb0bd3500751c39686e	[2.4676811938123496e+176, -1.8507608953592623e+176]	def f(n)\n          x = 0.0\n          y = 1.0\n          i = 0\n          
 56bcba9795510ae298d1929763e4b300	100	foo = false\n        bar = true\n        quu = false\n        \n        cas
 56be47cd692556e12f7876ff5251e406	[[10, 100, 10, 100, 20, 200, 30, 300], [1, -1, 2, -2]]	r = []\n        c = {}\n        [1, 2, 3].each do |i|\n          begin\n   
@@ -1746,6 +1748,7 @@
 88d4180cc8261b799934c513e7ea401c	13	def f(a,b)\n          a + b\n        end\n        f(5,7)\n        f(4,9)\n  
 88f8e9f112097e82f8a521e470848673	["<1>", "'x'"]	module AncInner\n              refine(Integer) { def wrap; "<#{to_s}
 88fba5d2266fa4ee0bba24a92af6c067	[[], 1]	->((*a, b)) { [a, b] }.call([1])
+890a5b6de0ff467859398b23a4f4c43a	[true, true, true, true, true, true, true, true, true, true, true, true]	require "set"\n        class Never\n          def ==(o) = false\n         
 8933c621a2a4cce4cee3e798523d76cd	1050	LCS_K2 = 7\n        def lcs_hot2\n          s = 0\n          i = 0\n       
 898daf8bc776af90627957e0256ba48d	[0, 0, 0, 0, 0, 0, 0, 0, 0, 76, 31, 0, 78, 6, 0, 31, 27, 28, 14, 78, 20, 84, 5, 0, 26, 15, 0, 25, 6, 84, 29, 83, 11, 9, 85, 25, 83, 6, 9, 27, 24, 69, 13, 27, 29]	def bxor!(a, b)\n          l = a.bytesize\n          lb = b.bytesize\n    
 89a90f1ae033d44d7cd236ed88be4129	:bar	class Foo\n              def bar; end\n            end\n            \n\n
@@ -2518,6 +2521,7 @@ c2d97a349b86a09c5fd224aef7dda8c9	["unknown keywords: :b, :c", "unknown keyword: 
 c2ddc4b987960c63ecfe548001121a15	501	def f; 1; end\n            a = 0; i = 0\n            while i < 20000\n
 c2f1188cf58009e1f4929f6667b6493e	["C", "M"]	module M\n            end\n            class S\n            end\n      
 c3423608f46c2ab24a0a71094cd5ae93	[1, 2, 1, 2]	class MyNum; def to_int; 2; end; end\nn = MyNum.new\nres = []; [1,2].cycle(n) { |x
+c36b1e25498098fb5ed62d696afcb18a	[true, true, true, true, true, true, true, true]	class Never\n          def ==(o) = false\n          def eql?(o) = false\n 
 c371620ea2df438989e85db786cb3351	[true, true]	GC.config(rgengc_allow_full_mark: false)\n            begin\n        
 c374efe593f3736150bcf4d3b491c4f6	:te2	ar = Object.new; def ar.to_ary; 5; end; begin; [1].product(ar); rescue TypeError
 c395a855a07a1b6fc115ed058695bea2	"İSTANBUL"	"istanbul".upcase(:turkic)


### PR DESCRIPTION
# Summary

A fresh 203-case benchmark sweep put `h == h` — a Hash compared with itself — at **79x CRuby**, the largest gap left. CRuby's `rb_hash_equal`, `rb_ary_equal`, `rb_struct_equal` and `Set#==` all answer `true` for the same object before looking at anything inside; monoruby compared entry by entry every time.

**It is not only a shortcut.** Hash lacked the *per-value* identity step too — the one `Array#==` already had — so a Hash was not equal to itself when it held something whose `==` says no:

```ruby
h = { x: Float::NAN }
h == h                                  # CRuby: true   monoruby: false
h.eql?(h)                               # CRuby: true   monoruby: false
{ x: Float::NAN } == { x: Float::NAN }  # CRuby: true   monoruby: false
```

Both steps are now in place: the container check in `Array#==` / `#eql?`, `Hash#==` / `#eql?`, `Set#==` and `Struct#==` / `#eql?`, and the per-value one in the Hash pair (`==` compares values with `rb_equal`, `eql?` checks identity before dispatching, as `rb_eql` does).

Same object, 100 entries / elements, 20000 iterations:

| | before | after | CRuby |
|---|---:|---:|---:|
| `h == h` | 0.1177s | **0.0010s** | 0.0015s |
| `s == s` (Set) | 0.0869s | **0.0010s** | 0.0016s |
| `a == a` | 0.0122s | **0.0011s** | 0.0015s |
| `st == st` (Struct, 500k) | 0.0870s | **0.0228s** | 0.0364s |

The recursion guard each of these already had is untouched: a container holding itself still compares as it did.

# A dead `Hash#dig`, and a negative result

The sweep also flagged `dig` at 3.3x, and the Rust implementation registered for it turned out to be **shadowed** by the Ruby one in builtins/hash.rb — it never ran. Reviving it measured *slower*, and the reason is worth recording: the Ruby body is JIT-compiled and inlined, while a builtin is an opaque native call that allocates a rest Array per level.

| three levels x 300k | JIT | `--no-jit` |
|---|---:|---:|
| Ruby `dig` (what runs today) | **0.118s** | 0.245s |
| Rust `dig` (the revival) | 0.133s | 0.158s |

Without the JIT the Rust one does win, which is what made the swap look attractive. The dead Rust function is deleted and the measurement noted in `hash.rb` where the next person will look. Closing the remaining `dig` gap needs something else — a JIT-inlinable builtin, or a cheaper Ruby formulation than a `respond_to?` probe and a splat recursion per level.

# Testing

- Full suite: **3639 passed / 0 failed** (default and `stress-spill-pool`)
- `cargo check --target aarch64-unknown-linux-gnu`: clean
- `tests/equal_identity.rs` covers each container equal to itself while holding a NaN and a `==`-refusing object, a value equal to itself across two different containers, everything the identity step must not swallow (differing contents, sizes, classes, a `compare_by_identity` mismatch, `eql?` vs `==` on `1` and `1.0`), and self-referential containers
- Unrelated Hash/Array benchmarks re-checked: unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_