### PR TITLE
Native Zlib checksums, a real Deflate/Inflate in the stub, and a 3x faster String#each_byte

### DIFF
--- a/monoruby/builtins/string.rb
+++ b/monoruby/builtins/string.rb
@@ -134,9 +134,19 @@ class String
     end
   end
 
-  def each_byte(&block)
-    return to_enum(:each_byte) unless block
-    bytes.each(&block)
+  # `rb_str_each_byte`: the length is re-read every iteration, so a
+  # block that shrinks the receiver stops early, as in CRuby. Written as
+  # a plain loop rather than `bytes.each(&block)` — that built a
+  # bytesize-element Array and a Proc per call, and the JIT inlines
+  # `bytesize` / `getbyte` / `yield` here, which makes this about 3x
+  # faster per byte.
+  def each_byte
+    return to_enum(:each_byte) { bytesize } unless block_given?
+    i = 0
+    while i < bytesize
+      yield getbyte(i)
+      i += 1
+    end
     self
   end
 

--- a/monoruby/src/builtins.rs
+++ b/monoruby/src/builtins.rs
@@ -49,6 +49,7 @@ mod symbol;
 mod thread;
 mod time;
 mod true_class;
+mod zlib;
 
 #[cfg(target_arch = "x86_64")]
 use crate::codegen::jitgen::AbstractState;
@@ -142,6 +143,7 @@ pub(crate) fn init_builtins(globals: &mut Globals) {
     set::init(globals);
     json::init(globals);
     digest::init(globals);
+    zlib::init(globals);
     main_object::init(globals);
     globals.object_class().include_module(kernel).unwrap();
 }

