### PR TITLE
Build a constant Hash literal once and copy it per evaluation

### DIFF
--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -5602,6 +5602,83 @@ mod tests {
     }
 
     #[test]
+    fn constant_hash_literal_is_copied_per_evaluation() {
+        // A constant literal is built once as a template and copied on
+        // each evaluation (`HashmapInner::from_literal_pairs` +
+        // `RValue::deep_copy`): every evaluation must still yield a
+        // fresh, unfrozen, independent Hash with a nil default.
+        run_test(
+            r##"
+            def f; {"name" => 1, "version" => 2, sym: 3, 4 => 5, 1.5 => 6, nil => 7, true => 8, false => 9}; end
+            a = f
+            b = f
+            a["name"] = 100
+            a[:new] = 200
+            b.delete("version")
+            r = [a, b, f, a.equal?(b), a.frozen?, a.default, a.compare_by_identity?, a.size, f.size]
+            r << f.keys.map(&:frozen?)
+            r << f.keys.map(&:class)
+            # A String key is the same frozen object on every evaluation.
+            r << f.keys[0].equal?(f.keys[0])
+            r << (f["name"] + f[:sym] + f[4] + f[1.5] + f[nil] + f[true] + f[false])
+            r
+            "##,
+        );
+        // Inline (all-immediate, up to three pairs), boxed, and past the
+        // chunking limit.
+        run_test(
+            r##"
+            def g; {1 => 2, :a => 3}; end
+            def h; {"a" => 1, "b" => 2}; end
+            x = g; y = g; x[:z] = 9
+            p = h; q = h; p["c"] = 3
+            [x, y, p, q, g.size, h.size, g.frozen?, h.frozen?, h.keys.all?(&:frozen?)]
+            "##,
+        );
+        run_test(
+            r##"
+            def big; {"k0"=>0,"k1"=>1,"k2"=>2,"k3"=>3,"k4"=>4,"k5"=>5,"k6"=>6,"k7"=>7,"k8"=>8,"k9"=>9,"k10"=>10,"k11"=>11,"k12"=>12,"k13"=>13,"k14"=>14,"k15"=>15,"k16"=>16,"k17"=>17,"k18"=>18,"k19"=>19,"k20"=>20,"k21"=>21,"k22"=>22,"k23"=>23,"k24"=>24,"k25"=>25,"k26"=>26,"k27"=>27,"k28"=>28,"k29"=>29,"k30"=>30,"k31"=>31,"k32"=>32,"k33"=>33,"k34"=>34,"k35"=>35,"k36"=>36,"k37"=>37,"k38"=>38,"k39"=>39}; end
+            a = big; b = big; a["k0"] = -1
+            [a.size, b.size, a["k0"], b["k0"], a["k39"], big.keys.first(3), big.values.sum]
+            "##,
+        );
+        // Duplicate keys: the later pair wins, once, and String keys
+        // compare by content.
+        run_test(
+            r##"
+            def d; {a: 1, "s" => 2, a: 3, "s" => 4, 1 => 5, 1 => 6}; end
+            [d, d.size, d.keys]
+            "##,
+        );
+        // Mutable String values keep the per-evaluation copy: each call
+        // gets its own value object, and mutating one leaves the next
+        // alone. Under `frozen_string_literal` the value is one shared
+        // frozen String, as it would be anywhere else in the file.
+        run_test(
+            r##"
+            def m; {"k" => "v"}; end
+            a = m; a["k"] << "!"
+            b = m
+            r = [a, b, a["k"].equal?(b["k"]), b["k"].frozen?]
+            src = "# frozen_string_literal: true\n{'k' => 'v', s: 'w'}"
+            h1 = eval(src); h2 = eval(src)
+            r << [h1, h1["k"].frozen?, h1[:s].frozen?, h1.frozen?, h1.equal?(h2), h1["k"].equal?(h2["k"])]
+            r
+            "##,
+        );
+        // A heap key or a computed element still takes the general path
+        // and behaves the same.
+        run_test(
+            r##"
+            k = "dyn"
+            def n(k); {k => 1, 2**70 => 2, 1e300 * 1e10 => 3, "lit" => 4}; end
+            a = n(k); b = n(k)
+            [a, a.equal?(b), a.keys[0].equal?(k), a.keys[3].frozen?, a.size]
+            "##,
+        );
+    }
+
+    #[test]
     fn hash_literal_duplicated_key_warning() {
         // A hash literal that repeats a *literal* key warns "key ... is
         // duplicated and overwritten" through `$stderr` (so a redirected

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -1828,6 +1828,32 @@ impl<'a> BytecodeGen<'a> {
         loc: Loc,
     ) -> Result<()> {
         self.warn_duplicated_hash_keys(&nodes, &splat);
+        if splat.is_empty()
+            && !nodes.is_empty()
+            && nodes
+                .iter()
+                .all(|(k, v)| self.is_static_hash_key(k) && self.is_static_hash_value(v))
+        {
+            // A constant literal — every key an immediate or a String
+            // (which a Hash freezes anyway) and every value immutable —
+            // is built once, here, and copied per evaluation by the
+            // `Literal` dispatch (`RValue::deep_copy` clones the table
+            // and shares the keys and values), instead of being
+            // re-inserted pair by pair each time: CRuby's `duphash`.
+            // A String value only counts under `frozen_string_literal`,
+            // where it is the same frozen object on every evaluation;
+            // otherwise each evaluation owes a fresh copy of it.
+            let enc = self.source_encoding();
+            let pairs: Vec<(Value, Value)> = nodes
+                .iter()
+                .map(|(k, v)| (self.static_hash_key(k, enc), self.static_hash_value(v, enc)))
+                .collect();
+            let template = Value::hash_from_inner(
+                crate::value::rvalue::HashmapInner::from_literal_pairs(&pairs),
+            );
+            self.emit_literal(ret, template);
+            return Ok(());
+        }
         if splat.is_empty() {
             if nodes.len() <= LITERAL_CHUNK_LEN {
                 let len = nodes.len();
@@ -1944,6 +1970,67 @@ impl<'a> BytecodeGen<'a> {
             remaining -= take;
         }
         Ok(())
+    }
+
+    /// Whether `node` is a key a constant Hash literal can hold: an
+    /// immediate (a Fixnum, a flonum, a Symbol, nil, true, false) or a
+    /// String literal. Both digest and compare without running Ruby
+    /// code, which is what lets the template be built at emission time
+    /// (`HashmapInner::from_literal_pairs`). A Bignum or a heap Float
+    /// is a heap key and takes the general path.
+    fn is_static_hash_key(&self, node: &Node) -> bool {
+        match &node.kind {
+            NodeKind::Integer(i) => Immediate::check_fixnum(*i).is_some(),
+            NodeKind::Float(f) => Immediate::flonum(*f).is_some(),
+            NodeKind::Symbol(_) | NodeKind::Nil | NodeKind::Bool(_) => true,
+            NodeKind::String(_) | NodeKind::Bytes(_) | NodeKind::EncodedString(..) => true,
+            _ => false,
+        }
+    }
+
+    /// Whether `node` is a value a constant Hash literal can share
+    /// between evaluations: any immutable literal, and a String literal
+    /// only under `frozen_string_literal` (a mutable String literal is a
+    /// fresh copy per evaluation).
+    fn is_static_hash_value(&self, node: &Node) -> bool {
+        match &node.kind {
+            NodeKind::Integer(_)
+            | NodeKind::Bignum(_)
+            | NodeKind::Float(_)
+            | NodeKind::Symbol(_)
+            | NodeKind::Nil
+            | NodeKind::Bool(_) => true,
+            NodeKind::String(_) | NodeKind::Bytes(_) | NodeKind::EncodedString(..) => {
+                self.frozen_string_literal()
+            }
+            _ => false,
+        }
+    }
+
+    /// The key `Value` of a static pair: a String key is the interned
+    /// frozen string, the same object on every evaluation (CRuby's
+    /// `fstring` for a literal key).
+    fn static_hash_key(&mut self, node: &Node, enc: crate::value::Encoding) -> Value {
+        match &node.kind {
+            NodeKind::String(s) => self.store.intern_frozen_str(s.as_bytes(), enc),
+            NodeKind::Bytes(b) => self.store.intern_frozen_str(b, enc),
+            NodeKind::EncodedString(b, name) => {
+                let enc = crate::value::Encoding::try_from_str(name)
+                    .unwrap_or(crate::value::Encoding::Utf8);
+                self.store.intern_frozen_str(b, enc)
+            }
+            _ => Value::from_const_ast(node, enc),
+        }
+    }
+
+    /// The value `Value` of a static pair (see `is_static_hash_value`).
+    fn static_hash_value(&mut self, node: &Node, enc: crate::value::Encoding) -> Value {
+        match &node.kind {
+            NodeKind::String(_) | NodeKind::Bytes(_) | NodeKind::EncodedString(..) => {
+                self.static_hash_key(node, enc)
+            }
+            _ => Value::from_const_ast(node, enc),
+        }
     }
 
     ///

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -1452,8 +1452,12 @@ impl RValue {
     }
 
     pub(super) fn deep_copy(&self) -> Self {
+        let mut header = self.header.newborn();
+        if unsafe { self.try_ty() } == Some(ObjTy::HASH) {
+            header.set_ty_flags(hash::sanitize_dup_flags(header.ty_flags()));
+        }
         RValue {
-            header: self.header.newborn(),
+            header,
             var_table: self.var_table.clone(),
             kind: unsafe {
                 match self.ty() {
@@ -1500,19 +1504,15 @@ impl RValue {
                             lhs.exclude_end(),
                         )
                     }
-                    /*ObjTy::HASH => {
-                        let mut map = RubyMap::default();
-                        let hash = self.as_hashmap();
-                        for (k, v) in hash.iter() {
-                            map.insert(
-                                HashKey(k.deep_copy(vm, globals)?),
-                                v.deep_copy(vm, globals)?,
-                                vm,
-                                globals,
-                            )?;
-                        }
-                        ObjKind::hash_from(map)
-                    }*/
+                    // The only Hash reaching here is the template of a
+                    // constant literal (`HashmapInner::from_literal_pairs`):
+                    // its keys are immediates or frozen Strings and its
+                    // values immutable, so the copy shares them — as
+                    // CRuby's `duphash` does — and only the table is
+                    // cloned.
+                    ObjTy::HASH => ObjKind {
+                        hash: ManuallyDrop::new(self.as_hashmap().clone_body()),
+                    },
                     ObjTy::REGEXP => {
                         let regexp = self.as_regex();
                         ObjKind::regexp(regexp.clone())

--- a/monoruby/src/value/rvalue/hash.rs
+++ b/monoruby/src/value/rvalue/hash.rs
@@ -410,6 +410,54 @@ impl HashmapInner {
         }
     }
 
+    /// The template of a constant Hash literal (`{"name" => 1, sym: 2}`
+    /// with only immediate or String keys and immutable values), built
+    /// at bytecode-emission time — so without a vm. Every key's digest
+    /// and `eql?` are vm-free (`packed_digest` / `string_digest`, exactly
+    /// what `insert` uses for them), so no Ruby code can run. Later
+    /// pairs overwrite earlier ones, as `insert` does. The literal is
+    /// materialized per evaluation by `RValue::deep_copy`.
+    pub(crate) fn from_literal_pairs(pairs: &[(Value, Value)]) -> Self {
+        debug_assert!(
+            pairs
+                .iter()
+                .all(|(k, _)| k.is_packed_value() || k.is_rstring_inner().is_some())
+        );
+        if pairs.len() <= INLINE_CAP && pairs.iter().all(|(k, _)| is_inline_key(*k)) {
+            let mut h = Self::default();
+            let mut m = h.as_mut();
+            for &(k, v) in pairs {
+                if let Some(i) = m.as_ref().inline_pos_noobs(k) {
+                    // SAFETY: rep is inline; i < len.
+                    unsafe { m.body_mut().inline[i].1 = v };
+                } else {
+                    let len = m.inline_len();
+                    // SAFETY: rep is inline; the slot exists (len < CAP).
+                    unsafe { m.body_mut().inline[len] = (k, v) };
+                    m.set_rep(len as u8 + 1);
+                }
+            }
+            return h;
+        }
+        let mut map = RubyMap::with_capacity(pairs.len());
+        for &(k, v) in pairs {
+            if k.is_packed_value() {
+                let hash = packed_digest(map.hasher(), k);
+                map.insert_prehashed(hash, Some(k), v);
+            } else {
+                let s = k.as_rstring_inner();
+                let hash = string_digest(map.hasher(), s);
+                map.insert_prehashed_with(hash, Some(k), v, |ek| string_key_eq(ek, k, s));
+            }
+        }
+        Self::from_parts(
+            REP_BOXED,
+            HashBody {
+                boxed: ManuallyDrop::new(BoxedHash::new(HashContent::Map(Box::new(map)))),
+            },
+        )
+    }
+
     fn new_boxed_with_default(map: RubyMap<Value, Value>, default: Option<HashDefault>) -> Self {
         Self::from_parts(
             REP_BOXED,

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -354,6 +354,7 @@
 19c3117422e24db6dd0e39d531d1f3f5	[true, true, true, false, false]	class C\n            include Comparable\n            attr_accessor :x\n 
 19f37cc8342f248bcc7ea2bff3525fb8	true	def f; caller_locations(1, 1)[0].lineno.is_a?(Integer); end\n       
 1a0f14b93dbac347cd85f619ff9eb079	1	count = Module.constants.size\n            module ModConstSpec1; end
+1a37ac01757c7cd301967989601e5c9b	[{"k" => "v!"}, {"k" => "v"}, false, false, [{"k" => "v", s: "w"}, true, true, false, false, true]]	def m; {"k" => "v"}; end\n            a = m; a["k"] << "!"\n         
 1a3da0f2d5820c3da4a22ebe3d606273	[nil, 0]	h = Hash.new(99)\n            h[:a] = 1\n            r = h.except(:a)
 1a561eac221bbb35c7021303bd9f4066	["DEFAULT", true, nil, "SYSTEM_DEFAULT"]	Signal.trap("USR2", "DEFAULT")\n            h = ->{}\n            a =
 1a67742c8115d3d19f33ca885e738ec5	[4, false, :from_block, :lam, 99]	res = []\n        class Y\n          def self.define_deep(&blk)\n         
@@ -839,6 +840,7 @@
 417394f1be1fb3cb921d2758ca5edc19	nil	defined?($there_is_no_such_global_xxxxx)\n            
 419d77b6e939231fdafd53d3c6c6ea9d	[1, 2, 42, 55, []]	def f(x,y,a=42,b=55,*z)\n            [x,y,a,b,z]\n        end\n        \n\n 
 419ee2f4a5f8c62a9f32d72169a9b695	[true, 100, 91, 97, 112]	[\n              Errno::ENETDOWN.ancestors.include?(SystemCallError)
+41ddfa3d947230443c7eb469c3269928	[{a: 3, "s" => 4, 1 => 6}, 3, [:a, "s", 1]]	def d; {a: 1, "s" => 2, a: 3, "s" => 4, 1 => 5, 1 => 6}; end\n      
 4201651c81088820aab64210097ab3f7	[2, "NoMethodError"]	r = Module.new do\n              refine Array do\n                ali
 420fd4ef995831a71e5964759ba88f3b	"ああabc"	"abc".rjust(5, "あ")
 421b2694d3c8d4c86d2dafb625fb56b3	["/no/such/path", nil]	m = Module.new do\n              autoload :Foo, "/no/such/path"\n    
@@ -899,6 +901,7 @@
 457f6a743618e9a691a1720e9d5b31b0	[1575.0276087749185, 6.073454154620117]	def call_block\n          yield\n        end\n        def f(n)\n          a
 4590827ce0f8f39bce38419577946094	[[1, true], [1, true], [1, true], [1, true], [1, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true], [2, true]]	def row\n          res = []\n          x = 0\n          while x < 60\n     
 459af0ef6a434f9f83be184be79da2d5	[[:mm, :whatever, [], nil], [:mm, :whatever, [1, 2], nil], [:mm, :whatever, [], :from_block], [:mm, :whatever, [3], nil], [:mm, :whatever_str, [], nil]]	class MM\n          def method_missing(name, *args, &blk) = [:mm, name, 
+45b7692889f0f92f83f9e66cf62a1155	[{1 => 2, a: 3, z: 9}, {1 => 2, a: 3}, {"a" => 1, "b" => 2, "c" => 3}, {"a" => 1, "b" => 2}, 2, 2, false, false, true]	def g; {1 => 2, :a => 3}; end\n            def h; {"a" => 1, "b" => 
 45c219e430e29dc7ecd467638b65c70b	[true, true, true]	pid = spawn("true")\n            t = Process.detach(pid)\n           
 45c9b7ea3cba52cd428385897c67b953	[true, false, false, false, true, false, true, false, true, false]	S = Struct.new(:a, :b)\n        T = Struct.new(:a, :b)\n        \n\n       
 45ca7b6809a873de22eb68bc015aef5c	["abc", "abcd"]	s = +"abc"; t = s.dup; t << "d"; [s, t]
@@ -1384,6 +1387,7 @@
 6b4af7ca5b9a5430ebaa6f57763959e3	true	(1 << 53) == (1 << 53).to_f
 6b5c527a35a6e84b5f466edc5a765e96	:OVERRIDDEN	class Integer; def -(o); :OVERRIDDEN; end; end; 3 - 4
 6b5df255bb3d61a71b92a9142b777854	[[164, 162], "EUC-JP"]	m = /./e.match("\\244\\242".dup.force_encoding(Encoding::EUC_JP))\n               [
+6b6d860f8e456a8193747381c47a8d69	[{"dyn" => 1, 1180591620717411303424 => 2, Infinity => 3, "lit" => 4}, false, false, true, 4]	k = "dyn"\n            def n(k); {k => 1, 2**70 => 2, 1e300 * 1e10 =
 6b6dfbea494d895f88178ed4fd8780ed	[[nil], [[1, 2]]]	[Enumerator.new { |y| y.yield },\n                Enumerator.new { |y| y.yield 1,
 6b7c29f7108cc984781c81784cefb56d	"aa"	eval("/a+?*/").match("aa")[0]
 6b82ebaaa0df8e456b952c1649290d36	["INT-NE", "RAW-B", false, true, true, true, true]	class Integer; def !=(o); "INT-NE"; end; end\n        class CustomEqB; d
@@ -2846,6 +2850,7 @@ da6b246283b4f211581ca1d5eb140461	"a b\\n"	IO.popen(["echo", "a b"]) { |io| io.re
 daa7019f1dfb40422c47287a212b59ec	[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]	class C\n          def foo; 1; end\n        end\n        res = []\n        
 dae52af79f68fd59e79d94c60e7c3a75	"US-ASCII"	s = "abc".dup.force_encoding("ASCII-8BIT")\n              s.unpack
 dae678c7230abbc68fd9e71f3ce16a0c	8400	class Target\n          def value_plus(n) = 2 + n\n        end\n        cl
+dae90ab3ae1aa4e8058cace910bd3a82	[40, 40, -1, 0, 39, ["k0", "k1", "k2"], 780]	def big; {"k0"=>0,"k1"=>1,"k2"=>2,"k3"=>3,"k4"=>4,"k5"=>5,"k6"=>6,"
 db00180168f82ac3f47a720c4c80a330	[]	[] | []
 db1d122ccf500fce3b16c8ab7548f6cf	"ab"	$/ = "cdef"; r = "abcdef".chomp; $/ = "\\n"; r
 db1e8e1f47867fdb41ead37f6e942df5	[42, 42, 42, 42, 42, 42, 42, 42, 84, 84, 84]	class A\n              attr_accessor :w\n            end\n            
@@ -2915,6 +2920,7 @@ e04102db31563efacf03513f5ddbcdd6	{"MONORUBY_ENV_TEST_SL1" => "x", "MONORUBY_ENV_
 e0430993ff49221b4ff142a12a2d9ee6	[1, [:gt, :lt, :gt, :lt]]	class C\n              attr_reader :calls\n              def initiali
 e051ec7a15469fca9105c948f78c2f26	[[:v], 50]	$nlr_log = []\n        def nlr_mid\n          yield\n        ensure\n      
 e093793f4006c99f09965c6fde38e86b	42	class Foo\n          def initialize\n            @x = 42\n          end\n  
+e0982ecc832e3a0a37c3aabbe59b1ec2	[{"name" => 100, "version" => 2, sym: 3, 4 => 5, 1.5 => 6, nil => 7, true => 8, false => 9, new: 200}, {"name" => 1, sym: 3, 4 => 5, 1.5 => 6, nil => 7, true => 8, false => 9}, {"name" => 1, "version" => 2, sym: 3, 4 => 5, 1.5 => 6, nil => 7, true => 8, false => 9}, false, false, nil, false, 9, 8, [true, true, true, true, true, true, true, true], [String, String, Symbol, Integer, Float, NilClass, TrueClass, FalseClass], true, 39]	def f; {"name" => 1, "version" => 2, sym: 3, 4 => 5, 1.5 => 6, nil 
 e09c62f66a3c3f3ed8999368ae421637	[true, [Errno::ENOENT, "No such file or directory @ rb_check_realpath_internal - /no_such_dir_zzq/x"], Errno::ELOOP, Errno::ELOOP]	(d="/tmp/mono_rp_#{Process.pid}"; Dir.mkdir(d); File.write("#{d}/file", ""); a=(
 e0a574583b5fc83f8c4cabc65c564a05	259.5522608117453	def call_block\n          yield\n        end\n        def p1\n          k =
 e0aaed5b5073da72fc373f05fb574de1	true	S = Struct.new(:a, :b)\n            \n\n            S.new(1, 2).hash !


### PR DESCRIPTION
## What

`{"name" => 1, "version" => 2, ...}` was rebuilt on every evaluation: each key literal deep-copied, then inserted one by one through the general path — about 1050 ns for eight String-keyed pairs, against CRuby's 60 ns. CRuby compiles such a literal into a prebuilt hash plus a `duphash`; this does the same.

A literal whose keys are all immediates (Fixnum, flonum, Symbol, nil, true, false) or String literals, and whose values are all immutable (a String value only under `frozen_string_literal`, where it is one shared frozen object anyway), is built at emission time (`HashmapInner::from_literal_pairs`, vm-free: those keys digest and compare through the same `packed_digest` / `string_digest` paths `insert` already uses for them, so no Ruby code can run) and emitted as a `Literal`. Each evaluation is then one `deep_copy`: a table clone that shares the keys and values. String keys are the interned frozen strings, the same object on every evaluation, as CRuby's fstring keys are. A literal with a computed key, a heap key (Bignum, a non-flonum Float), a mutable String value or a `**` splat keeps the pair-by-pair path.

`RValue::deep_copy` gains its Hash arm (shallow: only the table is cloned) and sanitizes the representation flags the way `dup` does. The JIT needs nothing new: `Literal` already lowers to the deep-copy call for a heap template.

## Numbers

ns per evaluation, release build, JIT warm:

| literal | master | this PR | YJIT |
|---|---|---|---|
| `{"a" => 1}` | 217 | 143 | 61 |
| four String-keyed pairs | 550 | 173 | 62 |
| eight String-keyed pairs | 1046 | 171 | 63 |
| eight Symbol-keyed pairs | 382 | 167 | 62 |
| eight Integer-keyed pairs | 516 | 166 | 61 |

What remains is the table clone (`Hash#dup` of the same 8 pairs costs 165 ns), which is a separate improvement.

On the ruby-bench workloads I checked (activerecord, rack, etanni, addressable) the per-iteration times are within noise of master: none has a constant hash literal on its hot path. Cachegrind puts addressable/equality at 6.405 G instructions on master and 6.414 G here, so the 5% wall-clock spread seen on that one is binary-layout noise rather than executed work.

## Tests

- `constant_hash_literal_is_copied_per_evaluation`: every evaluation yields a fresh, unfrozen, independent Hash with a nil default; String keys are frozen and identical across evaluations; the inline (all-immediate, up to three pairs), boxed and past-chunk-limit (40 pairs) shapes; duplicate keys (later wins, once); mutable String values still copied per evaluation while `frozen_string_literal` values are shared; and a literal with a computed or heap key still taking the general path. All compared against a live CRuby, 25 runs each so the JIT path is covered.
- The existing duplicate-key warning test still passes (the warning is emitted before the template check).
- ruby/spec `language/hash_spec.rb` and `core/hash`: same results as master.
- Full `cargo test` suite green; aarch64 cross-check compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_