### PR TITLE
Hand salvaged GC pages beyond a resident reserve back to the OS

### DIFF
--- a/doc/gc.md
+++ b/doc/gc.md
@@ -66,7 +66,8 @@ thread_local! { pub static ALLOC: RefCell<Allocator<RValue>> }   // alloc.rs
 | `current_page` / `head_page` / `pages` | 現ページ / 最上位ページ / 割り当て済みページ一覧 |
 | `used_in_current` | 現ページのバンプ位置 |
 | `free` / `free_list_count` | フリーリスト先頭と要素数 |
-| `free_pages` | 空きになって再利用待ちのページ |
+| `free_pages` | 空きになって再利用待ちのページ(常駐したまま) |
+| `released_pages` / `total_released_pages` | 空きページのうち OS に返したもの(`madvise`)と、その累計 |
 | `total_gc_counter` / `minor_gc_count` / `major_gc_count` | GC 回数の各カウンタ |
 | `minors_since_major` | 直近メジャー以降のマイナー回数(kind 判定に使用) |
 | `old_count` | old 世代オブジェクト数(昇格で +1、メジャーで 0 リセット) |
@@ -600,8 +601,20 @@ res = src.flat_map { |rf, gf, bf| (0...64).map { |i| [i * rf, i * gf, i * bf] } 
 ### 空きページの回収(`salvage_empty_pages`, `alloc.rs:1250`)
 
 スイープ前に、全セルが未マーク(`all_dead`)のページを `pages` から外して
-中身をドロップし `free_pages` へ戻す。以後の割り当てで再利用される(OS へは返さず、
-アリーナ予約内で回す)。
+中身をドロップし `free_pages` へ戻す。以後の割り当てで再利用される。
+
+`free_pages` のうち予備(稼働中ページ数の 1/8、最低 2 枚:
+`FREE_PAGE_RESERVE_FRACTION` / `FREE_PAGE_RESERVE_MIN`)を超えた分は
+`release_excess_free_pages` が OS に返す(`released_pages` へ移し、Linux は
+`madvise(MADV_DONTNEED)`、macOS は `MADV_FREE_REUSABLE`)。アドレスはアリーナ予約内に
+留まり、`free_pages` が尽きたときに `take_free_page` が(macOS では `MADV_FREE_REUSE`
+を打って)再び稼働に戻す。返したページの中身は不定だが、稼働に戻るページは
+`clear_old_bits` とバンプ割り当てが読む前にすべて書き直すので問題ない。
+
+以前は空きページを常駐させたままだったため、ワークロードのピーク時のヒープが
+そのまま RSS に残っていた(lee: 生存 22 ページに対して常駐 ~140 ページ、30 MB)。
+予備は 2 回の収集ぶんの成長(トリガー予算は稼働ページの 1/16)を賄うので、
+定常状態のヒープは常駐ページを回し、縮んだヒープだけが再タッチのページフォルトを払う。
 
 ---
 

--- a/monoruby/src/alloc.rs
+++ b/monoruby/src/alloc.rs
@@ -485,6 +485,20 @@ const OLD_GROWTH_FACTOR: usize = 2;
 /// would only add overhead.
 const OLD_OBJECT_FLOOR: usize = 16384;
 
+/// How many salvaged (all-dead) pages stay resident for reuse before the
+/// rest are handed back to the OS: `1/FREE_PAGE_RESERVE_FRACTION` of the
+/// pages in service, and never fewer than `FREE_PAGE_RESERVE_MIN`.
+///
+/// A page that empties out used to sit on `free_pages` forever, so a
+/// workload's *peak* heap stayed resident: lee's collector needed 22
+/// pages for its live set while the arena kept ~115 touched (30 MB RSS
+/// for 5.5 MB of objects). The reserve covers the growth between two
+/// collections (the trigger budget is `1/GC_HEAP_FRACTION` of the pages
+/// in service), so a steady-state heap reuses resident pages and only a
+/// heap that shrank pays the page faults of re-touching released ones.
+const FREE_PAGE_RESERVE_FRACTION: usize = 8;
+const FREE_PAGE_RESERVE_MIN: usize = 2;
+
 /// How deep the mark phase may walk the object graph with plain
 /// recursion before it starts deferring children to the mark queue
 /// (`Allocator::scan_children`).
@@ -642,6 +656,14 @@ pub struct Allocator<T> {
     free: Option<std::ptr::NonNull<T>>,
     /// Deallocated pages.
     free_pages: VecDeque<PageRef<T>>,
+    /// Salvaged pages whose memory has been handed back to the OS
+    /// (`release_page`): still part of the arena, reused after
+    /// `free_pages` runs dry. Their contents are undefined until a
+    /// page enters service again, which re-initialises everything it
+    /// reads (`clear_old_bits`, then the bump allocator writes cells).
+    released_pages: VecDeque<PageRef<T>>,
+    /// Pages released to the OS so far (monotonic; `GC.stat`-style).
+    total_released_pages: usize,
     /// Counter of GC execution.
     total_gc_counter: usize,
     /// Counter of minor (young-generation) GC executions. Always 0 until
@@ -906,6 +928,8 @@ impl<T: GCBox> Allocator<T> {
             mark_counter: 0,
             free: None,
             free_pages: VecDeque::new(),
+            released_pages: VecDeque::new(),
+            total_released_pages: 0,
             total_gc_counter: 0,
             minor_gc_count: 0,
             major_gc_count: 0,
@@ -1104,7 +1128,42 @@ impl<T: GCBox> Allocator<T> {
     /// Pages salvaged by a previous sweep and waiting to be reused
     /// (CRuby's `heap_empty_pages`).
     pub fn empty_page_count(&self) -> usize {
-        self.free_pages.len()
+        self.free_pages.len() + self.released_pages.len()
+    }
+
+    /// Salvaged pages currently handed back to the OS (a subset of
+    /// [`empty_page_count`](Self::empty_page_count)).
+    pub fn released_page_count(&self) -> usize {
+        self.released_pages.len()
+    }
+
+    /// Pages handed back to the OS so far (monotonic).
+    pub fn total_released_pages(&self) -> usize {
+        self.total_released_pages
+    }
+
+    /// Released pages that still have memory resident behind them, per
+    /// `mincore(2)`. Linux drops an `MADV_DONTNEED` range at once, so this
+    /// is zero right after a release. Test-only: it costs a syscall per
+    /// page, and it is the process-independent way to check the release
+    /// actually happened (a whole-process RSS reading is shared with every
+    /// other test thread's arena).
+    #[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
+    pub(crate) fn resident_released_pages(&self) -> usize {
+        // SAFETY: `sysconf` has no preconditions.
+        let os_page = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as usize;
+        let mut vec = vec![0u8; ALLOC_SIZE / os_page];
+        self.released_pages
+            .iter()
+            .filter(|page| {
+                // SAFETY: `page` is an `ALLOC_SIZE`-sized block of the arena
+                // mapping and `vec` holds one byte per OS page of it.
+                let rc = unsafe {
+                    libc::mincore(page.as_ptr() as _, ALLOC_SIZE, vec.as_mut_ptr() as _)
+                };
+                rc == 0 && vec.iter().any(|b| b & 1 != 0)
+            })
+            .count()
     }
 
     /// Object slots the in-service pages hold in total.
@@ -1270,7 +1329,7 @@ impl<T: GCBox> Allocator<T> {
             // Allocate new page.
             self.used_in_current = 1;
             self.pages.push(self.current_page);
-            self.current_page = match self.free_pages.pop_front() {
+            self.current_page = match self.take_free_page() {
                 Some(page) => page,
                 None => {
                     self.total_allocated_pages += 1;
@@ -1894,6 +1953,36 @@ impl<T: GCBox> Allocator<T> {
                 }
             }
         }
+        self.release_excess_free_pages();
+    }
+
+    /// The salvaged pages kept resident: see [`FREE_PAGE_RESERVE_FRACTION`].
+    fn free_page_reserve(&self) -> usize {
+        (self.page_count() / FREE_PAGE_RESERVE_FRACTION).max(FREE_PAGE_RESERVE_MIN)
+    }
+
+    /// Hand every salvaged page beyond the reserve back to the OS. The
+    /// pages stay in the arena (on `released_pages`) and come back into
+    /// service after the resident ones are used up.
+    fn release_excess_free_pages(&mut self) {
+        let reserve = self.free_page_reserve();
+        while self.free_pages.len() > reserve {
+            let page = self.free_pages.pop_back().unwrap();
+            release_page(page);
+            self.released_pages.push_back(page);
+            self.total_released_pages += 1;
+        }
+    }
+
+    /// A salvaged page for reuse: a resident one first, else one that was
+    /// released to the OS (its memory is reclaimed on the way).
+    fn take_free_page(&mut self) -> Option<PageRef<T>> {
+        if let Some(page) = self.free_pages.pop_front() {
+            return Some(page);
+        }
+        let page = self.released_pages.pop_front()?;
+        reclaim_page(page);
+        Some(page)
     }
 
     ///
@@ -2107,6 +2196,50 @@ impl<T: GCBox> Allocator<T> {
             self.free_list_count, self.allocated, self.used_in_current
         );
     }*/
+}
+
+/// Hand a whole, all-dead page back to the OS while keeping its address
+/// range in the arena. Linux drops the pages outright (`MADV_DONTNEED`:
+/// RSS falls now, a later touch faults in zero pages); macOS is told they
+/// are reusable (`MADV_FREE_REUSABLE`, the form whose accounting also
+/// lowers RSS immediately). Other platforms keep the page resident. The
+/// page is a whole `ALLOC_SIZE`-aligned block, so the advice covers
+/// exactly its cells and bitmaps.
+fn release_page<T>(page: PageRef<T>) {
+    #[cfg(target_os = "linux")]
+    let advice = libc::MADV_DONTNEED;
+    #[cfg(target_os = "macos")]
+    let advice = libc::MADV_FREE_REUSABLE;
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        let _ = page;
+        return;
+    }
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    // SAFETY: `page` is an `ALLOC_SIZE`-aligned, `ALLOC_SIZE`-sized block
+    // of the arena mapping that no live object references (every cell was
+    // dropped by `drop_inner_cells` and none is on the free list).
+    // Advice failing only means the memory stays resident.
+    unsafe {
+        let _ = libc::madvise(page.as_ptr() as *mut libc::c_void, ALLOC_SIZE, advice);
+    }
+}
+
+/// The counterpart of [`release_page`] when a released page re-enters
+/// service. Linux needs nothing (the first touch faults the pages back
+/// in); macOS wants `MADV_FREE_REUSE` so its accounting counts them again.
+fn reclaim_page<T>(page: PageRef<T>) {
+    #[cfg(target_os = "macos")]
+    // SAFETY: as in `release_page`; the page is about to be re-initialised.
+    unsafe {
+        let _ = libc::madvise(
+            page.as_ptr() as *mut libc::c_void,
+            ALLOC_SIZE,
+            libc::MADV_FREE_REUSE,
+        );
+    }
+    #[cfg(not(target_os = "macos"))]
+    let _ = page;
 }
 
 ///

--- a/monoruby/src/builtins/gc.rs
+++ b/monoruby/src/builtins/gc.rs
@@ -488,6 +488,58 @@ mod tests {
     use crate::tests::*;
 
     #[test]
+    fn empty_pages_go_back_to_the_os() {
+        // Grow the heap with garbage, collect, and the pages that emptied
+        // out beyond the resident reserve are handed back: they still
+        // count as empty pages (reusable), and on Linux the memory behind
+        // them is gone at once. The residency check asks `mincore` about
+        // this thread's arena rather than reading the process RSS, which
+        // every other test thread's arena moves too.
+        let res = run_test_no_result_check(
+            r##"
+            keep = []
+            400.times { |i| keep << Array.new(2000) { |j| [i, j] } }
+            pages_peak = GC.stat(:heap_allocated_pages)
+            keep = nil
+            GC.start
+            GC.start
+            [pages_peak, GC.stat(:heap_allocated_pages), GC.stat(:heap_empty_pages)]
+            "##,
+        );
+        let v: Vec<i64> = res
+            .as_array()
+            .iter()
+            .map(|v| v.try_fixnum().unwrap())
+            .collect();
+        let (pages_peak, pages_after, empty) = (v[0], v[1], v[2]);
+        assert!(pages_peak > 100, "heap did not grow: {v:?}");
+        assert!(pages_after < pages_peak / 4, "pages stayed in service: {v:?}");
+        assert!(empty > pages_peak / 2, "salvaged pages not accounted as empty: {v:?}");
+        // The allocator is thread-local and outlives the `Globals` above,
+        // so it still holds the post-collection page lists here.
+        let (released, resident) = crate::alloc::ALLOC.with(|alloc| {
+            let alloc = alloc.borrow();
+            (
+                alloc.released_page_count() as i64,
+                #[cfg(any(target_os = "linux", target_os = "macos"))]
+                alloc.resident_released_pages(),
+                #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+                0,
+            )
+        });
+        assert!(
+            released > pages_peak / 2,
+            "salvaged pages not released: {v:?} released={released}"
+        );
+        if cfg!(target_os = "linux") {
+            assert_eq!(
+                resident, 0,
+                "released pages still resident: {v:?} released={released}"
+            );
+        }
+    }
+
+    #[test]
     fn gc_compact_is_a_full_gc_noop() {
         // The `GC.compact if GC.respond_to?(:compact)` guard idiom must
         // run the call, and the return keeps CRuby's shape (per-type

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -1132,6 +1132,9 @@ impl Globals {
                 eprintln!("live objects (last gc):  {}", alloc.live_count());
                 eprintln!("free list (last gc):     {}", alloc.free_count());
                 eprintln!("active pages:            {}", alloc.pages_len());
+                eprintln!("empty pages (resident):  {}", alloc.empty_page_count() - alloc.released_page_count());
+                eprintln!("empty pages (released):  {}", alloc.released_page_count());
+                eprintln!("total released pages:    {}", alloc.total_released_pages());
             });
             alloc::malloc_stats::dump();
         }


### PR DESCRIPTION
## Summary

A page whose every cell died left `pages` for `free_pages` and stayed there, resident, until reused, so a workload's *peak* heap stayed in RSS for good: lee's collector needed 22 pages for its live set while the arena kept ~140 touched (30 MB of RSS for 5.5 MB of objects).

`salvage_empty_pages` now keeps a reserve of salvaged pages resident (1/8 of the pages in service, at least 2, which covers the growth between two collections whose trigger budget is 1/16) and hands the rest back with `madvise` (`MADV_DONTNEED` on Linux, `MADV_FREE_REUSABLE` on macOS, reclaimed with `MADV_FREE_REUSE` when a page re-enters service). The addresses stay in the arena on `released_pages` and are reused after the resident ones run dry; a page entering service rewrites everything it reads, so the released contents being undefined does not matter.

- `GC.stat(:heap_empty_pages)` counts both resident and released empty pages.
- The `gc-log` profile reports the resident/released split and the running total of released pages.
- `doc/gc.md` describes the reserve and the release path.

## Results (RSS at the end of a run)

| benchmark | before | after |
|---|---|---|
| lee | 83 MB | 53 MB |
| activerecord | 158 MB | 142 MB |
| rack | 64 MB | 60 MB |
| splay | unchanged (live set fills the heap) | |

Wall time is within noise on all four (lee 433/457 ms vs 435/470 ms).

## Test

`empty_pages_go_back_to_the_os` grows the heap with garbage, collects, and checks that the salvaged pages are accounted as empty, that more than half of the peak page count was released, and (Linux) that `mincore` reports none of the released pages resident. The residency check asks about this thread's arena rather than the process RSS, which every other test thread's arena moves too when the lib tests share one process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_