--- a/monoruby/src/builtins/zlib.rs
+++ b/monoruby/src/builtins/zlib.rs
@@ -1,0 +1,220 @@
+use super::*;
+use std::sync::LazyLock;
+
+//
+// Zlib checksum backend.
+//
+// `Zlib` itself is the pure-Ruby stub in `stdlib/zlib.rb` (monoruby cannot
+// load zlib.so). Its `Zlib.crc32` / `Zlib.adler32` used to be Ruby loops
+// over `each_byte` — 50 ns a byte, against the 0.3 ns of zlib's table
+// walk — and chunky_png runs a CRC over every 170 KB IDAT it writes. The
+// stub keeps the argument semantics (`nil`, `to_str`, the 32-bit mask on
+// the seed) and hands the byte walk to these two helpers, the same split
+// as `String.__digest` for `Digest`.
+//
+
+pub(super) fn init(globals: &mut Globals) {
+    globals.define_builtin_class_func(STRING_CLASS, "__crc32", crc32, 2);
+    globals.define_builtin_class_func(STRING_CLASS, "__adler32", adler32, 2);
+}
+
+/// String.__crc32(data, crc) -> Integer
+///
+/// zlib's `crc32(crc, data)`: `data` must be a String and `crc` an
+/// Integer already reduced to 32 bits.
+#[monoruby_builtin]
+fn crc32(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let data_v = lfp.arg(0);
+    let data = data_v.expect_bytes(&globals.store)?;
+    let seed = lfp.arg(1).expect_integer(&globals.store)? as u32;
+    Ok(Value::integer(crc32_update(seed, data) as i64))
+}
+
+/// String.__adler32(data, adler) -> Integer
+///
+/// zlib's `adler32(adler, data)`, same contract as `__crc32`.
+#[monoruby_builtin]
+fn adler32(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let data_v = lfp.arg(0);
+    let data = data_v.expect_bytes(&globals.store)?;
+    let seed = lfp.arg(1).expect_integer(&globals.store)? as u32;
+    Ok(Value::integer(adler32_update(seed, data) as i64))
+}
+
+/// Slicing-by-8 tables for the reflected CRC-32 (polynomial 0xEDB88320):
+/// `TABLES[k][b]` is the CRC contribution of byte `b` sitting `k` bytes
+/// before the end of an 8-byte word.
+static CRC_TABLES: LazyLock<[[u32; 256]; 8]> = LazyLock::new(|| {
+    let mut t = [[0u32; 256]; 8];
+    for i in 0..256u32 {
+        let mut c = i;
+        for _ in 0..8 {
+            c = if c & 1 == 1 { 0xEDB8_8320 ^ (c >> 1) } else { c >> 1 };
+        }
+        t[0][i as usize] = c;
+    }
+    for k in 1..8 {
+        for i in 0..256 {
+            let prev = t[k - 1][i];
+            t[k][i] = t[0][(prev & 0xff) as usize] ^ (prev >> 8);
+        }
+    }
+    t
+});
+
+/// `crc32(crc, buf, len)`: continue the CRC-32 `crc` over `data`.
+pub(crate) fn crc32_update(crc: u32, data: &[u8]) -> u32 {
+    let t = &*CRC_TABLES;
+    let mut crc = !crc;
+    let mut chunks = data.chunks_exact(8);
+    for c in &mut chunks {
+        let lo = u32::from_le_bytes([c[0], c[1], c[2], c[3]]) ^ crc;
+        let hi = u32::from_le_bytes([c[4], c[5], c[6], c[7]]);
+        crc = t[7][(lo & 0xff) as usize]
+            ^ t[6][((lo >> 8) & 0xff) as usize]
+            ^ t[5][((lo >> 16) & 0xff) as usize]
+            ^ t[4][(lo >> 24) as usize]
+            ^ t[3][(hi & 0xff) as usize]
+            ^ t[2][((hi >> 8) & 0xff) as usize]
+            ^ t[1][((hi >> 16) & 0xff) as usize]
+            ^ t[0][(hi >> 24) as usize];
+    }
+    for &b in chunks.remainder() {
+        crc = t[0][((crc ^ b as u32) & 0xff) as usize] ^ (crc >> 8);
+    }
+    !crc
+}
+
+/// `adler32(adler, buf, len)`: continue the Adler-32 `adler` over `data`.
+pub(crate) fn adler32_update(adler: u32, data: &[u8]) -> u32 {
+    const BASE: u32 = 65521;
+    // The largest run of bytes whose sums stay inside a u32 (zlib's NMAX).
+    const NMAX: usize = 5552;
+    let mut a = adler & 0xffff;
+    let mut b = (adler >> 16) & 0xffff;
+    for run in data.chunks(NMAX) {
+        for &byte in run {
+            a += byte as u32;
+            b += a;
+        }
+        a %= BASE;
+        b %= BASE;
+    }
+    (b << 16) | a
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::*;
+
+    fn crc32_naive(crc: u32, data: &[u8]) -> u32 {
+        let mut c = !crc;
+        for &b in data {
+            c ^= b as u32;
+            for _ in 0..8 {
+                c = if c & 1 == 1 { 0xEDB8_8320 ^ (c >> 1) } else { c >> 1 };
+            }
+        }
+        !c
+    }
+
+    fn adler32_naive(adler: u32, data: &[u8]) -> u32 {
+        let mut a = (adler & 0xffff) as u64;
+        let mut b = ((adler >> 16) & 0xffff) as u64;
+        for &byte in data {
+            a = (a + byte as u64) % 65521;
+            b = (b + a) % 65521;
+        }
+        ((b as u32) << 16) | a as u32
+    }
+
+    #[test]
+    fn checksums_match_the_reference_values() {
+        assert_eq!(crc32_update(0, b"123456789"), 0xCBF4_3926);
+        assert_eq!(crc32_update(0, b""), 0);
+        assert_eq!(adler32_update(1, b"Wikipedia"), 0x11E6_0398);
+        assert_eq!(adler32_update(1, b""), 1);
+    }
+
+    #[test]
+    fn sliced_crc_and_chunked_adler_agree_with_the_byte_loops() {
+        // Every remainder length around the 8-byte slice, a seed, and a
+        // run long enough to cross the Adler NMAX boundary.
+        let data: Vec<u8> = (0..20_000u32)
+            .map(|i| (i.wrapping_mul(2654435761) >> 13) as u8)
+            .collect();
+        for len in (0..40).chain([5551, 5552, 5553, 11104, 20_000]) {
+            let d = &data[..len];
+            assert_eq!(crc32_update(0, d), crc32_naive(0, d), "crc len {len}");
+            assert_eq!(crc32_update(0xDEAD_BEEF, d), crc32_naive(0xDEAD_BEEF, d), "crc seed len {len}");
+            assert_eq!(adler32_update(1, d), adler32_naive(1, d), "adler len {len}");
+            assert_eq!(adler32_update(0x1234_5678, d), adler32_naive(0x1234_5678, d), "adler seed len {len}");
+        }
+        // Splitting a run continues the checksum exactly.
+        let (l, r) = data.split_at(777);
+        assert_eq!(crc32_update(crc32_update(0, l), r), crc32_update(0, &data));
+        assert_eq!(adler32_update(adler32_update(1, l), r), adler32_update(1, &data));
+    }
+
+    #[test]
+    fn zlib_checksums() {
+        run_tests(&[
+            r#"require "zlib"; [Zlib.crc32, Zlib.adler32, Zlib.crc32(nil), Zlib.crc32(nil, 5), Zlib.adler32(nil, 5), Zlib.crc32("", 5), Zlib.adler32("", 5)]"#,
+            r#"require "zlib"; [Zlib.crc32("abc"), Zlib.adler32("abc"), Zlib.crc32("abc", 2**32 - 1), Zlib.crc32("abc", 2**32), Zlib.crc32("abc", 2**40 + 7), Zlib.crc32("abc", -1), Zlib.crc32("abc", 1.5)]"#,
+            r#"require "zlib"; [Zlib.crc32("あ"), Zlib.adler32("あ"), Zlib.crc32("abc", Zlib.crc32("IDAT"))]"#,
+            r#"require "zlib"; o = Object.new; def o.to_str; "abc"; end; [Zlib.crc32(o), Zlib.adler32(o)]"#,
+            r#"require "zlib"; s = ("x" * 7000) + (0..255).map(&:chr).join; [Zlib.crc32(s), Zlib.adler32(s), Zlib.crc32(s, Zlib.crc32(s))]"#,
+            r#"require "zlib"; a = "abc" * 10; b = "defg" * 500; [Zlib.crc32_combine(Zlib.crc32(a), Zlib.crc32(b), b.bytesize) == Zlib.crc32(a + b), Zlib.adler32_combine(Zlib.adler32(a), Zlib.adler32(b), b.bytesize) == Zlib.adler32(a + b), Zlib.crc32_combine(7, 9, 0), Zlib.adler32_combine(7, 9, 0)]"#,
+        ]);
+        run_test_error(r#"require "zlib"; Zlib.crc32("abc", "1")"#);
+        run_test_error(r#"require "zlib"; Zlib.crc32(123)"#);
+        run_test_error(r#"require "zlib"; Zlib.adler32(:abc)"#);
+    }
+
+    #[test]
+    fn zlib_deflate_stored() {
+        // Up to one stored block the NO_COMPRESSION output is
+        // byte-identical to CRuby's. Past that zlib splits where its
+        // caller's output buffer happens to end, so only the framing,
+        // the trailer and the round trip are compared. The other levels
+        // differ in the header's FLEVEL bits alone, which is all a
+        // stored stream can carry of them.
+        run_tests(&[
+            r#"require "zlib"; [0, 1, 5, 100, 65530].map { |n| s = "x" * n; d = Zlib::Deflate.deflate(s, 0); [d.bytesize, d.encoding.name, d[0, 7].unpack("C*"), d[-4..].unpack("C*"), Zlib::Inflate.inflate(d) == s] }"#,
+            r#"require "zlib"; [65531, 65532, 70000, 200000].map { |n| s = "x" * n; d = Zlib::Deflate.deflate(s, 0); [d.encoding.name, d[0, 3].unpack("C*"), d[-4..].unpack("C*"), Zlib::Inflate.inflate(d) == s] }"#,
+            r#"require "zlib"; s = (0..255).map(&:chr).join * 3; d = Zlib::Deflate.deflate(s, Zlib::NO_COMPRESSION); [d == Zlib::Deflate.deflate(s, 0), Zlib::Inflate.inflate(d) == s.b, Zlib::Inflate.inflate(d).encoding.name]"#,
+            r#"require "zlib"; [-1, 0, 1, 2, 5, 6, 7, 9, nil].map { |l| d = l.nil? ? Zlib::Deflate.deflate("abc") : Zlib::Deflate.deflate("abc", l); [d[0, 2].unpack("C*"), Zlib::Inflate.inflate(d)] }"#,
+            r#"require "zlib"; d = Zlib::Deflate.new(Zlib::NO_COMPRESSION); d << "abc"; r = [d.finished?, d.total_in]; d << "def"; out = d.finish; r << d.finished? << d.total_out; d.close; r << d.closed?; [out.unpack("C*"), r]"#,
+            r#"require "zlib"; d = Zlib::Deflate.new(0); out = d.deflate("hello", Zlib::FINISH); [out.unpack("C*"), Zlib::Inflate.inflate(out)]"#,
+            r#"require "zlib"; o = Object.new; def o.to_str; "abc"; end; Zlib::Inflate.inflate(Zlib::Deflate.deflate(o, 0))"#,
+        ]);
+        run_test_error(r#"require "zlib"; Zlib::Deflate.deflate("abc", 10)"#);
+        run_test_error(r#"require "zlib"; Zlib::Deflate.deflate("abc", -2)"#);
+        run_test_error(r#"require "zlib"; Zlib::Deflate.deflate(nil)"#);
+        run_test_error(r#"require "zlib"; Zlib::Deflate.deflate(123)"#);
+        // A closed stream answers nothing but `closed?`.
+        run_test_error(r#"require "zlib"; d = Zlib::Deflate.new; d.close; d.finished?"#);
+        run_test_error(r#"require "zlib"; d = Zlib::Deflate.new; d.close; d << "x""#);
+    }
+
+    #[test]
+    fn zlib_inflate() {
+        // Streams a real zlib produced: a fixed-Huffman block, a
+        // dynamic-Huffman block, and stored blocks with a multi-block
+        // split. Each is decoded and compared with its plaintext.
+        run_tests(&[
+            r#"require "zlib"; Zlib::Inflate.inflate([120, 156, 203, 72, 205, 201, 201, 87, 200, 64, 39, 117, 20, 202, 243, 139, 114, 82, 20, 1, 184, 181, 11, 70].pack("C*"))"#,
+            r#"require "zlib"; text = (1..20).map { |i| "line #{i}: #{i * i} #{(i * 7919) % 1000}\n" }.join; d = [120, 218, 45, 207, 203, 13, 67, 49, 8, 68, 209, 253, 171, 98, 74, 240, 240, 179, 113, 63, 89, 68, 122, 74, 255, 203, 96, 153, 229, 69, 8, 29, 222, 239, 239, 3, 110, 16, 201, 124, 222, 83, 178, 97, 88, 186, 110, 233, 70, 98, 250, 188, 101, 181, 25, 136, 25, 55, 125, 67, 28, 158, 126, 51, 54, 52, 224, 180, 155, 179, 14, 37, 76, 245, 230, 218, 8, 131, 186, 220, 204, 141, 69, 200, 228, 77, 142, 58, 61, 6, 152, 163, 7, 71, 37, 172, 97, 187, 88, 48, 154, 65, 90, 70, 61, 152, 68, 90, 227, 120, 116, 25, 88, 209, 60, 30, 95, 1, 231, 106, 32, 227, 128, 3, 115, 52, 145, 101, 148, 149, 8, 105, 36, 75, 169, 98, 112, 107, 38, 243, 60, 69, 88, 52, 84, 10, 106, 5, 213, 53, 158, 63, 235, 56, 74, 2].pack("C*"); [Zlib::Inflate.inflate(d) == text, Zlib::Inflate.inflate(d).encoding.name]"#,
+            r#"require "zlib"; s = ("ab" * 40000) + "\x00\xff".b * 10; d = Zlib::Deflate.deflate(s, 0); i = Zlib::Inflate.new; i << d[0, 1000]; i << d[1000..]; out = i.finish; i.close; [out == s.b, out.bytesize, i.closed?]"#,
+            r#"require "zlib"; Zlib::Inflate.inflate("\x78\x01\x01\x03\x00\xfc\xffabc\x02\x4d\x01\x27".b)"#,
+            r#"require "zlib"; [Zlib::Inflate.inflate("\x78\x01\x03\x00\x00\x00\x00\x01".b), Zlib::Inflate.inflate(Zlib::Deflate.deflate("", 0))]"#,
+        ]);
+        // Bad header, bad Adler-32, truncated stream, preset dictionary.
+        run_test_error(r#"require "zlib"; Zlib::Inflate.inflate("garbage")"#);
+        run_test_error(r#"require "zlib"; Zlib::Inflate.inflate("\x78\x01\x01\x03\x00\xfc\xffabc\x02\x4d\x01\x28".b)"#);
+        run_test_error(r#"require "zlib"; Zlib::Inflate.inflate("\x78\x01\x01\x03\x00\xfc\xffab".b)"#);
+        run_test_error(r#"require "zlib"; Zlib::Inflate.inflate("\x78\x20\x01\x03\x00\xfc\xffabc\x02\x4d\x01\x27".b)"#);
+        run_test_error(r#"require "zlib"; Zlib::Inflate.inflate(nil)"#);
+    }
+}

--- a/monoruby/stdlib/zlib.rb
+++ b/monoruby/stdlib/zlib.rb
@@ -1,9 +1,25 @@
-# Minimal Zlib stub for monoruby.
+# Zlib for monoruby.
 #
-# Zlib is a C extension (zlib.so) that monoruby cannot load. ActiveRecord
-# only uses Zlib.crc32 for a couple of hash helpers (fixtures.rb,
-# migration.rb), so this stub provides a pure-Ruby CRC-32 plus no-op
-# versions of the surface area commonly referenced by Rails.
+# Zlib is a C extension (zlib.so) that monoruby cannot load, so this file
+# provides the module in Ruby. What it offers:
+#
+# - `Zlib.crc32` / `Zlib.adler32` (and the `_combine` variants) with the
+#   real argument semantics, over the native byte walk in
+#   `src/builtins/zlib.rs` (`String.__crc32` / `String.__adler32`).
+# - `Zlib::Deflate`, which writes a genuine zlib stream — header, stored
+#   (uncompressed) deflate blocks, Adler-32 trailer — that any zlib can
+#   inflate. No compression is performed at any level; the level only
+#   picks the header's FLEVEL bits and is validated as zlib would.
+# - `Zlib::Inflate`, a complete RFC 1951 decoder (stored, fixed-Huffman
+#   and dynamic-Huffman blocks) inside the RFC 1950 wrapper, so streams
+#   produced by a real zlib (PNG image data, compressed text chunks)
+#   decode correctly.
+# - The streaming `Deflate.new` / `Inflate.new` objects, buffered: input
+#   accumulates and the whole stream is processed at `finish`.
+#
+# Not provided: gzip framing (`GzipReader` / `GzipWriter` fall back to a
+# plain file), preset dictionaries, and incremental output before
+# `finish`.
 
 module Zlib
   VERSION = "3.1.0"
@@ -67,52 +83,477 @@ module Zlib
   class StreamEnd < Error; end
   class InProgressError < Error; end
 
-  # Standard CRC-32 (polynomial 0xEDB88320), computed lazily.
-  CRC_TABLE = begin
-    table = Array.new(256)
-    256.times do |i|
-      c = i
-      8.times { c = (c & 1 == 1 ? (0xEDB88320 ^ (c >> 1)) : (c >> 1)) }
-      table[i] = c
+  # ---------------------------------------------------------------------
+  # Checksums
+  #
+  # `do_checksum` in zlib.c: the seed is `NUM2ULONG`'d (so it is reduced
+  # to 32 bits and a Float is truncated), a nil string yields the
+  # checksum of nothing regardless of the seed (0 for CRC-32, 1 for
+  # Adler-32), anything else goes through `to_str`.
+
+  def self.crc32(string = nil, crc = nil)
+    if string.nil?
+      0
+    else
+      String.__crc32(__checksum_input(string), crc.nil? ? 0 : __checksum_seed(crc))
     end
-    table.freeze
   end
 
-  def self.crc32(string = "", crc = 0)
-    c = crc ^ 0xFFFFFFFF
-    string.to_s.each_byte do |b|
-      c = CRC_TABLE[(c ^ b) & 0xFF] ^ (c >> 8)
+  def self.adler32(string = nil, adler = nil)
+    if string.nil?
+      1
+    else
+      String.__adler32(__checksum_input(string), adler.nil? ? 1 : __checksum_seed(adler))
     end
-    c ^ 0xFFFFFFFF
   end
 
-  def self.adler32(string = "", adler = 1)
-    s1 = adler & 0xFFFF
-    s2 = (adler >> 16) & 0xFFFF
-    string.to_s.each_byte do |b|
-      s1 = (s1 + b) % 65521
-      s2 = (s2 + s1) % 65521
+  def self.__checksum_input(string)
+    return string if string.is_a?(String)
+    converted = String.try_convert(string)
+    if converted.nil?
+      raise TypeError, "no implicit conversion of #{string.nil? ? "nil" : string.class} into String"
     end
-    (s2 << 16) | s1
+    converted
   end
 
+  def self.__checksum_seed(seed)
+    unless seed.is_a?(Integer)
+      seed = seed.to_int if seed.is_a?(Float)
+      unless seed.is_a?(Integer)
+        raise TypeError, "no implicit conversion of #{seed.class} into Integer"
+      end
+    end
+    seed & 0xFFFFFFFF
+  end
+
+  # `crc32_combine` (crc32.c): advance `crc1` over `len2` zero bytes with
+  # GF(2) matrix exponentiation, then fold `crc2` in (a zero `len2`
+  # still folds, as in zlib 1.3).
   def self.crc32_combine(crc1, crc2, len2)
+    len2 = 0 if len2 < 0
+    odd = Array.new(32, 0)
+    even = Array.new(32, 0)
+    odd[0] = 0xEDB88320
+    row = 1
+    n = 1
+    while n < 32
+      odd[n] = row
+      row <<= 1
+      n += 1
+    end
+    __gf2_matrix_square(even, odd)
+    __gf2_matrix_square(odd, even)
+    loop do
+      __gf2_matrix_square(even, odd)
+      crc1 = __gf2_matrix_times(even, crc1) if len2 & 1 == 1
+      len2 >>= 1
+      break if len2 == 0
+      __gf2_matrix_square(odd, even)
+      crc1 = __gf2_matrix_times(odd, crc1) if len2 & 1 == 1
+      len2 >>= 1
+      break if len2 == 0
+    end
     crc1 ^ crc2
   end
 
-  def self.adler32_combine(adler1, adler2, len2)
-    adler1 ^ adler2
+  def self.__gf2_matrix_times(mat, vec)
+    sum = 0
+    i = 0
+    while vec != 0
+      sum ^= mat[i] if vec & 1 == 1
+      vec >>= 1
+      i += 1
+    end
+    sum
   end
 
-  class Deflate
-    def self.deflate(string, level = nil)
-      string.dup
+  def self.__gf2_matrix_square(square, mat)
+    n = 0
+    while n < 32
+      square[n] = __gf2_matrix_times(mat, mat[n])
+      n += 1
     end
   end
 
-  class Inflate
+  # `adler32_combine` (adler32.c).
+  def self.adler32_combine(adler1, adler2, len2)
+    base = 65521
+    return 0xFFFFFFFF if len2 < 0
+    rem = len2 % base
+    sum1 = adler1 & 0xFFFF
+    sum2 = (rem * sum1) % base
+    sum1 += (adler2 & 0xFFFF) + base - 1
+    sum2 += ((adler1 >> 16) & 0xFFFF) + ((adler2 >> 16) & 0xFFFF) + base - rem
+    sum1 -= base if sum1 >= base
+    sum1 -= base if sum1 >= base
+    sum2 -= base << 1 if sum2 >= base << 1
+    sum2 -= base if sum2 >= base
+    sum1 | (sum2 << 16)
+  end
+
+  # ---------------------------------------------------------------------
+  # Deflate — stored blocks only.
+
+  class ZStream
+    def initialize
+      @input = "".b
+      @output = nil
+      @closed = false
+      @finished = false
+    end
+
+    def <<(string)
+      __check_open
+      @input << __coerce_string(string).b
+      self
+    end
+
+    def finish
+      __check_open
+      __finish_stream unless @finished
+      @finished = true
+      @output
+    end
+
+    def finished?
+      __check_open
+      @finished
+    end
+    alias stream_end? finished?
+
+    def close
+      @closed = true
+      nil
+    end
+    alias end close
+
+    def closed?
+      @closed
+    end
+    alias ended? closed?
+
+    def reset
+      __check_open
+      @input = "".b
+      @output = nil
+      @finished = false
+      nil
+    end
+
+    def total_in
+      __check_open
+      @input.bytesize
+    end
+
+    def total_out
+      __check_open
+      @output ? @output.bytesize : 0
+    end
+
+    private
+
+    # Everything but `closed?` is an error on a closed stream
+    # (`zstream_ensure_valid` in zlib.c).
+    def __check_open
+      raise Zlib::Error, "stream is not ready" if @closed
+    end
+
+    def __coerce_string(string)
+      return string if string.is_a?(String)
+      converted = String.try_convert(string)
+      if converted.nil?
+        raise TypeError, "no implicit conversion of #{string.nil? ? "nil" : string.class} into String"
+      end
+      converted
+    end
+  end
+
+  class Deflate < ZStream
+    # The largest stored block zlib itself emits when its output buffer
+    # allows (deflate_stored keeps four bytes of the 65535 maximum for
+    # the pending block header), so up to this size the
+    # `deflate(s, NO_COMPRESSION)` output is byte-identical to CRuby's.
+    STORED_BLOCK_MAX = 65531
+
+    def self.deflate(string, level = DEFAULT_COMPRESSION)
+      d = new(level)
+      d << string
+      d.finish
+    end
+
+    def initialize(level = DEFAULT_COMPRESSION, window_bits = MAX_WBITS,
+                   mem_level = DEF_MEM_LEVEL, strategy = DEFAULT_STRATEGY)
+      super()
+      level = __to_level(level)
+      raise Zlib::StreamError, "stream error" if level < -1 || level > 9
+      @level = level
+    end
+
+    def deflate(string, flush = NO_FLUSH)
+      self << string
+      flush == FINISH ? finish : "".b
+    end
+
+    def flush(flush = SYNC_FLUSH)
+      flush == FINISH ? finish : "".b
+    end
+
+    private
+
+    def __to_level(level)
+      return level if level.is_a?(Integer)
+      return DEFAULT_COMPRESSION if level.nil?
+      unless level.respond_to?(:to_int)
+        raise TypeError, "no implicit conversion of #{level.class} into Integer"
+      end
+      level.to_int
+    end
+
+    # RFC 1950 header, RFC 1951 stored blocks, Adler-32 trailer.
+    def __finish_stream
+      data = @input
+      out = "".b
+      flevel = case @level
+               when 0, 1 then 0
+               when 2, 3, 4, 5 then 1
+               when 7, 8, 9 then 3
+               else 2
+               end
+      cmf = 0x78
+      flg = flevel << 6
+      flg += 31 - ((cmf << 8) | flg) % 31
+      out << cmf.chr << flg.chr
+      size = data.bytesize
+      pos = 0
+      loop do
+        len = size - pos
+        len = STORED_BLOCK_MAX if len > STORED_BLOCK_MAX
+        final = pos + len >= size
+        out << (final ? 1 : 0).chr
+        out << (len & 0xFF).chr << (len >> 8).chr
+        nlen = len ^ 0xFFFF
+        out << (nlen & 0xFF).chr << (nlen >> 8).chr
+        out << data.byteslice(pos, len) if len > 0
+        pos += len
+        break if final
+      end
+      out << [Zlib.adler32(data)].pack("N")
+      @output = out
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Inflate — a complete RFC 1951 decoder (after Mark Adler's puff.c).
+
+  class Inflate < ZStream
     def self.inflate(string)
-      string.dup
+      i = new
+      i << string
+      i.finish
+    end
+
+    def initialize(window_bits = MAX_WBITS)
+      super()
+    end
+
+    def inflate(string = nil)
+      self << string unless string.nil?
+      "".b
+    end
+
+    def sync_point?
+      false
+    end
+
+    private
+
+    # Base lengths / distances and their extra-bit counts, indexed by
+    # symbol (RFC 1951 §3.2.5).
+    LENGTH_BASE = [3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31,
+                   35, 43, 51, 59, 67, 83, 99, 115, 131, 163, 195, 227, 258].freeze
+    LENGTH_EXTRA = [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2,
+                    3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0].freeze
+    DIST_BASE = [1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193,
+                 257, 385, 513, 769, 1025, 1537, 2049, 3073, 4097, 6145,
+                 8193, 12289, 16385, 24577].freeze
+    DIST_EXTRA = [0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6,
+                  7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13].freeze
+    # Order in which code-length code lengths are transmitted.
+    CLEN_ORDER = [16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15].freeze
+
+    # The fixed-Huffman tables (§3.2.6), built once.
+    FIXED_TABLES = begin
+      lengths = Array.new(288)
+      288.times do |i|
+        lengths[i] = if i < 144 then 8
+                     elsif i < 256 then 9
+                     elsif i < 280 then 7
+                     else 8
+                     end
+      end
+      [lengths, Array.new(30, 5)]
+    end
+
+    def __finish_stream
+      @data = @input
+      @pos = 0
+      @bitbuf = 0
+      @bitcnt = 0
+      size = @data.bytesize
+      raise Zlib::BufError, "buffer error" if size < 2
+      cmf = @data.getbyte(0)
+      flg = @data.getbyte(1)
+      if ((cmf << 8) | flg) % 31 != 0 || cmf & 0x0F != 8 || (cmf >> 4) > 7
+        raise Zlib::DataError, "incorrect header check"
+      end
+      raise Zlib::NeedDict, "need dictionary" if flg & 0x20 != 0
+      @pos = 2
+      out = "".b
+      loop do
+        final = __bits(1)
+        case __bits(2)
+        when 0 then __stored(out)
+        when 1 then __codes(out, __huffman(FIXED_TABLES[0]), __huffman(FIXED_TABLES[1]))
+        when 2 then __dynamic(out)
+        else raise Zlib::DataError, "invalid block type"
+        end
+        break if final == 1
+      end
+      # Drop to a byte boundary, then check the Adler-32 trailer.
+      @bitbuf = 0
+      @bitcnt = 0
+      raise Zlib::BufError, "buffer error" if @pos + 4 > size
+      expected = (@data.getbyte(@pos) << 24) | (@data.getbyte(@pos + 1) << 16) |
+                 (@data.getbyte(@pos + 2) << 8) | @data.getbyte(@pos + 3)
+      raise Zlib::DataError, "incorrect data check" if Zlib.adler32(out) != expected
+      @output = out
+    end
+
+    def __bits(need)
+      while @bitcnt < need
+        b = @data.getbyte(@pos)
+        raise Zlib::BufError, "buffer error" if b.nil?
+        @pos += 1
+        @bitbuf |= b << @bitcnt
+        @bitcnt += 8
+      end
+      v = @bitbuf & ((1 << need) - 1)
+      @bitbuf >>= need
+      @bitcnt -= need
+      v
+    end
+
+    def __stored(out)
+      @bitbuf = 0
+      @bitcnt = 0
+      raise Zlib::BufError, "buffer error" if @pos + 4 > @data.bytesize
+      len = @data.getbyte(@pos) | (@data.getbyte(@pos + 1) << 8)
+      nlen = @data.getbyte(@pos + 2) | (@data.getbyte(@pos + 3) << 8)
+      raise Zlib::DataError, "invalid stored block lengths" if len != (nlen ^ 0xFFFF)
+      @pos += 4
+      raise Zlib::BufError, "buffer error" if @pos + len > @data.bytesize
+      out << @data.byteslice(@pos, len)
+      @pos += len
+    end
+
+    # Canonical Huffman table from code lengths: `[count, symbol]`, where
+    # `count[len]` is how many codes have that length and `symbol` lists
+    # the symbols in code order.
+    def __huffman(lengths)
+      count = Array.new(16, 0)
+      lengths.each { |l| count[l] += 1 }
+      count[0] = 0
+      offs = Array.new(16, 0)
+      len = 1
+      while len < 15
+        offs[len + 1] = offs[len] + count[len]
+        len += 1
+      end
+      symbol = Array.new(lengths.size, 0)
+      lengths.each_with_index do |l, s|
+        next if l == 0
+        symbol[offs[l]] = s
+        offs[l] += 1
+      end
+      [count, symbol]
+    end
+
+    def __decode(table)
+      count, symbol = table
+      code = 0
+      first = 0
+      index = 0
+      len = 1
+      while len <= 15
+        code |= __bits(1)
+        c = count[len]
+        return symbol[index + (code - first)] if code - c < first
+        index += c
+        first += c
+        first <<= 1
+        code <<= 1
+        len += 1
+      end
+      raise Zlib::DataError, "invalid code"
+    end
+
+    def __codes(out, lencode, distcode)
+      loop do
+        sym = __decode(lencode)
+        if sym < 256
+          out << sym.chr
+        elsif sym == 256
+          return
+        else
+          sym -= 257
+          raise Zlib::DataError, "invalid literal/length code" if sym >= 29
+          len = LENGTH_BASE[sym] + __bits(LENGTH_EXTRA[sym])
+          dsym = __decode(distcode)
+          raise Zlib::DataError, "invalid distance code" if dsym >= 30
+          dist = DIST_BASE[dsym] + __bits(DIST_EXTRA[dsym])
+          raise Zlib::DataError, "invalid distance too far back" if dist > out.bytesize
+          start = out.bytesize - dist
+          if dist >= len
+            out << out.byteslice(start, len)
+          else
+            # Overlapping copy: the run repeats itself.
+            len.times { |k| out << out.getbyte(start + k).chr }
+          end
+        end
+      end
+    end
+
+    def __dynamic(out)
+      nlen = __bits(5) + 257
+      ndist = __bits(5) + 1
+      ncode = __bits(4) + 4
+      raise Zlib::DataError, "too many length or distance symbols" if nlen > 286 || ndist > 30
+      lengths = Array.new(19, 0)
+      ncode.times { |i| lengths[CLEN_ORDER[i]] = __bits(3) }
+      lencode = __huffman(lengths)
+      lengths = []
+      while lengths.size < nlen + ndist
+        sym = __decode(lencode)
+        if sym < 16
+          lengths << sym
+        else
+          if sym == 16
+            raise Zlib::DataError, "invalid bit length repeat" if lengths.empty?
+            rep = lengths.last
+            n = 3 + __bits(2)
+          elsif sym == 17
+            rep = 0
+            n = 3 + __bits(3)
+          else
+            rep = 0
+            n = 11 + __bits(7)
+          end
+          raise Zlib::DataError, "invalid bit length repeat" if lengths.size + n > nlen + ndist
+          n.times { lengths << rep }
+        end
+      end
+      raise Zlib::DataError, "invalid code -- missing end-of-block" if lengths[256] == 0
+      __codes(out, __huffman(lengths[0, nlen]), __huffman(lengths[nlen, ndist]))
     end
   end
 


### PR DESCRIPTION
## What

chunky_png runs `Zlib.crc32` over every 170 KB IDAT it writes, and the pure-Ruby stub computed it as an `each_byte` loop: 8.7 ms per call against CRuby's 0.05 ms, about 90 ms of every 680 ms benchmark iteration.

- **`Zlib.crc32` / `Zlib.adler32` walk the bytes natively** (`String.__crc32` / `String.__adler32` in `src/builtins/zlib.rs`, slicing-by-8 CRC and the NMAX-chunked Adler; the same split as `String.__digest` for `Digest`). The stub keeps zlib.c's argument semantics: a nil string yields the empty checksum whatever the seed, the seed is reduced to 32 bits and a Float truncated, anything else goes through `to_str`.
- **`crc32_combine` / `adler32_combine`** were `a ^ b`; they are now zlib's algorithms.
- **`Zlib::Deflate.deflate` returned its input unchanged**, so every PNG chunky_png wrote was corrupt. It now emits a genuine zlib stream: RFC 1950 header (FLEVEL from the level, validated as zlib does), stored blocks of 65531 bytes, Adler-32 trailer. Up to one block the `NO_COMPRESSION` output is byte-identical to CRuby's. No compression is performed at any level.
- **`Zlib::Inflate` is a complete RFC 1951 decoder** (stored, fixed- and dynamic-Huffman blocks) with the header and Adler-32 checks, so streams a real zlib produced decode: a chunky_png encode → decode round trip of a 240×180 image now succeeds. `Deflate.new` / `Inflate.new` buffer their input and process the whole stream at `finish`, which is how chunky_png drives them.
- **`String#each_byte`** is a `while` over `bytesize` / `getbyte` / `yield` instead of `bytes.each(&block)`: no bytesize-element Array, no Proc, and the JIT inlines all three. The length is re-read every iteration as `rb_str_each_byte` does (a block that shrinks the receiver stops early), and the enumerator now carries its size.

## Numbers

| | master | this PR | CRuby / YJIT |
|---|---|---|---|
| `Zlib.crc32`, 173 KB | 8.65 ms | 0.10 ms | 0.05 ms |
| `Zlib.adler32`, 173 KB | 5.69 ms | 0.05 ms | 0.06 ms |
| `String#each_byte`, per byte, `{ \|b\| s += b }` | 25.1 ns | 7.8 ns | 7.7 ns (YJIT, same loop) |
| chunky-png (ruby-bench, avg iter) | 681 ms | 527 ms | 445 ms (YJIT) |

## Tests

- Rust unit tests: the sliced CRC and chunked Adler against byte-at-a-time references at every remainder length and across the NMAX boundary, plus the reference vectors.
- `run_tests` against a live CRuby: checksum argument semantics and errors, stored-block framing and round trips, level validation, closed-stream errors, and inflating fixed-Huffman, dynamic-Huffman (a CRuby level-9 stream embedded as a fixture) and multi-block stored streams, including the bad-header, bad-Adler, truncated and preset-dictionary error cases.
- ruby/spec `library/zlib`: 92 examples with 147 failures+errors on master → 103 examples with 129. What remains is the gzip framing and the incremental streaming API (`inflate` returning partial output, `<< nil`), which the stub does not attempt.
- ruby/spec `core/string/{each_byte,bytes,getbyte}_spec.rb`: all pass.
- Full `cargo test` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_