### PR TITLE
docs: consolidate the README and wiki into the book, and publish the missing design documents

### DIFF
--- a/.github/portal/index.html
+++ b/.github/portal/index.html
@@ -15,6 +15,8 @@
     --accent-dark: #1b5e20;
     --accent-blue: #1565c0;
     --accent-blue-dark: #0d47a1;
+    --accent-doc: #5e35b1;
+    --accent-doc-dark: #4527a0;
     --border: #eaeaea;
     --code-bg: #f5f5f5;
   }
@@ -58,6 +60,12 @@
     box-shadow: 0 2px 6px rgba(21, 101, 192, 0.25);
   }
   .cta .primary-blue:hover { background: var(--accent-blue-dark); }
+  .cta .primary-doc {
+    background: var(--accent-doc);
+    color: #fff;
+    box-shadow: 0 2px 6px rgba(94, 53, 177, 0.25);
+  }
+  .cta .primary-doc:hover { background: var(--accent-doc-dark); }
   .cta .secondary {
     background: #f0f0f0;
     color: var(--fg);
@@ -98,6 +106,7 @@
 <body>
 
 <nav class="cta">
+  <a class="primary-doc" href="./docs/">Documentation →</a>
   <a class="primary-blue" href="./bench/">Performance vs YJIT (x86-64) →</a>
   <a class="primary-blue" href="./bench-arm64/">Performance vs YJIT (aarch64) →</a>
   <a class="primary" href="./spec/">ruby/spec compliance dashboard →</a>

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 Ruby implementation with yet another JIT compiler written in Rust.
 
+- 📖 **[Documentation](https://sisshiki1969.github.io/monoruby/docs/)** — [installation and build](https://sisshiki1969.github.io/monoruby/docs/installation.html), [benchmarks](https://sisshiki1969.github.io/monoruby/docs/benchmarks.html), [development and build options](https://sisshiki1969.github.io/monoruby/docs/development.html), architecture overviews and the full design documents.
+- 📊 **[Project portal](https://sisshiki1969.github.io/monoruby/)** — benchmark and ruby/spec dashboards, re-measured on every push to `master` that touches the interpreter.
+
 ## What's New in 2026
 
 Monthly highlights of improvements since January 2026 (with representative PRs).
@@ -90,7 +93,8 @@ Monthly highlights of improvements since January 2026 (with representative PRs).
 ## Compatibility
 
 Conformance with Ruby has improved dramatically over the course of 2026, driven by an extensive [ruby/spec](https://github.com/ruby/spec)-based compliance effort.
-As of July 2026, monoruby passes 100% of the command-line specs, 99.6% of the language specs, and about 90% of the core-library specs.
+Pass rates are re-measured on every interpreter change and published on the project portal: as of commit `a13bfe0` (2026-08-31) monoruby passes **97.6%** of the [core specs](https://sisshiki1969.github.io/monoruby/spec/) (22468 / 23029 examples) and **59.1%** of the [library specs](https://sisshiki1969.github.io/monoruby/library/).
+As of July 2026 it also passed 100% of the command-line specs and 99.6% of the language specs.
 Daily-updated pass statistics, compared with CRuby / TruffleRuby / JRuby, are published at [rubyspec-stats](https://sisshiki1969.github.io/rubyspec-stats/).
 
 ## Prerequisites
@@ -102,15 +106,13 @@ Daily-updated pass statistics, compared with CRuby / TruffleRuby / JRuby, are pu
 
 ## How to run
 
-Please see [wiki](https://github.com/sisshiki1969/monoruby/wiki/Build-and-Install) for details. 
+See [Installation and Build](https://sisshiki1969.github.io/monoruby/docs/installation.html) for prebuilt binaries, platform notes, what the build installs, and the full command-line reference.
 
-(1) Install nightly Rust.
+(1) Install Rust.
 
-First of all, install Rust nightly.
-[Check here to install Rust](https://www.rust-lang.org/ja/tools/install)
+[Check here to install Rust](https://www.rust-lang.org/tools/install) if you have no Rust yet.
 
-_Caution!!_ **only nightly Rust works** for monoruby.
-[See here to work with nightly Rust](https://rust-lang.github.io/rustup/concepts/channels.html#working-with-nightly-rust).
+_Caution!!_ **only nightly Rust works** for monoruby. You do not have to select the channel yourself: `rust-toolchain.toml` pins the exact nightly the project is tested against, and `rustup` installs and uses it automatically the first time you run `cargo` in the checkout.
 
 (2) Clone this repository.
 
@@ -135,6 +137,14 @@ or
 
 ```sh
 > bin/irm
+```
+
+(5) or, install `monoruby` and `irm` onto your `PATH`.
+
+```sh
+> cargo install --path monoruby
+> monoruby test.rb
+> irm
 ```
 
 ## Using monoruby in GitHub Actions
@@ -177,12 +187,14 @@ Inputs and outputs:
 
 ## Benchmark
 
-Up-to-date benchmark results (yjit-bench, measured on every push to master) and a ruby/spec compliance dashboard are published on [the project portal](https://sisshiki1969.github.io/monoruby/). The numbers below are from older one-off measurements.
+Up-to-date benchmark results (yjit-bench, re-measured on every interpreter change) and the ruby/spec compliance dashboards are published on [the project portal](https://sisshiki1969.github.io/monoruby/). On the x86-64 run of commit `a13bfe0` (2026-08-31), over the 59 benchmarks that completed on both interpreters, monoruby averaged 1.28x the speed of CRuby+YJIT (geometric mean).
 
-### 1. Optcarrot banechmark
+The [Benchmarks](https://sisshiki1969.github.io/monoruby/docs/benchmarks.html) chapter of the documentation explains the measurement methodology and how to reproduce a run locally. The numbers below are older one-off measurements, kept for the record.
+
+### 1. Optcarrot benchmark
 
 Several Ruby implementations described below were measured by [optcarrot](https://github.com/mame/optcarrot) benchmark.
-Please see [wiki](https://github.com/sisshiki1969/monoruby/wiki/Optcarrot-benchmark) for details. 
+See [Benchmarks — optcarrot](https://sisshiki1969.github.io/monoruby/docs/benchmarks.html#optcarrot-april-2024) for details.
 
 #### Versions of used Rubies
 
@@ -202,7 +214,7 @@ Please see [wiki](https://github.com/sisshiki1969/monoruby/wiki/Optcarrot-benchm
 ### 2. Other benchmarks
 
 Several Ruby implementations described below were measured by [yjit-bench](https://github.com/Shopify/yjit-bench).
-Please see [wiki](https://github.com/sisshiki1969/monoruby/wiki/General-benchmarks) for details.
+See [Benchmarks — yjit-bench](https://sisshiki1969.github.io/monoruby/docs/benchmarks.html#yjit-bench-december-2024) for the raw data.
 
 #### Versions of used Rubies
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Ruby implementation with yet another JIT compiler written in Rust.
 
-- 📖 **[Documentation](https://sisshiki1969.github.io/monoruby/docs/)** — [installation and build](https://sisshiki1969.github.io/monoruby/docs/installation.html), [benchmarks](https://sisshiki1969.github.io/monoruby/docs/benchmarks.html), [development and build options](https://sisshiki1969.github.io/monoruby/docs/development.html), architecture overviews and the full design documents.
+- 📖 **[Documentation](https://sisshiki1969.github.io/monoruby/docs/)** — [installation and build](https://sisshiki1969.github.io/monoruby/docs/installation.html), [development and build options](https://sisshiki1969.github.io/monoruby/docs/development.html), [benchmark](https://sisshiki1969.github.io/monoruby/docs/benchmarks.html) and [compatibility](https://sisshiki1969.github.io/monoruby/docs/compatibility.html), architecture overviews and the full design documents.
 - 📊 **[Project portal](https://sisshiki1969.github.io/monoruby/)** — benchmark and ruby/spec dashboards, re-measured on every push to `master` that touches the interpreter.
 
 ## What's New in 2026
@@ -96,6 +96,8 @@ Conformance with Ruby has improved dramatically over the course of 2026, driven 
 Pass rates are re-measured on every interpreter change and published on the project portal: as of commit `a13bfe0` (2026-08-31) monoruby passes **97.6%** of the [core specs](https://sisshiki1969.github.io/monoruby/spec/) (22468 / 23029 examples) and **59.1%** of the [library specs](https://sisshiki1969.github.io/monoruby/library/).
 As of July 2026 it also passed 100% of the command-line specs and 99.6% of the language specs.
 Daily-updated pass statistics, compared with CRuby / TruffleRuby / JRuby, are published at [rubyspec-stats](https://sisshiki1969.github.io/rubyspec-stats/).
+
+The [Compatibility](https://sisshiki1969.github.io/monoruby/docs/compatibility.html) chapter of the documentation breaks the numbers down by category, explains how they are measured, and lists the behaviours that differ from CRuby by design.
 
 ## Prerequisites
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -18,21 +18,40 @@
 - [Stub code for JIT'ed code](design/jit.md)
 - [Unified low-level IR (LIR)](design/lir.md)
 - [Separating the abstract interpreter from register allocation](design/regalloc_separation.md)
+- [Trace-wide abstract state and chain joins](design/trace_chain_joins.md)
 - [Inline asm functions](design/inline.md)
 - [JIT argument forwarding (Japanese)](design/arg_forwarding_jit.md)
 - [x86-64 / aarch64 JIT backend differences](design/arch_difference.md)
+- [Invariants compiled code speculates on (Japanese)](design/jit_invariants.md)
+- [Version guards, salvage and the megamorphic gate](design/jit_invalidation.md)
+- [Basic-op redefinition (Japanese)](design/bop_redefinition.md)
+- [Chain deoptimization](design/chain_deopt.md)
+- [Reading the deopt log](design/deopt_log.md)
+- [Receiver-polymorphic call sites (Japanese)](design/polymorphic_call.md)
+
+---
+
 - [GC — mechanism and implementation (Japanese)](design/gc.md)
 - [Thread / Fiber / non-blocking IO / preemption (Japanese)](design/threads.md)
 - [Thread / Fiber state transition diagrams (Japanese)](design/scheduler_state_diagram.md)
 - [Safepoints (Japanese)](design/safepoint.md)
 - [Signal handling (Japanese)](design/signal.md)
+
+---
+
 - [Exception handling — mechanism and CRuby contrast](design/exception_handling.md)
 - [Stack layout for the interpreter / JIT'ed code](design/stack_frame.md)
 - [Method argument processing (Japanese)](design/method_args.md)
 - [Native (builtin) function registration](design/native_func.md)
 - [CREF — Class / Constant Reference](design/cref.md)
+- [Refinements and method resolution](design/refinements.md)
+- [TOPLEVEL_BINDING and the main script](design/toplevel_binding.md)
 - [super resolution via the caller PC (Japanese)](design/super_resolution.md)
+
+---
+
 - [Per-encoding character iteration design](design/encoding_char_iteration_design.md)
 - [C extension support — design notes (Japanese)](design/c_extention.md)
 - [ruby/spec hang countermeasures (Japanese)](design/ruby_spec_skip_tags.md)
+- [optcarrot --opt profile (Japanese)](design/optcarrot_opt_profile.md)
 - [Progress summary (April 2025 – April 2026)](design/progress_2025-2026.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -2,6 +2,12 @@
 
 [Introduction](introduction.md)
 
+# Getting Started
+
+- [Installation and Build](installation.md)
+- [Benchmarks](benchmarks.md)
+- [Development and Build Options](development.md)
+
 # Architecture
 
 - [Architecture Overview](architecture-overview.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,8 +5,12 @@
 # Getting Started
 
 - [Installation and Build](installation.md)
-- [Benchmarks](benchmarks.md)
 - [Development and Build Options](development.md)
+
+# Performance and Compatibility
+
+- [Benchmark](benchmarks.md)
+- [Compatibility](compatibility.md)
 
 # Architecture
 

--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -1,4 +1,4 @@
-# Benchmarks
+# Benchmark
 
 monoruby is performance-focused, and performance is measured continuously
 rather than quoted from a README. This page covers the live dashboards, how to
@@ -15,8 +15,9 @@ portal](https://sisshiki1969.github.io/monoruby/):
 | --- | --- |
 | [Performance vs YJIT (x86-64)](https://sisshiki1969.github.io/monoruby/bench/) | Per-benchmark speed relative to CRuby + YJIT, plus a history chart per benchmark |
 | [Performance vs YJIT (aarch64)](https://sisshiki1969.github.io/monoruby/bench-arm64/) | The same suite on an Apple Silicon runner |
-| [ruby/spec core dashboard](https://sisshiki1969.github.io/monoruby/spec/) | Pass rates for the `core` spec group |
-| [ruby/spec library dashboard](https://sisshiki1969.github.io/monoruby/library/) | Pass rates for the `library` spec group |
+
+The portal also hosts the two ruby/spec dashboards; those are covered in
+[Compatibility](compatibility.md).
 
 Methodology, from `.github/workflows/bench.yml`:
 

--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -1,0 +1,170 @@
+# Benchmarks
+
+monoruby is performance-focused, and performance is measured continuously
+rather than quoted from a README. This page covers the live dashboards, how to
+reproduce a measurement locally, and the historical one-off comparisons that
+used to live in the project wiki.
+
+## Live dashboards
+
+Every push to `master` that touches the interpreter re-runs the benchmark
+suite and republishes the [project
+portal](https://sisshiki1969.github.io/monoruby/):
+
+| Dashboard | What it shows |
+| --- | --- |
+| [Performance vs YJIT (x86-64)](https://sisshiki1969.github.io/monoruby/bench/) | Per-benchmark speed relative to CRuby + YJIT, plus a history chart per benchmark |
+| [Performance vs YJIT (aarch64)](https://sisshiki1969.github.io/monoruby/bench-arm64/) | The same suite on an Apple Silicon runner |
+| [ruby/spec core dashboard](https://sisshiki1969.github.io/monoruby/spec/) | Pass rates for the `core` spec group |
+| [ruby/spec library dashboard](https://sisshiki1969.github.io/monoruby/library/) | Pass rates for the `library` spec group |
+
+Methodology, from `.github/workflows/bench.yml`:
+
+- The suite is [yjit-bench](https://github.com/Shopify/yjit-bench), run with
+  `--rss --harness=harness-warmup`, monoruby against `ruby --yjit` on the same
+  runner in the same job.
+- The reference CRuby is 4.0.2 (`ruby/setup-ruby`), and monoruby is installed
+  with `cargo install --path monoruby --locked`.
+- Each benchmark gets a 400-second timeout per interpreter; a benchmark that
+  times out or exits non-zero is recorded as a failure rather than silently
+  dropped, and shows on the dashboard as a gap.
+- The published `ratio` is **× YJIT, higher = monoruby faster**, 1× being
+  parity. `latest.json` and `data/history.csv` next to each dashboard hold the
+  raw numbers if you want to plot them yourself.
+
+As a snapshot: on the x86-64 run of commit `a13bfe0` (2026-08-31), 59 of the
+76 benchmarks produced a ratio on both interpreters; over those the geometric
+mean was **1.28× YJIT**, with monoruby ahead on 30 of them. The spread is
+wide in both directions — from ~16× on `string_malloc_pressure` down to ~0.3×
+on `send_bmethod` — which is the point of reading the dashboard rather than a
+single headline number.
+
+## Reproducing a measurement locally
+
+The helper scripts in `bin/` wrap the two harnesses the project uses. Most of
+them assume [benchmark-driver](https://github.com/benchmark-driver/benchmark-driver)
+and `rbenv`-managed reference Rubies; adjust the version strings inside to
+match what you have installed.
+
+| Script | What it runs |
+| --- | --- |
+| `bin/bench` | The standard set (`app_fib`, `so_nbody`, `so_mandelbrot`, `app_aobench`, plb2) via benchmark-driver, against `4.0.5 --yjit` and `4.0.5 --zjit` |
+| `bin/compare` | Comparing **two git refs of monoruby** against each other — `bin/compare HEAD~1 HEAD` by default, over `app_fib`, `so_nbody`, `so_mandelbrot`, `quick_sort`, `integer`, `vm_send`, `vm_block`, `vm_yield` |
+| `bin/ruby-bench` | The full yjit-bench suite (expects a `../ruby-bench` checkout), the same harness CI uses |
+| `bin/optcarrot` | optcarrot on ruby, `ruby --yjit` and monoruby in turn (expects `../optcarrot`) |
+| `bin/opt.rb` | optcarrot fps history over 3000 frames, the data behind the fps-history charts |
+| `bin/index` | Array / Hash element access (`benchmark/index.yaml`) |
+| `bin/inline` | Integer and Math methods, i.e. the inline-asm builtins, also run with `--no-jit` for contrast |
+| `bin/ivar` | Instance-variable get/set, generic and `attr_`-generated |
+| `bin/send` | Method dispatch, `Class.new`, Array literals and constant lookup |
+| `bin/times` | `Integer#times`, JIT'ed Array / Hash work, `block_given?` |
+
+`bin/compare` is the one to reach for when you want to know whether a change
+you just made helped:
+
+```sh
+bin/compare                          # HEAD~1 vs HEAD, standard benchmarks
+bin/compare abc1234 def5678          # two specific commits
+bin/compare HEAD~5 HEAD app_fib.yml  # one benchmark
+```
+
+For a single script, a release build is enough:
+
+```sh
+cargo build --release
+target/release/monoruby benchmark/app_fib.rb
+```
+
+Benchmark scripts and their benchmark-driver YAML configs live in
+`benchmark/`. Passing `--no-jit` gives you the VM-only baseline for the same
+script, which is often more informative than an absolute number.
+
+## Profiling
+
+```sh
+# Flame graph via Linux perf (needs ../FlameGraph)
+bin/perf benchmark/app_fib.rb
+
+# or by hand
+cargo build --release --features perf
+perf record target/release/monoruby benchmark/app_fib.rb
+perf report
+```
+
+The `perf` feature makes monoruby emit perf-compatible symbol maps so
+JIT-compiled frames get names instead of raw addresses.
+`.cargo/config.toml` sets `-Cforce-frame-pointers=yes` globally, which is what
+makes the stacks walkable.
+
+`--features profile` collects deopt and recompile statistics instead of a time
+profile — see [Development and Build Options](development.md#measurement-and-profiling).
+[Where optcarrot --opt spends its time](design/optcarrot_opt_profile.md) is a
+worked example of both.
+
+## Historical measurements
+
+The two comparisons below are one-off measurements previously published in the
+project wiki. They are kept for the record and are **not** re-measured; for
+current numbers use the live dashboards above.
+
+### optcarrot (April 2024)
+
+Measured with [optcarrot](https://github.com/mame/optcarrot).
+
+Rubies:
+
+- ruby 3.4.0dev (2024-04-27T08:56:20Z master 9ea77cb351) [x86_64-linux]
+- truffleruby 24.0.1, like ruby 3.2.2, Oracle GraalVM JVM [x86_64-linux]
+- truffleruby 24.0.1, like ruby 3.2.2, Oracle GraalVM Native [x86_64-linux]
+- monoruby 3e348afd4141c40978342e67ad26d42dc0b8d2a7
+
+![optcarrot benchmark](design/optcarrot_benchmark.png)
+
+fps history, 0–3000 frames:
+
+![optcarrot fps history](design/optcarrot_fps_history.png)
+
+With `--opt` (optcarrot's self-rewriting optimization mode):
+
+![optcarrot fps history, --opt](design/optcarrot_fps_history_opt.png)
+
+### yjit-bench (December 2024)
+
+Speed ratio against truffleruby; higher is better. Measured with
+[yjit-bench](https://github.com/Shopify/yjit-bench) using
+`--rss --harness=harness-warmup`. Benchmark sources are from
+[ruby/ruby's `benchmark/`](https://github.com/ruby/ruby/tree/master/benchmark)
+and [plb2](https://github.com/attractivechaos/plb2).
+
+Rubies:
+
+- monoruby 0.3.0
+- ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [x86_64-linux]
+- truffleruby 24.1.1, like ruby 3.2.4, Oracle GraalVM Native [x86_64-linux]
+
+![micro benchmarks](design/chart.png)
+
+Raw data — execution time in milliseconds, resident set size (RSS) in MiB.
+`monoruby/yjit` and `monoruby/truffle` are time ratios; above 1 means monoruby
+is faster.
+
+| bench         | monoruby (ms) | RSS (MiB) | yjit (ms) | RSS (MiB) | truffle (ms) | RSS (MiB) | monoruby/yjit | monoruby/truffle |
+| :------------ | ------------: | --------: | --------: | --------: | -----------: | --------: | ------------: | ---------------: |
+| bedcov        |        4412.0 |     234.3 |    4803.9 |     413.8 |       1881.8 |    1909.5 |         0.918 |            2.345 |
+| binarytrees   |         175.0 |      28.7 |     137.0 |      22.0 |         31.7 |    1126.4 |         1.278 |            5.525 |
+| matmul        |          39.7 |      35.0 |     121.8 |      22.8 |          1.4 |     803.2 |         0.326 |           29.059 |
+| nbody         |           8.5 |      27.7 |      21.9 |      14.0 |          1.1 |     690.2 |         0.389 |            7.473 |
+| nqueens       |          14.7 |      24.7 |      31.0 |      14.2 |          7.2 |     637.9 |         0.475 |            2.044 |
+| optcarrot     |         520.4 |      79.0 |     720.9 |      54.7 |        432.2 |    1506.3 |         0.722 |            1.204 |
+| rubykon       |         214.9 |      34.9 |     348.2 |      18.6 |         65.2 |    2279.9 |         0.617 |            3.298 |
+| so_mandelbrot |          39.9 |      22.9 |     509.5 |      14.5 |         26.3 |     548.8 |         0.078 |            1.517 |
+| sudoku        |          41.6 |      23.9 |      88.8 |      14.9 |         17.5 |    1165.2 |         0.469 |            2.381 |
+| fib           |          16.7 |      23.5 |      17.4 |      15.0 |          8.8 |     483.4 |         0.960 |            1.895 |
+
+### Machine
+
+Both historical runs used the same machine:
+
+- Architecture: x86_64
+- CPU(s): 32 — 13th Gen Intel(R) Core(TM) i9-13900HX, 16 cores / 2 threads per core
+- Caches (sum of all): L1d 768 KiB (16), L1i 512 KiB (16), L2 32 MiB (16), L3 36 MiB (1)

--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -1,0 +1,107 @@
+# Compatibility
+
+monoruby aims at CRuby 4.0 compatibility, and measures it against
+[ruby/spec](https://github.com/ruby/spec) — the executable specification
+suite CRuby itself is tested with. The suite is re-run on every push to
+`master` that touches the interpreter, and the results are published as live
+dashboards.
+
+## Dashboards
+
+| Dashboard | Scope |
+| --- | --- |
+| [ruby/spec core](https://sisshiki1969.github.io/monoruby/spec/) | The `core/` group — the built-in classes and modules |
+| [ruby/spec library](https://sisshiki1969.github.io/monoruby/library/) | The `library/` group — the standard library |
+| [rubyspec-stats](https://sisshiki1969.github.io/rubyspec-stats/) | Daily pass rates for monoruby, CRuby, TruffleRuby and JRuby side by side |
+
+Each dashboard carries a per-category table, a history chart, and the raw
+`latest.json` / `data/history.csv` behind it. The core dashboard also
+publishes per-branch pages for branches under active spec work.
+
+## Where things stand
+
+As of commit `a13bfe0` (2026-08-31):
+
+| Group | Examples | Passing | Pass rate | Categories at 100% |
+| --- | ---: | ---: | ---: | ---: |
+| `core` | 23029 | 22468 | **97.6%** | 39 / 59 |
+| `library` | 5330 | 3148 | **59.1%** | 23 / 59 |
+
+Additionally, as of July 2026 monoruby passed 100% of the command-line specs
+and 99.6% of the language specs.
+
+The core figure is the result of a sustained compliance push through 2026 —
+the first published measurement, on 2026-04-27, was **59.5%**:
+
+| Date | Commit | Examples | Pass rate |
+| --- | --- | ---: | ---: |
+| 2026-04-27 | `7d2dd48` | 22520 | 59.5% |
+| 2026-08-31 | `a13bfe0` | 23029 | 97.6% |
+
+The largest core categories are in good shape — `array` 100% over 2898
+examples, `file` 99.6%, `kernel` 99.5%, `module` 98.9%, `io` 96.2%, and
+`string` 95.4% over 3905. What remains is concentrated rather than spread out:
+`tracepoint` (TracePoint is deliberately not implemented — the JIT's
+speculation assumes its absence, see [Invariants compiled code speculates
+on](design/jit_invariants.md)), `objectspace` at 39.3%, then `time`,
+`marshal` and `encoding` in the 89–95% band.
+
+The library group is the frontier. `matrix` and `net-http` are essentially
+complete (100% and 99.5%), while the biggest gaps are `socket` (40.2% over
+1129 examples), `stringio` (67.5%), `net-ftp` (54.9%) and `bigdecimal`
+(68.6%). Libraries needing facilities monoruby does not have — `openssl`,
+`coverage`, `mkmf`, `irb` — sit at 0%.
+
+## How the numbers are produced
+
+Both dashboards come from the same workflow shape
+(`.github/workflows/spec-core.yml` and `spec-library.yml`):
+
+- Every `*_spec.rb` under the group is run through `mspec`, category by
+  category, in batches of 10 files.
+- Each batch runs under a hard 60-second deadline with `timeout -k 5`. The
+  `-k` matters: monoruby installs its own `SIGTERM` handler which is deferred
+  to a VM poll point, so a process stuck in a blocking read never dies to a
+  plain `TERM`.
+- A killed batch prints no summary line, which would lose the tally for all
+  ten files, so the batch is re-run one file at a time — completing files are
+  counted after all, and the hanging file is pinned down and recorded in
+  `data/timeouts.csv`. Both groups currently record **zero** timeouts.
+- `--excl-tag fails` excludes examples tagged in this repository's
+  `spec/tags/`. That list is deliberately tiny — **6 examples** in 4 files at
+  present, covering `Refinement#import_methods` from a C extension,
+  `$LOAD_PATH.resolve_feature_path` for a `.so`, the `/o` Regexp modifier,
+  and three refinement-driven pattern-matching cases. The published pass rate
+  is therefore very close to an unfiltered one.
+
+The audit that cut the skip list down from coarse file-level exclusions to
+that handful is written up in [ruby/spec hang
+countermeasures](design/ruby_spec_skip_tags.md). Green threads removed the
+last structural hangs: blocking IO now parks the calling thread on the
+scheduler's fd poller instead of blocking the process, so specs like
+`core/io/copy_stream_spec.rb` and `core/io/select_spec.rb` run to completion.
+
+## Running the specs yourself
+
+ruby/spec and mspec are cloned alongside the monoruby checkout, not inside
+it. See [Development and Build Options →
+ruby/spec](development.md#rubyspec) for the layout and the commands.
+
+## Deliberate differences from CRuby
+
+A few behaviours differ by design rather than by omission:
+
+- **TracePoint is not implemented.** Compiled code speculates on its absence.
+- **Backtraces are formatted lazily.** Raise, unwind and catch record what is
+  needed; the backtrace string is not built until something asks for it. See
+  [Exception handling](design/exception_handling.md).
+- **The garbage collector is non-moving**, single-threaded and stop-the-world
+  (generational since June 2026). Compiled code relies on objects not moving.
+- **Threads are M:1 green threads** with time-slice preemption, not OS
+  threads. See [Thread / Fiber / non-blocking IO /
+  preemption](design/threads.md).
+- **C extensions cannot be loaded.** Libraries that CRuby backs with a C
+  extension — `json`, `date`, `digest`, `stringio`, `zlib`, `openssl` and
+  others — are either reimplemented in Rust/Ruby and shipped in the vendored
+  tree, or unavailable. [C extension support](design/c_extention.md) is a
+  design study, not a shipped feature.

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -1,0 +1,441 @@
+# Development and Build Options
+
+This page collects the build features, environment variables and helper
+scripts used when working *on* monoruby, rather than with it. For getting a
+working binary in the first place see [Installation and
+Build](installation.md).
+
+## Cargo features
+
+Every feature is off by default. They are diagnostic or stress switches: none
+of them changes what a correct program computes, and none is needed for a
+normal build.
+
+The JIT is **always** compiled in regardless of features — it is disabled at
+run time with `--no-jit`. (The old `jit` / `jit_x86` build cfgs and the
+`no-jit` feature are gone; backend selection is purely by `target_arch`.)
+
+### Dumping the compilation pipeline
+
+| Feature | Effect |
+| --- | --- |
+| `emit-bc` | Dump bytecode to stderr (implies `dump-bc`, `dump-traceir`) |
+| `emit-asm` | Dump generated machine code to stderr (implies `dump-bc`, `dump-traceir`, `jit-log`) |
+| `emit-cfg` | Write each JIT-compiled function's control-flow graph to `.cfg/fid-<id>.dot` (implies `dump-bc`, `dump-traceir`) |
+| `dump-bc` | Enable the bytecode dumper |
+| `dump-traceir` | Enable the TraceIR dumper |
+| `dump-require` | Log `require` / `load` file resolution |
+
+### JIT diagnostics
+
+| Feature | Effect |
+| --- | --- |
+| `jit-log` | Log JIT compilation events |
+| `jit-debug` | Detailed JIT debug output (implies `dump-traceir`) |
+| `deopt` | Log deoptimizations (implies `jit-log`, `dump-bc`, `dump-traceir`) |
+| `chain-deopt-log` | Trace every chain-deopt escalation to stderr. Deliberately **not** implied by `deopt` / `profile`: it fires hundreds of thousands of times per activerecord iteration and once wrote 160 MB of stderr in five iterations |
+| `profile` | Collect deopt / recompile statistics (implies `dump-traceir` for the deopt-site table, but not the bytecode dumps) |
+| `perf` | Emit perf-compatible symbol maps so JIT frames get names |
+
+### GC
+
+| Feature | Effect |
+| --- | --- |
+| `gc-log` | Log GC statistics at exit |
+| `gc-debug` | GC debug assertions |
+| `gc-stress` | Start in `GC.stress` and collect at **every** safepoint |
+| `gc-verify` | After every minor GC, independently re-mark the whole live graph from the roots, so a missed write barrier trips an assertion. Debug-only and very slow |
+
+### Register allocation and allocator experiments
+
+| Feature | Effect |
+| --- | --- |
+| `stress-spill-pool` | Shrink `PHYS_FPR_POOL` to 2 so almost every float-resident slot becomes a spilled virtual FP register, stressing the spill paths |
+| `shadow-placement` | Record every physical FP placement in emission order, producing a per-compile fingerprint of the lowering. The gate for the abstract-interpreter / register-allocation separation |
+| `phys-table` | Move the physical FP placement *policy* out of the resolver into an explicit table-backed function. Byte-identical to the formula it replaces |
+| `phys-loop-aware` | The loop-aware FP allocation policy: keep loop-carried floats resident so a fresh value spills instead of evicting one. Non-byte-identical by design |
+| `mimalloc` | Route the global allocator's delegation to mimalloc instead of glibc, changing exactly one variable for an A/B |
+
+The last three are gated on measurement and are off until their A/B clears;
+see [Separating the abstract interpreter from register
+allocation](design/regalloc_separation.md).
+
+## Worked example: reading the pipeline
+
+Everyone loves Fibonacci, so all three dumps below are of the same
+`benchmark/app_fib.rb`:
+
+```ruby
+def fib n
+  if n < 3
+    1
+  else
+    fib(n-1) + fib(n-2)
+  end
+end
+
+puts fib(34)
+```
+
+### Bytecode (`--features emit-bc`)
+
+```sh
+cargo build --release --features emit-bc
+target/release/monoruby benchmark/app_fib.rb 2> fib.bytecode > /dev/null
+```
+
+Each method and block is dumped as a register-based instruction listing,
+grouped into basic blocks (`BBx`). `%n` is a bytecode register (`SlotId`);
+`_%n` marks a result the next instruction consumes directly without the value
+ever being stored. The bracketed columns on the right are inline-cache slots,
+shown as `<INVALID>` here because the dump happens at compile time, before any
+cache has been filled.
+
+```text
+<fib> benchmark/app_fib.rb:1
+FuncId(3835) SIMPLE stack reg_num:5 owner:[] local_vars:1 temp:3
+ParamsInfo { required_num: 1, optional_num: 0, rest: None, rest_is_implicit: false, post_num: 0, args_names: [Some(n)], kw_names: [], kw_required: [], kw_rest: None, block_param: None, forwarding: false, it_param: false, forbid_keyword: false }
+[]
+  BB0
+    :00000 [02] init_method reg:4 arg:1 stack_offset:8
+    :00001 [03] %2 = 3
+    :00002 [03] _%2 = %1 < %2                        [<INVALID>][<INVALID>]
+    :00003 [02] condnotbr _%2 => BB2
+  BB1
+    :00004 [03] %2 = 1
+    :00005 [02] ret %2
+  BB2
+    :00006 [03] %2 = 1
+    :00007 [03] %2 = %1 - %2                         [<INVALID>][<INVALID>]
+    :00008 [03] %2 = %0.fib(%2)                      [<INVALID>] -
+    :00010 [04] %3 = 2
+    :00011 [04] %3 = %1 - %3                         [<INVALID>][<INVALID>]
+    :00012 [04] %3 = %0.fib(%3)                      [<INVALID>] -
+    :00014 [03] %2 = %2 + %3                         [<INVALID>][<INVALID>]
+    :00015 [02] ret %2
+```
+
+`%0` is `self`, `%1` is the parameter `n`, and `[nn]` is the source line.
+See [Method argument processing](design/method_args.md) for what the
+`ParamsInfo` counters mean.
+
+### JIT-compiled machine code (`--features emit-asm`)
+
+```sh
+cargo build --release --features emit-asm
+target/release/monoruby benchmark/app_fib.rb 2> fib.disas > /dev/null
+```
+
+Each bytecode instruction is printed with the machine code it lowered to, so
+the dump reads as an annotated disassembly. The bracketed columns are now the
+*resolved* inline caches — `[Integer][Integer]` for the arithmetic, and
+`[#<Class:main>] FuncId(3835)` for the recursive call — because by the time
+the JIT runs, the VM has executed the method often enough to fill them. That
+is exactly the type information the compiler speculates on; see [Invariants
+compiled code speculates on](design/jit_invariants.md).
+
+```text
+==> start whole compile: FuncId(3835) <Object#fib> self_class: #<Class:main> benchmark/app_fib.rb:1
+  >>> [0] ISeqId(2164) <Object#fib> self_class:#<Class:main>
+      offset:Pos(251180) code: 517 bytes  data: 0 bytes
+  BB0
+    :00000 init_method reg:4 arg:1 stack_offset:8
+      000000: push   rbp
+      000001: mov    rbp,rsp
+      000004: sub    rsp,0x80
+      00000b: movabs rax,0x4
+      000015: mov    QWORD PTR [rbp-0x48],rax
+      000019: mov    QWORD PTR [rbp-0x50],rax
+      00001d: mov    QWORD PTR [rbp-0x58],rax
+      000021: cmp    DWORD PTR [rip+0x7ffc2ad4],0x0        # 0x7ffc2afc
+      000028: jne    0x3ffc60be
+    :00001 %2 = 3
+    :00002 _%2 = %1 < %2                        [Integer][Integer]
+      00002e: mov    r8,QWORD PTR [rbp-0x40]
+      000032: test   r8,0x1
+      000039: je     0x3ffc60e9
+      00003f: cmp    r8,0x7
+      000043: jge    0x55
+    :00003 condnotbr _%2 => BB2
+  BB1
+    :00004 %2 = 1
+    :00005 ret %2
+      000049: movabs rax,0x3
+      000053: leave
+      000054: ret
+  BB2
+    :00006 %2 = 1
+    :00007 %2 = %1 - %2                         [Integer][Integer]
+      000055: mov    r8,QWORD PTR [rbp-0x40]
+      000059: sub    r8,0x2
+      00005d: jo     0x3ffc61ce
+    :00008 %2 = %0.fib(%2)                      [#<Class:main>] FuncId(3835)
+      000063: mov    eax,DWORD PTR [rip+0x7ffc2a6b]        # 0x7ffc2ad4
+      000069: cmp    eax,DWORD PTR [rip+0xffffffffffffff8d]        # 0xfffffffc
+      00006f: jne    0x3ffc61dd
+      000075: cmp    rsp,QWORD PTR [rbx+0x18]
+      000079: jle    0x3ffc6344
+
+      … call sequence and the second recursive call elided …
+
+    :00014 %2 = %2 + %3                         [Integer][Integer]
+      0001d5: mov    r9,QWORD PTR [rbp-0x48]
+      0001d9: test   r9,0x1
+      0001e0: je     0x3ffc6540
+      0001e6: test   r8,0x1
+      0001ed: je     0x3ffc6548
+      0001f3: sub    r9,0x1
+      0001f7: add    r9,r8
+      0001fa: jo     0x3ffc6550
+    :00015 ret %2
+      000200: mov    rax,r9
+      000203: leave
+      000204: ret
+  <<<
+Object#fib #<Class:main> None (522 bytes, 1223 bytes) [wm0:CodePtr(139715286390055)-CodePtr(139715286390577) wm1:CodePtr(139716359894468)-CodePtr(139716359895691)] 5.462877ms
+- [ISeqId(2164)] <Object#fib> self_class:#<Class:main>
+
+```
+
+Things worth reading out of that listing:
+
+- **The guards are the speculation.** `test r8,0x1` / `je` is the Fixnum tag
+  check on `n`; the `jo` after each `sub` / `add` catches overflow out of the
+  63-bit Fixnum range; and `movl rax,[rip+global_version]` /
+  `cmpl rax,[rip+cached_version]` / `jne` before each call is the class-version
+  guard. Every one of those branch targets is a side exit.
+- **Fixnums are tagged, and the constants are pre-encoded.** `n < 3` compiles
+  to `cmp r8,0x7` because `3` as a Fixnum is `3 << 1 | 1`; `n - 1` is
+  `sub r8,0x2`; and the base case returns `movabs rax,0x3`, which is `1`.
+  The final `sub r9,0x1; add r9,r8` strips one tag bit before adding. See
+  [Value Representation](value-representation.md).
+- **No accumulator register.** Values live in whatever GP register the
+  per-basic-block allocator picked (`r8` and `r9` here), with the frame at
+  `[rbp-…]`. The fixed `r15` accumulator was retired in June 2026.
+- **`cmp rsp,[rbx+0x18]` before each call** is the stack-limit check; `rbx`
+  holds `&mut Executor`.
+
+The summary line reports the code size and the two code regions the compiler
+emitted into: `wm0` is the fast path, `wm1` the out-of-line page holding the
+recompile and deopt stubs each failing guard jumps to.
+
+### CFG (`--features emit-cfg`)
+
+`emit-cfg` writes one DOT file per JIT-compiled function into a `.cfg/`
+directory under the current working directory, named by `FuncId`:
+
+```sh
+cargo build --release --features emit-cfg
+target/release/monoruby benchmark/app_fib.rb > /dev/null
+dot -Tsvg .cfg/fid-3835.dot -o fib-cfg.svg
+```
+
+Only functions that actually reach the JIT are dumped, so the set of files
+also tells you what got compiled.
+
+## Testing
+
+```sh
+cargo test              # unit + integration tests
+bin/test                # the full CI scope: tests + coverage + benchmarks + optcarrot + spec
+```
+
+`bin/test` is what CI runs. In order it:
+
+1. Runs `cargo llvm-cov nextest` with `stress-spill-pool` (plus `gc-stress`
+   only when `GC_STRESS=1` is exported).
+2. Builds a debug benchmark binary with the **same** feature list, so a
+   `GC_STRESS=1` run stresses the benchmark / optcarrot / spec phases too.
+3. Runs the benchmark scripts and `diff`s their output against CRuby
+   (`app_fib`, `tarai`, `so_nbody`, plb2 `nqueen` / `sudoku`, and
+   `so_mandelbrot` both with and without the JIT).
+4. Runs optcarrot plain and with `--opt`, comparing output against CRuby.
+5. Runs a ruby/spec subset if `../spec` and `../mspec` exist.
+6. Writes an `lcov.info` coverage report.
+
+`SKIP_COV=1` runs the whole script without llvm-cov instrumentation.
+
+### The snapshot oracle
+
+Tests compare monoruby's output against CRuby, but they do **not** spawn CRuby
+per test. The single-code helpers — `run_test`, `run_test_once`, `run_test2`,
+`run_test_with_prelude` — memoize expected output in the checked-in file
+`monoruby/tests/ruby_oracle.tsv` (`code-hash → output`, key-sorted and
+flock-serialized so concurrent nextest processes cooperate). A live `ruby` is
+invoked only on a cache miss, and the fresh entry is written back — **commit
+it**. The batched helpers (`run_tests`, `run_tests2`, and the binop/unop
+generators built on them) always spawn a live CRuby, because their generated
+code strings churn too much to be worth snapshotting.
+
+`MONORUBY_TEST_ORACLE` selects the mode:
+
+| Value | Behavior |
+| --- | --- |
+| unset / `snapshot` | Replay stored entries; spawn and record on a miss (the default) |
+| `ruby` | Always spawn CRuby and refresh stale entries in place — use this after bumping the reference CRuby version |
+
+```sh
+rm monoruby/tests/ruby_oracle.tsv && cargo test   # regenerate from scratch
+MONORUBY_TEST_ORACLE=ruby cargo test              # re-verify against a new CRuby
+```
+
+Tests whose expected value varies per host or OS must use `run_test_live` /
+`run_test_once_live`, which always compare against a live CRuby: anything
+touching `Dir.home` / `Dir.pwd`, absolute checkout paths, `~user` expansion
+(`/root` vs macOS `/var/root`), or `realpath` under `/tmp` (a symlink to
+`/private/tmp` on macOS). As a safety net a cached entry that disagrees with
+monoruby is re-verified against a live CRuby before failing — grep test output
+for `re-verifying against a live ruby` to find tests that should move to the
+`_live` helpers.
+
+Running the suite needs a host `ruby` matching the vendored pin (**4.0.2**,
+from `monoruby/vendor/ruby-stdlib/.ruby-version`). Since Ruby 3.4 `bigdecimal`
+is no longer a default gem, so install it explicitly or every
+`tests/bigdecimal.rs` test fails with `LoadError`:
+
+```sh
+gem install bigdecimal
+```
+
+### GC stress
+
+`gc-stress` collects at **every** safepoint. It is what finds unrooted-`Value`
+bugs — a builtin that creates a `Value` and then re-enters Ruby — and it is
+opt-in precisely because it is expensive: stacked on llvm-cov it took the
+x86-64 nextest phase from ~10 minutes to ~100, and a full `bin/test` scope
+under stress is an hours-scale job.
+
+```sh
+GC_STRESS=1 bin/test    # applies to every phase, not just nextest
+```
+
+Nothing enables it implicitly, so the automatic CI never pays for it. Instead
+dispatch the manual `gc-stress` workflow from the Actions tab when touching
+the GC, frame layout, argument binding, or any builtin that creates a `Value`
+and re-enters Ruby. Its inputs are `arch` (`both` / `x86_64` / `aarch64`),
+`scope` (`nextest` = the unit + integration suite, minutes; `full` = the whole
+`bin/test` scope, hours), `test_filter` (a nextest `-E` expression), and
+`no_fail_fast`. It runs on `ubuntu-latest` and **native** arm64
+(`ubuntu-24.04-arm`), not qemu, and collects no coverage.
+
+Tests whose loop counts exist only to reach the JIT thresholds should shrink
+them under `cfg!(feature = "gc-stress")` (see `tests/method_call.rs`), or they
+blow past nextest's per-test cap.
+
+### ruby/spec
+
+ruby/spec is cloned **outside** the monoruby repository, alongside it:
+
+```
+parent/
+├── monoruby/    # this repository
+├── spec/        # ruby/spec
+└── mspec/       # the mspec runner
+```
+
+```sh
+cd /path/to/parent-of-monoruby
+git clone --depth 1 https://github.com/ruby/spec.git spec
+git clone --depth 1 https://github.com/ruby/mspec.git mspec
+
+cd monoruby && cargo install --path monoruby
+
+cd ../spec
+../mspec/bin/mspec run core/array -t monoruby              # one category
+../mspec/bin/mspec run core/array/flatten_spec.rb -t monoruby  # one file
+../mspec/bin/mspec run core/array -t monoruby --format dotted
+```
+
+`bin/spec` from the monoruby checkout runs a standard set of categories in one
+go. Pass rates are published continuously on the [spec
+dashboard](https://sisshiki1969.github.io/monoruby/spec/); see [ruby/spec hang
+countermeasures](design/ruby_spec_skip_tags.md) for how the suite avoids
+hangs.
+
+### aarch64
+
+On an x86-64 host the aarch64 backend is cross-compiled and run under
+qemu-user:
+
+```sh
+bin/setup-aarch64-cross   # qemu-aarch64, aarch64-linux-gnu-gcc, rust std
+bin/test-aarch64          # same scope as bin/test, for aarch64
+```
+
+`bin/test-aarch64` takes `SKIP_HEAVY=1` (skip the benchmarks and specs that
+take over ten minutes under emulation), `SKIP_COV=1`, and `STRESS=1`. The
+`.cargo/config.toml` wiring points `aarch64-unknown-linux-gnu` at that cross
+toolchain and runner, which is why the CI job on a *native* arm64 runner
+overrides `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_{LINKER,RUNNER}` — otherwise
+it would emulate everything.
+
+## Measurement and profiling
+
+`--features profile` collects deopt and recompile statistics: which sites
+deoptimized, how often, and why. The reasons are the `RecompileReason`
+variants — `NotCached`, `MethodNotFound`, `IvarIdNotFound`,
+`ClassVersionGuardFailed`, `BecamePolymorphic`, `ConstVersionGuardFailed`.
+
+`--features deopt` logs individual deoptimizations;
+[Reading the deopt log](design/deopt_log.md) explains the format, including
+how the log names the guard that actually branched when exits have been
+deduplicated.
+
+For time rather than counts, see [Benchmarks](benchmarks.md#profiling).
+
+## JIT thresholds
+
+A function is compiled after **20 calls** (`COUNT_START_COMPILE`) and a loop
+after **100 iterations** (`COUNT_LOOP_START_COMPILE`). Both drop to 5 and 15
+in test builds, so tests reach compiled code without long warm-up loops.
+
+## Vendored and pinned dependencies
+
+`hashbrown/` is a workspace member (a local fork). `smallvec` is also a fork
+but is consumed as a git dependency rather than in-tree.
+
+The `ruby-prism` wrapper is pinned to the `monoruby-vendored` branch of
+[`sisshiki1969/prism`](https://github.com/sisshiki1969/prism). That fork has
+two branches:
+
+- `monoruby` — the minimal upstream-bound diff (the Rust `parse_with_options`
+  API plus `ruby-prism-sys` bindgen allowlist additions). The base for any
+  upstream PR to `ruby/prism`.
+- `monoruby-vendored` — `monoruby` plus one commit checking in the C sources
+  the upstream `vendored.rs` build script needs, so consumers need neither
+  bundler nor `rake cargo:build`.
+
+To bump the prism revision: push to the fork's `monoruby` branch, run
+`bin/refresh-prism-vendored` (which rebuilds and force-pushes
+`monoruby-vendored`), then `cargo update -p ruby-prism` here.
+
+`bin/vendor-ruby-stdlib` re-snapshots CRuby's pure-Ruby stdlib and default
+gems into `monoruby/vendor/ruby-stdlib/`. It is a maintenance step, never run
+by `cargo build`.
+
+## Continuous integration
+
+| Workflow | Trigger | What it does |
+| --- | --- | --- |
+| `rust.yml` | push / PR to `master` | `bin/test` on x86-64 Linux (with coverage to Codecov) and on native Apple Silicon |
+| `bench.yml` | push to `master` touching the interpreter | yjit-bench vs YJIT on x86-64 and aarch64, published to the portal |
+| `spec-core.yml`, `spec-library.yml` | push to `master` touching the interpreter, plus a weekly cron | ruby/spec pass rates, published to the portal |
+| `docs.yml` | push to `master` touching `doc/**` or `docs/**` | Builds this book with mdBook and publishes it to `gh-pages` under `/docs/` |
+| `release-binaries.yml` | push to `master`, release published, dispatch | Prebuilt binaries for the `setup-monoruby` action |
+| `gc-stress.yml` | **dispatch only** | The stress run described above |
+
+Neither `rust.yml` job sets `GC_STRESS`, so neither pays the per-safepoint
+cost.
+
+## Documentation
+
+This book lives in `docs/`. `docs/build.sh` copies `doc/*.md` and the diagrams
+into `docs/src/design/` (gitignored) and runs `mdbook build`; `docs.yml`
+publishes the result. If you add a design document to `doc/`, give it a
+chapter in `docs/src/SUMMARY.md` — mdBook renders only what `SUMMARY.md`
+lists, so an unlisted document is copied and then silently dropped.
+
+```sh
+bash docs/build.sh          # output in docs/book/
+mdbook serve docs           # live preview
+```

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,0 +1,233 @@
+# Installation and Build
+
+monoruby is a standalone Ruby implementation: it does **not** need CRuby or
+any other Ruby runtime to build or to run. There are two ways to get it — a
+prebuilt binary, or a build from source.
+
+## Supported platforms
+
+| Platform | Status |
+| --- | --- |
+| x86-64 Linux | Fully supported (VM + JIT). Primary CI target. |
+| aarch64 macOS (Apple Silicon) | Fully supported (VM + JIT). CI runs natively on `macos-latest`. |
+| aarch64 Linux | Supported (VM + JIT). Exercised by the manual `gc-stress` workflow on `ubuntu-24.04-arm`. |
+
+Both architectures lower the complete instruction set; the JIT never declines
+a compile on either. See [x86-64 / aarch64 JIT backend
+differences](design/arch_difference.md) for what actually differs between the
+two backends.
+
+## Prebuilt binaries
+
+Releases carry prebuilt tarballs, and a rolling `nightly` prerelease is
+rebuilt on every push to `master`. The easiest way to consume them is the
+`setup-monoruby` GitHub Action that this repository doubles as, modeled after
+[ruby/setup-ruby](https://github.com/ruby/setup-ruby). The ref after `@`
+selects the version:
+
+```yaml
+steps:
+  - uses: sisshiki1969/monoruby@master # or a release tag
+  - run: monoruby my_script.rb
+```
+
+The action downloads a release asset when one exists for the ref and platform
+(seconds), and otherwise builds from source once per monoruby revision ×
+runner OS/arch and caches the result with `actions/cache`. Automatic builds
+cover x86-64 Linux; Linux arm64 and macOS arm64 assets are published on demand
+by dispatching the `release binaries` workflow. See the [README's action
+section](https://github.com/sisshiki1969/monoruby#using-monoruby-in-github-actions)
+for the full input/output table.
+
+Each asset is a tarball containing `bin/monoruby`, `bin/irm`, and the
+`monoruby-home/v<version>/` runtime tree described under [What the build
+installs](#what-the-build-installs) below. Because the binary bakes in the
+build machine's install-root path, point `MONORUBY_INSTALL_ROOT` at wherever
+you extracted that tree.
+
+## Building from source
+
+### 1. Install Rust
+
+**Only nightly Rust works.** monoruby uses several nightly-only language
+features (`box_patterns`, `iter_next_chunk`, `step_trait`,
+`coverage_attribute`), so a stable toolchain fails to build.
+
+You do not have to select the channel by hand: `rust-toolchain.toml` pins the
+exact nightly the project is developed and tested against, and `rustup`
+installs and uses it automatically the first time you run `cargo` in the
+checkout.
+
+```toml
+# rust-toolchain.toml
+[toolchain]
+channel = "nightly-2026-08-18"
+```
+
+If you have no Rust at all yet, [install
+rustup](https://www.rust-lang.org/tools/install) first.
+
+### 2. Clone the repository
+
+```sh
+git clone https://github.com/sisshiki1969/monoruby.git
+cd monoruby
+```
+
+### 3. Platform-specific dependencies
+
+On **aarch64 macOS** only, monoruby links the system libffi instead of the
+bundled one (the bundled `libffi-sys` fails to link `_ffi_prep_cif_machdep` on
+arm64):
+
+```sh
+brew install libffi pkg-config
+export PKG_CONFIG_PATH="$(brew --prefix libffi)/lib/pkgconfig"
+```
+
+Linux and x86-64 macOS need nothing extra.
+
+### 4. Build and run
+
+```sh
+cargo build --release
+cargo run --release -- test.rb
+```
+
+The debug profile is built at `opt-level = 1` (set in the workspace
+`Cargo.toml`), so a debug build is usable for day-to-day work — but use
+`--release` for anything you intend to measure.
+
+A one-liner:
+
+```sh
+cargo run --release -- -e "puts 100"
+```
+
+### 5. Install
+
+```sh
+cargo install --path monoruby
+```
+
+This puts two binaries on your `PATH`:
+
+```sh
+monoruby test.rb   # the interpreter
+irm                # the REPL
+```
+
+From a checkout you can launch the REPL without installing:
+
+```sh
+cargo run --bin irm
+# or
+bin/irm
+```
+
+## What the build installs
+
+`monoruby/build.rs` runs on every `cargo build` and is **host-Ruby
+independent** — it does not need a `ruby` on `PATH` to produce a correct,
+reproducible build. It does two things:
+
+1. **Bakes the reported Ruby version.** `MONORUBY_RUBY_VERSION` is read from
+   `monoruby/vendor/ruby-stdlib/.ruby-version` (currently **4.0.2**) and
+   reported at run time as `RUBY_VERSION`. Taking it from the vendored
+   snapshot rather than a host `ruby` keeps the version monoruby reports in
+   step with the stdlib it actually ships.
+
+2. **Installs the runtime tree** into a per-version root,
+   `~/.monoruby/v<version>/` (e.g. `~/.monoruby/v0.3.0/`), whose absolute path
+   is baked into the binary as `MONORUBY_INSTALL_ROOT`:
+
+   | Source | Installed as | Contents |
+   | --- | --- | --- |
+   | `monoruby/vendor/ruby-stdlib/` | `<root>/lib/` | Checked-in CRuby stdlib + default-gem snapshot |
+   | `monoruby/builtins/` | `<root>/builtins/` | Ruby files loaded at interpreter start (`startup.rb`, `enumerable.rb`, …) |
+   | `monoruby/stdlib/`, `monoruby/gem/` | `<root>/lib/` and `<root>/stub/` | monoruby's own host-independent replacements for C-extension-backed libraries |
+
+   The install is staged in a private directory and swapped in with an atomic
+   rename, so a running monoruby never sees a half-populated tree, and the
+   per-version namespacing keeps concurrent builds and multiple checkouts from
+   clobbering each other.
+
+`build.rs` declares `cargo:rerun-if-changed` for each of those trees, so
+editing `builtins/`, `stdlib/` or `gem/` reinstalls on the next build, and
+deleting `~/.monoruby` re-triggers the whole install.
+
+Setting `MONORUBY_INSTALL_ROOT` in the **runtime** environment overrides the
+baked path, which is what makes a distributed binary relocatable.
+
+## Do I need a host Ruby?
+
+**To build and run monoruby: no.** The stdlib is vendored and the version is
+read from the snapshot.
+
+A host `ruby` is used for exactly two optional things:
+
+- **Host-installed (non-default) gems.** At startup `src/ruby_probe.rs`
+  invokes a host `ruby` once — if one is present and is 4.0 or later — to
+  discover `$LOAD_PATH` and `Gem.paths.path`, and caches the answer in
+  `~/.monoruby/{library_path,gem_path}` so the ~50 ms spawn is paid once per
+  machine. Precedence is `MONORUBY_GEM_PATH` / `MONORUBY_LOAD_PATH`, then
+  `GEM_PATH`, then the cache files, then the probe. `MONORUBY_REPROBE=1`
+  forces a fresh probe. With no host Ruby, those caches stay empty and the
+  vendored stdlib still loads normally — you will just see this on startup:
+
+  ```text
+  Warning: failed to read library path file: "~/.monoruby/library_path". Ruby may not be installed.
+  ```
+
+  It is a warning, not an error: only host-installed gems are unavailable.
+
+- **Running the test suite**, which compares monoruby's output against CRuby.
+  See [Development and Build Options](development.md#testing).
+
+## Command-line options
+
+monoruby accepts CRuby's command-line switches:
+
+```text
+Usage: monoruby [switches] [--] [programfile] [arguments]
+  -0[octal]       specify record separator (\0, if no argument)
+  -a              autosplit mode with -n or -p (splits $_ into $F)
+  -i[extension]   edit ARGV files in place (make backup if extension supplied)
+  -c              check syntax only
+  -Cdirectory     cd to directory before executing your script
+  -d, --debug     set debugging flags (set $DEBUG to true)
+  -e 'command'    one line of script. Several -e's allowed. Omit [programfile]
+  -Eex[:in], --encoding=ex[:in]
+                  specify the default external and internal character encodings
+  -Fpattern       split() pattern for autosplit (-a)
+  -Idirectory     specify $LOAD_PATH directory (may be used more than once)
+  -l              enable line ending processing
+  -n              assume 'while gets(); ... end' loop around your script
+  -p              assume loop like -n but print line also like sed
+  -rlibrary       require the library before executing your script
+  -s              enable some switch parsing for switches after script name
+  -S              look for the script using PATH environment variable
+  -U              set the internal encoding to UTF-8
+  -v              print the version number, then turn on verbose mode
+  -w              turn warnings on for your script
+  -W[level=2|:category]
+                  set warning level; 0=silence, 1=medium, 2=verbose
+  -x[directory]   strip off text before #!ruby line and perhaps cd to directory
+  -h              show this message, --help for more options
+  --ast           dump the parsed ruby-prism AST and exit
+  --no-jit        disable just-in-time compilation
+  --no-gc         disable garbage collection
+  --enable=feature[,...], --disable=feature[,...]
+                  enable or disable features (gems, did_you_mean, rubyopt,
+                  frozen-string-literal, all)
+```
+
+`RUBYOPT` is honoured for the subset of switches CRuby permits there.
+
+The three monoruby-specific switches are worth knowing:
+
+- `--no-jit` — run everything in the bytecode VM. The JIT is always compiled
+  into the binary; this disables it at run time. Useful for isolating a JIT
+  bug from a VM bug, and as the baseline half of a JIT A/B.
+- `--no-gc` — disable garbage collection entirely.
+- `--ast` — dump the parsed prism AST and exit.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -2,15 +2,26 @@
 
 [monoruby](https://github.com/sisshiki1969/monoruby) is a Ruby implementation written from scratch in Rust, featuring a register-based bytecode VM and a just-in-time (JIT) compiler for x86-64 and aarch64 (Apple Silicon). It is fast — comparable to CRuby with YJIT/ZJIT on many benchmarks — and has no dependency on any other Ruby runtime.
 
-This site documents monoruby's internals.
+This site is monoruby's documentation: how to build and run it, how it performs, and how it works inside.
 
+- The **Getting Started** section covers [installing and building](installation.md), [benchmarks](benchmarks.md) and the [build options and test workflow](development.md) used when developing monoruby itself.
 - The **Architecture** section contains overview pages: start with the [Architecture Overview](architecture-overview.md).
 - The **Design Documents** section renders the full design documents from the repository's [`doc/`](https://github.com/sisshiki1969/monoruby/tree/master/doc) directory (some are written in Japanese, as marked).
 
+## Quick start
+
+```sh
+git clone https://github.com/sisshiki1969/monoruby.git
+cd monoruby
+cargo install --path monoruby   # nightly Rust is installed automatically by rust-toolchain.toml
+monoruby -e 'puts "hello"'
+```
+
+See [Installation and Build](installation.md) for prebuilt binaries, the GitHub Action, platform notes and the full command-line reference.
+
 ## Related resources
 
-- [README](https://github.com/sisshiki1969/monoruby#readme) — features, installation, monthly changelog
-- [Build and Install](https://github.com/sisshiki1969/monoruby/wiki/Build-and-Install) — build instructions (wiki)
-- [Benchmark results](https://sisshiki1969.github.io/monoruby/bench/) — continuously updated yjit-bench comparison
+- [README](https://github.com/sisshiki1969/monoruby#readme) — features and the monthly changelog
+- [Benchmark dashboard](https://sisshiki1969.github.io/monoruby/bench/) — continuously updated yjit-bench comparison, re-run on every push to `master` that touches the interpreter
 - [ruby/spec dashboard](https://sisshiki1969.github.io/monoruby/spec/) — spec compliance for this repository
 - [rubyspec-stats](https://sisshiki1969.github.io/rubyspec-stats/) — daily ruby/spec pass rates across Ruby implementations

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -4,7 +4,8 @@
 
 This site is monoruby's documentation: how to build and run it, how it performs, and how it works inside.
 
-- The **Getting Started** section covers [installing and building](installation.md), [benchmarks](benchmarks.md) and the [build options and test workflow](development.md) used when developing monoruby itself.
+- The **Getting Started** section covers [installing and building](installation.md) monoruby, and the [build options and test workflow](development.md) used when developing it.
+- The **Performance and Compatibility** section is where the live dashboards are explained: [Benchmark](benchmarks.md) for speed against CRuby+YJIT, [Compatibility](compatibility.md) for ruby/spec conformance.
 - The **Architecture** section contains overview pages: start with the [Architecture Overview](architecture-overview.md).
 - The **Design Documents** section renders the full design documents from the repository's [`doc/`](https://github.com/sisshiki1969/monoruby/tree/master/doc) directory (some are written in Japanese, as marked).
 


### PR DESCRIPTION
Documentation only — no source changes. Three commits, best read in order.

## 1. Publish the 10 design documents that were being dropped

`docs/build.sh` copies every `doc/*.md` into `src/design/`, but mdBook renders only what `SUMMARY.md` lists, so ten design documents were copied and then silently discarded — they never reached gh-pages `/docs/`:

`trace_chain_joins`, `jit_invariants`, `jit_invalidation`, `bop_redefinition`, `chain_deopt`, `deopt_log`, `polymorphic_call`, `refinements`, `toplevel_binding`, `optcarrot_opt_profile`

Each gets a chapter, titled and language-marked from the descriptions in `doc/README.md` and placed next to what it belongs with (the invariants cluster after `arch_difference`, `refinements` / `toplevel_binding` after `cref`, and so on). SUMMARY separators now divide the four groups the section had already been ordered into, since a flat list of 31 entries is no longer navigable.

`handoff_record_stream.md` and `plan-activerecord.md` stay unlisted — they are the planning memos `build.sh` deletes before the build. `doc/README.md` is the index itself, which `SUMMARY.md` supersedes inside the book.

## 2. Fold the README and the wiki into the book

Install steps, benchmark results and the build-option reference lived in three places that had drifted apart: the README, the GitHub wiki, and nowhere in the book. Three new chapters consolidate them, checked against the code rather than copied:

**`installation.md`** — platforms, prebuilt binaries and the `setup-monoruby` action, building from source, `cargo install`, the per-version runtime tree `build.rs` installs under `~/.monoruby/v<version>`, when a host Ruby is and is not needed, and the full switch list from `print_usage()`.

Corrections to the wiki's version:
- `rust-toolchain.toml` pins the nightly, so "install Rust nightly" is not a manual step
- the aarch64 macOS libffi requirement (`brew install libffi pkg-config`) was undocumented
- the reported `RUBY_VERSION` now comes from the vendored snapshot (4.0.2), not a host `ruby`

**`benchmarks.md`** — the live dashboards and their methodology (yjit-bench, `harness-warmup`, 400 s per-interpreter timeout, `ratio` = × YJIT), the `bin/` helper scripts, profiling, and the wiki's two historical comparisons kept verbatim but dated and labelled as one-off measurements.

**`development.md`** — the complete cargo feature set. `Cargo.toml` has six the old table omitted: `gc-verify`, `chain-deopt-log`, `mimalloc`, `shadow-placement`, `phys-table`, `phys-loop-aware`. Plus the snapshot oracle and `MONORUBY_TEST_ORACLE`, `GC_STRESS`, ruby/spec and aarch64 setup, and CI.

The wiki's `emit-bc` / `emit-asm` listings were stale — they still showed the `r15` accumulator, retired in June 2026 — so both dumps were **regenerated from `benchmark/app_fib.rb` against this commit**. The `emit-cfg` entry now says where the `.dot` files actually go (`.cfg/`, one per JIT-compiled function), verified by running it.

**Links to the published book**: a Documentation button on the portal (`.github/portal/index.html`, deployed to the site root by `spec-core.yml`) and a Documentation line at the top of the README, which the portal also renders. The README's four wiki links now point at the corresponding book sections, and its spec figure is refreshed from the live dashboard — "about 90% of the core-library specs" is now 97.6%.

## 3. Benchmark and Compatibility chapters

Split into a "Performance and Compatibility" part where each chapter owns its own dashboards. Benchmark keeps the two yjit-bench dashboards; `compatibility.md` is new and takes the spec ones.

`compatibility.md` covers the current standing (core 97.6%, 22468/23029, 39 of 59 categories at 100%; library 59.1%, 23 of 59) and the 2026 trend the history CSV records — 59.5% on 2026-04-27 to 97.6% on 2026-08-31. It also says how the number is produced, which matters for reading it: batches of ten spec files under a 60-second `timeout -k 5` (the `-k` is load-bearing — monoruby's SIGTERM handler is deferred to a VM poll point), a killed batch re-run file-by-file so the tally survives and the hanging file is recorded, zero timeouts currently recorded in either group, and `--excl-tag fails` excluding all of 6 examples from `spec/tags/` — so the published rate is close to unfiltered. Finally, the differences that are by design rather than by omission: no TracePoint, lazy backtraces, non-moving GC, green threads, no C extension loading.

## Verification

Built with mdBook v0.5.4, the version `docs.yml` pins. Every internal link and anchor across the book resolves, with one pre-existing exception: two source-file relative links in `doc/lir.md` (`../monoruby/src/codegen/jitgen/lir.rs` and `asmir/compile_shared.rs`) 404 inside the book. They are unrelated to this change and left alone.

## Follow-up, not included here

The five wiki pages are untouched, so their content is now duplicated by the book and will go stale. Replacing each with a pointer to the corresponding chapter seems right, but editing the wiki was outside this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_015bskFB9Z6XRozNMQQe9o36)_