### PR TITLE
Trace each example to stderr when running ruby/spec (spec/default.mspec)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,8 +7,9 @@
 #     - run: monoruby my_script.rb
 #
 # With the `rubyspec: 'true'` input the action also prepares a ruby/spec
-# workspace (clones spec/ruby + spec/mspec and copies this repo's spec/tags
-# into the tag locations mspec resolves), ready for
+# workspace (clones spec/ruby + spec/mspec, copies this repo's spec/tags
+# into the tag locations mspec resolves, and installs this repo's
+# spec/default.mspec, which mspec picks up by itself), ready for
 # `spec/mspec/bin/mspec ci --target monoruby spec/ruby/...`.
 #
 # Install strategy, in order:
@@ -69,9 +70,11 @@ inputs:
     description: >
       Also set up a ruby/spec workspace for running the Ruby specs against
       the installed monoruby: clone ruby/spec into spec/ruby and ruby/mspec
-      into spec/mspec (both in $GITHUB_WORKSPACE), and copy this repo's
-      spec/tags into the tag locations mspec resolves. Used by conformance
-      trackers such as rubyspec-stats; off by default.
+      into spec/mspec (both in $GITHUB_WORKSPACE), copy this repo's
+      spec/tags into the tag locations mspec resolves, and install this
+      repo's spec/default.mspec (mspec loads it automatically; it traces
+      each example to stderr so a hung run still names the culprit). Used
+      by conformance trackers such as rubyspec-stats; off by default.
     required: false
     default: "false"
 
@@ -239,15 +242,19 @@ runs:
     # this repo at the action ref), so they stay in step with the monoruby
     # version the consumer selected — no extra clone needed.
     #
-    # Tag lookup depends on whether an mspec config file is loaded. mspec
-    # searches config[:path] = ['.', 'spec'] for `default.mspec` — in this
-    # workspace layout NEITHER exists (ruby/spec's own default.mspec sits at
-    # spec/ruby/default.mspec, which is not searched), so mspec falls back to
+    # Tag lookup: mspec searches config[:path] = ['.', 'spec'] for
+    # `default.mspec`, and the only one it finds here is this repo's
+    # spec/default.mspec (ruby/spec's own sits at spec/ruby/default.mspec,
+    # which is not searched). Ours does not set :tags_patterns, so mspec keeps
     # its built-in pattern `[[%r(spec/), 'spec/tags/'], [/_spec.rb$/, '_tags.txt']]`:
     # `spec/ruby/core/file/flock_spec.rb` -> `spec/tags/ruby/core/file/flock_tags.txt`.
-    # Copy into BOTH locations so the tags keep working even if a config file
-    # ever becomes loadable and switches the mapping to ruby/spec's
-    # `[%r(core/), 'tags/core/']` style (spec/ruby/tags/...).
+    # Copy into BOTH locations so the tags keep working even if the mapping
+    # ever switches to ruby/spec's `[%r(core/), 'tags/core/']` style
+    # (spec/ruby/tags/...).
+    #
+    # spec/default.mspec itself only registers an example trace (each
+    # example's description goes to stderr as it starts); see the file for
+    # why that matters for hung runs.
     - name: Set up ruby/spec workspace
       if: inputs.rubyspec == 'true'
       shell: bash
@@ -260,3 +267,4 @@ runs:
           cp -R "$GITHUB_ACTION_PATH/spec/tags/." spec/tags/ruby/
           cp -R "$GITHUB_ACTION_PATH/spec/tags/." spec/ruby/tags/
         fi
+        cp "$GITHUB_ACTION_PATH/spec/default.mspec" spec/default.mspec

