### PR TITLE
Draw a Random instance's generator in place, and size a literal Array copy up front

### DIFF
--- a/monoruby/src/builtins/random.rs
+++ b/monoruby/src/builtins/random.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::globals::prng::{Mt, build_mt, next_real, rand_int, ulong_limited};
+use crate::globals::prng::{
+    Mt, MtDraw, MtInPlace, build_mt, next_real, next_real_inclusive, rand_int, ulong_limited,
+};
 use num::{Signed, Zero};
 
 //
@@ -110,6 +112,52 @@ fn store_mt(globals: &mut Globals, self_: Value, mt: &Mt, cnt: u64) -> Result<()
         .store
         .set_ivar(self_, ivar_cnt(), Value::integer(cnt as i64))?;
     Ok(())
+}
+
+/// Run `f` over the instance's live generator *in place* — the
+/// `/random_state` String is advanced where it lies (`MtInPlace`), so a
+/// draw costs O(1) instead of a 2.5 KB deserialize/serialize round trip.
+/// The count ivar is updated afterwards. A missing or malformed state
+/// String is materialized from `(seed, count)` first.
+///
+/// `f` must not run Ruby code: it holds a mutable borrow of the state
+/// String's buffer. Coerce arguments before calling this.
+fn with_mt_in_place<R>(
+    globals: &mut Globals,
+    self_: Value,
+    f: impl FnOnce(&mut MtInPlace<'_>, &mut u64) -> R,
+) -> Result<R> {
+    let (seed, mut cnt) = load_state(globals, self_);
+    let state_ok = globals
+        .store
+        .get_ivar(self_, ivar_state())
+        .and_then(|v| v.is_rstring_inner().map(|s| s.len() == Mt::STATE_BYTES))
+        .unwrap_or(false);
+    if !state_ok {
+        let mt = mt_at(seed, cnt);
+        globals
+            .store
+            .set_ivar(self_, ivar_state(), Value::bytes(mt.to_bytes()))?;
+    }
+    let mut state = globals.store.get_ivar(self_, ivar_state()).unwrap();
+    let res = {
+        let bytes = state.as_rstring_inner_mut().as_bytes_mut();
+        match MtInPlace::new(bytes) {
+            Some(mut mt) => f(&mut mt, &mut cnt),
+            None => {
+                // A state String of the right length but an impossible
+                // position: rebuild it and go again.
+                let fresh = mt_at(seed, cnt).to_bytes();
+                bytes.copy_from_slice(&fresh);
+                let mut mt = MtInPlace::new(bytes).expect("freshly serialized state");
+                f(&mut mt, &mut cnt)
+            }
+        }
+    };
+    globals
+        .store
+        .set_ivar(self_, ivar_cnt(), Value::integer(cnt as i64))?;
+    Ok(res)
 }
 
 ///
@@ -371,23 +419,33 @@ fn random_rand(
 #[monoruby_builtin]
 fn rand(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let self_ = lfp.self_val();
-    let (mut mt, mut c) = load_mt(globals, self_);
-    let result = inst_rand_op(vm, globals, &mut mt, &mut c, lfp.try_arg(0))?;
-    store_mt(globals, self_, &mt, c)?;
-    Ok(result)
+    // Argument coercion may run Ruby code; it happens before the
+    // generator's buffer is borrowed for the draw.
+    let req = prepare_rand(vm, globals, lfp.try_arg(0))?;
+    with_mt_in_place(globals, self_, |mt, c| draw_rand(mt, c, req))
 }
 
-/// Core `Random#rand` dispatch operating on a reconstructed MT.
-fn inst_rand_op(
-    vm: &mut Executor,
-    globals: &mut Globals,
-    mt: &mut Mt,
-    c: &mut u64,
-    arg: Option<Value>,
-) -> Result<Value> {
+/// A `Random#rand` request with its argument fully coerced, so the draw
+/// itself runs no Ruby code.
+enum RandReq {
+    /// `rand` — a Float in `[0, 1)`.
+    Real,
+    /// `rand(int)` — an Integer in `[0, max)`.
+    Int(num::BigInt),
+    /// `rand(float)` — a Float in `[0, max)` (`0.0` means `[0, 1)`).
+    FloatMax(f64),
+    /// `rand(a..b)` over Integers: `start + [0, span)`.
+    IntRange { start: i64, span: i64 },
+    /// `rand(a..b)` with a Float end point: `s + real * (e - s)`, the
+    /// real drawn inclusively for `..` (CRuby `int_pair_to_real_inclusive`)
+    /// and half-open for `...`.
+    FloatRange { start: f64, end: f64, excl: bool },
+}
+
+fn prepare_rand(vm: &mut Executor, globals: &mut Globals, arg: Option<Value>) -> Result<RandReq> {
     let arg = match arg {
         Some(v) => v,
-        None => return Ok(Value::float(next_real(mt, c))),
+        None => return Ok(RandReq::Real),
     };
     // Range: `rand(a..b)` / `rand(a...b)`.
     if let Some(r) = arg.is_range() {
@@ -400,18 +458,21 @@ fn inst_rand_op(
         {
             let span = e - s + if excl { 0 } else { 1 };
             if span <= 0 {
-                return Ok(Value::nil());
+                // `Random#rand` rejects an empty range (`Kernel#rand`
+                // is the one that answers nil).
+                return Err(MonorubyErr::argumenterr(format!(
+                    "invalid argument - {}",
+                    arg.inspect(&globals.store)
+                )));
             }
-            let v = rand_int(mt, c, &num::BigInt::from(span));
-            return Ok(Value::integer(s + v.try_fixnum().unwrap_or(0)));
+            return Ok(RandReq::IntRange { start: s, span });
         }
         // If either end point is a Float, both are treated as Floats.
         let to_f = |v: Value| -> Option<f64> {
             v.try_float().or_else(|| v.try_fixnum().map(|i| i as f64))
         };
         if let (Some(s), Some(e)) = (to_f(start), to_f(end)) {
-            let f = next_real(mt, c);
-            return Ok(Value::float(s + f * (e - s)));
+            return Ok(RandReq::FloatRange { start: s, end: e, excl });
         }
         return Err(MonorubyErr::argumenterr("bad value for range"));
     }
@@ -421,8 +482,7 @@ fn inst_rand_op(
         if max < 0.0 {
             return Err(MonorubyErr::argumenterr(format!("invalid argument - {max}")));
         }
-        let f = next_real(mt, c);
-        return Ok(Value::float(if max == 0.0 { f } else { f * max }));
+        return Ok(RandReq::FloatMax(max));
     }
     // Integer maximum (Fixnum or Bignum), or anything #to_int-coercible.
     let max = match arg.unpack() {
@@ -442,7 +502,27 @@ fn inst_rand_op(
             "invalid argument - {big}"
         )));
     }
-    Ok(rand_int(mt, c, &big))
+    Ok(RandReq::Int(big))
+}
+
+/// The draw for a prepared request, against any generator.
+fn draw_rand<M: MtDraw>(mt: &mut M, c: &mut u64, req: RandReq) -> Value {
+    match req {
+        RandReq::Real => Value::float(next_real(mt, c)),
+        RandReq::Int(big) => rand_int(mt, c, &big),
+        RandReq::FloatMax(max) => {
+            let f = next_real(mt, c);
+            Value::float(if max == 0.0 { f } else { f * max })
+        }
+        RandReq::IntRange { start, span } => {
+            let v = rand_int(mt, c, &num::BigInt::from(span));
+            Value::integer(start + v.try_fixnum().unwrap_or(0))
+        }
+        RandReq::FloatRange { start, end, excl } => {
+            let f = if excl { next_real(mt, c) } else { next_real_inclusive(mt, c) };
+            Value::float(start + f * (end - start))
+        }
+    }
 }
 
 /// Shared implementation for `Random.rand`, `Random.random_number`,
@@ -527,13 +607,14 @@ fn instance_bytes(
         return Err(MonorubyErr::argumenterr("negative string size".to_string()));
     }
     let size = size as usize;
-    let (mut mt, cnt) = load_mt(globals, self_);
     // ceil(size/4) 32-bit words are consumed (a trailing partial word
     // still draws a full u32, matching CRuby).
     let words = size.div_ceil(4) as u64;
     let mut buf = vec![0u8; size];
-    mt.fill_bytes(&mut buf);
-    store_mt(globals, self_, &mt, cnt + words)?;
+    with_mt_in_place(globals, self_, |mt, cnt| {
+        mt.fill_bytes(&mut buf);
+        *cnt += words;
+    })?;
     Ok(Value::bytes(buf))
 }
 
@@ -729,6 +810,36 @@ mod tests {
         );
         run_test_error("Random.urandom(-1)");
         run_test_error("Random.urandom('woo')");
+    }
+
+    #[test]
+    fn random_draws_in_place_across_refills() {
+        // The state String is advanced where it lies; the table is
+        // regenerated in place every 624 words. Walk well past several
+        // refills through every draw kind, then compare the stream, the
+        // count-sensitive `==`, and a dup's independence with CRuby.
+        run_test(
+            r##"
+            r = Random.new(42)
+            1300.times { r.rand }
+            a = [r.rand, r.rand(100), r.rand(1 << 40), r.rand(2 ** 70) % 1000, r.rand(1.5), r.rand(3..9), r.rand(3...4), r.rand(1.0..2.0), r.rand(1.0...2.0), r.rand(1..2.5), r.bytes(6).bytes]
+            700.times { r.bytes(3) }
+            a << r.rand << r.rand(7)
+            d = r.dup
+            a << (d == r) << d.rand << r.rand << (d == r)
+            s = Random.new(42); 1300.times { s.rand }
+            a << (s.rand == a[0])
+            o = Object.new; def o.to_int; 10; end
+            a << r.rand(o).between?(0, 9)
+            a
+            "##,
+        );
+        run_test_error("Random.new(1).rand(-1)");
+        run_test_error("Random.new(1).rand(0)");
+        run_test_error("Random.new(1).rand(-0.5)");
+        run_test_error(r#"Random.new(1).rand("x"..."y")"#);
+        run_test_error("Random.new(1).rand(5..1)");
+        run_test_error("Random.new(1).rand(5...5)");
     }
 
     #[test]

--- a/monoruby/src/globals/prng.rs
+++ b/monoruby/src/globals/prng.rs
@@ -69,27 +69,12 @@ impl Mt {
 
     pub(crate) fn next_u32(&mut self) -> u32 {
         if self.mti >= MT_N {
-            let mt = &mut self.mt;
-            for kk in 0..MT_N - MT_M {
-                let y = (mt[kk] & MT_UPPER) | (mt[kk + 1] & MT_LOWER);
-                mt[kk] = mt[kk + MT_M] ^ (y >> 1) ^ if y & 1 != 0 { MT_MATRIX_A } else { 0 };
-            }
-            for kk in MT_N - MT_M..MT_N - 1 {
-                let y = (mt[kk] & MT_UPPER) | (mt[kk + 1] & MT_LOWER);
-                mt[kk] =
-                    mt[kk + MT_M - MT_N] ^ (y >> 1) ^ if y & 1 != 0 { MT_MATRIX_A } else { 0 };
-            }
-            let y = (mt[MT_N - 1] & MT_UPPER) | (mt[0] & MT_LOWER);
-            mt[MT_N - 1] = mt[MT_M - 1] ^ (y >> 1) ^ if y & 1 != 0 { MT_MATRIX_A } else { 0 };
+            refill(&mut self.mt);
             self.mti = 0;
         }
-        let mut y = self.mt[self.mti];
+        let y = self.mt[self.mti];
         self.mti += 1;
-        y ^= y >> 11;
-        y ^= (y << 7) & 0x9d2c_5680;
-        y ^= (y << 15) & 0xefc6_0000;
-        y ^= y >> 18;
-        y
+        temper(y)
     }
 
     /// Serialized size of a generator: 624 little-endian `u32` words
@@ -125,9 +110,43 @@ impl Mt {
         Some(Self { mt, mti })
     }
 
+}
+
+/// Regenerate the 624-word table (`mt19937ar` `genrand_int32`'s
+/// refill), shared by the in-memory generator and the in-place one.
+fn refill(mt: &mut [u32; MT_N]) {
+    for kk in 0..MT_N - MT_M {
+        let y = (mt[kk] & MT_UPPER) | (mt[kk + 1] & MT_LOWER);
+        mt[kk] = mt[kk + MT_M] ^ (y >> 1) ^ if y & 1 != 0 { MT_MATRIX_A } else { 0 };
+    }
+    for kk in MT_N - MT_M..MT_N - 1 {
+        let y = (mt[kk] & MT_UPPER) | (mt[kk + 1] & MT_LOWER);
+        mt[kk] = mt[kk + MT_M - MT_N] ^ (y >> 1) ^ if y & 1 != 0 { MT_MATRIX_A } else { 0 };
+    }
+    let y = (mt[MT_N - 1] & MT_UPPER) | (mt[0] & MT_LOWER);
+    mt[MT_N - 1] = mt[MT_M - 1] ^ (y >> 1) ^ if y & 1 != 0 { MT_MATRIX_A } else { 0 };
+}
+
+/// The output tempering applied to one table word.
+#[inline]
+fn temper(mut y: u32) -> u32 {
+    y ^= y >> 11;
+    y ^= (y << 7) & 0x9d2c_5680;
+    y ^= (y << 15) & 0xefc6_0000;
+    y ^= y >> 18;
+    y
+}
+
+/// A source of MT19937 words: the in-memory [`Mt`] behind the global
+/// PRNG, or [`MtInPlace`], a `Random` instance's serialized state
+/// advanced where it lives. Every draw helper below is written against
+/// this so both share one implementation of CRuby's algorithms.
+pub(crate) trait MtDraw {
+    fn next_u32(&mut self) -> u32;
+
     /// CRuby `rb_rand_bytes`: little-endian 32-bit chunks; a trailing
     /// partial word still consumes a full draw.
-    pub(crate) fn fill_bytes(&mut self, dest: &mut [u8]) {
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
         let mut chunks = dest.chunks_exact_mut(4);
         for c in &mut chunks {
             c.copy_from_slice(&self.next_u32().to_le_bytes());
@@ -137,6 +156,69 @@ impl Mt {
             let b = self.next_u32().to_le_bytes();
             rem.copy_from_slice(&b[..rem.len()]);
         }
+    }
+}
+
+impl MtDraw for Mt {
+    fn next_u32(&mut self) -> u32 {
+        Mt::next_u32(self)
+    }
+}
+
+/// A generator operating directly on its serialized state (the
+/// `Mt::to_bytes` layout) — the `/random_state` String of a `Random`
+/// instance, borrowed for the duration of one builtin call.
+///
+/// A draw touches one table word and the position, so it costs O(1)
+/// where deserializing, drawing and re-serializing the 2.5 KB state cost
+/// ~10k instructions per `Random#rand` (splay draws 12k times per
+/// iteration). Only the refill, once every 624 words, decodes the table
+/// into a stack copy and writes it back.
+pub(crate) struct MtInPlace<'a>(&'a mut [u8]);
+
+impl<'a> MtInPlace<'a> {
+    /// `None` unless `bytes` is a well-formed state.
+    pub(crate) fn new(bytes: &'a mut [u8]) -> Option<Self> {
+        if bytes.len() != Mt::STATE_BYTES {
+            return None;
+        }
+        let s = Self(bytes);
+        (s.mti() <= MT_N).then_some(s)
+    }
+
+    #[inline]
+    fn word(&self, i: usize) -> u32 {
+        u32::from_le_bytes(self.0[i * 4..i * 4 + 4].try_into().unwrap())
+    }
+
+    #[inline]
+    fn mti(&self) -> usize {
+        self.word(MT_N) as usize
+    }
+
+    #[inline]
+    fn set_mti(&mut self, mti: usize) {
+        self.0[MT_N * 4..MT_N * 4 + 4].copy_from_slice(&(mti as u32).to_le_bytes());
+    }
+}
+
+impl MtDraw for MtInPlace<'_> {
+    fn next_u32(&mut self) -> u32 {
+        let mut mti = self.mti();
+        if mti >= MT_N {
+            let mut mt = [0u32; MT_N];
+            for (w, c) in mt.iter_mut().zip(self.0[..MT_N * 4].chunks_exact(4)) {
+                *w = u32::from_le_bytes(c.try_into().unwrap());
+            }
+            refill(&mut mt);
+            for (c, w) in self.0[..MT_N * 4].chunks_exact_mut(4).zip(mt.iter()) {
+                c.copy_from_slice(&w.to_le_bytes());
+            }
+            mti = 0;
+        }
+        let y = self.word(mti);
+        self.set_mti(mti + 1);
+        temper(y)
     }
 }
 
