### PR TITLE
Build interpolation results and Array#join in place, format Integers directly

### DIFF
--- a/monoruby/src/builtins/array.rs
+++ b/monoruby/src/builtins/array.rs
@@ -2059,7 +2059,15 @@ fn join(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
 
     let mut visited: HashSet<u64> = HashSet::default();
     visited.insert(ary.id());
-    let mut result: Vec<u8> = Vec::new();
+    // Size the buffer from the elements that are already Strings (the
+    // common case is all of them) plus the separators, so the join
+    // allocates once instead of growing by doubling.
+    let estimate = ary
+        .iter()
+        .map(|v| v.is_rstring_inner().map_or(8, |s| s.len()))
+        .sum::<usize>()
+        + sep_bytes.len() * ary.len().saturating_sub(1);
+    let mut result: Vec<u8> = Vec::with_capacity(estimate);
     // `None` means "nothing appended yet"; the first emitted
     // fragment seeds the running encoding (CRuby's left-wins
     // rule on 7-bit content).
@@ -2075,9 +2083,11 @@ fn join(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> R
         &mut result,
         &mut state,
     )?;
-    let final_enc = state.map(|(e, _)| e).unwrap_or(Encoding::UsAscii);
-    // Eager-classify so the join's result has its cr cached.
-    let inner = RStringInner::from_encoding_scanned(&result, final_enc);
+    // The running state carries the result's code range (the fold in
+    // `merge_join_state`), so the buffer is adopted as-is: no copy and
+    // no re-scan of the bytes just written.
+    let (final_enc, final_cr) = state.unwrap_or((Encoding::UsAscii, CodeRange::SevenBit));
+    let inner = RStringInner::from_vec_cr(result, final_enc, final_cr);
     Ok(Value::string_from_inner(inner))
 }
 
@@ -2112,14 +2122,20 @@ fn merge_join_state(
         None => return Some((other_enc, other_cr)),
     };
     let combined_enc = Encoding::compatible(cur_enc, cur_cr, other_enc, other_cr)?;
-    // Combined code range is the "max" of the two: SevenBit
-    // (both clean) < Valid (at least one carried real characters)
-    // < Broken / Unknown.
+    // The result's code range is the fold `concatenate_string_inner`
+    // uses: two well-formed sides stay well-formed, and anything
+    // involving a broken or unclassified side is left for a later scan
+    // — a broken piece can complete an earlier broken one (`"\xE3"` +
+    // `"\x81\x82"` joins to a valid `"あ"`), so `Broken` must not be
+    // recorded as final. `Encoding::compatible` only asks whether a side
+    // is 7-bit, so the negotiation sees no difference.
     let combined_cr = match (cur_cr, other_cr) {
         (CodeRange::SevenBit, CodeRange::SevenBit) => CodeRange::SevenBit,
-        (CodeRange::Broken, _) | (_, CodeRange::Broken) => CodeRange::Broken,
-        (CodeRange::Unknown, _) | (_, CodeRange::Unknown) => CodeRange::Unknown,
-        _ => CodeRange::Valid,
+        (
+            CodeRange::SevenBit | CodeRange::Valid,
+            CodeRange::SevenBit | CodeRange::Valid,
+        ) => CodeRange::Valid,
+        _ => CodeRange::Unknown,
     };
     Some((combined_enc, combined_cr))
 }
@@ -7642,6 +7658,28 @@ mod tests {
             r#"[C.new].join("-")"#,
             r#"class C; def to_ary; [1, 2]; end; end"#,
         );
