### PR TITLE
Pre-size the hash a literal past the inline capacity builds

### DIFF
--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -816,8 +816,11 @@ fn gen_hash_inner(
 ) -> Result<crate::value::rvalue::HashmapInner> {
     // Build the HashmapInner directly (not a RubyMap first) so a small
     // literal with packed keys lands in the inline representation without
-    // ever touching the heap.
-    let mut map = crate::value::rvalue::HashmapInner::default();
+    // ever touching the heap. A literal past the inline capacity is
+    // pre-sized instead: its length is known here, and inserting through
+    // the inline→boxed growth ladder costs a representation switch plus
+    // a rehash per doubling (an 8-pair literal was ~2.4x CRuby+YJIT).
+    let mut map = crate::value::rvalue::HashmapInner::with_capacity(len);
     if len > 0 {
         let mut iter = unsafe { std::slice::from_raw_parts(src.sub(len * 2 - 1), len * 2) }
             .iter()


### PR DESCRIPTION
## Problem

`gen_hash` — the runtime shared by the VM `Hash` op and the JIT slow path on both arches — built every hash literal by inserting into a default `HashmapInner`. A literal with more than `INLINE_CAP` (3) pairs therefore paid the whole inline→boxed growth ladder on every evaluation: a representation switch plus a rehash per capacity doubling.

Found while investigating the `addressable-*` benchmarks: `Addressable::URI.parse` builds an 8-symbol-key options hash per call, and that literal measured **1249 ns vs YJIT's 523 ns** (2.4x). The broader finding there is that the addressable gap is a diffuse ~2x on Hash-with-Symbol-key operations (literal build, `[]`, `has_key?`, `keys &`), of which this is the cheapest fix.

## Fix

The literal's length is known up front — build with `HashmapInner::with_capacity(len)` instead of `default()`. `with_capacity` already exists (used by `#to_h` / `#transform_*` bulk fills) and keeps `len <= INLINE_CAP` on the inline representation, so small packed-key literals behave exactly as before; only the >3-pair case changes, skipping the growth ladder it would have climbed anyway.

The 8-pair literal drops 1249 ns → **978 ns**.

## Tests

- `cargo test`: 3656 passed / 0 failed
- ruby/spec `core/hash`: unchanged (1 pre-existing failure)
- aarch64 covered by the shared runtime (no arch-specific code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_