### PR TITLE
bench: add CRuby ZJIT (ruby/ruby HEAD, built per run) as a third engine

### DIFF
--- a/.github/bench-pages/index.html
+++ b/.github/bench-pages/index.html
@@ -57,9 +57,11 @@
 </style>
 </head>
 <body>
-<h1>monoruby × ruby <code>--yjit</code> <span id="archBadge" style="font-size:0.55em;color:#888;font-weight:400"></span></h1>
+<h1>monoruby × ruby <code>--yjit</code> / <code>--zjit</code> <span id="archBadge" style="font-size:0.55em;color:#888;font-weight:400"></span></h1>
 <div class="meta">
-  Per-benchmark relative speed against <code>ruby 4.0.1 --yjit</code>, measured on every <code>master</code> push with
+  Per-benchmark speed of monoruby and CRuby HEAD's <code>--zjit</code> (built fresh from
+  ruby/ruby master on each run), both shown relative to the <code>ruby 4.0.2 --yjit</code>
+  baseline (1&times;), measured on every <code>master</code> push with
   <a href="https://github.com/Shopify/yjit-bench">Shopify/yjit-bench</a> (<code>--rss --harness=harness-warmup</code>).
   Each benchmark process is bounded with <code>timeout(1)</code>; benchmarks that crash or time out are listed in red with the cause.
   Source: <a href="latest.json">latest.json</a>, <a href="data/history.csv">history.csv</a>. Back to <a href="../">portal</a>.
@@ -68,7 +70,7 @@
   (function() {
     const arch = location.pathname.includes('arm64') ? 'aarch64' : 'x86-64';
     document.getElementById('archBadge').textContent = '(' + arch + ')';
-    document.title = 'monoruby — Performance vs YJIT (' + arch + ')';
+    document.title = 'monoruby — Performance vs YJIT/ZJIT (' + arch + ')';
   })();
 </script>
 
@@ -82,14 +84,15 @@
 <section>
   <h2>Per-benchmark history</h2>
   <p class="meta">
-    monoruby and YJIT per-commit history, one chart per benchmark. Only successful
-    measurements are plotted; benchmarks that never produced a result on both sides
-    are omitted entirely.
+    monoruby and ZJIT per-commit history relative to the YJIT&nbsp;4.0.2 baseline, one
+    chart per benchmark. Only successful measurements are plotted (the ZJIT line starts
+    at the commit it was first measured); benchmarks that never produced a comparable
+    result are omitted entirely.
   </p>
   <div class="controls">
     <label class="control-yratio">
       <input type="checkbox" id="historyYRatio" checked>
-      show YJIT / monoruby ratio instead of raw ms
+      show speed relative to YJIT (&times;, higher = faster) instead of raw ms
     </label>
     <span id="historyCount" class="meta"></span>
   </div>
@@ -108,9 +111,12 @@
         <th>Benchmark</th>
         <th>monoruby (ms)</th>
         <th>YJIT (ms)</th>
-        <th>YJIT / monoruby</th>
+        <th>ZJIT (ms)</th>
+        <th>monoruby (&times; YJIT)</th>
+        <th>ZJIT (&times; YJIT)</th>
         <th>monoruby reason</th>
         <th>yjit reason</th>
+        <th>zjit reason</th>
       </tr>
     </thead>
     <tbody></tbody>
@@ -134,17 +140,25 @@ async function loadJson(path) {
     return;
   }
 
-  // Bar chart sort: ratio DESC, monoruby-failed at the bottom.
+  // Any zjit measurement at all in this snapshot? Legacy latest.json
+  // (and runs where the ruby HEAD build failed) have none, and the page
+  // then renders single-series, exactly as before zjit existed.
+  const hasZjit = benches.some(b => b.zjit_ms != null);
+
+  // Bar chart sort: monoruby ratio DESC; rows without a YJIT baseline at
+  // the very bottom, monoruby-failed rows just above them.
   const sortKey = b => {
+    if (b.yjit_failed)     return -2;
     if (b.monoruby_failed) return -1;
-    if (b.yjit_failed)     return Infinity;
     return b.ratio;
   };
   benches.sort((a, b) => sortKey(b) - sortKey(a));
 
   const tos = (data.timeouts) || {};
   const meta = "snapshot: " + data.timestamp + " @ " + data.commit
-    + (tos.monoruby ? " (timeouts: monoruby " + tos.monoruby + "s, yjit " + tos.yjit + "s)" : "");
+    + (data.ruby_head ? " \u00b7 zjit: ruby/ruby@" + data.ruby_head : "")
+    + (tos.monoruby ? " (timeouts: monoruby " + tos.monoruby + "s, yjit " + tos.yjit + "s"
+        + (tos.zjit ? ", zjit " + tos.zjit + "s" : "") + ")" : "");
   document.getElementById("latestMeta").textContent = meta;
 
   // Fixed linear axis: 0 on the left, 4× (monoruby four times faster) on
@@ -161,18 +175,22 @@ async function loadJson(path) {
     return "#c62828";
   };
 
-  const failed = b => b.monoruby_failed || b.yjit_failed;
+  // A row draws no bars at all when the YJIT baseline is missing, or
+  // when every compared engine failed.
+  const barless = b =>
+    b.yjit_failed || (b.monoruby_failed && (!hasZjit || b.zjit_failed));
 
-  // For failed runs, surface what went wrong with which side.
+  // For barless rows, surface what went wrong with which side.
   const failureText = b => {
     const parts = [];
     if (b.monoruby_failed) parts.push("monoruby: " + (b.monoruby_reason || "failed"));
     if (b.yjit_failed)     parts.push("yjit: "     + (b.yjit_reason     || "failed"));
+    if (hasZjit && b.zjit_failed) parts.push("zjit: " + (b.zjit_reason || "failed"));
     return parts.join("  /  ");
   };
 
   document.getElementById("latestBarWrap").style.height =
-    Math.max(280, benches.length * 26) + "px";
+    Math.max(280, benches.length * (hasZjit ? 34 : 26)) + "px";
 
   // Always draws a bold red vertical line at x=1 (YJIT/monoruby parity),
   // regardless of whether 1 happens to fall on a tick position.
@@ -194,8 +212,8 @@ async function loadJson(path) {
   };
 
   // Plugin draws the failure reason as text inside the chart area for
