### PR TITLE
bench: raise the arm64 job timeout to 350 min for the three-engine pass

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -235,7 +235,12 @@ jobs:
 
   bench-arm64:
     runs-on: macos-latest
-    timeout-minutes: 240
+    # The three-engine pass needs ~245-260 min on this runner (the zjit
+    # pass alone is ~2.5 h on arm64): the first zjit run hit the old
+    # 240-min cap during its final engine pass, ~90% done, and published
+    # nothing. 350 leaves headroom while staying under the 360-min
+    # GitHub-hosted maximum.
+    timeout-minutes: 350
     env:
       CARGO_TERM_COLOR: always
     steps:


### PR DESCRIPTION
The first three-engine bench run's `bench-arm64` job was killed by its own `timeout-minutes: 240` at 05:08, during its **final** engine pass, roughly 90% of the way through the benchmark list — so the run published nothing for arm64 and the arm64 dashboard is still on the last two-engine snapshot. (The amd64 job finished in 1h54 and its ZJIT data is already live.)

From the job log: the two-engine pass used to take ~77 min on this runner, but the zjit pass alone adds ~2.5 h on arm64, putting the full three-engine pass at ~245–260 min — just past the old cap. Raise `bench-arm64` to **350 min**, which leaves ~1.5 h of headroom while staying under the 360-min GitHub-hosted maximum. `bench-amd64` stays at 240 (it needs less than half of that).

One-line diff plus a comment recording the sizing, so the next person doesn't lower it back.

If the zjit pass keeps growing (it is bounded above by ~77 benchmarks × the 400 s per-benchmark timeout), the next lever is a lower `ZJ_TIMEOUT` on arm64 rather than a higher job timeout — noted here for the future, not included in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUYnhjixuUEzA5hgWUdckX

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUYnhjixuUEzA5hgWUdckX)_