### PR TITLE
Box a deferred float home when the block-handing bet fails

### DIFF
--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -1474,6 +1474,9 @@ impl<'a> JitContext<'a> {
         // given up has to leave the value in its slot. Note them now, while
         // we still know what they were.
         let held = state.held_constants();
+        // The same, for the float locals whose boxed slot store the
+        // block-handing `unbox_to_S` deferred to a spill home.
+        let deferred_homes = state.deferred_float_homes();
         let compiled = self.compile_specialized_func(
             state,
             iseq,
@@ -1533,6 +1536,12 @@ impl<'a> JitContext<'a> {
             // caller's `acc`.
             if had_deopt || generic_yield {
                 state.forget_constants(ir);
+                // A deferred float home is the same bet in the other
+                // representation: the block reaching us from the VM reads
+                // the *slot*, which the deferral left stale. Box it here,
+                // on the one path into the call, exactly like the
+                // constants above.
+                state.home_deferred_floats(ir, &deferred_homes, generic_yield);
             }
         }
         let evict = ir.new_evict();

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1280,6 +1280,65 @@ impl SlotState {
             .collect()
     }
 
+    ///
+    /// Every local whose boxed slot store `unbox_to_S` deferred to a
+    /// spill home — the raw f64 is current in the home and the slot is
+    /// stale. Only the `keep_claims` arm creates these, so this is read
+    /// at exactly one place: the block-handing call site's
+    /// bet-confirmation (`specialized_iseq`).
+    ///
+    pub(in crate::codegen::jitgen) fn deferred_float_homes(&self) -> Vec<(SlotId, FPReg)> {
+        self.locals()
+            .filter_map(|slot| match self.mode(slot) {
+                LinkMode::F(fpr) if fpr.0 >= PHYS_FPR_POOL => Some((slot, fpr)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    ///
+    /// Make the slot of each still-deferred home current again, on the
+    /// one path into a block-handing call whose bet failed.
+    ///
+    /// The read twin of `forget_constants`. A `C` claim says the slot
+    /// need not be read; a deferred home says the same about a float, and
+    /// both are false the moment the block can run outside this unit — it
+    /// reads the caller's local through its outer chain, off the stack
+    /// slot, which the deferral left holding whatever was there before
+    /// (`nil`, for a local whose only write was the deferred store).
+    ///
+    /// The binding itself survives unless *widen*, because the callee's
+    /// already-emitted stores write the *home*: dropping it would make
+    /// the continuation read a slot the compiled block never refreshes,
+    /// losing every `a += ...` the block performed. A deopt under the
+    /// call cannot read a stale slot either — chain escalation means the
+    /// continuation never runs compiled, and the deopt write-back boxes
+    /// the home. *widen* is for the generic-yield case, where the block
+    /// is not compiled here at all: its stores land in the slot, so the
+    /// continuation has to read the slot too.
+    ///
+    pub(in crate::codegen::jitgen) fn home_deferred_floats(
+        &mut self,
+        ir: &mut AsmIr,
+        deferred: &[(SlotId, FPReg)],
+        widen: bool,
+    ) {
+        for &(slot, fpr) in deferred {
+            // A path inside the callee's compile may already have widened
+            // the slot (a `StoreDynVar` the compiler saw), in which case
+            // the store that widened it made the slot current.
+            if self.mode(slot) != LinkMode::F(fpr) {
+                continue;
+            }
+            ir.spill(Spill::Fpr(fpr, slot));
+            if widen {
+                let guarded = self.guarded(slot);
+                self.clear(slot);
+                self.set_mode(slot, LinkMode::S(guarded));
+            }
+        }
+    }
+
     /// Resume overlay: adopt the return-path join's claims where this
     /// (parked) frame holds a plain `S`.
     ///

--- a/monoruby/tests/float_across_block_call.rs
+++ b/monoruby/tests/float_across_block_call.rs
@@ -256,3 +256,41 @@ fn a_float_untouched_by_the_block() {
         PRELUDE,
     );
 }
+
+/// The float lives only in a *spill* home across the call, so the boxed
+/// slot store is deferred — and then a side exit inside the callee hands
+/// the rest of it, the `yield` included, back to the VM. The block reads
+/// the caller's local off the slot the deferral left unwritten, and sees
+/// the `nil` the frame was set up with.
+///
+/// Reported from a JIT-compiled DOOM renderer as
+/// `comparison of Float with NilClass failed` (`sprite_scale` read as
+/// `nil` inside a `reverse_each` block).
+#[test]
+fn a_deferred_home_read_after_a_side_exit() {
+    run_test_once(
+        r#"
+        class C
+          def initialize
+            @a = [0.0, 1.0, 2.0]
+            @hit = 0
+          end
+          def poison(v) = @a[1] = v
+          def f(d)
+            s = 160.0 / d
+            @a.each do |x|
+              @hit += 1 if !x.nil? && x < s
+            end
+            @hit
+          end
+        end
+        c = C.new
+        res = 0
+        5000.times do |i|
+          c.poison(i % 97 == 96 ? nil : (i % 17).to_f)
+          res = c.f(2.0 + (i % 13))
+        end
+        res
+        "#,
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -2079,6 +2079,7 @@ a32e5a59e048d15bbb352b6fdb7e1699	[0, 0.0, 6, 8.5, 15.25, "abc"]	[[].sum, [].sum(
 a32ecda935b7e94450e788b8832e13a4	[3, 1, 5, 3]	class C\n            include Comparable\n            attr_accessor :x\n 
 a331276eee9103e6d3857063f69777b4	[:foo, :bar]	$res = []\n            class C\n              def self.singleton_meth
 a34c4e369e6d5139f06cb9ce6026b999	42	class C\n          def self.class_method\n            42\n          end\n  
+a359b845a5de697d94d846bfda30d830	14614	class C\n          def initialize\n            @a = [0.0, 1.0, 2.0]\n     
 a3618f8ad00f6c37b513a42900293bee	[[233], "Windows-1250", [234, 247, 241], "Ω≈±", [240, 210, 201, 215, 197, 212], "Привет", [146, 165, 225, 226], "абв"]	(a="é".encode("Windows-1250").bytes; b="é".encode("Windows-1250").encoding.name;
 a3921c92237d852a5bc1ad370ba61b79	["Enumerator::Yielder", true]	y = nil\n            Enumerator.new { |yy| y = yy; yy.yield 1 }.firs
 a3baab6cd54895307ab33a2e43c7a755	true	rng = Random.new(42)\n        a = rng.rand(100)\n        a.is_a?(Integer)


### PR DESCRIPTION
## The bug

A JIT-compiled DOOM renderer died after a few thousand frames with

```
renderer.rb:1533:in 'block in Doom::Render::Renderer#draw_sprite_with_masking':
comparison of Float with NilClass failed (ArgumentError)
	from <internal:array>:112:in 'Array#reverse_each'
```

The block's outer local `sprite_scale = @projection / spr.dist` read as `nil`, while `@projection` and `spr.dist` — read from the same outer frame, on the same line — were fine. So the frame chain was right and the slot itself was simply never written. `--no-jit` runs clean.

## Why

A call that hands out its block homes every unboxed local in its slot first, because the block reads the caller's locals off the stack. For a *spill*-resident float, `unbox_to_S`'s `keep_claims` arm skips that store — the callee reads the value through the chain claim instead, so boxing here would re-pay at every call the store the deferral removed.

That holds only while the callee's compiled body is the only thing that runs. `specialized_iseq` already knows when it is not (a side exit in the compiled subtree, or a `yield` that did not inline) and gives up the frame's constant claims there, on the grounds that

> The values are in their slots either way (`unbox_to_S` wrote them on the way in), so this costs no code.

For a deferred float home that is exactly what did not happen. The slot still holds what the frame was set up with, and the block — now running in the VM — reads `nil`.

## The fix

Give the deferral up on the same bet failure, as the read twin of `forget_constants`.

- The store goes **before** the call, where the constants' does.
- The binding **survives** it. The callee's already-emitted stores write the *home*; dropping the binding would make the continuation read a slot the compiled block never refreshes, losing every `a += ...` the block performed. (The first cut did drop it, and `float_across_block_call::a_builtin_callee` returned `[4.5, 4.5]` instead of `[7.5, 18.0]`.)
- Only a **generic yield** widens: there the block is not compiled here at all, so its stores land in the slot and the continuation has to read the slot too.

## Verification

- New test `float_across_block_call::a_deferred_home_read_after_a_side_exit` — a 20-line reduction that raises the same `comparison of Float with NilClass failed` before the fix and matches CRuby after. Confirmed to fail with the fix reverted.
- `cargo nextest run`: 3423/3423 pass.
- The DOOM repro: crashes within ~100 s before, runs 180 s clean after.
- No measurable cost — DOOM headless bench 219.3 → 219.1 fps, `app_aobench` 4.17 → 4.12 s, `so_nbody` / `so_mandelbrot` / `binarytrees` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)