+    }
+
+    #[test]
+    fn join_result_code_range_is_trusted() {
+        // The join adopts its buffer with the code range it tracked
+        // while appending, instead of re-scanning the result, so the
+        // tracked value has to be right — in particular a broken piece
+        // completed by the next one must be re-classified, not recorded
+        // as broken.
+        run_tests(&[
+            r#"a = ["\xE3".b.force_encoding("UTF-8"), "\x81\x82".b.force_encoding("UTF-8")]; j = a.join; [j.valid_encoding?, j.ascii_only?, j == "あ", j.encoding.name]"#,
+            r#"a = ["a", "\xE3".b.force_encoding("UTF-8"), "\x81\x82".b.force_encoding("UTF-8"), "b"]; j = a.join("-"); [j.valid_encoding?, j.ascii_only?, j.bytes]"#,
+            r#"j = ["abc", "あ", "def"].join; [j.valid_encoding?, j.ascii_only?, j.encoding.name, j.length]"#,
+            r#"j = ["abc", "def"].join(", "); [j.valid_encoding?, j.ascii_only?, j.encoding.name]"#,
+            r#"j = ["abc", "\xff".b.force_encoding("UTF-8")].join; [j.valid_encoding?, j.ascii_only?]"#,
+            r#"j = ["abc", "\xff".b].join; [j.valid_encoding?, j.ascii_only?, j.encoding.name]"#,
+            // Non-String elements (the size estimate is only a guess
+            // for these) and results longer than the inline buffer.
+            r#"j = [1, :sym, nil, 2.5, "x" * 40, [3, [4]]].join("/"); [j, j.bytesize, j.valid_encoding?, j.ascii_only?]"#,
+            r#"j = (["あいう"] * 20).join("、"); [j.bytesize, j.length, j.valid_encoding?, j.ascii_only?]"#,
+            r#"j = ["x"].join("あ"); [j, j.ascii_only?, j.encoding.name]"#,
+        ]);
     }
 
     #[test]

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -12055,6 +12055,38 @@ mod tests {
     }
 
     #[test]
