### PR TITLE
Fix the basic-op mixin false positive that made `lee` 3.2x slower

### DIFF
--- a/doc/bop_redefinition.md
+++ b/doc/bop_redefinition.md
@@ -647,6 +647,69 @@ refinement が置き換えたはずの算術をそのまま出してしまう。
 **refine しただけのコストが消えた。** VM 側の asm ガードは呼び出し地点の
 文脈を持たないグローバル語なので粗いまま（正しさは dispatch が担保する）。
 
+### Step 4 — mixin 経由の再定義（#1214, #1219）— **実装済み**
+
+Step 1 で「メソッド表を変更する全経路に検知点を置く」と決めたが、経路が
+1 本抜けていた。**モジュール経由**である。
+
+```ruby
+module M
+  def +(o) = super(o) * 2
+end
+class Integer
+  prepend M
+end
+```
+
+`insert_method` が受け取る `class_id` は `M` であって `Integer` ではない。
+表が記録しているペアは `(Integer, "+")` なので `contains(M, "+")` は false、
+何も立たず両ティアがビルトインを撃ち続けた。順序を入れ替えて
+`prepend` を先にしても同じ（定義そのものが走らない）。
+
+検知点は 2 つ:
+
+- `insert_method` → `check_mixed_in_basic_op(module_id, name)` —
+  モジュールに後からメソッドが入った場合
+- `append_features` / `prepend_features` → `check_mixin_basic_ops(module)` —
+  すでにメソッドを持つモジュールが後から差し込まれた場合
+
+**罠 — 「モジュールがその名前を定義しているか」は問いとして間違っている。**
+最初の実装はこう書いた:「`name` が BOP 名で、かつ `module_id` が基本演算
+クラス `C` の祖先にあるなら `(C, name)` を再定義済みにする」。これは
+**ユーザコードの `include Comparable` ひとつでプロセス中の整数 fast path が
+全滅する**。`Comparable` は `<` `<=` `>` `>=` `==` を定義しており、
+`Integer` はブートストラップ以来それを include している。つまり
+「祖先のモジュールがその名前を定義している」は*どんなプログラムでも常に真*
+で、一方 `Integer` 自身の `<` はルックアップで勝ち続けるので**実際には何も
+変わっていない**。
+
+正しい問いは「**そのクラスは今もビルトインに解決するか**」である。
+`arm_basic_ops` が起動時に全ペアの解決先 `FuncId` をスナップショットし
+（`BasicOpTable::armed_funcs`）、mixin 検知はそれと現在の解決先を比較する。
+`Integer.prepend M`（M が `+` を持つ）なら解決先が動くので立ち、
+`class Foo; include Comparable; end` なら動かないので立たない。
+
+**実測（yjit-bench `lee`, x86-64）。** この誤検知は 1 回の `include` で
+`Integer#< <= > >= == != === <=> !`、`Float`・`String`・`Symbol` の同種、
+計 27 ペアを恒久的に落とした。`lee` は `require "json"` の過程で
+`Comparable` を include するため直撃した:
+
+| | median |
+| --- | ---: |
+| 誤検知の前（`037a720`） | 512 ms |
+| 誤検知の入った master（`21ed6aa`） | 1728 ms |
+| 解決先比較を入れた後 | 520 ms |
+
+CI の履歴では amd64 が 478 ms → 1550 ms（YJIT 比 1.48x → 0.44x）、
+arm64 は 400 秒のタイムアウトに達した。
+
+回帰テストは `basic_op.rs` の
+`a_mixin_that_displaces_nothing_keeps_the_basic_ops` / 
+`a_prepend_that_displaces_the_builtin_retires_its_pair`。前者は「何も
+落ちない」ことを、後者は「落ちるべきものは落ちる」ことを表の状態に対して
+直接主張する — 値の比較では、fast path が消えても答えは正しいままなので
+検出できない。
+
 ### Step 3 の当初計画（記録として保存）
 
 Step 2 の (op, class) ビットマスクができれば、#1066 が要求する

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -445,7 +445,17 @@ impl Store {
     /// names, so arming any earlier reports the interpreter monkey-patching
     /// itself. See `basic_op::BasicOpTable`.
     pub(crate) fn arm_basic_ops(&mut self) {
-        self.basic_ops.arm();
+        // Snapshot what every pair resolves to right now. The mixin
+        // checks compare against this baseline, so that including a
+        // module a basic-op class already carries — `Comparable`, say —
+        // is recognised as changing nothing.
+        let resolved = self
+            .basic_ops
+            .pairs()
+            .into_iter()
+            .map(|(class_id, name)| ((class_id, name), self.resolve_basic_op(class_id, name)))
+            .collect();
+        self.basic_ops.arm(resolved);
     }
 
     /// Whether any basic op has been redefined. Read by the fast paths that

--- a/monoruby/src/globals/store/basic_op.rs
+++ b/monoruby/src/globals/store/basic_op.rs
@@ -156,6 +156,13 @@ pub(crate) struct BasicOpTable {
     /// `JitContext::assume_basic_op`. The VM's assembly guard has no call
     /// site to ask about and stays coarse.
     refined_set: HashSet<(ClassId, IdentId)>,
+    /// What each pair resolved to at [`Self::arm`]. The mixin checks
+    /// compare against this rather than asking whether a module merely
+    /// *defines* the name: `Comparable` defines `<` and `Integer` has
+    /// included it since bootstrap, so "the module defines it" is true
+    /// for every `include Comparable` in the program while the
+    /// resolution — `Integer`'s own `<` — never moves.
+    armed_funcs: HashMap<(ClassId, IdentId), Option<FuncId>>,
     /// Pairs replaced since the last drain, awaiting CRuby's
     /// `:performance` warning ("Redefining 'Integer#+' disables
     /// interpreter and JIT optimizations"). Marking happens deep inside
@@ -182,14 +189,35 @@ impl BasicOpTable {
             redefined_set: HashSet::default(),
             globally_redefined_set: HashSet::default(),
             refined_set: HashSet::default(),
+            armed_funcs: HashMap::default(),
             pending_warnings: Vec::new(),
         }
     }
 
     /// Start reporting. Called once, after startup.rb and the gems have
-    /// loaded and before user code runs.
-    pub(crate) fn arm(&mut self) {
+    /// loaded and before user code runs. `resolved` is what each pair
+    /// answers at that moment — the baseline the mixin checks compare
+    /// against.
+    pub(crate) fn arm(&mut self, resolved: Vec<((ClassId, IdentId), Option<FuncId>)>) {
         self.armed = true;
+        self.armed_funcs = resolved.into_iter().collect();
+    }
+
+    /// Every pair in the table, for the caller that resolves them at
+    /// [`Self::arm`] time.
+    pub(crate) fn pairs(&self) -> Vec<(ClassId, IdentId)> {
+        self.set.iter().copied().collect()
+    }
+
+    /// What `class_id#name` resolved to when the table was armed.
+    /// `None` when the pair has no snapshot at all (the table is not
+    /// armed yet), which callers treat as "assume it moved".
+    pub(crate) fn armed_func(
+        &self,
+        class_id: ClassId,
+        name: IdentId,
+    ) -> Option<Option<FuncId>> {
+        self.armed_funcs.get(&(class_id, name)).copied()
     }
 
     /// Whether replacing `class_id#name` invalidates a fast path.
@@ -266,6 +294,110 @@ impl BasicOpTable {
 mod tests {
     use super::*;
     use crate::tests::*;
+
+    /// Run `code` and report which pairs it left marked as redefined.
+    fn redefined_pairs_after(code: &str) -> Vec<String> {
+        let mut globals = Globals::new_test();
+        globals
+            .run(code, std::path::Path::new("."))
+            .unwrap_or_else(|err| {
+                err.show_error_message_and_all_loc(&globals.store);
+                panic!("code under test raised");
+            });
+        BASIC_OP_DEFS
+            .iter()
+            .filter(|(class_id, name)| {
+                globals
+                    .store
+                    .basic_op_redefined_for(*class_id, IdentId::get_id(name))
+            })
+            .map(|(class_id, name)| format!("{}#{}", globals.store.get_class_name(*class_id), name))
+            .collect()
+    }
+
+    /// A mixin that displaces nothing must leave the table alone.
+    ///
+    /// `Comparable` defines `<`, `<=`, `>`, `>=` and `==`, and `Integer`,
+    /// `Float` and `String` have included it since bootstrap. So "a
+    /// module in this class's ancestry defines the name" holds for
+    /// *every* `include Comparable` in any program — while `Integer`'s
+    /// own `<` goes on winning the lookup. Answering that question
+    /// rather than "does the class still resolve to the builtin?" made
+    /// one unrelated `include` — from user code or from a required
+    /// library — evict every integer fast path in the process, which
+    /// cost the `lee` benchmark a factor of three.
+    #[test]
+    fn a_mixin_that_displaces_nothing_keeps_the_basic_ops() {
+        let marked = redefined_pairs_after(
+            r##"
+            module BareMixin
+              def <(o) = :never_reached
+              def ==(o) = :never_reached
+              def +(o) = :never_reached
+            end
+            # Including a module a basic-op class already carries.
+            class UsesComparable
+              include Comparable
+              def <=>(o) = 0
+            end
+            # Including a fresh module that happens to name basic ops.
+            class UsesBareMixin
+              include BareMixin
+            end
+            # Reopening the module a basic-op class already includes —
+            # the same question one level further out. `Integer#<` still
+            # shadows `Comparable#<`.
+            module Comparable
+              def clamp_ish(a, b) = self
+            end
+            # Defining basic-op names on an ordinary class.
+            class Unrelated
+              def +(o) = :never_reached
+              def [](i) = :never_reached
+            end
+            "##,
+        );
+        assert!(
+            marked.is_empty(),
+            "these pairs were retired by mixins that displace nothing: {marked:?}"
+        );
+    }
+
+    /// The other direction, so the check above cannot be satisfied by
+    /// simply never marking anything: a prepend that *does* displace the
+    /// builtin still retires exactly its own pair.
+    #[test]
+    fn a_prepend_that_displaces_the_builtin_retires_its_pair() {
+        assert_eq!(
+            vec!["Integer#+".to_string()],
+            redefined_pairs_after(
+                r##"
+                module Shadow
+                  def +(o) = super(o) * 2
+                end
+                class Integer
+                  prepend Shadow
+                end
+                "##,
+            )
+        );
+        // ... and in the other order, with the method arriving after the
+        // module is already spliced in.
+        assert_eq!(
+            vec!["Integer#*".to_string()],
+            redefined_pairs_after(
+                r##"
+                module Late; end
+                class Integer
+                  prepend Late
+                end
+                module Late
+                  def *(o) = super(o)
+                end
+                "##,
+            )
+        );
+    }
 
     #[test]
     fn basic_op_defs_have_no_duplicates() {

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -2449,9 +2449,19 @@ impl Store {
     /// records names the class, not the module, so nothing marked it
     /// and both tiers kept firing the builtin.
     ///
+    /// The deciding question is not "does the module define this name?"
+    /// but "does the class still resolve it to the builtin?" — those
+    /// differ constantly. `Comparable` defines `<`, `<=`, `>`, `>=` and
+    /// `==`, and `Integer` has included it since bootstrap, so a bare
+    /// `class Foo; include Comparable; end` anywhere in the program
+    /// satisfies the ancestry test for `(Integer, :<)` while changing
+    /// nothing at all: `Integer`'s own `<` still wins the lookup.
+    /// Asking the resolution is what keeps an unrelated `include` from
+    /// evicting every integer fast path in the program.
+    ///
     /// Only a name that appears somewhere in `BASIC_OP_DEFS` gets past
-    /// the first test, so the ancestry walk runs for `+`, `<<`, `==`, …
-    /// and over the handful of classes the table pairs that name with.
+    /// the first test, so the walk runs for `+`, `<<`, `==`, … and over
+    /// the handful of classes the table pairs that name with.
     ///
     fn check_mixed_in_basic_op(&mut self, module_id: ClassId, name: IdentId) {
         if !self.basic_ops.is_basic_op_name(name) {
@@ -2460,10 +2470,37 @@ impl Store {
         for class_id in self.basic_ops.classes_for_name(name) {
             // The `class_id == module_id` case is the ordinary
             // redefinition `insert_method` already handled.
-            if class_id != module_id && self.class_in_ancestors(class_id, module_id) {
+            if class_id != module_id
+                && self.class_in_ancestors(class_id, module_id)
+                && !self.basic_op_resolves_as_armed(class_id, name)
+            {
                 self.set_bop_redefine(class_id, name);
             }
         }
+    }
+
+    ///
+    /// Whether `class_id#name` still resolves to the method the table
+    /// was armed with — the snapshot [`Store::arm_basic_ops`] takes
+    /// once the builtins have finished defining themselves.
+    ///
+    /// A pair with no snapshot is reported as changed, so an unknown
+    /// pair costs a fast path rather than correctness.
+    ///
+    fn basic_op_resolves_as_armed(&self, class_id: ClassId, name: IdentId) -> bool {
+        let Some(armed) = self.basic_ops.armed_func(class_id, name) else {
+            return false;
+        };
+        armed == self.resolve_basic_op(class_id, name)
+    }
+
+    /// What `class_id#name` resolves to right now, in the form the
+    /// snapshot records. `None` for a name no ancestor defines — a real
+    /// state for the pairs inherited from `Object` / `BasicObject`
+    /// (`Integer#!`, `NilClass#==`, …).
+    pub(super) fn resolve_basic_op(&self, class_id: ClassId, name: IdentId) -> Option<FuncId> {
+        self.search_method(self[class_id].get_module(), name)
+            .and_then(|entry| entry.func_id())
     }
 
     ///


### PR DESCRIPTION
## Problem

The mixin detection added in #1214 asked the wrong question. It retired a basic-op pair whenever a module in the class's ancestry *defined* the name — but `Comparable` defines `<` `<=` `>` `>=` `==`, and `Integer` / `Float` / `String` have included it since bootstrap. So the condition held for every `include Comparable` in any program, while `Integer`'s own `<` went on winning the lookup and nothing had actually changed.

One unrelated `include` therefore permanently retired **27 pairs** (`Integer#< <= > >= == != === <=> !` plus the `Float` / `String` / `Symbol` equivalents) — and with them every integer fast path in both tiers. yjit-bench's `lee` reaches it through `require "json"`, whose load path includes `Comparable`.

The bench-pages history shows the regression starting exactly at #1214 (`21ed6aa`): amd64 478 ms → 1550 ms (1.48x → 0.44x vs YJIT), arm64 hitting the 400-second timeout.

## Fix

The right question is: **does the class still resolve this op to the builtin?** `arm_basic_ops` now snapshots the `FuncId` each pair resolves to at the moment the table is armed (`BasicOpTable::armed_funcs`), and both mixin checks (`insert_method` into an already-mixed-in module, and `append_features` / `prepend_features` of a module that already has methods) compare the *current* resolution against that snapshot. A `prepend` that displaces the builtin still moves the resolution and still retires its pair; an `include` that changes nothing leaves the table alone.

## Measured (`lee`, x86-64, same machine)

| | median |
|---|---:|
| `037a720` (before #1214) | 512 ms |
| `21ed6aa` (current master) | 1728 ms |
| this branch | 520 ms |

With the fix, a trace of `lee` shows **0** basic-op invalidations (before: 111, of which 102 came from `Comparable`).

## Tests

- `cargo test`: 3658 passed / 0 failed (default and `stress-spill-pool`); `cargo check --target aarch64-unknown-linux-gnu` clean; no ruby/spec changes (module/string/kernel/enumerable counts unchanged).
- The new regression tests (`a_mixin_that_displaces_nothing_keeps_the_basic_ops`, `a_prepend_that_displaces_the_builtin_retires_its_pair`) assert against the **table's state**, not computed values — a lost fast path still gives the right answer, so only the state can catch this class of bug. Verified by temporarily disabling the fix: the test names the same 27 pairs the benchmark lost.
- `doc/bop_redefinition.md` gains a Step 4 section recording the detection points, this trap, and the measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_