### PR TITLE
Keep a Random instance's generator live instead of replaying its stream

### DIFF
--- a/monoruby/src/builtins/random.rs
+++ b/monoruby/src/builtins/random.rs
@@ -732,6 +732,36 @@ mod tests {
     }
 
     #[test]
+    fn random_live_state() {
+        // dup / clone get their own generator (initialize_copy): the copy
+        // continues the source's stream independently, and stays == to
+        // its source only while both have drawn the same number of words.
+        run_tests(&[
+            r#"(a=Random.new(7); a.rand; b=a.dup; [a.rand(100), b.rand(100), a == b])"#,
+            r#"(a=Random.new(7); b=a.clone; x=b.rand; [x == Random.new(7).rand, a == b, a.rand == x])"#,
+            r#"(a=Random.new(9); b=a.dup; 3.times { b.rand }; [a.rand(1000), b.rand(1000)])"#,
+            r#"(a=Random.new(5); b=a.dup; a.bytes(7); b.bytes(7); a == b)"#,
+            // Bytes and shuffle/sample draw from — and advance — the same
+            // live state as rand.
+            r#"(r=Random.new(11); [r.bytes(5).bytes, r.rand(100), (1..10).to_a.shuffle(random: r), r.rand(100)])"#,
+            r#"(r=Random.new(13); [(1..20).to_a.sample(3, random: r), r.rand])"#,
+            // The private state digest tracks the generator.
+            r#"(r=Random.new(3); s0=r.send(:state); r.rand; [s0 == r.send(:state), r.send(:state) == Random.new(3).tap { |q| q.rand }.send(:state)])"#,
+            r#"(r=Random.new(2**70); r.rand(2**40); r.rand(2**40))"#,
+        ]);
+        // An allocated-but-uninitialized instance has no state ivar: the
+        // rebuild-from-(seed, count) fallback serves it.
+        run_test(
+            r#"
+        r = Random.allocate
+        a = r.rand
+        b = r.rand(10)
+        [a.is_a?(Float) && a >= 0.0 && a < 1.0, b.is_a?(Integer) && b >= 0 && b < 10, r.seed.is_a?(Integer)]
+        "#,
+        );
+    }
+
+    #[test]
     fn random_cruby_parity() {
         // Bit-identical to CRuby (run_tests compares against `ruby`):
         // seed accessor, deterministic stream, bytes, ranges, ==, eql,

--- a/monoruby/src/builtins/random.rs
+++ b/monoruby/src/builtins/random.rs
@@ -15,6 +15,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_class_func(klass, "bytes", random_bytes, 1);
     globals.define_builtin_class_func(klass, "new_seed", new_seed, 0);
     globals.define_private_builtin_func_with(klass, "initialize", random_init_m, 0, 1, false);
+    globals.define_private_builtin_func(klass, "initialize_copy", random_init_copy, 1);
     globals.define_builtin_func_with(klass, "rand", rand, 0, 1, false);
     // CRuby defines `Random::Formatter#random_number` in C (random.c) and the
     // stdlib `random/formatter` builds its helpers on it; binding it here on
@@ -30,18 +31,30 @@ pub(super) fn init(globals: &mut Globals) {
 
 // --- CRuby-compatible Mersenne-Twister helpers ---------------------------
 //
-// A per-instance `Random` stores its original seed and the number of
-// 32-bit words drawn so far in two internal ivars. Each operation
-// rebuilds the MT generator from the seed (CRuby's `init_by_array`,
-// which `rand_mt::Mt::new_with_key` implements), skips the already-drawn
-// words, performs the operation, and persists the new draw count. This
-// reproduces CRuby's exact stream without serialising MT internal state.
+// A per-instance `Random` keeps three internal ivars: its original seed
+// (`Random#seed`), the number of 32-bit words drawn so far, and the
+// generator's *live* state — the 624-word MT table plus position,
+// serialized into a binary String (`Mt::to_bytes`). Each operation
+// deserializes the state, draws, and writes the advanced state back, so
+// a draw costs O(1) regardless of how many preceded it.
+//
+// It used to persist only `(seed, count)` and rebuild the generator from
+// the seed on every call, replaying every previously drawn word — O(n)
+// per draw, quadratic over a generator's lifetime. yjit-bench `splay`
+// draws from one `Random.new(42)` forever: each iteration was slower
+// than the last (1.0 s → 1.9 s and climbing), the harness never
+// converged, and the run hit the 400 s cap. The rebuild path survives
+// as `mt_at`, the fallback for an instance whose state ivar is missing
+// (e.g. an allocated-but-uninitialized object).
 
 fn ivar_seed() -> IdentId {
     IdentId::get_id("/random_seed")
 }
 fn ivar_cnt() -> IdentId {
     IdentId::get_id("/random_cnt")
+}
+fn ivar_state() -> IdentId {
+    IdentId::get_id("/random_state")
 }
 
 fn load_state(globals: &Globals, self_: Value) -> (Value, u64) {
@@ -65,15 +78,45 @@ fn mt_at(seed: Value, cnt: u64) -> Mt {
     mt
 }
 
+/// The instance's live generator and draw count. Deserialized from the
+/// state ivar; rebuilt from `(seed, count)` only when that ivar is
+/// absent or malformed.
+fn load_mt(globals: &Globals, self_: Value) -> (Mt, u64) {
+    let (seed, cnt) = load_state(globals, self_);
+    let mt = globals
+        .store
+        .get_ivar(self_, ivar_state())
+        .and_then(|v| v.is_rstring_inner().and_then(|s| Mt::from_bytes(s.as_bytes())))
+        .unwrap_or_else(|| mt_at(seed, cnt));
+    (mt, cnt)
+}
+
+/// Persist the generator and draw count. The state String is rewritten
+/// in place when present (it is private to this instance — `dup`
+/// clones it in `initialize_copy`), else created.
+fn store_mt(globals: &mut Globals, self_: Value, mt: &Mt, cnt: u64) -> Result<()> {
+    let bytes = mt.to_bytes();
+    match globals.store.get_ivar(self_, ivar_state()) {
+        Some(mut v) if v.is_rstring_inner().is_some() => {
+            v.replace_with_inner(RStringInner::bytes(&bytes));
+        }
+        _ => {
+            globals
+                .store
+                .set_ivar(self_, ivar_state(), Value::bytes(bytes))?;
+        }
+    }
+    globals
+        .store
+        .set_ivar(self_, ivar_cnt(), Value::integer(cnt as i64))?;
+    Ok(())
+}
+
 ///
 /// A multi-draw session over one `Random` instance's generator.
 ///
-/// Because a `Random` persists only its seed and draw count, every
-/// single operation rebuilds the MT and replays it (`mt_at`). A caller
-/// that needs one draw per element — `Array#shuffle` — would make that
-/// replay quadratic, so it opens a session instead: the MT is built
-/// once, advanced across every draw, and the final word count written
-/// back by `finish`.
+/// The generator is loaded once, advanced across every draw — one per
+/// element for `Array#shuffle` — and written back by `finish`.
 ///
 pub(super) struct RandomDraw {
     receiver: Value,
@@ -83,12 +126,8 @@ pub(super) struct RandomDraw {
 
 impl RandomDraw {
     pub(super) fn new(globals: &Globals, receiver: Value) -> Self {
-        let (seed, cnt) = load_state(globals, receiver);
-        Self {
-            receiver,
-            mt: mt_at(seed, cnt),
-            cnt,
-        }
+        let (mt, cnt) = load_mt(globals, receiver);
+        Self { receiver, mt, cnt }
     }
 
     /// Uniform integer in `[0, max]` — CRuby's `rb_random_ulong_limited`
@@ -97,12 +136,9 @@ impl RandomDraw {
         ulong_limited(&mut self.mt, &mut self.cnt, max)
     }
 
-    /// Persist the advanced word count back onto the receiver.
+    /// Persist the advanced generator back onto the receiver.
     pub(super) fn finish(self, globals: &mut Globals) -> Result<()> {
-        globals
-            .store
-            .set_ivar(self.receiver, ivar_cnt(), Value::integer(self.cnt as i64))?;
-        Ok(())
+        store_mt(globals, self.receiver, &self.mt, self.cnt)
     }
 }
 
@@ -159,10 +195,41 @@ fn random_init_m(
         Some(v) => coerce_seed(vm, globals, v)?,
     };
     globals.store.set_ivar(self_, ivar_seed(), seed)?;
+    let mt = build_mt(seed);
+    // A fresh state String: never share one between instances.
+    globals
+        .store
+        .set_ivar(self_, ivar_state(), Value::bytes(mt.to_bytes()))?;
     globals
         .store
         .set_ivar(self_, ivar_cnt(), Value::integer(0))?;
     Ok(Value::nil())
+}
+
+///
+/// ### Random#initialize_copy (the #dup / #clone hook)
+///
+/// The shallow copy shares the state String with the original, and the
+/// state is advanced in place — give the copy its own so the two
+/// generators continue independently (CRuby: a dup'd Random replays the
+/// same sequence as its source from that point on).
+#[monoruby_builtin]
+fn random_init_copy(
+    _: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let self_ = lfp.self_val();
+    let src = lfp.arg(0);
+    let (mt, cnt) = load_mt(globals, src);
+    globals
+        .store
+        .set_ivar(self_, ivar_state(), Value::bytes(mt.to_bytes()))?;
+    globals
+        .store
+        .set_ivar(self_, ivar_cnt(), Value::integer(cnt as i64))?;
+    Ok(self_)
 }
 
 ///
@@ -180,8 +247,7 @@ fn inst_seed(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
 #[monoruby_builtin]
 fn inst_state(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     use std::hash::{Hash, Hasher};
-    let (seed, cnt) = load_state(globals, lfp.self_val());
-    let mt = mt_at(seed, cnt);
+    let (mt, _) = load_mt(globals, lfp.self_val());
     let mut h = std::collections::hash_map::DefaultHasher::new();
     mt.hash(&mut h);
     Ok(Value::integer(h.finish() as i64))
@@ -199,10 +265,9 @@ fn inst_eq(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) ->
     if self_.class() != other.class() {
         return Ok(Value::bool(false));
     }
-    let (sa, ca) = load_state(globals, self_);
-    let (sb, cb) = load_state(globals, other);
-    let eq = mt_at(sa, ca) == mt_at(sb, cb);
-    Ok(Value::bool(eq))
+    let (ma, _) = load_mt(globals, self_);
+    let (mb, _) = load_mt(globals, other);
+    Ok(Value::bool(ma == mb))
 }
 
 ///
@@ -306,13 +371,9 @@ fn random_rand(
 #[monoruby_builtin]
 fn rand(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
-    let (seed, cnt) = load_state(globals, self_);
-    let mut mt = mt_at(seed, cnt);
-    let mut c = cnt;
+    let (mut mt, mut c) = load_mt(globals, self_);
     let result = inst_rand_op(vm, globals, &mut mt, &mut c, lfp.try_arg(0))?;
-    globals
-        .store
-        .set_ivar(self_, ivar_cnt(), Value::integer(c as i64))?;
+    store_mt(globals, self_, &mt, c)?;
     Ok(result)
 }
 
@@ -466,16 +527,13 @@ fn instance_bytes(
         return Err(MonorubyErr::argumenterr("negative string size".to_string()));
     }
     let size = size as usize;
-    let (seed, cnt) = load_state(globals, self_);
-    let mut mt = mt_at(seed, cnt);
+    let (mut mt, cnt) = load_mt(globals, self_);
     // ceil(size/4) 32-bit words are consumed (a trailing partial word
     // still draws a full u32, matching CRuby).
     let words = size.div_ceil(4) as u64;
     let mut buf = vec![0u8; size];
     mt.fill_bytes(&mut buf);
-    globals
-        .store
-        .set_ivar(self_, ivar_cnt(), Value::integer((cnt + words) as i64))?;
+    store_mt(globals, self_, &mt, cnt + words)?;
     Ok(Value::bytes(buf))
 }
 

--- a/monoruby/src/globals/prng.rs
+++ b/monoruby/src/globals/prng.rs
@@ -365,3 +365,36 @@ impl Prng {
         self.mt.fill_bytes(dest)
     }
 }
+
+#[cfg(test)]
+mod state_bytes_tests {
+    use super::*;
+
+    #[test]
+    fn mt_state_round_trips_through_bytes() {
+        let mut mt = Mt::new_with_key(&[42]);
+        for _ in 0..1000 {
+            mt.next_u32();
+        }
+        let bytes = mt.to_bytes();
+        assert_eq!(bytes.len(), Mt::STATE_BYTES);
+        let mut back = Mt::from_bytes(&bytes).unwrap();
+        assert!(back == mt);
+        // The restored generator continues the same stream.
+        for _ in 0..2000 {
+            assert_eq!(back.next_u32(), mt.next_u32());
+        }
+    }
+
+    #[test]
+    fn mt_from_bytes_rejects_malformed_state() {
+        assert!(Mt::from_bytes(&[]).is_none());
+        assert!(Mt::from_bytes(&vec![0u8; Mt::STATE_BYTES - 1]).is_none());
+        assert!(Mt::from_bytes(&vec![0u8; Mt::STATE_BYTES + 1]).is_none());
+        // A position past the table is rejected.
+        let mut bytes = Mt::init_genrand(1).to_bytes();
+        let n = bytes.len();
+        bytes[n - 4..].copy_from_slice(&(MT_N as u32 + 1).to_le_bytes());
+        assert!(Mt::from_bytes(&bytes).is_none());
+    }
+}

--- a/monoruby/src/globals/prng.rs
+++ b/monoruby/src/globals/prng.rs
@@ -92,6 +92,39 @@ impl Mt {
         y
     }
 
+    /// Serialized size of a generator: 624 little-endian `u32` words
+    /// plus the `u32` position — the live state a `Random` instance keeps
+    /// in its `/random_state` ivar (`builtins/random.rs`).
+    pub(crate) const STATE_BYTES: usize = MT_N * 4 + 4;
+
+    /// The generator's full state as bytes (see `STATE_BYTES`).
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(Self::STATE_BYTES);
+        for w in &self.mt {
+            out.extend_from_slice(&w.to_le_bytes());
+        }
+        out.extend_from_slice(&(self.mti as u32).to_le_bytes());
+        out
+    }
+
+    /// Rebuild a generator from `to_bytes` output; `None` if the buffer
+    /// is not a well-formed state.
+    pub(crate) fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != Self::STATE_BYTES {
+            return None;
+        }
+        let mut mt = [0u32; MT_N];
+        for (i, c) in bytes[..MT_N * 4].chunks_exact(4).enumerate() {
+            mt[i] = u32::from_le_bytes([c[0], c[1], c[2], c[3]]);
+        }
+        let b = &bytes[MT_N * 4..];
+        let mti = u32::from_le_bytes([b[0], b[1], b[2], b[3]]) as usize;
+        if mti > MT_N {
+            return None;
+        }
+        Some(Self { mt, mti })
+    }
+
     /// CRuby `rb_rand_bytes`: little-endian 32-bit chunks; a trailing
     /// partial word still consumes a full draw.
     pub(crate) fn fill_bytes(&mut self, dest: &mut [u8]) {

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -2800,6 +2800,7 @@ d71c934480e135d29e482184c781d14a	[true, :PRIV]	module RcvV\n              class 
 d72491ac5b346cc00a4b205572a40779	false	ENV[""]      = nil\n            ENV["a=b"]   = nil\n            ENV.k
 d73852b1cc0988b573a8ac0d26714459	true	class C\n          def initialize; @percent = 7; @start = Time.now; end\n
 d743ebb1ae4f3634827d1cf257e34b99	[4, 8, 12, 16, 20]	(1..10).filter_map { |i| i * 2 if i.even? }
+d75925b6d715ab922640059a7e8b5f45	[true, true, true]	r = Random.allocate\n        a = r.rand\n        b = r.rand(10)\n        [
 d7727c6111808f529a320fda4e7cb48b	[[195]]	m = /#{/./}/s.match("\\303\\251".dup.force_encoding(Encoding::Windows_31J))\n      
 d774e46c066fe58e1b5886fed882b4a9	5	c = Class.new { def orig; 5; end }\n            c.class_eval { alias
 d77d6e3d33b3312be174ad8da7e0e5f2	100	::E = 100\n            \n\n          Object::E\n            


### PR DESCRIPTION
## Problem (why yjit-bench `splay` hits the 400 s cap)

A `Random` instance persisted only `(seed, words-drawn)` and **rebuilt the Mersenne Twister from the seed on every operation, replaying every word drawn so far** — O(n) per draw, quadratic over the generator's lifetime (`builtins/random.rs` `mt_at`, called from `Random#rand` / `#bytes` / `RandomDraw::new`).

`splay` draws from one `Random.new(42)` forever, so each harness iteration was slower than the last (1.0 s → 1.9 s and climbing; cachegrind: **21% of all instructions in `Mt::next_u32` replay**), the MAD convergence criterion was never met, and the run hit the cap. Micro: 5 batches of 20k draws from one instance took 1.07 s, 3.0 s, 4.9 s, 6.9 s, **8.5 s** (CRuby: 1.2 ms each). `Kernel#rand`, which keeps a live generator, was already at CRuby parity — and rewriting splay to use it removed the growth entirely, confirming the diagnosis.

## Fix

The instance now keeps its **live generator state** — the 624-word table plus position, serialized by the new `Mt::to_bytes` / `from_bytes` into a binary String in a third hidden ivar (`/random_state`) — and every operation deserializes, draws, and writes the advanced state back in place. The seed and draw count are kept as before (`Random#seed`, the `RandomDraw` session used by `Array#shuffle`/`sample`), and the old rebuild survives as the fallback for an instance with no state ivar. A new `initialize_copy` gives a dup/clone its own state String so the two generators diverge independently (CRuby semantics).

## Results

- **Byte-identical to CRuby** across `rand` / `rand(n)` / `rand(float)` / `rand(range)` / `bytes` / `shuffle(random:)` / `sample(random:)` / `dup` / `clone` / `==` / Bignum seeds (diffed script output).
- splay: iterations no longer trend upward — ~260 ms median with only the GC sawtooth; the harness converges normally.
- 100k draws from one instance: 8.5 s+ (and rising) → **95 ms**, O(1). Each draw still copies the 2.5 KB state in and out (CRuby: 6 ms); an in-place update or a native object kind is the obvious follow-up, but it is a constant factor, not the pathology.

## Tests

- `cargo test`: 3660 passed / 0 failed; ruby/spec `core/random`: 87 examples, 0 failures.
- `cargo check --target aarch64-unknown-linux-gnu` clean (arch-neutral change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_