### PR TITLE
Pop the compile queue from the front in O(1)

### DIFF
--- a/monoruby/src/globals/store/function.rs
+++ b/monoruby/src/globals/store/function.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::bytecodegen::CompileInfo;
+use std::collections::VecDeque;
 
 pub(crate) const FUNCDATA_CODEPTR: u64 = std::mem::offset_of!(FuncData, codeptr) as _;
 pub(crate) const FUNCDATA_META: u64 = std::mem::offset_of!(FuncData, meta) as _;
@@ -371,7 +372,12 @@ mod tests {
 
 pub(crate) struct Funcs {
     pub(in crate::globals) info: MonoVec<FuncInfo>,
-    compile_info: Vec<CompileInfo>,
+    /// FIFO of not-yet-compiled function bodies, consumed by
+    /// `bytecode_compile`. A deque, not a `Vec`: entries embed the whole AST
+    /// (hundreds of bytes each), and a 30k-`def` script queues 30k of them —
+    /// `Vec::remove(0)` per pop made loading such a file quadratic in memmove
+    /// (~6 s for a 30k-method file; `pop_front` brings it to ~250 ms).
+    compile_info: VecDeque<CompileInfo>,
 }
 
 impl std::ops::Index<FuncId> for Funcs {
@@ -393,7 +399,7 @@ impl std::default::Default for Funcs {
         info.push(FuncInfo::default());
         Self {
             info,
-            compile_info: vec![],
+            compile_info: VecDeque::new(),
         }
     }
 }
@@ -639,7 +645,7 @@ impl Funcs {
     }
 
     pub fn get_compile_info(&mut self) -> CompileInfo {
-        self.compile_info.remove(0)
+        self.compile_info.pop_front().unwrap()
     }
 
     pub(crate) fn clear_compile_info(&mut self) {
@@ -663,7 +669,7 @@ impl Funcs {
     }
 
     pub(super) fn add_compile_info(&mut self, compile_info: CompileInfo) {
-        self.compile_info.push(compile_info);
+        self.compile_info.push_back(compile_info);
     }
 
     pub(super) fn new_native_func(


### PR DESCRIPTION
## Problem

`bytecode_compile` drains the pending-function queue with `Vec::remove(0)`, which memmoves every remaining entry on each pop — and each entry is a whole `CompileInfo` with the function's AST embedded. A script defining *n* methods therefore copies O(n²) `CompileInfo` bytes at load time.

On yjit-bench's `30k_ifelse` / `30k_methods` / `30k_variables` files (30,000 `def`s each), callgrind shows **87% of all instructions executed during load (15.4 billion) inside memcpy** called from `bytecode_compile_func`:

| loading the 30k-method file | time |
|---|---:|
| monoruby (before) | 6142 ms |
| CRuby | 209 ms |
| monoruby (this fix) | **240 ms** |

This affects every large file load, not just the benchmarks — the 30k_* benchmark totals drop accordingly (`30k_variables` full run 24 s → 14 s here). Steady-state iteration medians are unchanged, as expected: the queue is only touched at load/eval time.

## Fix

`VecDeque` + `pop_front()`. FIFO order is load-bearing (block bodies are queued and consumed positionally during compilation, and `clear_compile_info` relies on drain-order semantics after a compile error), so only the container changes; `push`/`clear`/panic-on-empty behavior are identical.

## Tests

- `cargo test`: 3658 passed / 0 failed
- `cargo check --target aarch64-unknown-linux-gnu` clean (arch-neutral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_