### PR TITLE
Stamp the loop-JIT bail sentinel on x86-64 too

### DIFF
--- a/monoruby/src/codegen/arch/x86_64/vmgen.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen.rs
@@ -921,12 +921,25 @@ impl Codegen {
         self.vm_execute_gc();
         {
             let count = self.jit.label();
+            let low = self.jit.label();
             self.jit.branch_if_captured(&cont);
+            // The codeptr slot holds 0 (not yet compiled — count toward the
+            // threshold), the 1-sentinel (a compile bailed — keep
+            // interpreting, never retry; see `gen_compile_loop`), or the
+            // compiled loop's address. Without the sentinel a bailing loop
+            // (e.g. a body containing `eval`) re-fired the compiler on
+            // every iteration once the counter crossed the threshold —
+            // ~100k aborted compiles for a 100k-iteration loop. Mirrors
+            // the aarch64 `vm_loop_start`, which has carried the sentinel
+            // all along (`clear_loop_jit_entries` already preserves it).
             monoasm! { &mut self.jit,
                 movq rax, [r13 - 8];
-                testq rax, rax;
-                jeq count;
+                cmpq rax, 1;
+                jbe  low;
                 jmp rax;
+            low:
+                jne  count;
+                jmp  cont;
             count:
                 addl [r13 - 16], 1;
                 cmpl [r13 - 16], (COUNT_LOOP_START_COMPILE);

--- a/monoruby/src/codegen/compiler.rs
+++ b/monoruby/src/codegen/compiler.rs
@@ -168,6 +168,7 @@ impl Codegen {
 
     #[cfg(target_arch = "x86_64")]
     pub(super) fn gen_compile_loop(&mut self, entry: &DestLabel, cont: &DestLabel) {
+        let run = self.jit.label();
         monoasm!( &mut self.jit,
         entry:
             movq rdi, r12;
@@ -177,7 +178,15 @@ impl Codegen {
             call rax;
             movq rax, [r13 - 8];
             testq rax, rax;
-            jeq cont;
+            jne run;
+            // The compile bailed (codeptr unpublished): stamp the
+            // 1-sentinel so `vm_loop_start` never fires the compiler for
+            // this loop again — without it, the counter sitting past the
+            // threshold re-ran the (aborting) compiler on every single
+            // iteration. Mirrors the aarch64 `vm_loop_start` bail path.
+            movq [r13 - 8], 1;
+            jmp cont;
+        run:
             jmp rax;
         );
     }

--- a/monoruby/tests/redefine.rs
+++ b/monoruby/tests/redefine.rs
@@ -766,3 +766,26 @@ fn const_version_nested_block_root_heals() {
         "##,
     );
 }
+
+#[test]
+fn loop_with_eval_does_not_storm_the_loop_jit() {
+    // A loop body containing `eval` cannot be loop-JIT-compiled (the
+    // front-end bails). The bail must be remembered via the LoopStart
+    // 1-sentinel — without it (the x86 bug this guards), the counter
+    // sitting past the threshold re-fired the aborting compiler on
+    // every iteration: ~100k aborted compiles for a 100k-iteration
+    // loop (28.5s instead of 0.16s for this shape at 100k).
+    run_test_once(
+        r##"
+        def target(x) = x + 1
+        s = 0
+        i = 0
+        while i < 2000
+          s += target(i)
+          eval("1 + 1") if i == 0
+          i += 1
+        end
+        s
+        "##,
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -1716,6 +1716,7 @@
 85e7593e9dd66c1c5a37afa22f1b7d68	"nil"	r, w = IO.pipe\n            t = Thread.new { sleep 0.2 }\n           
 85e7620ff95003251b4405ba74cbfb03	[0, 0]	path = "/tmp/mr_fsync_test.txt"\n            r = File.open(path, "w"
 85fe2b8468951fc30f0d8cabe844b706	Module	m = Module.new\n        m.class\n        
+8603e6ae1d240418c0c2c021929e70ad	2001000	def target(x) = x + 1\n        s = 0\n        i = 0\n        while i < 200
 860c557ff310749db06b9beabc01cc56	["Process::Status", 0]	IO.popen(["true"]) { |io| io.read }\n            [$?.class.to_s, $?.
 861e99795f6f1ed683e95e52e573c574	["US-ASCII"]	"abc".dup.force_encoding("US-ASCII").split("").map(&:encoding).map(&:to_s).uniq
 8634204d0d711f3c760e95c063499f29	["superclass must be an instance of Class (given an instance of Integer)", "superclass must be an instance of Class (given an instance of Integer)", "superclass must be an instance of Class (given an instance of String)", "superclass must be an instance of Class (given an instance of String)", "superclass must be an instance of Class (given an instance of Symbol)", "superclass must be an instance of Class (given an instance of Symbol)", "superclass must be an instance of Class (given an instance of Module)", "superclass must be an instance of Class (given an instance of Module)", "can't make subclass of singleton class", "can't make subclass of singleton class"]	res = []\n        [42, "s", :sym, Module.new, Object.new.singleton_class


### PR DESCRIPTION
## Problem

When a loop compile bails (the front-end refuses the body — an `eval` in it, a `Lambda`, `redo`, an unsupported shape), nothing on x86-64 recorded the failure: the `LoopStart` codeptr slot stayed 0 while the hit counter sat **past** the threshold (`jae`), so `vm_loop_start` re-fired the aborting compiler on **every single iteration**.

Repro:

```ruby
def target(x) = x + 1
s = 0; i = 0
while i < 100_000
  s += target(i)
  eval("def zz_#{i} = 1") if i % 10_000 == 0
  i += 1
end
puts s
```

| | before | after |
|---|---:|---:|
| aborted loop compiles | ~99,900 | **1** |
| wall time | 28.5 s | **0.16 s** |

## Fix

aarch64 has carried the answer all along: its `vm_loop_start` stamps the **1-sentinel** into the codeptr slot on bail ("compile bailed, interpret") and skips both the counter and the compiler when it sees it — and the shared invalidation path (`clear_loop_jit_entries`) already preserves 0/1 slots on both arches. This ports the same protocol to the x86 `vm_loop_start` / `gen_compile_loop` pair. The compiled-loop fast path stays three instructions (`cmpq rax, 1; jbe low; jmp rax` — same count as the old `test/jeq/jmp`).

## Tests

- `cargo test`: 3659 passed / 0 failed, including a new regression test (`loop_with_eval_does_not_storm_the_loop_jit`).
- Normal loop JIT unaffected: a loop without `eval` still compiles exactly once; `30k_methods` / `lee` medians unchanged.
- `cargo check --target aarch64-unknown-linux-gnu` clean (aarch64 untouched — it already had the sentinel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_