--- a/doc/ruby_spec_skip_tags.md
+++ b/doc/ruby_spec_skip_tags.md
@@ -109,6 +109,16 @@ example を統計へ復帰させること。
 ln -sfn /path/to/monoruby/spec/tags /path/to/spec/tags
 ```
 
+なお、monoruby リポジトリ側の `spec/default.mspec` は別物で、setup action
+（`rubyspec: "true"`）が rubyspec-stats のワークスペース直下 `spec/` に
+コピーする設定ファイル。`tags_patterns` は設定しない（mspec 組み込みの
+`spec/tags/ruby/...` 解決のまま）。中身は example トレースのみ: 各 example の
+description を実行直前に stderr へ出す。mspec 自身の `--timeout` は対象
+プロセス内の監視スレッドなので、メインスレッドがカーネル内（`waitpid` 等）で
+ブロックすると monoruby では発火せず、外側の `timeout(1)` に kill されて
+結果ファイルが空になる。トレースがあれば CI ログの最後の description が
+ハングした example であり、そのままタグに書ける。
+
 ## bisect 手法（ローカル）
 
 CI には "Bisect monoruby core hang" ワークフローがあるが、監査全体は

--- a/spec/default.mspec
+++ b/spec/default.mspec
@@ -1,0 +1,29 @@
+# mspec configuration for a ruby/spec workspace laid out by this repo's
+# setup action (`rubyspec: "true"`, see action.yml):
+#
+#   spec/ruby/          ruby/spec
+#   spec/mspec/         ruby/mspec
+#   spec/tags/          this repo's spec/tags
+#   spec/default.mspec  this file
+#
+# mspec loads `default.mspec` from the current directory or `spec/` by
+# itself -- in the `mspec` driver and in the mspec-ci/mspec-run child that
+# runs the examples -- so nothing on the command line needs to reference
+# this file. (An engine-specific name, `monoruby.mspec`, would not be
+# picked up: monoruby reports RUBY_ENGINE "ruby".)
+#
+# Example trace: print each example's description to stderr right before
+# it runs. mspec's own `--timeout` is a watchdog thread inside the target
+# process and cannot fire while monoruby's main thread blocks in the
+# kernel (e.g. in waitpid), so a hung run is only ever killed from the
+# outside by timeout(1), which leaves an empty results file and, until
+# now, no hint of where it was. With this trace the last description in
+# the log is the example that was running -- the one to tag.
+class ExampleTrace
+  def before(state)
+    STDERR.puts state.description
+    STDERR.flush
+  end
+end
+
+MSpec.register :before, ExampleTrace.new


### PR DESCRIPTION
## Changes

- `spec/default.mspec` (new): mspec config that registers a `:before` action printing each example's description to stderr right before it runs.
- `action.yml`: the `rubyspec: "true"` step also copies that file to `spec/default.mspec` in the workspace. mspec loads it automatically (it searches `.` and `spec/`), in both the `mspec` driver and the `mspec-ci` child, so rubyspec-stats' `ci.yml` needs no change.
- `doc/ruby_spec_skip_tags.md`: short note on the trace.

## Why

mspec's own `--timeout` is a watchdog thread inside the target process; it cannot fire while monoruby's main thread blocks in the kernel (e.g. `waitpid`), so a hung ruby/spec run in rubyspec-stats is only ever killed by the outer `timeout(1)`. That leaves an empty results file and no record of which example hung — the two recent core hangs (`process/waitall_spec.rb`, `process/fork_spec.rb`) had to be located by counting `--marker` dots, which only identifies the file. With the trace, the last description in the CI log is the hanging example, ready to be put in a tag file.

The config does not set `:tags_patterns`, so tag lookup keeps mspec's built-in `spec/tags/ruby/...` mapping.

## Verification (local, nightly binary)

- Normal run of `process/abort_spec.rb`, `process/fork_spec.rb`, `array/first_spec.rb`: descriptions in stderr, `stats.yml` intact (29 examples, 0 failures), fork specs still fully tagged out.
- Simulated hang (spec with `sleep 100`, `timeout -k 5 5`): exit 137, empty `stats.yml`, and `ZZ trace hangs forever` as the last stderr line.

Cost: one line per example (core ≈ 23k lines in the step log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gxL6QM3ZPtgV14QddDq1W

---
_Generated by [Claude Code](https://claude.ai/code/session_017gxL6QM3ZPtgV14QddDq1W)_