@@ -175,11 +257,24 @@ pub(crate) fn build_mt(seed: Value) -> Mt {
 }
 
 /// CRuby `genrand_real` (53-bit, two draws).
-pub(crate) fn next_real(mt: &mut Mt, cnt: &mut u64) -> f64 {
+pub(crate) fn next_real<M: MtDraw>(mt: &mut M, cnt: &mut u64) -> f64 {
     let a = (mt.next_u32() >> 5) as f64;
     let b = (mt.next_u32() >> 6) as f64;
     *cnt += 2;
     (a * 67108864.0 + b) * (1.0 / 9007199254740992.0)
+}
+
+/// CRuby `int_pair_to_real_inclusive`: uniform Float in `[0, 1]` (both
+/// ends included), two draws — the mapping an *inclusive* float-range
+/// `rand(a..b)` uses.
+pub(crate) fn next_real_inclusive<M: MtDraw>(mt: &mut M, cnt: &mut u64) -> f64 {
+    let a = mt.next_u32() as u128;
+    let b = mt.next_u32() as u128;
+    *cnt += 2;
+    let x = (a << 32) | b;
+    let m = (1u128 << 53) | 1;
+    let r = ((x * m) >> 64) as u64;
+    (r as f64) * (1.0 / 9007199254740992.0)
 }
 
 fn make_mask(mut x: u32) -> u32 {
@@ -204,7 +299,12 @@ fn make_mask(mut x: u32) -> u32 {
 /// A retry abandons a partially written pass, but the pass that returns
 /// assigns every index, so no stale digit can survive into the result and
 /// the buffer needs no clearing in between.
-pub(crate) fn limited_rand_into(mt: &mut Mt, cnt: &mut u64, limit: &[u32], digits: &mut [u32]) {
+pub(crate) fn limited_rand_into<M: MtDraw>(
+    mt: &mut M,
+    cnt: &mut u64,
+    limit: &[u32],
+    digits: &mut [u32],
+) {
     let len = limit.len();
     debug_assert_eq!(len, digits.len());
     loop {
@@ -240,7 +340,7 @@ pub(crate) fn limited_rand_into(mt: &mut Mt, cnt: &mut u64, limit: &[u32], digit
 
 /// [`limited_rand_into`] for the variable-width (Bignum) callers, which
 /// cannot size a buffer at compile time.
-pub(crate) fn limited_rand(mt: &mut Mt, cnt: &mut u64, limit: &[u32]) -> Vec<u32> {
+pub(crate) fn limited_rand<M: MtDraw>(mt: &mut M, cnt: &mut u64, limit: &[u32]) -> Vec<u32> {
     let mut digits = vec![0u32; limit.len()];
     limited_rand_into(mt, cnt, limit, &mut digits);
     digits
@@ -249,7 +349,7 @@ pub(crate) fn limited_rand(mt: &mut Mt, cnt: &mut u64, limit: &[u32]) -> Vec<u32
 /// CRuby `rb_random_ulong_limited`: uniform integer in `[0, max]`, drawn
 /// from `mt` without allocating. This is the draw behind every
 /// `Array#shuffle` / `#sample` index.
-pub(crate) fn ulong_limited(mt: &mut Mt, cnt: &mut u64, max: u64) -> u64 {
+pub(crate) fn ulong_limited<M: MtDraw>(mt: &mut M, cnt: &mut u64, max: u64) -> u64 {
     if max == 0 {
         return 0;
     }
@@ -287,7 +387,7 @@ pub(crate) fn digits_to_value(digits: &[u32]) -> Value {
 }
 
 /// `rand(max)` for an integer `max` (> 0): uniform in `[0, max)`.
-pub(crate) fn rand_int(mt: &mut Mt, cnt: &mut u64, max: &num::BigInt) -> Value {
+pub(crate) fn rand_int<M: MtDraw>(mt: &mut M, cnt: &mut u64, max: &num::BigInt) -> Value {
     let limit = max - 1u32;
     let digits = limited_rand(mt, cnt, &to_le_digits(&limit));
     digits_to_value(&digits)
@@ -339,12 +439,8 @@ impl Prng {
     /// (both ends included), two draws — the mapping an *inclusive*
     /// float-range `rand` uses.
     pub(crate) fn next_real_inclusive(&mut self) -> f64 {
-        let a = self.mt.next_u32() as u128;
-        let b = self.mt.next_u32() as u128;
-        let x = (a << 32) | b;
-        let m = (1u128 << 53) | 1;
-        let r = ((x * m) >> 64) as u64;
-        (r as f64) * (1.0 / 9007199254740992.0)
+        let mut cnt = 0;
+        next_real_inclusive(&mut self.mt, &mut cnt)
     }
 
     /// CRuby `rb_random_ulong_limited`: uniform integer in `[0, max]`.

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -1481,10 +1481,11 @@ impl RValue {
                     ObjTy::IO_BUFFER => ObjKind::io_buffer(self.as_io_buffer().clone()),
                     ObjTy::ARGF => ObjKind::argf(self.as_argf().clone()),
                     ObjTy::ARRAY => {
-                        let mut v = vec![];
-                        for e in self.as_array().iter() {
-                            v.push(e.deep_copy());
-                        }
+                        // Sized up front: a literal past the inline
+                        // capacity (`[0, 1, …, 9]`) is copied on every
+                        // evaluation, and growing from empty cost three
+                        // reallocations per copy — 80% of the copy.
+                        let v: Vec<Value> = self.as_array().iter().map(|e| e.deep_copy()).collect();
                         ObjKind::array(ArrayInner::from_vec(v))
                     }
                     ObjTy::RANGE => {

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -1371,6 +1371,14 @@ impl RStringInner {
         unsafe { &mut self.content.owned }
     }
 
+    /// The bytes, for overwriting in place at the same length (a shared
+    /// view is detached first). The cached code range is dropped, since
+    /// the caller may write anything.
+    pub(crate) fn as_bytes_mut(&mut self) -> &mut [u8] {
+        self.cr.set(CodeRange::Unknown);
+        self.owned_mut().as_mut_slice()
+    }
+
     /// Detach a shared string from its root in place — `uniquify` for
     /// callers outside this module (the JIT's inline `String#<<` calls
     /// this through `runtime::str_detach` and retries its append on the

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -241,6 +241,7 @@
 10406c07428dfa0886a1bab13dabf6f4	"comparison of String with 7 failed"	begin; "a" < 7; rescue ArgumentError => e; e.message; end
 1044a6ff811467108220b77d16c0df20	nil	GC.start
 10630cb5c02e6154a16815f1db4afaa8	[[:get, []], [2]]	class C\n                 def initialize; @log = []; end\n                 def []=
+1064214475f653609918e0669d1287fc	[0.03158614482564204, 5, 309460860262, 208, 1.0635907791763746, 4, 3, 1.6253046607137025, 1.7834227259416147, 1.9183869748893747, [126, 137, 1, 124, 6, 104], 0.8733366617238478, 5, true, 0.9193919732144173, 0.9193919732144173, true, true, true]	r = Random.new(42)\n            1300.times { r.rand }\n            a 
 10763a10e14efbbc495d2a2b48c4e475	[3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17, 18, 18, 19, 19, 20, 20, 21, 21, 22, 22]	class Foo\n              @@foo = 1\n              def foo\n           
 10825d3f920402467ed0762277926bd9	[1, 2]	def method_with_block\n          Fiber.new {\n            [1,2].each { |x
 10992a62d5e09476c2e0a3c43fd20025	[true, [:a, :b]]	S = Struct.new(:a, :b, keyword_init: true)\n            \n\n          
@@ -1064,6 +1065,7 @@
 506afd7190c9d45ecdef2e801c939176	:te	begin; 1.instance_eval { undef to_s }; :no; rescue TypeError; :te; end
 5078669efc5be0d889fb3ff62604139e	[5350, 1, 2]	class Ka; def v = 1; end\n            class Kb; def v = 2; end\n     
 507f32e0a72a071583d973ffea3c15c7	["Hello Dave at New York!", "Hello Gave at Hawaii!"]	Customer = Struct.new(:name, :address) do\n            def greeting\n    
+5084a8e909415b5d3fcf1ba2101d0cff		r = Random.new(42)\n            1300.times { r.rand }\n            a 
 509d9bea76f0e1d8349ff37b354accf3	2	k = Class.new { define_method(:m) { [1, 2, 3].each { |x| return x i
 50a5f1523f40c371eae52d5bdb271289	[:@b]	class Foo\n              def initialize\n                @a = 1\n     
 50dc75cab4d7c00e25ec748ffac45bee	"[C2, M, C1, M, Object, Kernel, BasicObject]"	module M\n            end\n            class C1\n            end\n     
@@ -1525,6 +1527,7 @@
 763b67d3ef3e1c8ffe7d61ecae99e06f	"/home/user/monoruby/monoruby/a.rb"	require File.expand_path("./b")\n        C::D\n        
 7679a579d835ee8b69befeae2cee0a2b	"Z"	class MyInt\n                  def to_int; 90; end\n             
 76816dc27924ee3f477d020204e7cbd2	:ok	old_stderr = $stderr\n            captured = String.new\n            
+7689440a9c2dac124b7cf3203bcc5d04	[0.03158614482564204, 5, 309460860262, 208, 1.0635907791763746, 4, 3, 1.6253046607137025, [83, 100, 142, 200, 61, 53], 0.2797035384714792, 1, true, 0.6005943333606173, 0.6005943333606173, true, true, true]	r = Random.new(42)\n            1300.times { r.rand }\n            a 
 768d732177da90b2c02a306f1f672d62	[[1, 2, nil], [true, nil], [true, nil], [42, nil], "Ary", ["Ary", 1], [[1, 2, nil]]]	class Ary;  def to_ary; [1, 2]; end; end\n        class Nily; def to_ary
 76980b7d628abc009ae2670280836614	[["ArgumentError", "only cause is given with no arguments"], ["StandardError", "hi"], ["TypeError", "exception object expected"], ["TypeError", "exception class/object expected"]]	results = []\n            # cause: only ⇒ ArgumentError "only cause 
 76a4361de08288d7f1e53eb3855bdaef	[:refused, "nil", "nil"]	require "socket"\n            # Grab a free port, close the listener


### PR DESCRIPTION
## What

Two of the non-GC costs the splay investigation turned up.

**`Random#rand` serialized its whole state on every draw.** A `Random` instance keeps its live Mersenne Twister state (624 words plus the position) in a binary String ivar. Each draw deserialized that into a stack generator, drew, re-serialized it word by word into a new String and swapped it into the ivar: about 10k instructions, 850 ns against CRuby's 46 ns, and splay draws 12k times per iteration (2.5% of its instructions).

The state String is now advanced where it lies. `MtInPlace` reads the position word, tempers one table word and writes the position back; only the refill, once every 624 words, decodes the table into a stack copy and writes it back, so a draw is O(1) amortized with no allocation. The draw helpers (`next_real`, `rand_int`, `ulong_limited`, `fill_bytes`, …) are written against an `MtDraw` trait, so the global PRNG's in-memory `Mt` and the in-place generator share one implementation of CRuby's algorithms — the stream is bit-identical to before (and to CRuby). `Random#rand` coerces its argument into a `RandReq` before the buffer is borrowed, so no Ruby code (`to_int`) can run while it is held. `Array#shuffle` / `#sample` keep their load-once/store-once session; the copies there are per call, not per element.

Two CRuby behaviors came along, both pinned by the new test: `Random#rand(5..1)` raises ArgumentError ("invalid argument - 5..1") where it answered nil, and an inclusive Float range `rand(1.0..2.0)` draws with `int_pair_to_real_inclusive` where it used the half-open real (`1.0...2.0` keeps `genrand_real`).

**A constant Array literal past the inline capacity grew its Vec from empty.** `[0, 1, …, 9]` is built once and `deep_copy`'d per evaluation (the JIT inlines the copy only up to `ARRAY_INLINE_CAPA = 5`); the copy pushed into `vec[]`, three reallocations per copy — 80% of the copy's cost and 8% of splay. It now collects into an exactly sized Vec.

## Numbers

| | master | this PR | YJIT |
|---|---|---|---|
| `Random#rand` | 849 ns | 160 ns | 46 ns |
| `Random#rand(100)` | 1018 ns | 377 ns | 53 ns |
| `Random#bytes(8)` | 950 ns | 220 ns | 93 ns |
| `[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]` | 149 ns | 72 ns | 52 ns |
| splay (ruby-bench, avg iter, two runs each) | 229 / 203 ms | 171 / 170 ms | 137 ms |
| splay RSS | 449 MiB | 413 MiB | 454 MiB |

The rest of splay's gap to YJIT is GC frequency (about 3.5× CRuby's collection count on this heap), which is a separate change to the trigger policy.

## Tests

- `random_draws_in_place_across_refills`: 1300 draws past two refills, then every draw kind (Float, Integer, Bignum, Float max, Integer / exclusive / inclusive-Float / mixed ranges, `bytes`), 700 more `bytes` calls, `dup` independence and count-sensitive `==`, a fresh generator reproducing the stream, a `to_int`-coercible argument, and the argument errors — all against a live CRuby.
- Existing `random_cruby_parity`, `random_live_state`, shuffle/sample tests pass; ruby/spec `core/random`, `core/kernel/{rand,srand}_spec.rb`, `core/array/{shuffle,sample}_spec.rb`, `library/securerandom`: identical to master.
- Full `cargo test` suite green; aarch64 cross-check compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_