-  // benchmarks where either implementation didn't produce a result.
-  // No bar is drawn for those rows (data is 0).
+  // benchmarks whose row shows no bar at all (partial failures keep
+  // their remaining bar; the reason stays in the tooltip and the table).
   const failureTextPlugin = {
     id: "failureText",
     afterDatasetsDraw(chart) {
@@ -206,7 +224,7 @@ async function loadJson(path) {
       ctx.textAlign = "left";
       ctx.textBaseline = "middle";
       benches.forEach((b, i) => {
-        if (!failed(b)) return;
+        if (!barless(b)) return;
         const y = ys.getPixelForValue(i);
         const x = chartArea.left + 8;
         ctx.fillText(failureText(b), x, y);
@@ -219,11 +237,18 @@ async function loadJson(path) {
     type: "bar",
     data: {
       labels: benches.map(b => b.name),
-      datasets: [{
-        label: "YJIT / monoruby",
-        data: benches.map(b => failed(b) ? null : (b.ratio || null)),
-        backgroundColor: benches.map(b => failed(b) ? "transparent" : barColor(b)),
-      }],
+      datasets: [
+        {
+          label: "monoruby (\u00d7 YJIT)",
+          data: benches.map(b => (b.monoruby_failed || b.yjit_failed) ? null : (b.ratio || null)),
+          backgroundColor: benches.map(b => barColor(b)),
+        },
+        ...(hasZjit ? [{
+          label: "ZJIT HEAD (\u00d7 YJIT)",
+          data: benches.map(b => (b.zjit_failed || b.yjit_failed) ? null : (b.zjit_ratio || null)),
+          backgroundColor: "rgba(123,31,162,0.7)",
+        }] : []),
+      ],
     },
     options: {
       indexAxis: "y",
@@ -235,7 +260,7 @@ async function loadJson(path) {
           max: X_MAX,
           title: {
             display: true,
-            text: "relative speed (× YJIT, higher = monoruby faster, 1× = parity)",
+            text: "relative speed (\u00d7 YJIT 4.0.2 = 1\u00d7, higher = faster)",
             align: "center",
           },
           grid: { color: "rgba(0,0,0,0.08)" },
@@ -273,19 +298,16 @@ async function loadJson(path) {
           callbacks: {
             label: ctx => {
               const b = benches[ctx.dataIndex];
-              if (failed(b)) {
-                const lines = [];
-                if (b.monoruby_failed) lines.push("monoruby: " + (b.monoruby_reason || "failed"));
-                if (b.yjit_failed)     lines.push("yjit: "     + (b.yjit_reason     || "failed"));
-                if (!b.monoruby_failed) lines.unshift("monoruby: " + b.monoruby_ms.toFixed(2) + " ms");
-                if (!b.yjit_failed)     lines.unshift("yjit: "     + b.yjit_ms.toFixed(2) + " ms");
-                return lines;
+              const lines = [];
+              if (ctx.parsed.x != null) {
+                lines.push(ctx.dataset.label + ": " + ctx.parsed.x.toFixed(2) + "\u00d7");
               }
-              return [
-                ctx.parsed.x.toFixed(2) + "× YJIT",
-                "monoruby: " + b.monoruby_ms.toFixed(2) + " ms",
-                "yjit:     " + b.yjit_ms.toFixed(2) + " ms",
-              ];
+              lines.push("monoruby: " + (b.monoruby_failed ? (b.monoruby_reason || "failed") : b.monoruby_ms.toFixed(2) + " ms"));
+              lines.push("yjit: " + (b.yjit_failed ? (b.yjit_reason || "failed") : b.yjit_ms.toFixed(2) + " ms"));
+              if (b.zjit_ms != null || b.zjit_failed != null) {
+                lines.push("zjit: " + (b.zjit_failed ? (b.zjit_reason || "failed") : b.zjit_ms.toFixed(2) + " ms"));
+              }
+              return lines;
             },
           },
         },
@@ -322,9 +344,12 @@ async function loadJson(path) {
     tr.appendChild(nameTd);
     tr.appendChild(numCell(b.monoruby_ms != null ? b.monoruby_ms.toFixed(3) : "", b.monoruby_failed));
     tr.appendChild(numCell(b.yjit_ms != null ? b.yjit_ms.toFixed(3) : "", b.yjit_failed));
+    tr.appendChild(numCell(b.zjit_ms != null ? b.zjit_ms.toFixed(3) : "", b.zjit_failed === true));
     tr.appendChild(numCell(b.ratio != null ? b.ratio.toFixed(3) + "x" : "", b.ratio == null));
+    tr.appendChild(numCell(b.zjit_ratio != null ? b.zjit_ratio.toFixed(3) + "x" : "", b.zjit_failed === true));
     tr.appendChild(reasonCell(b.monoruby_failed ? (b.monoruby_reason || "failed") : ""));
     tr.appendChild(reasonCell(b.yjit_failed     ? (b.yjit_reason     || "failed") : ""));
+    tr.appendChild(reasonCell(b.zjit_failed     ? (b.zjit_reason     || "failed") : ""));
     tbody.appendChild(tr);
   }
 })();
@@ -386,6 +411,9 @@ function parseCsv(text) {
       monoruby_ms: num(f[3]),
       yjit_ms:     num(f[4]),
       ratio:       num(f[5]),
+      // 13-field rows (zjit era) carry the zjit time at the end; on
+      // older rows this reads out as null.
+      zjit_ms:     num(f[10]),
     }));
 
   const grid         = document.getElementById("historyGrid");
@@ -403,11 +431,11 @@ function parseCsv(text) {
     arr.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
   }
 
-  // A row counts only when both sides produced a finite time; a benchmark
-  // that never managed that (crash / timeout on every run) gets no card.
+  // A row counts only when the YJIT baseline has a time and at least one
+  // compared engine does too; a benchmark that never managed that gets
+  // no card. (num() already yields null-or-finite.)
   const usable = r =>
-    r.monoruby_ms != null && isFinite(r.monoruby_ms) &&
-    r.yjit_ms     != null && isFinite(r.yjit_ms);
+    r.yjit_ms != null && (r.monoruby_ms != null || r.zjit_ms != null);
 
   const names = [...byName.keys()]
     .filter(n => byName.get(n).some(usable))
@@ -470,52 +498,90 @@ function parseCsv(text) {
     const showRatio = yRatioBox.checked;
     const entry = cards.get(name);
     const points = byName.get(name).filter(usable);
+    const hasZ = points.some(p => p.zjit_ms != null);
 
-    // Latest measured ratio, shown next to the title.
+    // Both ratios are "speed as a multiple of YJIT's": yjit time over
+    // the engine's own time, higher = faster than YJIT, 1 = parity.
+    const mrRatio = p => p.monoruby_ms == null ? null
+      : (p.ratio != null ? p.ratio : p.yjit_ms / p.monoruby_ms);
+    const zjRatio = p => p.zjit_ms == null ? null : p.yjit_ms / p.zjit_ms;
+
+    // Latest measured values, shown next to the title.
     const last = points[points.length - 1];
-    entry.latest.textContent = showRatio
-      ? (last.ratio != null && isFinite(last.ratio) ? last.ratio.toFixed(2) + "×" : "")
-      : last.monoruby_ms.toFixed(1) + " / " + last.yjit_ms.toFixed(1) + " ms";
+    if (showRatio) {
+      const mv = mrRatio(last), zv = zjRatio(last);
+      if (mv != null && zv == null) {
+        entry.latest.textContent = mv.toFixed(2) + "\u00d7";
+        entry.latest.title = "monoruby \u00d7YJIT (latest commit)";
+      } else {
+        const parts = [];
+        if (mv != null) parts.push("M " + mv.toFixed(2) + "\u00d7");
+        if (zv != null) parts.push("Z " + zv.toFixed(2) + "\u00d7");
+        entry.latest.textContent = parts.join(" \u00b7 ");
+        entry.latest.title = "monoruby \u00d7YJIT \u00b7 ZJIT \u00d7YJIT (latest commit)";
+      }
+    } else {
+      const f1 = v => v == null ? "\u2013" : v.toFixed(1);
+      entry.latest.textContent = hasZ
+        ? f1(last.monoruby_ms) + " / " + f1(last.yjit_ms) + " / " + f1(last.zjit_ms) + " ms"
+        : f1(last.monoruby_ms) + " / " + f1(last.yjit_ms) + " ms";
+      entry.latest.title = hasZ ? "monoruby / YJIT / ZJIT (ms)" : "monoruby / YJIT (ms)";
+    }
 
     const labels  = points.map(p => p.timestamp);
     const commits = points.map(p => p.commit);
 
+    const lineDefaults = {
+      tension: 0.15,
+      borderWidth: 2,
+      pointRadius: 0,
+      pointHoverRadius: 4,
+      spanGaps: true,
+    };
     const datasets = showRatio
-      ? [{
-          label: "YJIT / monoruby",
-          data: points.map(p =>
-            p.ratio != null && isFinite(p.ratio) ? p.ratio : p.yjit_ms / p.monoruby_ms),
-          borderColor: "#2e7d32",
-          backgroundColor: "rgba(46,125,50,0.15)",
-          tension: 0.15,
-          fill: true,
-          borderWidth: 2,
-          pointRadius: 0,
-          pointHoverRadius: 4,
-        }]
+      ? [
+          {
+            label: "monoruby (\u00d7 YJIT)",
+            data: points.map(mrRatio),
+            borderColor: "#2e7d32",
+            backgroundColor: "rgba(46,125,50,0.15)",
+            fill: !hasZ,
+            ...lineDefaults,
+          },
+          ...(hasZ ? [{
+            label: "ZJIT (\u00d7 YJIT)",
+            data: points.map(zjRatio),
+            borderColor: "#7b1fa2",
+            backgroundColor: "rgba(123,31,162,0.12)",
+            fill: false,
+            ...lineDefaults,
+          }] : []),
+        ]
       : [
           {
             label: "monoruby",
             data: points.map(p => p.monoruby_ms),
             borderColor: "#1565c0",
             backgroundColor: "rgba(21,101,192,0.10)",
-            tension: 0.15,
             fill: false,
-            borderWidth: 2,
-            pointRadius: 0,
-            pointHoverRadius: 4,
+            ...lineDefaults,
           },
           {
             label: "YJIT",
             data: points.map(p => p.yjit_ms),
             borderColor: "#ef6c00",
             backgroundColor: "rgba(239,108,0,0.10)",
-            tension: 0.15,
             fill: false,
-            borderWidth: 2,
-            pointRadius: 0,
-            pointHoverRadius: 4,
+            ...lineDefaults,
           },
+          ...(hasZ ? [{
+            label: "ZJIT",
+            data: points.map(p => p.zjit_ms),
+            borderColor: "#7b1fa2",
+            backgroundColor: "rgba(123,31,162,0.10)",
+            fill: false,
+            ...lineDefaults,
+          }] : []),
         ];
 
     const cfg = {
@@ -547,7 +613,9 @@ function parseCsv(text) {
           },
         },
         plugins: {
-          legend: showRatio
+          // A single-series ratio chart needs no legend; anything with a
+          // ZJIT line (and every raw-ms chart) does.
+          legend: (showRatio && !hasZ)
             ? { display: false }
             : { display: true, position: "top", align: "end", labels: { boxWidth: 10, font: { size: 10 } } },
           tooltip: {

--- a/.github/scripts/aggregate_portal.rb
+++ b/.github/scripts/aggregate_portal.rb
@@ -1,0 +1,105 @@
+# Builds bench-results/portal.json from yjit-bench's raw.json and
+# raw.failures.json. Shared by the amd64 and arm64 bench jobs (the two
+# per-job heredocs it replaces had already drifted once). Prints the
+# JSON document to stdout.
+#
+# Environment:
+#   GITHUB_WORKSPACE   checkout root; bench-results/ lives under it
+#   TIMESTAMP          snapshot timestamp (ISO 8601)
+#   SHORT_SHA          monoruby commit the run measured
+#   MR_TIMEOUT, YJ_TIMEOUT, ZJ_TIMEOUT
+#                      per-engine timeout(1) budget in seconds
+#   RUBY_HEAD_SHA      short sha of the ruby/ruby HEAD the zjit engine
+#                      was built from ('' when unavailable)
+#   ZJIT_BUILD         'ok' when the ruby HEAD build succeeded, anything
+#                      else marks zjit results as missing because of the
+#                      build rather than the benchmarks
+require 'json'
+
+out = ENV['GITHUB_WORKSPACE'] + '/bench-results'
+raw = JSON.parse(File.read(out + '/data/raw.json'))
+fails_path = out + '/data/raw.failures.json'
+fails = File.exist?(fails_path) ? JSON.parse(File.read(fails_path)) : {}
+
+ENGINES = %w[monoruby yjit zjit].freeze
+data  = ENGINES.to_h { |e| [e, raw.dig('raw_data', e) || {}] }
+efail = ENGINES.to_h { |e| [e, fails[e] || {}] }
+timeouts = {
+  'monoruby' => ENV.fetch('MR_TIMEOUT', '400').to_i,
+  'yjit'     => ENV.fetch('YJ_TIMEOUT', '400').to_i,
+  'zjit'     => ENV.fetch('ZJ_TIMEOUT', '400').to_i,
+}
+
+reason = ->(status, timeout_s) {
+  return nil if status.nil?
+  case status
+  when 0   then 'ok'
+  when 1   then 'exit 1'
+  when 124 then "timeout (#{timeout_s}s)"
+  when 137 then "SIGKILL after timeout (#{timeout_s}s)"
+  when 132 then 'SIGILL'
+  when 134 then 'SIGABRT'
+  when 136 then 'SIGFPE'
+  when 138 then 'SIGBUS'
+  when 139 then 'SIGSEGV'
+  when 143 then 'SIGTERM'
+  else
+    if status > 128
+      "signal #{status - 128} (exit #{status})"
+    else
+      "exit #{status}"
+    end
+  end
+}
+
+median = ->(arr) {
+  return nil if arr.nil? || arr.empty?
+  s = arr.sort
+  n = s.size
+  n.odd? ? s[n / 2] : (s[n / 2 - 1] + s[n / 2]) / 2.0
+}
+
+ms_for = ->(engine, name) {
+  d = data[engine][name]
+  med = d ? median.call(d['bench']) : nil
+  (med && med > 0) ? med * 1000.0 : nil
+}
+
+zjit_built = ENV['ZJIT_BUILD'] == 'ok'
+# When the ruby HEAD build failed there are no zjit rows at all; name
+# the build as the cause instead of the generic 'no result'.
+zjit_fallback = zjit_built ? 'no result' : 'ruby HEAD build failed'
+
+all_names = (data.values.flat_map(&:keys) + efail.values.flat_map(&:keys)).uniq.sort
+
+benches = all_names.map do |name|
+  mr_ms = ms_for.call('monoruby', name)
+  yj_ms = ms_for.call('yjit', name)
+  zj_ms = ms_for.call('zjit', name)
+  {
+    name: name,
+    monoruby_ms: mr_ms,
+    yjit_ms: yj_ms,
+    zjit_ms: zj_ms,
+    # YJIT (4.0.2) is the baseline: both ratios are "speed as a multiple
+    # of YJIT's" — yjit time over the engine's own time, higher = faster
+    # than YJIT, 1.0 = YJIT parity.
+    ratio:      (mr_ms && yj_ms) ? yj_ms / mr_ms : nil,
+    zjit_ratio: (zj_ms && yj_ms) ? yj_ms / zj_ms : nil,
+    monoruby_failed: mr_ms.nil?,
+    yjit_failed: yj_ms.nil?,
+    zjit_failed: zj_ms.nil?,
+    monoruby_reason: mr_ms.nil? ? (reason.call(efail['monoruby'][name], timeouts['monoruby']) || 'no result') : nil,
+    yjit_reason:     yj_ms.nil? ? (reason.call(efail['yjit'][name], timeouts['yjit']) || 'no result') : nil,
+    zjit_reason:     zj_ms.nil? ? (reason.call(efail['zjit'][name], timeouts['zjit']) || zjit_fallback) : nil,
+  }
+end
+
+head_sha = ENV['RUBY_HEAD_SHA'].to_s
+puts JSON.generate(
+  timestamp: ENV['TIMESTAMP'],
+  commit: ENV['SHORT_SHA'],
+  ruby_head: (zjit_built && !head_sha.empty?) ? head_sha : nil,
+  timeouts: timeouts,
+  benchmarks: benches,
+)

--- a/.github/scripts/append_history.rb
+++ b/.github/scripts/append_history.rb
@@ -1,3 +1,10 @@
+# Appends one CSV row per benchmark to history.csv from a portal.json.
+# Column order matters: consumers parse positionally (the published file
+# carried a stale header for months), so new columns are only ever added
+# at the END of the row. Current schema (13 columns):
+#   timestamp,commit,benchmark,monoruby_ms,yjit_ms,ratio,
+#   monoruby_failed,yjit_failed,monoruby_reason,yjit_reason,
+#   zjit_ms,zjit_failed,zjit_reason
 require 'json'
 
 data = JSON.parse(File.read(ARGV[0]))
@@ -8,9 +15,12 @@ q   = ->(s) { s.nil? ? '' : '"' + s.to_s.gsub('"', '""') + '"' }
 data['benchmarks'].each do |b|
   mr   = b['monoruby_failed'] ? '' : '%.4f' % b['monoruby_ms']
   yj   = b['yjit_failed']     ? '' : '%.4f' % b['yjit_ms']
+  zj   = b['zjit_failed'] == false ? '%.4f' % b['zjit_ms'] : ''
   ra   = b['ratio']           ? '%.4f' % b['ratio'] : ''
   mr_r = q.call(b['monoruby_reason'])
   yj_r = q.call(b['yjit_reason'])
+  zj_r = q.call(b['zjit_reason'])
   $stdout.puts [ts, sha, b['name'], mr, yj, ra,
-                b['monoruby_failed'], b['yjit_failed'], mr_r, yj_r].join(',')
+                b['monoruby_failed'], b['yjit_failed'], mr_r, yj_r,
+                zj, b['zjit_failed'], zj_r].join(',')
 end

--- a/.github/scripts/summary_rows.rb
+++ b/.github/scripts/summary_rows.rb
@@ -1,0 +1,22 @@
+# Emits the markdown table rows for the GITHUB_STEP_SUMMARY benchmark
+# table, from bench-results/portal.json. The header row lives in the
+# workflow (it carries the per-arch title).
+require 'json'
+
+data = JSON.parse(File.read(ENV['GITHUB_WORKSPACE'] + '/bench-results/portal.json'))
+
+fmt_ms = ->(failed, v) { failed ? '**ERROR**' : '%.3f' % v }
+fmt_ratio = ->(v) { v ? '%.3fx' % v : '-' }
+
+data['benchmarks'].each do |b|
+  mr = fmt_ms.call(b['monoruby_failed'], b['monoruby_ms'])
+  yj = fmt_ms.call(b['yjit_failed'], b['yjit_ms'])
+  zj = fmt_ms.call(b['zjit_failed'], b['zjit_ms'])
+  reasons = %w[monoruby yjit zjit].filter_map { |e|
+    r = b["#{e}_reason"]
+    "#{e}: #{r}" if r
+  }.join(' / ')
+  puts "| #{b['name']} | #{mr} | #{yj} | #{zj} " \
+       "| #{fmt_ratio.call(b['ratio'])} | #{fmt_ratio.call(b['zjit_ratio'])} " \
+       "| #{reasons.empty? ? '-' : reasons} |"
+end

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,6 +11,7 @@ on:
       - 'rubymap/**'
       - 'Cargo.toml'
       - '.github/workflows/bench.yml'
+      - '.github/scripts/**'
       - '.github/portal/**'
       - '.github/bench-pages/**'
 
@@ -37,14 +38,42 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install system deps for yjit-bench
+      - name: Install system deps for yjit-bench and the ruby HEAD build
+        # libssl-dev/zlib1g-dev/libffi-dev are for the ruby HEAD build
+        # (rubygems needs openssl+zlib so each benchmark's
+        # `bundle install` works under the zjit ruby); autoconf drives
+        # its autogen.sh. The rest are yjit-bench gem dependencies.
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            libmagickwand-dev imagemagick libsqlite3-dev libpq-dev libyaml-dev
+            libmagickwand-dev imagemagick libsqlite3-dev libpq-dev libyaml-dev \
+            autoconf libssl-dev zlib1g-dev libffi-dev
 
       - name: Install monoruby (release)
         run: RUSTFLAGS=-Cforce-frame-pointers cargo install --path monoruby --locked
+
+      - name: Build ruby HEAD (ZJIT)
+        # ruby/ruby master is rebuilt from scratch on every run (no cache,
+        # by design: the point is to track ZJIT's HEAD). master does
+        # occasionally fail to build — that must not cost the monoruby /
+        # YJIT numbers, so this step only drops the zjit engine on
+        # failure and the dashboard records why. The nightly Rust
+        # toolchain installed above satisfies ZJIT's rustc >= 1.85
+        # requirement; the 4.0.2 ruby installed above is BASERUBY.
+        id: zjit
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          git clone --depth 1 https://github.com/ruby/ruby.git ../ruby-head
+          echo "sha=$(git -C ../ruby-head rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          cd ../ruby-head
+          ./autogen.sh
+          ./configure --prefix="$HOME/ruby-head" \
+            --enable-zjit --disable-yjit --disable-install-doc
+          make -j"$(getconf _NPROCESSORS_ONLN)"
+          make install
+          "$HOME/ruby-head/bin/ruby" --zjit -e 'puts RUBY_DESCRIPTION'
 
       - name: Clone yjit-bench (Shopify/yjit-bench)
         run: git clone --depth 1 https://github.com/Shopify/yjit-bench.git ../ruby-bench
@@ -75,19 +104,29 @@ jobs:
           echo "## Pre-run resource snapshot"
           { echo '### df -h'; df -h; echo; echo '### free -h'; free -h; } | tee -a "$GITHUB_STEP_SUMMARY"
 
-      - name: Run yjit-bench (monoruby vs ruby --yjit)
+      - name: Run yjit-bench (monoruby vs ruby --yjit / --zjit)
         id: run
         working-directory: ../ruby-bench
         shell: bash
         env:
           MR_TIMEOUT: '400'
           YJ_TIMEOUT: '400'
+          ZJ_TIMEOUT: '400'
         run: |
           set +e
           set -uo pipefail
 
           OUT="$GITHUB_WORKSPACE/bench-results"
           mkdir -p "$OUT/data"
+
+          # The zjit engine rides on the HEAD build when it exists;
+          # "$@" expands to nothing (safely, even under `set -u` on old
+          # bash) when the build failed and the run proceeds two-engined.
+          if [ -x "$HOME/ruby-head/bin/ruby" ]; then
+            set -- -e "zjit::timeout --foreground -k 5 ${ZJ_TIMEOUT} $HOME/ruby-head/bin/ruby --zjit"
+          else
+            set --
+          fi
 
           ./run_benchmarks.rb \
             --no-sudo \
@@ -98,6 +137,7 @@ jobs:
             --out-name="$OUT/data/raw" \
             -e "monoruby::timeout --foreground -k 5 ${MR_TIMEOUT} $HOME/.cargo/bin/monoruby" \
             -e "yjit::timeout --foreground -k 5 ${YJ_TIMEOUT} $(command -v ruby) --yjit" \
+            "$@" \
             2>&1 | tee "$OUT/run.log"
 
           true
@@ -109,6 +149,7 @@ jobs:
             echo "short_sha=$SHORT_SHA"
             echo "mr_timeout=${MR_TIMEOUT}"
             echo "yj_timeout=${YJ_TIMEOUT}"
+            echo "zj_timeout=${ZJ_TIMEOUT}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Post-run resource snapshot
@@ -123,102 +164,24 @@ jobs:
           SHORT_SHA: ${{ steps.run.outputs.short_sha }}
           MR_TIMEOUT: ${{ steps.run.outputs.mr_timeout }}
           YJ_TIMEOUT: ${{ steps.run.outputs.yj_timeout }}
+          ZJ_TIMEOUT: ${{ steps.run.outputs.zj_timeout }}
+          RUBY_HEAD_SHA: ${{ steps.zjit.outputs.sha }}
+          ZJIT_BUILD: ${{ steps.zjit.outcome == 'success' && 'ok' || 'failed' }}
         shell: bash
         run: |
           set -euo pipefail
 
-          OUT="$GITHUB_WORKSPACE/bench-results"
-
-          ruby -rjson <<'RUBY' > "$OUT/portal.json"
-          out = ENV['GITHUB_WORKSPACE'] + '/bench-results'
-          raw = JSON.parse(File.read(out + '/data/raw.json'))
-          fails_path = out + '/data/raw.failures.json'
-          fails = File.exist?(fails_path) ? JSON.parse(File.read(fails_path)) : {}
-
-          mr_data = raw.dig('raw_data', 'monoruby') || {}
-          yj_data = raw.dig('raw_data', 'yjit') || {}
-          mr_fails = fails['monoruby'] || {}
-          yj_fails = fails['yjit']     || {}
-          mr_to = ENV.fetch('MR_TIMEOUT', '400').to_i
-          yj_to = ENV.fetch('YJ_TIMEOUT', '400').to_i
-
-          reason = ->(status, timeout_s) {
-            return nil if status.nil?
-            case status
-            when 0   then 'ok'
-            when 1   then 'exit 1'
-            when 124 then "timeout (#{timeout_s}s)"
-            when 137 then "SIGKILL after timeout (#{timeout_s}s)"
-            when 132 then 'SIGILL'
-            when 134 then 'SIGABRT'
-            when 136 then 'SIGFPE'
-            when 138 then 'SIGBUS'
-            when 139 then 'SIGSEGV'
-            when 143 then 'SIGTERM'
-            else
-              if status > 128
-                "signal #{status - 128} (exit #{status})"
-              else
-                "exit #{status}"
-              end
-            end
-          }
-
-          median = ->(arr) {
-            return nil if arr.nil? || arr.empty?
-            s = arr.sort
-            n = s.size
-            n.odd? ? s[n / 2] : (s[n / 2 - 1] + s[n / 2]) / 2.0
-          }
-
-          all_names = (mr_data.keys + yj_data.keys + mr_fails.keys + yj_fails.keys).uniq.sort
-
-          benches = all_names.map do |name|
-            mr = mr_data[name]
-            yj = yj_data[name]
-            mr_med = mr ? median.call(mr['bench']) : nil
-            yj_med = yj ? median.call(yj['bench']) : nil
-            mr_ms = (mr_med && mr_med > 0) ? mr_med * 1000.0 : nil
-            yj_ms = (yj_med && yj_med > 0) ? yj_med * 1000.0 : nil
-            ratio = (mr_ms && yj_ms) ? yj_ms / mr_ms : nil
-            {
-              name: name,
-              monoruby_ms: mr_ms,
-              yjit_ms: yj_ms,
-              ratio: ratio,
-              monoruby_failed: mr_ms.nil?,
-              yjit_failed: yj_ms.nil?,
-              monoruby_reason: mr_ms.nil? ? (reason.call(mr_fails[name], mr_to) || 'no result') : nil,
-              yjit_reason:     yj_ms.nil? ? (reason.call(yj_fails[name], yj_to) || 'no result') : nil,
-            }
-          end
-
-          puts JSON.generate(
-            timestamp: ENV['TIMESTAMP'],
-            commit: ENV['SHORT_SHA'],
-            timeouts: { 'monoruby' => mr_to, 'yjit' => yj_to },
-            benchmarks: benches,
-          )
-          RUBY
+          ruby "$GITHUB_WORKSPACE/.github/scripts/aggregate_portal.rb" \
+            > "$GITHUB_WORKSPACE/bench-results/portal.json"
 
           {
-            echo "## Benchmark vs YJIT (yjit-bench, x86-64)"
+            echo "## Benchmark vs YJIT / ZJIT (yjit-bench, x86-64)"
             echo ""
-            echo "monoruby commit: \`$SHORT_SHA\`  (timeouts: monoruby ${MR_TIMEOUT}s, yjit ${YJ_TIMEOUT}s)"
+            echo "monoruby commit: \`$SHORT_SHA\`  zjit: ruby/ruby@\`${RUBY_HEAD_SHA:-n/a}\` (timeouts: monoruby ${MR_TIMEOUT}s, yjit ${YJ_TIMEOUT}s, zjit ${ZJ_TIMEOUT}s)"
             echo ""
-            echo "| Benchmark | monoruby (ms) | YJIT (ms) | YJIT / monoruby | monoruby reason | yjit reason |"
-            echo "| --- | ---: | ---: | ---: | --- | --- |"
-            ruby -rjson <<'RUBY'
-          data = JSON.parse(File.read(ENV['GITHUB_WORKSPACE'] + '/bench-results/portal.json'))
-          data['benchmarks'].each do |b|
-            mr = b['monoruby_failed'] ? '**ERROR**' : '%.3f' % b['monoruby_ms']
-            yj = b['yjit_failed']     ? '**ERROR**' : '%.3f' % b['yjit_ms']
-            ratio = b['ratio'] ? '%.3fx' % b['ratio'] : '-'
-            mr_r = b['monoruby_reason'] || '-'
-            yj_r = b['yjit_reason']     || '-'
-            puts "| #{b['name']} | #{mr} | #{yj} | #{ratio} | #{mr_r} | #{yj_r} |"
-          end
-          RUBY
+            echo "| Benchmark | monoruby (ms) | YJIT (ms) | ZJIT (ms) | monoruby (x YJIT) | ZJIT (x YJIT) | reasons |"
+            echo "| --- | ---: | ---: | ---: | ---: | ---: | --- |"
+            ruby "$GITHUB_WORKSPACE/.github/scripts/summary_rows.rb"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload results
@@ -251,15 +214,37 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install system deps for yjit-bench (macOS)
+      - name: Install system deps for yjit-bench and the ruby HEAD build (macOS)
         run: |
-          brew install coreutils imagemagick sqlite libpq libyaml libffi pkg-config
+          brew install coreutils imagemagick sqlite libpq libyaml libffi pkg-config \
+            autoconf automake openssl@3
           # GNU coreutils provides `timeout --foreground` used by the bench wrapper.
           echo "$(brew --prefix coreutils)/libexec/gnubin" >> "$GITHUB_PATH"
           echo "PKG_CONFIG_PATH=$(brew --prefix libffi)/lib/pkgconfig" >> "$GITHUB_ENV"
 
       - name: Install monoruby (release)
         run: cargo install --path monoruby --locked
+
+      - name: Build ruby HEAD (ZJIT)
+        # Mirrors the amd64 job: fresh build every run, and a failed
+        # ruby/ruby master build only drops the zjit engine. openssl@3
+        # is keg-only, so configure is pointed at it explicitly
+        # (rubygems needs it for each benchmark's `bundle install`).
+        id: zjit
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          git clone --depth 1 https://github.com/ruby/ruby.git ../ruby-head
+          echo "sha=$(git -C ../ruby-head rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          cd ../ruby-head
+          ./autogen.sh
+          ./configure --prefix="$HOME/ruby-head" \
+            --enable-zjit --disable-yjit --disable-install-doc \
+            --with-openssl-dir="$(brew --prefix openssl@3)"
+          make -j"$(getconf _NPROCESSORS_ONLN)"
+          make install
+          "$HOME/ruby-head/bin/ruby" --zjit -e 'puts RUBY_DESCRIPTION'
 
       - name: Clone yjit-bench (Shopify/yjit-bench)
         run: git clone --depth 1 https://github.com/Shopify/yjit-bench.git ../ruby-bench
@@ -285,19 +270,28 @@ jobs:
           gem install --no-document bundler
           bundle install || true
 
-      - name: Run yjit-bench (monoruby vs ruby --yjit)
+      - name: Run yjit-bench (monoruby vs ruby --yjit / --zjit)
         id: run
         working-directory: ../ruby-bench
         shell: bash
         env:
           MR_TIMEOUT: '400'
           YJ_TIMEOUT: '400'
+          ZJ_TIMEOUT: '400'
         run: |
           set +e
           set -uo pipefail
 
           OUT="$GITHUB_WORKSPACE/bench-results"
           mkdir -p "$OUT/data"
+
+          # See the amd64 job: "$@" carries the zjit engine only when the
+          # HEAD build produced a binary.
+          if [ -x "$HOME/ruby-head/bin/ruby" ]; then
+            set -- -e "zjit::timeout --foreground -k 5 ${ZJ_TIMEOUT} $HOME/ruby-head/bin/ruby --zjit"
+          else
+            set --
+          fi
 
           ./run_benchmarks.rb \
             --no-sudo \
@@ -308,6 +302,7 @@ jobs:
             --out-name="$OUT/data/raw" \
             -e "monoruby::timeout --foreground -k 5 ${MR_TIMEOUT} $HOME/.cargo/bin/monoruby" \
             -e "yjit::timeout --foreground -k 5 ${YJ_TIMEOUT} $(command -v ruby) --yjit" \
+            "$@" \
             2>&1 | tee "$OUT/run.log"
 
           true
@@ -319,6 +314,7 @@ jobs:
             echo "short_sha=$SHORT_SHA"
             echo "mr_timeout=${MR_TIMEOUT}"
             echo "yj_timeout=${YJ_TIMEOUT}"
+            echo "zj_timeout=${ZJ_TIMEOUT}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Aggregate to portal JSON
@@ -327,102 +323,24 @@ jobs:
           SHORT_SHA: ${{ steps.run.outputs.short_sha }}
           MR_TIMEOUT: ${{ steps.run.outputs.mr_timeout }}
           YJ_TIMEOUT: ${{ steps.run.outputs.yj_timeout }}
+          ZJ_TIMEOUT: ${{ steps.run.outputs.zj_timeout }}
+          RUBY_HEAD_SHA: ${{ steps.zjit.outputs.sha }}
+          ZJIT_BUILD: ${{ steps.zjit.outcome == 'success' && 'ok' || 'failed' }}
         shell: bash
         run: |
           set -euo pipefail
 
-          OUT="$GITHUB_WORKSPACE/bench-results"
-
-          ruby -rjson <<'RUBY' > "$OUT/portal.json"
-          out = ENV['GITHUB_WORKSPACE'] + '/bench-results'
-          raw = JSON.parse(File.read(out + '/data/raw.json'))
-          fails_path = out + '/data/raw.failures.json'
-          fails = File.exist?(fails_path) ? JSON.parse(File.read(fails_path)) : {}
-
-          mr_data = raw.dig('raw_data', 'monoruby') || {}
-          yj_data = raw.dig('raw_data', 'yjit') || {}
-          mr_fails = fails['monoruby'] || {}
-          yj_fails = fails['yjit']     || {}
-          mr_to = ENV.fetch('MR_TIMEOUT', '400').to_i
-          yj_to = ENV.fetch('YJ_TIMEOUT', '400').to_i
-
-          reason = ->(status, timeout_s) {
-            return nil if status.nil?
-            case status
-            when 0   then 'ok'
-            when 1   then 'exit 1'
-            when 124 then "timeout (#{timeout_s}s)"
-            when 137 then "SIGKILL after timeout (#{timeout_s}s)"
-            when 132 then 'SIGILL'
-            when 134 then 'SIGABRT'
-            when 136 then 'SIGFPE'
-            when 138 then 'SIGBUS'
-            when 139 then 'SIGSEGV'
-            when 143 then 'SIGTERM'
-            else
-              if status > 128
-                "signal #{status - 128} (exit #{status})"
-              else
-                "exit #{status}"
-              end
-            end
-          }
-
-          median = ->(arr) {
-            return nil if arr.nil? || arr.empty?
-            s = arr.sort
-            n = s.size
-            n.odd? ? s[n / 2] : (s[n / 2 - 1] + s[n / 2]) / 2.0
-          }
-
-          all_names = (mr_data.keys + yj_data.keys + mr_fails.keys + yj_fails.keys).uniq.sort
-
-          benches = all_names.map do |name|
-            mr = mr_data[name]
-            yj = yj_data[name]
-            mr_med = mr ? median.call(mr['bench']) : nil
-            yj_med = yj ? median.call(yj['bench']) : nil
-            mr_ms = (mr_med && mr_med > 0) ? mr_med * 1000.0 : nil
-            yj_ms = (yj_med && yj_med > 0) ? yj_med * 1000.0 : nil
-            ratio = (mr_ms && yj_ms) ? yj_ms / mr_ms : nil
-            {
-              name: name,
-              monoruby_ms: mr_ms,
-              yjit_ms: yj_ms,
-              ratio: ratio,
-              monoruby_failed: mr_ms.nil?,
-              yjit_failed: yj_ms.nil?,
-              monoruby_reason: mr_ms.nil? ? (reason.call(mr_fails[name], mr_to) || 'no result') : nil,
-              yjit_reason:     yj_ms.nil? ? (reason.call(yj_fails[name], yj_to) || 'no result') : nil,
-            }
-          end
-
-          puts JSON.generate(
-            timestamp: ENV['TIMESTAMP'],
-            commit: ENV['SHORT_SHA'],
-            timeouts: { 'monoruby' => mr_to, 'yjit' => yj_to },
-            benchmarks: benches,
-          )
-          RUBY
+          ruby "$GITHUB_WORKSPACE/.github/scripts/aggregate_portal.rb" \
+            > "$GITHUB_WORKSPACE/bench-results/portal.json"
 
           {
-            echo "## Benchmark vs YJIT (yjit-bench, aarch64)"
+            echo "## Benchmark vs YJIT / ZJIT (yjit-bench, aarch64)"
             echo ""
-            echo "monoruby commit: \`$SHORT_SHA\`  (timeouts: monoruby ${MR_TIMEOUT}s, yjit ${YJ_TIMEOUT}s)"
+            echo "monoruby commit: \`$SHORT_SHA\`  zjit: ruby/ruby@\`${RUBY_HEAD_SHA:-n/a}\` (timeouts: monoruby ${MR_TIMEOUT}s, yjit ${YJ_TIMEOUT}s, zjit ${ZJ_TIMEOUT}s)"
             echo ""
-            echo "| Benchmark | monoruby (ms) | YJIT (ms) | YJIT / monoruby | monoruby reason | yjit reason |"
-            echo "| --- | ---: | ---: | ---: | --- | --- |"
-            ruby -rjson <<'RUBY'
-          data = JSON.parse(File.read(ENV['GITHUB_WORKSPACE'] + '/bench-results/portal.json'))
-          data['benchmarks'].each do |b|
-            mr = b['monoruby_failed'] ? '**ERROR**' : '%.3f' % b['monoruby_ms']
-            yj = b['yjit_failed']     ? '**ERROR**' : '%.3f' % b['yjit_ms']
-            ratio = b['ratio'] ? '%.3fx' % b['ratio'] : '-'
-            mr_r = b['monoruby_reason'] || '-'
-            yj_r = b['yjit_reason']     || '-'
-            puts "| #{b['name']} | #{mr} | #{yj} | #{ratio} | #{mr_r} | #{yj_r} |"
-          end
-          RUBY
+            echo "| Benchmark | monoruby (ms) | YJIT (ms) | ZJIT (ms) | monoruby (x YJIT) | ZJIT (x YJIT) | reasons |"
+            echo "| --- | ---: | ---: | ---: | ---: | ---: | --- |"
+            ruby "$GITHUB_WORKSPACE/.github/scripts/summary_rows.rb"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload results
@@ -488,16 +406,17 @@ jobs:
             mkdir -p "$GH_PAGES_DIR/$SUBDIR/data"
 
             local CSV="$GH_PAGES_DIR/$SUBDIR/data/history.csv"
-            local HEADER="timestamp,commit,benchmark,monoruby_ms,yjit_ms,ratio,monoruby_failed,yjit_failed,monoruby_reason,yjit_reason"
+            # New columns only ever go at the END of this header:
+            # consumers parse rows positionally, and older rows keep
+            # their original (shorter) field count.
+            local HEADER="timestamp,commit,benchmark,monoruby_ms,yjit_ms,ratio,monoruby_failed,yjit_failed,monoruby_reason,yjit_reason,zjit_ms,zjit_failed,zjit_reason"
 
             if [ ! -f "$CSV" ]; then
               echo "$HEADER" > "$CSV"
             elif [ "$(head -n 1 "$CSV")" != "$HEADER" ]; then
-              # The header was only ever written when the file was created,
-              # so the live file still names its columns after the original
-              # iterations/sec schema (`monoruby_ips,yjit_ips,ratio`) even
-              # though every row since has been the 10-column ms schema.
-              # Rewrite just line 1 so the names match the data.
+              # A schema change (or the original stale monoruby_ips
+              # header) leaves line 1 out of date; rewrite just that
+              # line so the names match the current schema.
               { echo "$HEADER"; tail -n +2 "$CSV"; } > "$CSV.new"
               mv "$CSV.new" "$CSV"
               echo "history.csv: refreshed stale header for $SUBDIR"


### PR DESCRIPTION
Adds CRuby's ZJIT to the benchmark comparison. Each bench run clones **ruby/ruby master** and builds it fresh (no cache, by design — the point is to track ZJIT's HEAD), then benchmarks three engines. **YJIT stays on the released 4.0.2 and is the baseline**: monoruby and ZJIT are both reported as multiples of the YJIT time (higher = faster than YJIT, 1× = parity).

## Workflow (`bench.yml`, both jobs)

- New **Build ruby HEAD (ZJIT)** step: `--enable-zjit --disable-yjit --disable-install-doc` into `$HOME/ruby-head`. The nightly Rust toolchain already installed satisfies ZJIT's rustc ≥ 1.85; the setup-ruby 4.0.2 serves as BASERUBY. Ubuntu gains `autoconf libssl-dev zlib1g-dev libffi-dev` (rubygems needs openssl+zlib so each benchmark's `bundle install` works under the HEAD ruby); macOS gains `autoconf automake openssl@3` with `--with-openssl-dir` since openssl@3 is keg-only.
- The build runs under `continue-on-error`: a broken ruby master only drops the zjit engine — the run proceeds two-engined and the dashboard says *"ruby HEAD build failed"* — instead of costing the monoruby/YJIT numbers. The engine is injected via `set -- -e "zjit::…"` / `"$@"`, which stays safe under `set -u` on macOS's bash 3.2.
- The duplicated per-job aggregation heredocs move to shared scripts (`.github/scripts/aggregate_portal.rb`, `summary_rows.rb`) — they had already drifted once, and each now needs zjit columns.

## Data

- `portal.json` gains `zjit_ms` / `zjit_failed` / `zjit_reason`, `zjit_ratio` (= yjit_ms / zjit_ms), and the ruby/ruby HEAD short sha (`ruby_head`, null when the build failed).
- `history.csv` appends `zjit_ms, zjit_failed, zjit_reason` at the **end** of the row (consumers parse positionally; older rows keep their shorter field count) and the header self-repairs to the 13-column schema via the existing mechanism.

## Dashboard

- **Snapshot bar chart**: two bars per benchmark — monoruby (grade-colored as before) and ZJIT HEAD (purple) — on the same fixed 0–4× axis with the red 1× YJIT-parity line. Rows without a YJIT baseline sort to the bottom and show the failure text; a partial failure just omits that engine's bar (reason stays in tooltip and table). The meta line shows the ruby/ruby HEAD sha.
- **History grid**: ratio mode draws monoruby and ZJIT lines against the 1× parity line — the ZJIT line starts at the commit it was first measured; raw mode draws all three times. Cards fall back to the single-series look wherever no zjit data exists, so the current live data renders unchanged.
- **Table**: ZJIT (ms), ZJIT (× YJIT) and zjit-reason columns.

## Verification

- Aggregate → summary → history scripts ran end-to-end on a three-engine fixture: per-engine failures carry their reasons, the build-failed path yields `ruby_head: null` + *"ruby HEAD build failed"*, CSV rows come out 13-field.
- Page rendered headlessly (Chromium/Playwright) against **(a)** the live zjit-less published data — unchanged: 61 cards, no page errors — and **(b)** a zjit-era fixture covering partial failures per engine, a >4× clip, a yjit-failed row, and the mid-history ZJIT start, in both ratio and raw modes with no page errors.
- Workflow YAML parses; every `run:` step passes `bash -n`; all three Ruby scripts pass `ruby -c`.

Note on runtime: the HEAD build adds roughly 15–25 min per job and the third engine extends the benchmark phase; both jobs stay well inside their 240-min timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUYnhjixuUEzA5hgWUdckX

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUYnhjixuUEzA5hgWUdckX)_