+    fn string_interpolation_formats_integers_in_place() {
+        // A Fixnum operand is written into the result buffer directly
+        // (no intermediate `to_s` String); the text must be exactly
+        // `Integer#to_s`, and the result's encoding / code range must
+        // negotiate as a 7-bit piece would.
+        run_tests(&[
+            r##"i = 0; ["#{i}", "#{-1}", "#{42}", "#{-9007199254740993}"]"##,
+            r##"a = 2**62 - 1; b = -(2**62); c = 2**62; d = -(2**62) - 1; ["#{a}", "#{b}", "#{c}", "#{d}", "#{2**80}", "#{-(2**80)}"]"##,
+            r##"s = "n#{1}#{22}#{333}"; [s, s.encoding.name, s.ascii_only?, s.valid_encoding?, s.frozen?]"##,
+            r##"s = "あ#{1}い#{-2}う"; [s, s.encoding.name, s.ascii_only?, s.valid_encoding?, s.length]"##,
+            r##"s = "v#{1.5}#{nil}#{true}#{:sym}#{2}"; [s, s.encoding.name]"##,
+            // Results longer than the inline buffer.
+            r##"s = "#{"x" * 30}#{123456789}#{"y" * 30}"; [s.bytesize, s.ascii_only?, s.valid_encoding?, s[28, 14]]"##,
+            r##"x = "\xff".b; s = "#{x}#{7}"; [s.bytes, s.encoding.name, s.ascii_only?]"##,
+            r##"e = "abc".encode("UTF-16LE"); s = "#{e}"; [s.encoding.name, s.bytesize]"##,
+        ]);
+        // A refined `Integer#to_s` still wins over the in-place path.
+        run_test(
+            r##"
+            module IntTos
+              refine Integer do
+                def to_s; "<int>"; end
+              end
+            end
+            using IntTos
+            i = 5
+            ["#{i}", "#{-1}#{i}", "#{2**70}"]
+            "##,
+        );
+    }
+
+    #[test]
     fn string_interpolation_falls_back_when_to_s_returns_non_string() {
         // Exercises `concatenate_string_inner`'s else branch:
         // `invoke_tos` returns the user-defined `to_s` result

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -932,7 +932,7 @@ fn concatenate_string_inner(
     arg: *mut Value,
     len: usize,
 ) -> Result<Value> {
-    use crate::value::rvalue::{CodeRange, Encoding, RStringInner};
+    use crate::value::rvalue::{CodeRange, Encoding, RStringInner, StringBuf};
     // Build the result as raw bytes so invalid byte sequences in any
     // operand survive interpolation (going through a Rust `String`
     // would silently rewrite them as U+FFFD via `from_utf8_lossy`).
@@ -954,53 +954,58 @@ fn concatenate_string_inner(
     // negotiation concatenate to a well-formed whole, since the
     // non-winning encoding's bytes are 7-bit (`Encoding::compatible`
     // admits nothing else).
-    let mut bytes: Vec<u8> = Vec::new();
+    //
+    // The bytes go straight into the String's own buffer, sized up
+    // front from the operands that are already Strings (the literal
+    // fragments and most interpolated values): a short result is
+    // assembled inline and never touches the heap, a long one gets
+    // its one allocation here and is adopted as-is at the end. An
+    // Integer operand is formatted into the buffer directly — it is
+    // the most common non-String operand, and going through `to_s`
+    // meant allocating a heap String only to copy it out again.
+    let refined = vm.to_s_is_refined(globals);
+    let mut estimate = 0;
+    for i in 0..len {
+        // SAFETY: `arg` points at operand 0 of `len` operand `Value`s
+        // laid out downward.
+        let v = unsafe { *arg.sub(i) };
+        estimate += match v.is_rstring_inner() {
+            Some(s) => s.len(),
+            None => 8,
+        };
+    }
+    let mut bytes = StringBuf::with_capacity(estimate);
     let mut enc: Option<Encoding> = None;
     let mut cr = CodeRange::SevenBit; // classify("") — the fold identity
+    let mut digits = [0u8; 20];
     for i in 0..len {
         let v = unsafe { *arg.sub(i) };
+        if !refined {
+            if let Some(n) = v.try_fixnum() {
+                let piece = format_i64(&mut digits, n);
+                append_piece(
+                    globals,
+                    &mut bytes,
+                    &mut enc,
+                    &mut cr,
+                    piece,
+                    Encoding::Utf8,
+                    CodeRange::SevenBit,
+                )?;
+                continue;
+            }
+        }
         let s_val = vm.invoke_tos(globals, v)?;
         if let Some(inner) = s_val.is_rstring_inner() {
-            let piece_enc = inner.encoding();
-            enc = Some(match enc {
-                None => piece_enc,
-                Some(prev) if prev == piece_enc => prev,
-                Some(prev) => {
-                    // Replicates `RStringInner::compatible_encoding`
-                    // with the accumulated side's tracked state.
-                    let piece_cr = inner.code_range();
-                    let accum_empty = bytes.is_empty();
-                    let piece_empty = inner.is_empty();
-                    let negotiated = if accum_empty && piece_empty {
-                        Some(prev)
-                    } else if accum_empty {
-                        if prev.is_ascii_compatible() && piece_cr == CodeRange::SevenBit {
-                            Some(prev)
-                        } else {
-                            Some(piece_enc)
-                        }
-                    } else if piece_empty {
-                        Some(prev)
-                    } else {
-                        if cr == CodeRange::Unknown {
-                            cr = prev.classify(&bytes);
-                        }
-                        Encoding::compatible(prev, cr, piece_enc, piece_cr)
-                    };
-                    negotiated.ok_or_else(|| {
-                        MonorubyErr::incompatible_encoding(&globals.store, prev, piece_enc)
-                    })?
-                }
-            });
-            cr = match (cr, inner.code_range()) {
-                (CodeRange::SevenBit, CodeRange::SevenBit) => CodeRange::SevenBit,
-                (
-                    CodeRange::SevenBit | CodeRange::Valid,
-                    CodeRange::SevenBit | CodeRange::Valid,
-                ) => CodeRange::Valid,
-                _ => CodeRange::Unknown,
-            };
-            bytes.extend_from_slice(inner.as_bytes());
+            append_piece(
+                globals,
+                &mut bytes,
+                &mut enc,
+                &mut cr,
+                inner.as_bytes(),
+                inner.encoding(),
+                inner.code_range(),
+            )?;
         } else {
             // `invoke_tos` returns the user-defined `to_s` result
             // verbatim for `RV::Object` receivers, so this branch is
@@ -1022,11 +1027,84 @@ fn concatenate_string_inner(
             bytes.extend_from_slice(s.as_bytes());
         }
     }
-    Ok(Value::string_from_inner(RStringInner::from_vec_cr(
+    Ok(Value::string_from_inner(RStringInner::from_buf_cr(
         bytes,
         enc.unwrap_or(Encoding::Utf8),
         cr,
     )))
+}
+
+/// Append one interpolation operand to the growing buffer, negotiating
+/// the accumulated `(enc, cr)` with the piece's under CRuby's
+/// `compatible_encoding` rules (see `concatenate_string_inner`).
+fn append_piece(
+    globals: &Globals,
+    bytes: &mut crate::value::rvalue::StringBuf,
+    enc: &mut Option<crate::value::rvalue::Encoding>,
+    cr: &mut crate::value::rvalue::CodeRange,
+    piece: &[u8],
+    piece_enc: crate::value::rvalue::Encoding,
+    piece_cr: crate::value::rvalue::CodeRange,
+) -> Result<()> {
+    use crate::value::rvalue::{CodeRange, Encoding};
+    *enc = Some(match *enc {
+        None => piece_enc,
+        Some(prev) if prev == piece_enc => prev,
+        Some(prev) => {
+            // Replicates `RStringInner::compatible_encoding` with the
+            // accumulated side's tracked state.
+            let accum_empty = bytes.is_empty();
+            let piece_empty = piece.is_empty();
+            let negotiated = if accum_empty && piece_empty {
+                Some(prev)
+            } else if accum_empty {
+                if prev.is_ascii_compatible() && piece_cr == CodeRange::SevenBit {
+                    Some(prev)
+                } else {
+                    Some(piece_enc)
+                }
+            } else if piece_empty {
+                Some(prev)
+            } else {
+                if *cr == CodeRange::Unknown {
+                    *cr = prev.classify(bytes);
+                }
+                Encoding::compatible(prev, *cr, piece_enc, piece_cr)
+            };
+            negotiated
+                .ok_or_else(|| MonorubyErr::incompatible_encoding(&globals.store, prev, piece_enc))?
+        }
+    });
+    *cr = match (*cr, piece_cr) {
+        (CodeRange::SevenBit, CodeRange::SevenBit) => CodeRange::SevenBit,
+        (
+            CodeRange::SevenBit | CodeRange::Valid,
+            CodeRange::SevenBit | CodeRange::Valid,
+        ) => CodeRange::Valid,
+        _ => CodeRange::Unknown,
+    };
+    bytes.extend_from_slice(piece);
+    Ok(())
+}
+
+/// The decimal digits of `n` (with a leading `-` when negative) written
+/// into the tail of `buf`; the same text as `Integer#to_s`.
+fn format_i64(buf: &mut [u8; 20], n: i64) -> &[u8] {
+    let mut pos = buf.len();
+    let mut m = n.unsigned_abs();
+    loop {
+        pos -= 1;
+        buf[pos] = b'0' + (m % 10) as u8;
+        m /= 10;
+        if m == 0 {
+            break;
+        }
+    }
+    if n < 0 {
+        pos -= 1;
+        buf[pos] = b'-';
+    }
+    &buf[pos..]
 }
 
 pub(super) extern "C" fn concatenate_regexp(
@@ -2708,4 +2786,29 @@ pub extern "C" fn _check_stack(vm: &mut Executor, globals: &mut Globals) -> bool
         }
     }
     invalid
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_i64;
+
+    #[test]
+    fn format_i64_matches_to_string() {
+        let mut buf = [0u8; 20];
+        for n in [
+            0,
+            1,
+            -1,
+            9,
+            10,
+            -10,
+            42,
+            -4611686018427387904,
+            4611686018427387903,
+            i64::MAX,
+            i64::MIN,
+        ] {
+            assert_eq!(format_i64(&mut buf, n), n.to_string().as_bytes(), "{n}");
+        }
+    }
 }

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -3579,15 +3579,19 @@ impl Executor {
         res
     }
 
-    pub(crate) fn invoke_tos(&mut self, globals: &mut Globals, receiver: Value) -> Result<Value> {
-        // A refinement of the receiver's `to_s` has to be honoured here
-        // too — interpolating an Integer is the common case, and that
-        // takes the built-in shortcut below unless a refinement is in
-        // play (`doc/refinements.md` §1(d)).
-        let refined_to_s = globals.store.refinements().is_active()
+    /// Whether a refinement of `to_s` is in effect at the current frame.
+    /// While one is, the built-in `to_s` shortcuts for immediates and
+    /// Strings must not be taken — interpolating an Integer is the
+    /// common case, and it has to see the refined method
+    /// (`doc/refinements.md` §1(d)).
+    pub(crate) fn to_s_is_refined(&mut self, globals: &mut Globals) -> bool {
+        globals.store.refinements().is_active()
             && globals.store.refinements().is_refined_name(IdentId::TO_S)
-            && !self.current_refinements(globals).is_empty();
-        if !refined_to_s {
+            && !self.current_refinements(globals).is_empty()
+    }
+
+    pub(crate) fn invoke_tos(&mut self, globals: &mut Globals, receiver: Value) -> Result<Value> {
+        if !self.to_s_is_refined(globals) {
             match receiver.unpack() {
                 // String operands round-trip via `to_s` to themselves
                 // (or to whatever the user-overridden `to_s` returns),

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -37,8 +37,8 @@ pub use string::{
     STRING_TY_MAX_INLINE_SHL, STRING_TY_OFFSET, map_bytes_to_utf8,
 };
 pub(crate) use string::{
-    STRING_SHARED_TAG, check_string_not_modified, share_string_buffer, string_snapshot,
-    string_substring,
+    STRING_SHARED_TAG, StringBuf, check_string_not_modified, share_string_buffer,
+    string_snapshot, string_substring,
 };
 pub(crate) use string::{eucjp_char_width, named_byte_const_name, sjis_char_width};
 pub use struct_inner::{STRUCT_INLINE_SLOTS, StructInner};

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -708,6 +708,12 @@ struct SharedContent {
     root: Value,
 }
 
+/// The owned byte buffer of a String: inline up to `STRING_INLINE_CAP`
+/// bytes, spilled to the heap beyond. Builders that know their result
+/// lands in a String assemble it in one of these and hand it over with
+/// `RStringInner::from_buf_cr`, so short results never allocate.
+pub(crate) type StringBuf = SmallVec<[u8; STRING_INLINE_CAP]>;
+
 /// Byte storage of a Ruby String: either an owned buffer (the plain
 /// `SmallVec`, inline ≤ `STRING_INLINE_CAP` bytes or spilled to the
 /// heap) or a zero-copy view into a frozen root's buffer. The active
@@ -1813,9 +1819,17 @@ impl RStringInner {
 
     /// O(1): take ownership of an already-built byte buffer with a
     /// pre-computed `cr` (the caller tracked it while building — see
-    /// `concatenate_string_inner`).
+    /// `Array#join`).
     pub(crate) fn from_vec_cr(bytes: Vec<u8>, encoding: Encoding, cr: CodeRange) -> Self {
         RStringInner::from(SmallVec::from_vec(bytes), encoding, cr)
+    }
+
+    /// O(1): take ownership of a buffer that was built directly in the
+    /// string's own representation — a short result never touched the
+    /// heap, a long one is adopted without a copy (see
+    /// `concatenate_string_inner`). `cr` was tracked by the builder.
+    pub(crate) fn from_buf_cr(bytes: StringBuf, encoding: Encoding, cr: CodeRange) -> Self {
+        RStringInner::from(bytes, encoding, cr)
     }
 
     /// O(N): build a string with the given encoding and pre-classify

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -573,6 +573,7 @@
 2a331dfdc06006cb6c2d9fb1b276af51	[false, false, true, true, true, true]	[Kernel.private_instance_methods(false).include?(:chop),\n          
 2a3de9772e2bbde8e6d892268ebbd6b6	:m	[1, 2].each.with_object(:m) { |v, m| }
 2a5869ecfcebdbb2da9022b23ccf267d	["constant", true, [:C]]	$res = []\n        parent = Class.new do\n          def self.inherited(su
+2a5b9f708b06a2c9976d7328b5e29c89	["<int>", "<int><int>", "<int>"]	module IntTos\n              refine Integer do\n                def t
 2a5cd0c05a4c867471eb9bdcd900f0a1	[[4, 5, 6], 8]	r = []\n        calls = 0\n        10.times { |i| r << i if (calls += 1; 
 2a7ebdf4fd301bbdfa3591753316bc4d	:OVERRIDDEN	class Float; def >=(o); :OVERRIDDEN; end; end; 3.0 >= 4.0
 2a9067ffb78152f7b45306f4f629c67a	[1, 2, 3, 4, [5, 6]]	def f(x,y,a=42,b=55,*z,c,d)\n            [x,y,a,b,z]\n        end\n       


### PR DESCRIPTION
## What

Template engines (erubi, etanni) and the ActiveRecord benchmark spend their time building strings, and two of the three construction paths did more copying than they needed.

- **Interpolation** (`concatenate_string_inner`) assembled its result in a fresh `Vec<u8>` grown by doubling, then copied it into the String's own buffer; an Integer operand went through `to_s`, which allocated a heap String only to be copied out again. It now builds in the String's `SmallVec` buffer, sized from the operands that are already Strings (the literal fragments and most interpolated values), and adopts it as-is via `RStringInner::from_buf_cr`: a short result never touches the heap, a long one allocates once. A Fixnum operand is formatted into the buffer directly (`format_i64`), negotiating encoding exactly as the 7-bit piece `to_s` would have produced. The refinement guard is hoisted into `Executor::to_s_is_refined`, so a refined `Integer#to_s` still wins (tested).
- **`Array#join`** pre-sizes its buffer and hands it over with the code range it tracked while appending (`from_vec_cr`), instead of finishing with a copy plus a full re-scan of the bytes it had just written. That made the tracked value load-bearing, which exposed a bug in `merge_join_state`: it recorded `Broken` as final, but a broken piece can be completed by the next one — `["\xE3", "\x81\x82"].join` is a valid `"あ"`, and after this PR's first cut it reported `valid_encoding?` false. The fold now defers any broken or unclassified side to a later scan, the same rule interpolation already used.

## Numbers

ns per operation, release build, JIT warm:

| | master | this PR | YJIT |
|---|---|---|---|
| `"#{a} #{b}"`, two short Strings | 184 | 134 | 115 |
| `"<td>#{a}</td><td>#{b}</td><td>#{c}</td>"` | 289 | 235 | 179 |
| `"#{i}"`, Fixnum | 216 | 96 | 147 |
| `"#{l} #{l}"`, 400-byte result | 281 | 223 | 169 |
| `8 strings.join` | 350 | 220 | 233 |
| `8 strings.join(", ")` | 425 | 287 | 386 |
| `40 strings.join("\n")` | 1069 | 803 | 1479 |

ruby-bench, average iteration: etanni 778 → 633 ms, erubi 365 → 296 ms (measured against the master before #1229, which also helps etanni).

The remaining gap to YJIT on plain-String interpolation is the runtime call plus the object allocation, not the byte handling.

## Not in this PR

`"#{1}".encoding` is UTF-8 in monoruby and US-ASCII in CRuby (CRuby seeds from the first fragment, `Integer#to_s`'s US-ASCII; monoruby seeds from an empty source-encoding literal). That is unchanged here — master behaves the same — and the new tests avoid asserting it.

## Tests

- `format_i64` against `to_string` at 0, ±1, the Fixnum bounds, `i64::MIN` / `i64::MAX`.
- Live-CRuby comparisons: Fixnum interpolation across the Fixnum / Bignum boundary, mixed with non-ASCII, binary and UTF-16 operands, results past the inline buffer, and a refined `Integer#to_s`.
- `Array#join` code range: the broken-then-completing case, ASCII / non-ASCII / binary mixes with `valid_encoding?` and `ascii_only?`, non-String elements, long results.
- ruby/spec `core/array/join_spec.rb`, `language/string_spec.rb`, `core/kernel/String_spec.rb`, `core/string/modulo_spec.rb`: same results as master (one pre-existing `%c` error).
- Full `cargo test` suite green; aarch64 cross-check compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_