### PR TITLE
psych stub: byte-scan the mapping-line hot paths

### DIFF
--- a/monoruby/stdlib/psych.rb
+++ b/monoruby/stdlib/psych.rb
@@ -94,7 +94,11 @@ module Psych
   # ------------------------------------------------------------------
   class Parser
     def initialize(yaml)
-      @lines = yaml.gsub("\r\n", "\n").split("\n")
+      # `gsub` with a String pattern goes through the regexp engine and
+      # scans the whole document; skip it when there is no CR at all
+      # (`include?` is a plain substring search).
+      yaml = yaml.gsub("\r\n", "\n") if yaml.include?("\r")
+      @lines = yaml.split("\n")
       @pos = 0
       @anchors = {}
     end
@@ -181,32 +185,31 @@ module Psych
     end
 
     def block_mapping_line?(line)
-      # Find the first non-leading-whitespace byte without allocating.
-      bytes = line.bytes
-      len = bytes.size
+      # Byte scan via `getbyte`: no per-line Integer array.
+      len = line.bytesize
       i = 0
-      while i < len && (bytes[i] == 0x20 || bytes[i] == 0x09)
+      while i < len && (line.getbyte(i) == 0x20 || line.getbyte(i) == 0x09)
         i += 1
       end
       return false if i == len
-      first = bytes[i]
+      first = line.getbyte(i)
       return false if first == 0x23 # '#'
-      return false if first == 0x2D && i + 1 < len && bytes[i + 1] == 0x20 # "- "
+      return false if first == 0x2D && i + 1 < len && line.getbyte(i + 1) == 0x20 # "- "
       # A block-mapping line is a key followed by ':' that is either
       # at end of line or followed by whitespace. Strings escape the
       # match (so we have to skip past balanced "..." or '...').
       while i < len
-        b = bytes[i]
+        b = line.getbyte(i)
         case b
         when 0x22 # '"'
           i += 1
-          while i < len && bytes[i] != 0x22
+          while i < len && line.getbyte(i) != 0x22
             i += 1
           end
           i += 1 # past closing "
         when 0x27 # "'"
           i += 1
-          while i < len && bytes[i] != 0x27
+          while i < len && line.getbyte(i) != 0x27
             i += 1
           end
           i += 1 # past closing '
@@ -218,7 +221,7 @@ module Psych
           if i + 1 == len
             return true
           end
-          nx = bytes[i + 1]
+          nx = line.getbyte(i + 1)
           return true if nx == 0x20 || nx == 0x09
           i += 1
         else
@@ -381,11 +384,29 @@ module Psych
           return [$1, $2]
         end
       end
-      if stripped =~ /\A(.*?)\s*:\s+(.*)\z/
-        return [$1, $2]
-      end
-      if stripped =~ /\A(.*?)\s*:\z/
-        return [$1, nil]
+      # The unquoted case, by byte scan — the two lazy-`.*?` regexps
+      # it replaces (`/\A(.*?)\s*:\s+(.*)\z/`, `/\A(.*?)\s*:\z/`) ran
+      # per mapping line and were the single largest cost of a load.
+      # Same matching: the first ':' followed by whitespace splits
+      # (key rstripped, value past the whitespace run); a ':' that is
+      # the last byte yields a nil value.
+      i = 0
+      len = stripped.bytesize
+      while i < len
+        if stripped.getbyte(i) == 0x3A # ':'
+          if i + 1 == len
+            return [stripped[0, i].rstrip, nil]
+          end
+          nx = stripped.getbyte(i + 1)
+          if nx == 0x20 || nx == 0x09
+            j = i + 1
+            while j < len && ((b = stripped.getbyte(j)) == 0x20 || b == 0x09)
+              j += 1
+            end
+            return [stripped[0, i].rstrip, stripped[j..-1]]
+          end
+        end
+        i += 1
       end
       [stripped, nil]
     end


### PR DESCRIPTION
## Context (why yjit-bench `psych-load` hits the 400 s cap)

`psych-load` under monoruby is **neither a hang nor a crash**: the benchmark completes with output byte-identical to CRuby+libyaml. The CI history (664 runs) shows monoruby failing 19% of the time vs YJIT 3% — and on the 2026-09-01 run **both** timed out. The cap is the warmup harness's MAD-convergence loop (0.1% target) racing the workflow's 400 s `timeout`: at ~3 s/iteration monoruby needed ~150 iterations to converge, a lottery a faster iteration wins far more often.

The constant factor came from the pure-Ruby psych stub (`stdlib/psych.rb`, standing in for libpsych). callgrind attributes the largest share of a `Psych.load` to the onigmo regexp engine (20%): two lazy-`.*?` regexps in `split_mapping_key` per mapping line, a whole-document `gsub("\r\n", "\n")` (a String pattern still goes through the regexp engine), and `block_mapping_line?` allocating an Integer Array per line for `line.bytes`.

## Change

- `split_mapping_key`: the unquoted case is now a `getbyte` scan for the first `:` followed by whitespace (or a trailing `:`), with the same key-rstrip / value-past-the-whitespace-run split the regexps produced.
- `Parser#initialize`: skip the `gsub` unless the text contains a CR (`include?` is a plain substring search).
- `block_mapping_line?`: `getbyte` loop instead of a `bytes` array.

## Results

- Output **unchanged**: byte-identical to the previous stub on the psych-load corpus and on quoted-key / trailing-colon / CRLF / `::` shapes (the corpus result equals CRuby+libyaml).
- psych-load, 10 loads of the corpus: **275–315 ms → 192–221 ms (−30%)**; full harness iteration 3.1 s → **2.2 s** locally (CRuby+YJIT: 1.65 s here) — i.e. the pure-Ruby stub now roughly matches libyaml on this workload.
- ruby/spec `library/yaml`: unchanged (24F/34E pre-existing).

## Note

While verifying I found a pre-existing stub bug unrelated to this change (left as-is to keep the PR a pure no-behavior-change speedup): a sequence under a key at the same indentation (`x:\n- 1\n- y: z`) loads as `x: nil` instead of `[1, {"y"=>"z"}]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_