### PR TITLE
Boot rubygems lazily, on the first reference to Gem

### DIFF
--- a/monoruby/builtins/gem_prelude.rb
+++ b/monoruby/builtins/gem_prelude.rb
@@ -1,0 +1,28 @@
+# The rubygems boot, deferred.
+#
+# CRuby's gem_prelude requires rubygems at every start. Loading the
+# vendored rubygems (some twenty files, `Gem::Specification` among them)
+# is most of monoruby's startup: about 8 MB of RSS and 90 ms for a
+# program that never touches `Gem`. Register the constant as an autoload
+# instead, so the first reference to `Gem` -- from a program, a library,
+# or `require "rubygems"` itself -- pays for the boot, and nothing else
+# does. `defined?(Gem)`, `Object.const_defined?(:Gem)` and
+# `Object.constants` all report the constant as present without loading
+# it, as with any autoload.
+#
+# `Kernel#gem` is the one rubygems entry point that is a method, not a
+# constant. Until the boot runs it is this stub, which boots rubygems and
+# re-dispatches to the definition `rubygems/core_ext/kernel_gem.rb` put
+# in its place.
+#
+# Skipped entirely under `--disable-gems`, so `Gem` is then undefined.
+autoload :Gem, "rubygems"
+
+module Kernel
+  private
+
+  def gem(gem_name, *requirements)
+    require "rubygems"
+    gem(gem_name, *requirements)
+  end
+end

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -592,8 +592,14 @@ impl Executor {
         if std::env::var_os("MONORUBY_SKIP_STARTUP").is_none() {
             let path = install_root().join("builtins").join("startup.rb");
             executor.require(globals, &path, false)?;
+            // The rubygems boot: `gem_prelude.rb` registers `Gem` as an
+            // autoload of "rubygems" (and a `Kernel#gem` stub that boots
+            // it), so the vendored rubygems is read only by the first
+            // program that reaches for it — a plain script skips its
+            // ~8 MB / ~90 ms.
             if !globals.no_gems {
-                executor.load_gems(globals);
+                let path = install_root().join("builtins").join("gem_prelude.rb");
+                executor.require(globals, &path, false)?;
             }
         }
         // TOPLEVEL_BINDING: registered as a *lazy* constant — defined
@@ -658,18 +664,6 @@ impl Executor {
         // stays within the allocated stack region.
         let stack_limit = unsafe { rsp.sub(FIBER_STACK_BUDGET) };
         self.stack_limit = stack_limit as usize;
-    }
-
-    /// The rubygems boot: `builtins/gem_prelude.rb` registers `Gem` as an
-    /// autoload of "rubygems" (and a `Kernel#gem` stub that boots it), so
-    /// the vendored rubygems is read only by the first program that
-    /// reaches for it — a plain script skips its ~8 MB / ~90 ms.
-    fn load_gems(&mut self, globals: &mut Globals) {
-        let path = install_root().join("builtins").join("gem_prelude.rb");
-        if let Err(err) = self.require(globals, &path, false) {
-            err.show_error_message_and_all_loc(&globals.store);
-            panic!("error occured in loading {}", path.display());
-        }
     }
 
     pub fn cfp(&self) -> Cfp {

--- a/monoruby/src/executor.rs
+++ b/monoruby/src/executor.rs
@@ -660,12 +660,15 @@ impl Executor {
         self.stack_limit = stack_limit as usize;
     }
 
+    /// The rubygems boot: `builtins/gem_prelude.rb` registers `Gem` as an
+    /// autoload of "rubygems" (and a `Kernel#gem` stub that boots it), so
+    /// the vendored rubygems is read only by the first program that
+    /// reaches for it — a plain script skips its ~8 MB / ~90 ms.
     fn load_gems(&mut self, globals: &mut Globals) {
-        for gem in ["rubygems"] {
-            if let Err(err) = self.require(globals, &std::path::PathBuf::from(gem), false) {
-                err.show_error_message_and_all_loc(&globals.store);
-                panic!("error occured in loading {gem}");
-            }
+        let path = install_root().join("builtins").join("gem_prelude.rb");
+        if let Err(err) = self.require(globals, &path, false) {
+            err.show_error_message_and_all_loc(&globals.store);
+            panic!("error occured in loading {}", path.display());
         }
     }
 
@@ -1301,22 +1304,37 @@ impl Executor {
             // `Gem.loaded_specs["gosu"].full_gem_path` then raises a
             // `NoMethodError` on `nil`. When the file we just loaded came
             // from a host gem (`/gems/`) or from a C-extension-gem stub
-            // (`~/.monoruby/stub`), ask the (already eagerly-loaded)
-            // vendored rubygems to activate the gem that provides this
-            // feature so its spec lands in `Gem.loaded_specs`, matching
-            // CRuby — keyed on the requested feature, not the resolved
-            // path, so a stub-shadowed gem still activates its host spec.
+            // (`~/.monoruby/stub`), ask the vendored rubygems to activate
+            // the gem that provides this feature so its spec lands in
+            // `Gem.loaded_specs`, matching CRuby — keyed on the requested
+            // feature, not the resolved path, so a stub-shadowed gem still
+            // activates its host spec.
             //
-            // The two gates matter for performance: the first activation
-            // forces rubygems to build its stub index over every installed
-            // gemspec (~100ms here), so we keep that cost off every
-            // program that doesn't actually reach for a host gem.
-            //  * `startup_flag` skips requires issued while startup.rb /
-            //    gem bootstrap runs — notably rubygems' own
-            //    `require "monitor"` (a default gem served from the stub
-            //    dir), which would otherwise build the index at every
-            //    boot for no benefit (default gems don't populate
-            //    `loaded_specs`).
+            // rubygems itself is booted lazily (`gem_prelude.rb` registers
+            // `Gem` as an autoload), and the two origins treat that
+            // differently:
+            //  * a host gem's file is proof the program uses host gems, so
+            //    the lookup goes through the autoload and boots rubygems
+            //    if nothing has yet;
+            //  * a stub's file is not: `json`, `set`, `monitor` and the
+            //    other default-gem stands-in are served from the same
+            //    directory, and booting rubygems (~8 MB, ~90 ms) for
+            //    `require "json"` would waste the deferral for most
+            //    programs. A stub only activates through a rubygems the
+            //    program already loaded — and not while that rubygems is
+            //    still booting: its own `require "monitor"` (a default gem
+            //    served from the stub dir) lands here after `module Gem`
+            //    has defined the constant, and activating it would build
+            //    the index at every boot for no benefit (default gems
+            //    don't populate `loaded_specs`). The `gosu` stub publishes
+            //    its own spec into `loaded_specs` regardless
+            //    (`native_shim.rb`).
+            //
+            // The remaining gates matter for performance: the first
+            // activation forces rubygems to build its stub index over every
+            // installed gemspec (~100ms here), so we keep that cost off
+            // every program that doesn't actually reach for a host gem.
+            //  * `startup_flag` skips requires issued while startup.rb runs.
             //  * the resolved-path gate skips the vendored stdlib (e.g.
             //    `require 'rbconfig'` resolves under `~/.monoruby/lib`),
             //    so a program that only touches the stdlib never pays the
@@ -1335,29 +1353,39 @@ impl Executor {
             //    not needed by the gosu/`full_gem_path` case this serves.
             // `require_relative` (`is_relative`) and absolute requires are
             // skipped too: their feature is a path, not a gem name.
-            // Best-effort — any raised error is swallowed (and cleared
-            // from `self`) so a successful require never fails over this
+            // Best-effort — any raised error (the rubygems boot included)
+            // is swallowed so a successful require never fails over this
             // bookkeeping.
             if !is_relative
                 && CODEGEN.with(|codegen| codegen.borrow().startup_flag)
                 && file_name.to_str().is_some_and(|s| !s.contains('/'))
-                && (canonicalized_path
+            {
+                let gem_id = IdentId::get_id("Gem");
+                let gem = if canonicalized_path
                     .to_str()
                     .is_some_and(|s| s.contains("/gems/"))
-                    || canonicalized_path.starts_with(install_root().join("stub")))
-                && let Some(gem) = globals
-                    .store
-                    .get_constant_noautoload(OBJECT_CLASS, IdentId::get_id("Gem"))
-            {
-                let feature = Value::string_from_str(&file_name.to_string_lossy());
-                let _ = self.invoke_method_if_exists(
-                    globals,
-                    IdentId::get_id("try_activate"),
-                    gem,
-                    &[feature],
-                    None,
-                    None,
-                );
+                {
+                    self.get_constant(globals, OBJECT_CLASS, gem_id)
+                        .ok()
+                        .flatten()
+                } else if canonicalized_path.starts_with(install_root().join("stub"))
+                    && !self.is_loading_path(&install_root().join("lib").join("rubygems.rb"))
+                {
+                    globals.store.get_constant_noautoload(OBJECT_CLASS, gem_id)
+                } else {
+                    None
+                };
+                if let Some(gem) = gem {
+                    let feature = Value::string_from_str(&file_name.to_string_lossy());
+                    let _ = self.invoke_method_if_exists(
+                        globals,
+                        IdentId::get_id("try_activate"),
+                        gem,
+                        &[feature],
+                        None,
+                        None,
+                    );
+                }
             }
             Ok(true)
         }

--- a/monoruby/tests/gem_prelude.rs
+++ b/monoruby/tests/gem_prelude.rs
@@ -113,6 +113,34 @@ fn a_stub_library_does_not_boot_rubygems() {
 }
 
 #[test]
+fn a_host_gem_boots_rubygems_and_is_activated() {
+    // A file served from a host gem's directory (`/gems/`) is proof the
+    // program uses host gems: the activation hook boots rubygems through
+    // the autoload and activates the gem, so `Gem.loaded_specs` fills in
+    // as in CRuby. `rake` is a bundled gem of every Ruby, but only
+    // reachable if a host Ruby was found; let the process report that.
+    let got = run(
+        &[],
+        &format!(
+            r#"before = {RUBYGEMS_LOADED}
+               begin
+                 require "rake"
+               rescue LoadError => e
+                 print "skip: #{{e.message}}"
+                 exit 0
+               end
+               p [before, {RUBYGEMS_LOADED}, Gem.loaded_specs.key?("rake"),
+                  $LOADED_FEATURES.grep(%r{{/rake\.rb\z}}).first&.include?("/gems/")]"#
+        ),
+    );
+    if let Some(reason) = got.strip_prefix("skip: ") {
+        eprintln!("skipped: no host rake gem here ({reason})");
+        return;
+    }
+    assert_eq!(got, "[false, true, true, true]");
+}
+
+#[test]
 fn disable_gems_leaves_gem_undefined() {
     let got = run(
         &["--disable=gems"],

--- a/monoruby/tests/gem_prelude.rs
+++ b/monoruby/tests/gem_prelude.rs
@@ -1,0 +1,122 @@
+//! Integration coverage for the deferred rubygems boot
+//! (`builtins/gem_prelude.rb`). Whether rubygems was *loaded* is a
+//! process-level fact (`$LOADED_FEATURES` of a fresh interpreter), so
+//! everything here spawns the real binary; the in-process `run_test`
+//! interpreters run with gems disabled.
+
+use std::process::Command;
+
+fn monoruby() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_monoruby"));
+    cmd.env_remove("RUBYOPT")
+        .env_remove("RUBYLIB")
+        .env_remove("RUBYPATH");
+    cmd
+}
+
+fn run(args: &[&str], code: &str) -> String {
+    let out = monoruby()
+        .args(args)
+        .arg("-e")
+        .arg(code)
+        .output()
+        .expect("failed to spawn monoruby");
+    assert!(
+        out.status.success(),
+        "monoruby exited with {:?}\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+const RUBYGEMS_LOADED: &str = r#"$LOADED_FEATURES.any? { |f| f.end_with?("/rubygems.rb") }"#;
+
+#[test]
+fn a_program_that_never_touches_gem_never_loads_rubygems() {
+    // The constant is there (defined, listed, autoload-registered) but
+    // rubygems itself has not been read.
+    let got = run(
+        &[],
+        &format!(
+            r#"p [{RUBYGEMS_LOADED}, defined?(Gem), Object.const_defined?(:Gem),
+                  Object.constants.include?(:Gem), Object.autoload?(:Gem)]"#
+        ),
+    );
+    assert_eq!(got, r#"[false, "constant", true, true, "rubygems"]"#);
+}
+
+#[test]
+fn the_first_reference_to_gem_boots_rubygems() {
+    let got = run(
+        &[],
+        &format!(
+            r#"before = {RUBYGEMS_LOADED}
+               v = Gem::VERSION
+               p [before, v.class, {RUBYGEMS_LOADED}, Object.autoload?(:Gem), Gem.respond_to?(:loaded_specs)]"#
+        ),
+    );
+    assert_eq!(got, "[false, String, true, nil, true]");
+}
+
+#[test]
+fn an_explicit_require_of_rubygems_still_works() {
+    // `require "rubygems"` while the autoload is pending is the direct
+    // load of the autoload's own file: it defines `Gem` and consumes the
+    // registration, and a later reference does not load it again.
+    let got = run(
+        &[],
+        &format!(
+            r#"r = require "rubygems"
+               p [r, {RUBYGEMS_LOADED}, Gem::Specification.name, require("rubygems")]"#
+        ),
+    );
+    assert_eq!(got, r#"[true, true, "Gem::Specification", false]"#);
+}
+
+#[test]
+fn kernel_gem_boots_rubygems_and_dispatches() {
+    // The stub `Kernel#gem` boots rubygems and hands over to the real
+    // one, which raises rubygems' own error (with its own message) for
+    // an unknown gem. Both the stub and the real method are private, as
+    // in CRuby.
+    let got = run(
+        &[],
+        &format!(
+            r#"priv = Kernel.private_method_defined?(:gem)
+               begin
+                 gem "monoruby-no-such-gem-xyz"
+               rescue Gem::MissingSpecError => e
+                 kind = e.class
+                 msg = e.message.start_with?("Could not find 'monoruby-no-such-gem-xyz' (>= 0)")
+               end
+               p [priv, kind, msg, {RUBYGEMS_LOADED}, Kernel.private_method_defined?(:gem)]"#
+        ),
+    );
+    assert_eq!(got, "[true, Gem::MissingSpecError, true, true, true]");
+}
+
+#[test]
+fn a_stub_library_does_not_boot_rubygems() {
+    // `json` and `set` resolve from monoruby's stub directory; requiring
+    // them must not drag rubygems in (the activation hook only asks a
+    // rubygems that is already loaded).
+    let got = run(
+        &[],
+        &format!(
+            r#"require "json"
+               require "set"
+               p [JSON.generate([1]), Set.new([1]).size, {RUBYGEMS_LOADED}]"#
+        ),
+    );
+    assert_eq!(got, r#"["[1]", 1, false]"#);
+}
+
+#[test]
+fn disable_gems_leaves_gem_undefined() {
+    let got = run(
+        &["--disable=gems"],
+        &format!(r#"p [defined?(Gem), Object.autoload?(:Gem), {RUBYGEMS_LOADED}]"#),
+    );
+    assert_eq!(got, "[nil, nil, false]");
+}


### PR DESCRIPTION
## Summary

Every start required the vendored rubygems outright (some twenty files, `Gem::Specification` among them), which was most of monoruby's startup: 8 MB of RSS (4 MB of bytecode metadata, 2 MB of heap pages, the rest in large buffers) and 90 ms for a program that never touches `Gem`. CRuby pays 3 MB for the same boot. The JIT, by comparison, adds about 1 MB at startup (`-e 1` compiles nothing).

`builtins/gem_prelude.rb` now registers `Gem` as an autoload of "rubygems", plus a private `Kernel#gem` stub that boots rubygems and re-dispatches to the definition `kernel_gem.rb` puts in its place. The constant is defined, listed and `const_defined?` from the start; the first reference (from a program, a library, `Kernel#gem`, or `require "rubygems"` itself) reads rubygems in. `--disable-gems` skips the prelude, leaving `Gem` undefined as before.

The activation hook in `Executor::require` (which asks rubygems to `try_activate` a gem whose file was just loaded, so `Gem.loaded_specs` fills in as in CRuby) had relied on rubygems being present:

- a host gem's file (`/gems/`) now boots rubygems through the autoload;
- a file from the stub directory does not, since `json`, `set`, `monitor` and the other default-gem stand-ins live there too and would otherwise re-create the cost for most programs. A stub activates only through a rubygems the program already loaded, and not while that rubygems is still booting (its own `require "monitor"` used to be kept out by the startup flag). The `gosu` stub publishes its own spec into `loaded_specs` regardless.

## Results (release build, Linux)

| program | before | after |
|---|---|---|
| `-e 1` | 0.12 s / 28.2 MB | 0.06 s / 19.7 MB |
| `require "json"` | 0.19 s / 30.5 MB | 0.06 s / 20.5 MB |
| `Gem::VERSION` | 0.12 s / 28.3 MB | 0.14 s / 28.3 MB |
| `require "rubygems"; Gem::Specification` | 0.13 s / 28.4 MB | 0.13 s / 28.3 MB |

## Tests

`tests/gem_prelude.rs` spawns the binary and checks: a program that never touches `Gem` never loads rubygems while the constant still reports as defined; the first reference boots it; an explicit `require "rubygems"` consumes the autoload; `Kernel#gem` boots and dispatches to rubygems (`Gem::MissingSpecError` with rubygems' message); `require "json"` / `"set"` do not boot it; `--disable=gems` leaves `Gem` undefined.

Full `cargo test` suite (with `stress-spill-pool`) passes, and `core/kernel/require_spec.rb` under mspec shows the same two pre-existing failures as master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_