### PR TITLE
bench-pages: fix the empty history grid — read history.csv by column position, repair its stale header

### DIFF
--- a/.github/bench-pages/index.html
+++ b/.github/bench-pages/index.html
@@ -355,30 +355,38 @@ function parseCsvRow(line) {
 }
 
 function parseCsv(text) {
-  const lines = text.replace(/\r/g, "").trim().split("\n");
-  if (lines.length < 2) return [];
-  const headers = parseCsvRow(lines[0]);
-  return lines.slice(1).map(line => {
-    const fields = parseCsvRow(line);
-    const obj = {};
-    headers.forEach((h, i) => obj[h] = fields[i]);
-    return obj;
-  });
+  return text.replace(/\r/g, "").trim().split("\n").map(parseCsvRow);
 }
 
 (async () => {
   const res = await fetch("data/history.csv?t=" + Date.now());
   if (!res.ok) return;
+  // Read the rows by position, not by header name: the published
+  // history.csv still carries the header the very first run wrote
+  // (`monoruby_ips,yjit_ips,ratio`), because the publish step only emits
+  // a header when the file does not exist yet. Column *order* has been
+  // stable throughout — timestamp, commit, benchmark, monoruby, yjit,
+  // ratio — so position is the reliable key.
+  //
+  // The seven oldest rows (one 2026-05-06 run) are 6-field rows holding
+  // iterations/sec rather than milliseconds; a run hours later replaced
+  // them with the current schema, so they are dropped instead of being
+  // plotted in the wrong unit.
+  const num = s => {
+    const v = parseFloat(s);
+    return isFinite(v) ? v : null;
+  };
   const rows = parseCsv(await res.text())
-    .map(r => ({
-      timestamp:    r.timestamp,
-      commit:       r.commit,
-      benchmark:    r.benchmark,
-      monoruby_ms:  r.monoruby_ms === "" ? null : parseFloat(r.monoruby_ms),
-      yjit_ms:      r.yjit_ms     === "" ? null : parseFloat(r.yjit_ms),
-      ratio:        r.ratio       === "" ? null : parseFloat(r.ratio),
-    }))
-    .filter(r => r.benchmark);
+    .slice(1)
+    .filter(f => f.length >= 8 && f[2])
+    .map(f => ({
+      timestamp:   f[0],
+      commit:      f[1],
+      benchmark:   f[2],
+      monoruby_ms: num(f[3]),
+      yjit_ms:     num(f[4]),
+      ratio:       num(f[5]),
+    }));
 
   const grid         = document.getElementById("historyGrid");
   const historyEmpty = document.getElementById("historyEmpty");

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -487,9 +487,20 @@ jobs:
 
             mkdir -p "$GH_PAGES_DIR/$SUBDIR/data"
 
-            if [ ! -f "$GH_PAGES_DIR/$SUBDIR/data/history.csv" ]; then
-              echo "timestamp,commit,benchmark,monoruby_ms,yjit_ms,ratio,monoruby_failed,yjit_failed,monoruby_reason,yjit_reason" \
-                > "$GH_PAGES_DIR/$SUBDIR/data/history.csv"
+            local CSV="$GH_PAGES_DIR/$SUBDIR/data/history.csv"
+            local HEADER="timestamp,commit,benchmark,monoruby_ms,yjit_ms,ratio,monoruby_failed,yjit_failed,monoruby_reason,yjit_reason"
+
+            if [ ! -f "$CSV" ]; then
+              echo "$HEADER" > "$CSV"
+            elif [ "$(head -n 1 "$CSV")" != "$HEADER" ]; then
+              # The header was only ever written when the file was created,
+              # so the live file still names its columns after the original
+              # iterations/sec schema (`monoruby_ips,yjit_ips,ratio`) even
+              # though every row since has been the 10-column ms schema.
+              # Rewrite just line 1 so the names match the data.
+              { echo "$HEADER"; tail -n +2 "$CSV"; } > "$CSV.new"
+              mv "$CSV.new" "$CSV"
+              echo "history.csv: refreshed stale header for $SUBDIR"
             fi
 
             ruby "$GITHUB_WORKSPACE/.github/scripts/append_history.rb" \


### PR DESCRIPTION
The per-benchmark history grid comes up empty on the live dashboard. Regression from #1209.

## Cause

`history.csv` on gh-pages still carries the header the very first run wrote back in May:

```
timestamp,commit,benchmark,monoruby_ips,yjit_ips,ratio            ← the published header
timestamp,commit,benchmark,monoruby_ms,yjit_ms,ratio,...          ← what every row since actually is
```

`publish_arch` only emits a header when the file does not exist, so the switch to the 10-column millisecond schema — hours later, on 2026-05-06 — never updated line 1. Parsing by header name therefore produced `undefined` for every row's monoruby/yjit time.

The old selector-based chart survived this because its default ratio view read only the `ratio` column, whose name happens to be unchanged across both schemas. Its raw-ms view was already broken by the same mismatch — that is what the earlier "raw ms mode draws nothing" report was really about; it was misdiagnosed as an axis-scale problem and never actually fixed. The new grid asks for both times to decide whether a benchmark is plottable, so every row was rejected and no cards were built at all.

## Changes

- **The page reads rows by column position** rather than by header name. Column order has been stable throughout (`timestamp, commit, benchmark, monoruby, yjit, ratio`), so position is the reliable key, and the page renders correctly against both the stale and the repaired header. The seven oldest rows are 6-field iterations/sec rows from a single run that a ms-schema run superseded the same day; they are dropped rather than plotted in the wrong unit.
- **`publish_arch` repairs the header**: when an existing `history.csv` has a first line that does not match the current schema, it rewrites just that line, so the published file stops advertising columns it no longer has.

## Verification

Rendered the page against the **live** published data — `latest.json` and the full 47,670-row `history.csv` downloaded from gh-pages — rather than the synthetic fixtures that masked this the first time:

- 61 cards built and all 61 drawn, `61 benchmarks` in the header, no console or page errors.
- Identical results before and after the header repair, so the page is correct either way.
- The header repair preserves all 47,669 data rows (last row byte-identical), and is a no-op on re-run.
- Workflow YAML parses and the `publish` step's shell passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUYnhjixuUEzA5hgWUdckX

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUYnhjixuUEzA5hgWUdckX)_