### PR TITLE
bench: run the darwin (arm64) job only by manual dispatch

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -2,6 +2,15 @@ name: bench vs YJIT
 
 on:
   workflow_dispatch:
+    inputs:
+      arch:
+        description: "Which benchmark jobs to run (darwin/arm64 only runs from here)"
+        type: choice
+        default: arm64
+        options:
+          - arm64
+          - amd64
+          - both
   push:
     branches: [master]
     paths:
@@ -20,6 +29,9 @@ permissions:
 
 jobs:
   bench-amd64:
+    # Runs on every master push; a manual dispatch includes it only when
+    # asked (arch: amd64 / both — the dispatch default is arm64-only).
+    if: ${{ github.event_name == 'push' || inputs.arch == 'amd64' || inputs.arch == 'both' }}
     runs-on: ubuntu-latest
     timeout-minutes: 240
     env:
@@ -234,6 +246,12 @@ jobs:
           retention-days: 30
 
   bench-arm64:
+    # NEVER runs automatically: the ~4.3 h three-engine pass burns far
+    # too much of the macOS runner allowance to pay on every master
+    # push. Run it from the Actions tab (workflow_dispatch, arch: arm64
+    # — the default — or both); the publish job tolerates its absence
+    # and simply leaves the arm64 dashboard at its last snapshot.
+    if: ${{ github.event_name == 'workflow_dispatch' && (inputs.arch == 'arm64' || inputs.arch == 'both') }}
     runs-on: macos-latest
     # The three-engine pass needs ~245-260 min on this runner (the zjit
     # pass alone is ~2.5 h on arm64): the first zjit run hit the old


### PR DESCRIPTION
The ~4.3 h three-engine arm64 pass consumes far too much of the macOS runner allowance to pay on every master push. This makes `bench-arm64` manual-only.

## Changes (`.github/workflows/bench.yml` only)

- **`bench-arm64` never starts automatically.** It runs only from a `workflow_dispatch`, gated by a new `arch` choice input:
  - `arm64` (**default**) — one click from the Actions tab runs just the darwin benchmark
  - `amd64` — manual x86-64-only run
  - `both` — the old dispatch behavior
- **Master pushes keep running `bench-amd64` exactly as before**; a dispatch includes it only when `arch` is `amd64` or `both`.
- No publish changes needed: it already runs under `always()`, downloads each artifact with `continue-on-error`, and skips a side whose `portal.json` is absent — so push-triggered runs simply leave the arm64 dashboard at its last manually-produced snapshot.

## Verification

- Workflow YAML parses; `bash -n` passes on all 24 `run:` steps.
- Job `if:` conditions reviewed against the event matrix: push → amd64 only; dispatch(arm64) → arm64 only; dispatch(amd64) → amd64 only; dispatch(both) → both; publish runs in every case (`always()` covers skipped needs).
- `inputs.arch` is empty on push events, so the amd64 condition short-circuits on `github.event_name == 'push'` and the arm64 condition is false — no expression errors outside dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUYnhjixuUEzA5hgWUdckX

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUYnhjixuUEzA5hgWUdckX)_