### PR TITLE
Share a GP register between a slot and its copies

### DIFF
--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -3088,3 +3088,46 @@ The type+liveness loop-entry float adoption (§16 L2-1, promoted to default-on i
 Only the build knob is gone; runtime behaviour is unchanged from the default-on
 state. The §31/§32 `layer2-float-by-type` × `stress-spill-pool` history is
 retained above as the record of the pressure bug that §39/§40 fixed.
+
+## 45. Slot copies share a GP register (many slots per register, as the fpr file)
+
+`%dst = %src` used to be a load/store pair through the stack home — and, since
+`Mov` flushed the GP file first, it also ended every run of register-resident
+integer work. On a copy-heavy body (yjit-bench `30k_variables`: 100 locals per
+method, mostly `vN = vM`) that was ~300 memory ops per call, each copy's load
+waiting on the previous copy's store (a store-forwarding chain), and 12× the
+cost of ZJIT's SSA form, where a copy is a renaming.
+
+The fpr file has always let one xmm back several slots (`vfpr: Vec<Vec<SlotId>>`,
+the `F`/`Sf` sharing `copy_slot` relies on). `GpRegFile` now has the same shape:
+`holders: Vec<Vec<Holder>>`, one holder set per allocatable register, each
+holder carrying its own dirty bit. `copy_slot`'s `S` arm binds `dst` **dirty**
+to `src`'s register (loading `src` clean into a fresh register first if it was
+not resident) and emits nothing; `Mov` no longer flushes for an `S`/`C`
+source. The store to `dst`'s home is owed at the register's eviction or the
+next flush, and is dropped if `dst` dies first (a `ret`, a popped temporary —
+`free_above_sp` retains per holder). Eviction spills every dirty holder of the
+victim (`alloc_reg` returns a `Vec` of spills; `evict_reg` is the shared
+primitive, also used where `Mul`/`Div` are about to destroy `rhs`'s register).
+
+Two rules follow from sharing:
+
+- An op may compute **in place** only in a register that will hold nothing
+  but its `lhs` (`will_hold_at_most`); a register shared with copies carries
+  their only value, so the result takes a distinct register.
+- The result register must be **reserved before the deopt snapshot**
+  (`plan_dst_reg` → `GpRegFile::reserve`, then `new_deopt`, then
+  `take_dst_reg`). The snapshot is taken before the popped operands are
+  cleared so the interpreter can re-read them from their homes; a victim
+  evicted *after* it stayed listed in it, and an overflow side exit then
+  stored the register — by now holding the result — into the victim's home.
+  Copies made this latent ordering bug reachable (plb2 `bedcov`'s
+  `splitmix32`: `z = x` kept `x` resident for the whole body, the second
+  multiply overflowed to a Bignum, and `x` came back a Float); it is fixed
+  for the copy-free case too.
+
+Result (x86-64, release): `30k_variables` 306 ms → 25 ms per iteration; the
+other benchmarks are flat. Tests: `tests/copy_propagation.rs` (in-place ops on
+a shared register, `Mul`/`Div` clobbering a shared operand, overflow and type
+deopts with copies outstanding, calls/allocations, loops, non-fixnum values,
+the `splitmix32` shape) and the `gp_alloc` unit tests.

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -782,7 +782,13 @@ impl<'a> JitContext<'a> {
                 state.unset_side_effect_guard();
             }
             TraceIr::Mov(dst, src) => {
-                state.flush_gp(ir);
+                // GP-aware for a stack-homed or constant `src`: the copy
+                // becomes a shared GP register (see `copy_slot`), so the
+                // residents stay live across it. The fpr forms read `src`'s
+                // stack home and are not resident-aware, so they flush.
+                if !matches!(state.mode(src), LinkMode::S(_) | LinkMode::C(_)) {
+                    state.flush_gp(ir);
+                }
                 state.copy_slot(ir, src, dst);
                 // Pure copy; dst now holds src's object, so src's proof
                 // transfers to it.

--- a/monoruby/src/codegen/jitgen/gp_alloc.rs
+++ b/monoruby/src/codegen/jitgen/gp_alloc.rs
@@ -106,27 +106,30 @@ pub(in crate::codegen::jitgen) enum GpAction {
     Spill { reg: GP, slot: SlotId },
 }
 
-/// What an allocatable register currently caches.
-#[derive(Clone, Copy)]
+/// One slot an allocatable register currently caches.
+#[derive(Clone, Copy, Debug, PartialEq)]
 struct Holder {
     slot: SlotId,
-    /// the register's value differs from `slot`'s stack home (a binop result);
-    /// a clean holder (freshly loaded, unmodified) needs no spill.
+    /// the register's value differs from `slot`'s stack home (a binop result,
+    /// or a copy that has not been stored yet); a clean holder (freshly loaded,
+    /// unmodified) needs no spill.
     dirty: bool,
-    /// monotonically-increasing stamp set when the slot was bound, used to pick
-    /// the oldest resident as the eviction victim (FIFO).
-    age: u64,
 }
 
-/// The per-basic-block GP register file: which slot, if any, each allocatable
-/// register currently caches. The `vgp`-style `holder` vector mirrors the xmm
-/// `FprAllocator`.
+/// The per-basic-block GP register file: which slots each allocatable register
+/// currently caches. The `vgp`-style `holders` vector mirrors the xmm
+/// `FprAllocator`, including its many-slots-per-register shape: a register
+/// holds a *set* of slots that all carry the same value, each with its own
+/// dirty bit. That is what makes a slot copy free — `%dst = %src` adds `dst` to
+/// `src`'s register as a dirty holder and emits nothing; the store to `dst`'s
+/// home is owed only when the register is evicted or the file is flushed, and
+/// is dropped entirely if `dst` dies first (a `ret`, a popped temporary).
 ///
 /// Held in the abstract state and driven online during the basic-block walk:
 /// the GP-aware operations (integer binops, integer compares/compare-branches,
-/// call/yield-result parking, concrete-literal defs) reuse/allocate registers
-/// through it, while every other instruction flushes the live GP residents
-/// back to their stack homes up front (via `flush_gp` →
+/// call/yield-result parking, concrete-literal defs, slot copies)
+/// reuse/allocate registers through it, while every other instruction flushes
+/// the live GP residents back to their stack homes up front (via `flush_gp` →
 /// [`Self::take_dirty_spills`]).
 ///
 /// It is flushed empty at every basic-block boundary, so although it rides
@@ -134,8 +137,12 @@ struct Holder {
 /// block merge (the per-block-locality the design requires).
 #[derive(Clone)]
 pub(in crate::codegen::jitgen) struct GpRegFile {
-    /// `holder[i]` is what `GP_ALLOC_SET[i]` caches (`None` = free).
-    holder: Vec<Option<Holder>>,
+    /// `holders[i]` is the set of slots `GP_ALLOC_SET[i]` caches (empty = free).
+    holders: Vec<Vec<Holder>>,
+    /// `age[i]`: monotonically-increasing stamp set when a slot was last bound
+    /// to `GP_ALLOC_SET[i]`, used to pick the oldest register as the eviction
+    /// victim (FIFO).
+    age: Vec<u64>,
     /// FIFO clock for victim selection.
     clock: u64,
 }
@@ -149,7 +156,8 @@ impl Default for GpRegFile {
 impl GpRegFile {
     pub(in crate::codegen::jitgen) fn new() -> Self {
         Self {
-            holder: vec![None; GP_ALLOC_SET.len()],
+            holders: vec![vec![]; GP_ALLOC_SET.len()],
+            age: vec![0; GP_ALLOC_SET.len()],
             clock: 0,
         }
     }
@@ -157,7 +165,7 @@ impl GpRegFile {
     /// True when no register is occupied (the common case — flushing then is a
     /// no-op, so the hot path pays nothing).
     pub(in crate::codegen::jitgen) fn is_empty(&self) -> bool {
-        self.holder.iter().all(|h| h.is_none())
+        self.holders.iter().all(|h| h.is_empty())
     }
 
     /// The `(reg, slot)` pairs of every resident, clean or dirty. Does not
@@ -168,22 +176,23 @@ impl GpRegFile {
     /// instead of round-tripping through the just-written stack home (a
     /// store-forwarding hop on the call's critical path).
     pub(in crate::codegen::jitgen) fn residents(&self) -> Vec<(GP, SlotId)> {
-        (0..self.holder.len())
-            .filter_map(|i| match self.holder[i] {
-                Some(Holder { slot, .. }) => Some((GP_ALLOC_SET[i], slot)),
-                _ => None,
-            })
-            .collect()
+        self.pairs(|_| true)
     }
 
     /// The `(reg, slot)` pairs of every **dirty** resident, for inclusion in a
     /// deopt / GC write-back (the values that differ from their stack home and
     /// must be re-homed if the VM resumes). Does not mutate the file.
     pub(in crate::codegen::jitgen) fn dirty_residents(&self) -> Vec<(GP, SlotId)> {
-        (0..self.holder.len())
-            .filter_map(|i| match self.holder[i] {
-                Some(Holder { slot, dirty: true, .. }) => Some((GP_ALLOC_SET[i], slot)),
-                _ => None,
+        self.pairs(|h| h.dirty)
+    }
+
+    fn pairs(&self, f: impl Fn(&Holder) -> bool) -> Vec<(GP, SlotId)> {
+        (0..self.holders.len())
+            .flat_map(|i| {
+                self.holders[i]
+                    .iter()
+                    .filter(|h| f(h))
+                    .map(move |h| (GP_ALLOC_SET[i], h.slot))
             })
             .collect()
     }
@@ -193,8 +202,8 @@ impl GpRegFile {
     /// flush). Clean residents need no store and are simply dropped.
     pub(in crate::codegen::jitgen) fn take_dirty_spills(&mut self) -> Vec<(GP, SlotId)> {
         let spills = self.dirty_residents();
-        for h in self.holder.iter_mut() {
-            *h = None;
+        for h in self.holders.iter_mut() {
+            h.clear();
         }
         spills
     }
@@ -210,15 +219,28 @@ impl GpRegFile {
 
     /// True when `reg` holds no resident (free for immediate reuse).
     pub(in crate::codegen::jitgen) fn is_free(&self, reg: GP) -> bool {
-        self.holder[Self::index_of(reg)].is_none()
+        self.holders[Self::index_of(reg)].is_empty()
+    }
+
+    /// True when `slot` is the **only** slot `reg` caches. An op may compute in
+    /// place in a register only under this condition: with more holders the
+    /// register carries other slots' (not yet stored) values, and overwriting
+    /// it would corrupt them.
+    pub(in crate::codegen::jitgen) fn holds_only(&self, reg: GP, slot: SlotId) -> bool {
+        matches!(self.holders[Self::index_of(reg)].as_slice(), [h] if h.slot == slot)
+    }
+
+    fn position_of(&self, slot: SlotId) -> Option<(usize, usize)> {
+        self.holders.iter().enumerate().find_map(|(i, hs)| {
+            hs.iter()
+                .position(|h| h.slot == slot)
+                .map(|j| (i, j))
+        })
     }
 
     /// The register currently caching `slot`, if any (the reuse lookup).
     pub(in crate::codegen::jitgen) fn reg_of(&self, slot: SlotId) -> Option<GP> {
-        self.holder
-            .iter()
-            .position(|h| h.map(|h| h.slot) == Some(slot))
-            .map(|i| GP_ALLOC_SET[i])
+        self.position_of(slot).map(|(i, _)| GP_ALLOC_SET[i])
     }
 
     /// The register caching `slot` only if that cache is **dirty** (its value
@@ -226,10 +248,9 @@ impl GpRegFile {
     /// register (`Mul`/`Div` destroy `rhs`): the dirty value must be written to
     /// its home first, since the register will not survive the op.
     pub(in crate::codegen::jitgen) fn dirty_reg_of(&self, slot: SlotId) -> Option<GP> {
-        self.holder
-            .iter()
-            .position(|h| matches!(h, Some(Holder { slot: s, dirty: true, .. }) if *s == slot))
-            .map(|i| GP_ALLOC_SET[i])
+        self.position_of(slot)
+            .filter(|&(i, j)| self.holders[i][j].dirty)
+            .map(|(i, _)| GP_ALLOC_SET[i])
     }
 
     /// A free register that is not `pinned`. Pinned registers hold operands that
@@ -237,53 +258,64 @@ impl GpRegFile {
     /// operand slot, `invalidate(dst)` leaves the operand's register unbound but
     /// still in use), so they must never be handed out even when free.
     fn find_free(&self, pinned: &[GP]) -> Option<GP> {
-        (0..self.holder.len())
-            .find(|&i| self.holder[i].is_none() && !pinned.contains(&GP_ALLOC_SET[i]))
+        (0..self.holders.len())
+            .find(|&i| self.holders[i].is_empty() && !pinned.contains(&GP_ALLOC_SET[i]))
             .map(|i| GP_ALLOC_SET[i])
     }
 
     /// Online allocation primitive for the codegen driver: return a register
-    /// (a free one, else the **oldest** non-`pinned` resident) plus the spill
-    /// the caller must emit when a dirty resident was evicted. The returned
-    /// register is left **unbound** — the caller binds it after loading/computing
-    /// the value (so the binop result always lands in a register).
-    pub(in crate::codegen::jitgen) fn alloc_reg(
-        &mut self,
-        pinned: &[GP],
-    ) -> (GP, Option<(GP, SlotId)>) {
+    /// (a free one, else the **oldest** non-`pinned` resident) plus the spills
+    /// the caller must emit for the dirty holders it evicted (one store per
+    /// dirty slot the victim carried). The returned register is left
+    /// **unbound** — the caller binds it after loading/computing the value (so
+    /// the binop result always lands in a register).
+    pub(in crate::codegen::jitgen) fn alloc_reg(&mut self, pinned: &[GP]) -> (GP, Vec<(GP, SlotId)>) {
         if let Some(reg) = self.find_free(pinned) {
-            return (reg, None);
+            return (reg, vec![]);
         }
-        let victim_idx = (0..self.holder.len())
+        let victim_idx = (0..self.holders.len())
             .filter(|&i| !pinned.contains(&GP_ALLOC_SET[i]))
-            .min_by_key(|&i| self.holder[i].unwrap().age)
+            .min_by_key(|&i| self.age[i])
             .expect("more pinned registers than the allocatable set");
         let reg = GP_ALLOC_SET[victim_idx];
-        let h = self.holder[victim_idx].unwrap();
-        let spill = if h.dirty { Some((reg, h.slot)) } else { None };
-        self.holder[victim_idx] = None;
-        (reg, spill)
+        (reg, self.evict_reg(reg))
+    }
+
+    /// Forget every holder of `reg`, returning the spills owed for its dirty
+    /// ones. Used when an op is about to destroy the register's value
+    /// (`Mul`/`Div` clobber `rhs`), and by [`Self::alloc_reg`] for its victim.
+    pub(in crate::codegen::jitgen) fn evict_reg(&mut self, reg: GP) -> Vec<(GP, SlotId)> {
+        let idx = Self::index_of(reg);
+        let spills = self.holders[idx]
+            .iter()
+            .filter(|h| h.dirty)
+            .map(|h| (reg, h.slot))
+            .collect();
+        self.holders[idx].clear();
+        spills
     }
 
     /// Internal `alloc` used by the pure `allocate_run` reference: like
-    /// [`Self::alloc_reg`] but emits the spill into `out`.
+    /// [`Self::alloc_reg`] but emits the spills into `out`.
     fn alloc(&mut self, pinned: &[GP], out: &mut Vec<GpAction>) -> GP {
-        let (reg, spill) = self.alloc_reg(pinned);
-        if let Some((reg, slot)) = spill {
+        let (reg, spills) = self.alloc_reg(pinned);
+        for (reg, slot) in spills {
             out.push(GpAction::Spill { reg, slot });
         }
         reg
     }
 
-    /// Record that `reg` now caches `slot`, dropping any prior cache of `slot`.
+    /// Record that `reg` now (also) caches `slot`, dropping any prior cache of
+    /// `slot`. The register's other holders are kept: they carry the same value,
+    /// which is exactly what a slot copy relies on (`%dst = %src` binds `dst`
+    /// dirty to `src`'s register). A register handed out by [`Self::alloc_reg`]
+    /// is empty, so binding a freshly produced value never shares by accident.
     pub(in crate::codegen::jitgen) fn bind(&mut self, reg: GP, slot: SlotId, dirty: bool) {
-        for h in self.holder.iter_mut() {
-            if h.map(|h| h.slot) == Some(slot) {
-                *h = None;
-            }
-        }
+        self.invalidate(slot);
         let age = self.tick();
-        self.holder[Self::index_of(reg)] = Some(Holder { slot, dirty, age });
+        let idx = Self::index_of(reg);
+        self.holders[idx].push(Holder { slot, dirty });
+        self.age[idx] = age;
     }
 
     /// If `slot` is a GP resident, return its register and mark it **clean** —
@@ -294,25 +326,65 @@ impl GpRegFile {
     /// cached (now clean), so a following integer op still reuses it and a later
     /// flush does not re-spill it.
     pub(in crate::codegen::jitgen) fn sync(&mut self, slot: SlotId) -> Option<GP> {
-        let idx = self
-            .holder
-            .iter()
-            .position(|h| h.map(|h| h.slot) == Some(slot))?;
-        self.holder[idx].as_mut().unwrap().dirty = false;
-        Some(GP_ALLOC_SET[idx])
+        let (i, j) = self.position_of(slot)?;
+        self.holders[i][j].dirty = false;
+        Some(GP_ALLOC_SET[i])
     }
 
     /// Free every register caching a slot at or above `sp` — those temporaries
     /// are dead (popped past the stack pointer), so they are dropped without a
     /// spill, mirroring `clear_above_next_sp`.
     pub(in crate::codegen::jitgen) fn free_above_sp(&mut self, sp: SlotId) {
-        for h in self.holder.iter_mut() {
-            if let Some(held) = *h
-                && held.slot >= sp
-            {
-                *h = None;
-            }
+        for h in self.holders.iter_mut() {
+            h.retain(|held| held.slot < sp);
         }
+    }
+
+    /// Whether, once the popped temporaries (`>= sp`) and the redefined `dst`
+    /// are dropped, `reg` caches nothing but (at most) `slot` — the condition
+    /// for an op to compute in place in `reg` without corrupting another
+    /// slot's only copy. Answered *before* those drops happen, so an op can
+    /// plan its result register ahead of its deopt snapshot.
+    pub(in crate::codegen::jitgen) fn will_hold_at_most(
+        &self,
+        reg: GP,
+        slot: SlotId,
+        sp: SlotId,
+        dst: Option<SlotId>,
+    ) -> bool {
+        self.holders[Self::index_of(reg)]
+            .iter()
+            .all(|h| h.slot == slot || h.slot >= sp || Some(h.slot) == dst)
+    }
+
+    /// Make room for one register to be allocated *after* `free_above_sp(sp)`
+    /// and `invalidate(dst)` have run, doing neither yet: if some non-`pinned`
+    /// register will be free by then, nothing is owed; otherwise the oldest
+    /// non-`pinned` register is evicted now and its dirty holders' spills are
+    /// returned. An op that side-exits (a deopt) takes its write-back snapshot
+    /// before it clears the popped operands, so that the interpreter can
+    /// re-read them from their homes; a victim evicted *after* that snapshot
+    /// would still be listed in it, and the deopt would then store the
+    /// register — by then overwritten with the result — into the victim's
+    /// home. Reserving here, before the snapshot, keeps every snapshotted
+    /// register intact up to the side exit.
+    pub(in crate::codegen::jitgen) fn reserve(
+        &mut self,
+        pinned: &[GP],
+        sp: SlotId,
+        dst: Option<SlotId>,
+    ) -> Vec<(GP, SlotId)> {
+        let free_later = |hs: &Vec<Holder>| hs.iter().all(|h| h.slot >= sp || Some(h.slot) == dst);
+        if (0..self.holders.len())
+            .any(|i| !pinned.contains(&GP_ALLOC_SET[i]) && free_later(&self.holders[i]))
+        {
+            return vec![];
+        }
+        let victim_idx = (0..self.holders.len())
+            .filter(|&i| !pinned.contains(&GP_ALLOC_SET[i]))
+            .min_by_key(|&i| self.age[i])
+            .expect("more pinned registers than the allocatable set");
+        self.evict_reg(GP_ALLOC_SET[victim_idx])
     }
 }
 
@@ -367,25 +439,17 @@ fn ensure(rf: &mut GpRegFile, slot: SlotId, pinned: &[GP], out: &mut Vec<GpActio
 
 /// Flush dirty residents to their stack homes and clear the file.
 fn flush_dirty(rf: &mut GpRegFile, out: &mut Vec<GpAction>) {
-    for i in 0..rf.holder.len() {
-        if let Some(Holder { slot, dirty: true, .. }) = rf.holder[i] {
-            out.push(GpAction::Spill {
-                reg: GP_ALLOC_SET[i],
-                slot,
-            });
-        }
-        rf.holder[i] = None;
+    for (reg, slot) in rf.take_dirty_spills() {
+        out.push(GpAction::Spill { reg, slot });
     }
 }
 
 impl GpRegFile {
     /// A slot is about to be redefined: drop any stale register cache of it (the
-    /// old value is dead, so no spill).
+    /// old value is dead, so no spill). The register's other holders stay.
     pub(in crate::codegen::jitgen) fn invalidate(&mut self, slot: SlotId) {
-        for h in self.holder.iter_mut() {
-            if h.map(|h| h.slot) == Some(slot) {
-                *h = None;
-            }
+        for h in self.holders.iter_mut() {
+            h.retain(|held| held.slot != slot);
         }
     }
 }
@@ -506,6 +570,69 @@ mod tests {
                 .iter()
                 .any(|a| matches!(a, GpAction::Spill { slot, .. } if *slot == sl(s))));
         }
+    }
+
+    /// A slot copy binds the destination to the source's register as a second
+    /// (dirty) holder: both resolve to the register, only the copy owes a store,
+    /// and the register is no longer a sole-holder (no in-place compute).
+    #[test]
+    fn copy_shares_the_register() {
+        let mut rf = GpRegFile::new();
+        rf.bind(R8, sl(1), /* dirty */ false);
+        rf.bind(R8, sl(2), /* dirty */ true);
+        assert_eq!(rf.reg_of(sl(1)), Some(R8));
+        assert_eq!(rf.reg_of(sl(2)), Some(R8));
+        assert_eq!(rf.dirty_reg_of(sl(1)), None);
+        assert_eq!(rf.dirty_reg_of(sl(2)), Some(R8));
+        assert!(!rf.holds_only(R8, sl(1)));
+        assert!(!rf.holds_only(R8, sl(2)));
+        assert_eq!(rf.dirty_residents(), vec![(R8, sl(2))]);
+        // Dropping one holder leaves the other, now alone in the register.
+        rf.invalidate(sl(1));
+        assert_eq!(rf.reg_of(sl(1)), None);
+        assert!(rf.holds_only(R8, sl(2)));
+        // The flush stores the copy only.
+        assert_eq!(rf.take_dirty_spills(), vec![(R8, sl(2))]);
+        assert!(rf.is_empty());
+    }
+
+    /// Evicting a shared register owes one store per dirty holder, and a
+    /// popped temporary among the holders is dropped without one.
+    #[test]
+    fn eviction_spills_every_dirty_holder() {
+        let mut rf = GpRegFile::new();
+        rf.bind(R8, sl(1), false);
+        rf.bind(R8, sl(2), true);
+        rf.bind(R8, sl(9), true);
+        rf.bind(R9, sl(3), true);
+        rf.bind(R10, sl(4), true);
+        rf.bind(GP::R11, sl(5), true);
+        // %9 is a temporary popped by the stack pointer: no store owed.
+        rf.free_above_sp(sl(9));
+        assert_eq!(rf.reg_of(sl(9)), None);
+        // The file is full; R8 (the oldest) is the victim, spilling %2 only.
+        let (reg, spills) = rf.alloc_reg(&[]);
+        assert_eq!(reg, R8);
+        assert_eq!(spills, vec![(R8, sl(2))]);
+        assert!(rf.is_free(R8));
+        assert_eq!(rf.reg_of(sl(1)), None);
+        // `evict_reg` does the same for a register an op is about to clobber.
+        assert_eq!(rf.evict_reg(R9), vec![(R9, sl(3))]);
+        assert!(rf.is_free(R9));
+    }
+
+    /// Rebinding a slot elsewhere removes it from its old register without
+    /// disturbing the register's other holders.
+    #[test]
+    fn rebind_moves_one_holder() {
+        let mut rf = GpRegFile::new();
+        rf.bind(R8, sl(1), false);
+        rf.bind(R8, sl(2), true);
+        rf.bind(R9, sl(2), true);
+        assert_eq!(rf.reg_of(sl(2)), Some(R9));
+        assert!(rf.holds_only(R8, sl(1)));
+        assert_eq!(rf.sync(sl(2)), Some(R9));
+        assert!(rf.dirty_residents().is_empty());
     }
 
     /// `sync` makes a resident's stack home current (returns its register) and

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -724,8 +724,8 @@ impl AbstractFrame {
         guarded: slot::Guarded,
     ) -> GP {
         self.def_S_guarded(dst, guarded);
-        let (gp, spill) = self.gp_regfile.alloc_reg(&[]);
-        if let Some((reg, slot)) = spill {
+        let (gp, spills) = self.gp_regfile.alloc_reg(&[]);
+        for (reg, slot) in spills {
             ir.reg2stack(reg, slot);
         }
         gp

--- a/monoruby/src/codegen/jitgen/state/binop.rs
+++ b/monoruby/src/codegen/jitgen/state/binop.rs
@@ -187,66 +187,51 @@ impl AbstractFrame {
         let (rhs_gp, rhs_guard) = self.gp_ensure(ir, rhs, &[lhs_gp]);
         // Same slot on both sides (`x + x`): one guard proves both operands.
         let rhs_guard = rhs_guard && lhs != rhs;
-        // 1b. For `Mul`/`Div`: if `rhs` is a dirty resident, write it to its home
-        //     and mark it clean *before* the deopt snapshot. The op clobbers
-        //     `rhs_gp` before the side-exit, so the snapshot must re-home `rhs`
-        //     from its (now-current) stack home, not from the dead register — a
+        // 1b. For `Mul`/`Div`: the op clobbers `rhs_gp` before the side-exit,
+        //     so every holder of that register — `rhs` and any slot copied from
+        //     it — is written to its home if dirty and forgotten *before* the
+        //     deopt snapshot. The snapshot must re-home them from their
+        //     (now-current) stack homes, not from the dead register — a
         //     `dirty_residents()` entry would otherwise store garbage to the slot
         //     on deopt (e.g. the untagged divisor, an invalid `Value`). A fresh /
         //     constant operand is already recoverable (its home is current, or it
-        //     re-materializes from `LinkMode::C`).
-        if rhs_clobbered && let Some(reg) = self.gp_regfile.dirty_reg_of(rhs) {
-            ir.reg2stack(reg, rhs);
-            self.gp_regfile.sync(rhs);
+        //     re-materializes from `LinkMode::C`). The register still physically
+        //     holds `rhs` for the op itself.
+        if rhs_clobbered {
+            for (reg, slot) in self.gp_regfile.evict_reg(rhs_gp) {
+                ir.reg2stack(reg, slot);
+            }
         }
-        // Whether `lhs`'s snapshot recovery depends on `lhs_gp` surviving the
-        // op: a dirty resident is re-homed *from the register* by the deopt
-        // write-back, so an in-place Add/Sub (which clobbers the register
-        // before the overflow side-exit) must not be chosen for it — see
-        // `binop_dst_reg`. Captured before the snapshot.
-        let lhs_dirty = self.gp_regfile.dirty_reg_of(lhs).is_some();
-        // 2. Snapshot the deopt write-back *before* clearing: it must re-home the
+        // 2. Plan the result register and make room for it *before* the deopt
+        //    snapshot (see `plan_dst_reg`). `Add`/`Sub` compute in the dst
+        //    position, preferring `lhs_gp` itself (in place, or a binding
+        //    transfer from a clean live resident — no move), and fall back to a
+        //    distinct register when `lhs` is dirty (its register must survive
+        //    to the side exit for the deopt write-back) or shared with other
+        //    slots. `Mul`/`Div` clobber `rhs` and (Div) produce in `rax`, so
+        //    pin both operands and take a distinct register. `x + x` (both
+        //    operands in one register) uses the tagged-order doubling
+        //    sequence, which reads the shared operand before any untag — so it
+        //    may compute in place in the shared register too.
+        let double = kind == BinOpK::Add && lhs_gp == rhs_gp;
+        let extra_pinned: &[GP] = if double && !rhs_clobbered { &[] } else { &[rhs_gp] };
+        let plan = self.plan_dst_reg(ir, lhs, lhs_gp, !rhs_clobbered, extra_pinned, dst);
+        // 3. Snapshot the deopt write-back *before* clearing: it must re-home the
         //    dirty residents that are live at this op's PC — which includes a
         //    dirty operand that is itself a dead-after temporary (a prior binop
         //    result consumed here). The guards and the overflow check below all
         //    side-exit to this point, where the interpreter re-reads the operands
         //    from their stack homes, so they have to be recoverable.
         let deopt = ir.new_deopt(self);
-        // 3. `dst` is about to be redefined: drop any stale GP cache of it (done
+        // 4. `dst` is about to be redefined: drop any stale GP cache of it (done
         //    after the snapshot, so a `dst` that aliases a dirty operand is still
-        //    re-homed for the re-execution).
-        if let Some(dst) = dst {
-            self.gp_regfile.invalidate(dst);
-        }
-        // 4. Clear `next_sp`: every temporary the stack pointer has popped is now
-        //    dead. `next_sp` is the sp *after* this op, so the operands — already
-        //    read into registers in step 1 — are freed here too. This must run
-        //    after the load (which still reads them) and before the result
-        //    allocation (so the result can reuse a freed operand's register).
-        let next_sp = self.next_sp();
-        self.gp_regfile.free_above_sp(next_sp);
-        // 5. Choose the result register and run the op. `Add`/`Sub` compute in
-        //    the dst position; `binop_dst_reg` prefers `lhs_gp` itself (in
-        //    place, or a binding transfer from a clean live resident — no
-        //    move), falling back to a distinct register when `lhs` is dirty
-        //    (its register must survive to the side exit for the deopt
-        //    write-back). `Mul`/`Div` clobber `rhs` and (Div) produce in
-        //    `rax`, so pin both operands and take a distinct register.
-        //    `x + x` (both operands in one register) uses the tagged-order
-        //    doubling sequence, which reads the shared operand before any
-        //    untag — so it may compute in place in the shared register too.
-        let double = kind == BinOpK::Add && lhs_gp == rhs_gp;
-        let dst_gp = if rhs_clobbered {
-            let (gp, spill) = self.gp_regfile.alloc_reg(&[lhs_gp, rhs_gp]);
-            if let Some((reg, slot)) = spill {
-                ir.reg2stack(reg, slot);
-            }
-            gp
-        } else if double {
-            self.binop_dst_reg(ir, lhs, lhs_gp, lhs_dirty, &[])
-        } else {
-            self.binop_dst_reg(ir, lhs, lhs_gp, lhs_dirty, &[rhs_gp])
-        };
+        //    re-homed for the re-execution). Then clear `next_sp`: every
+        //    temporary the stack pointer has popped is now dead. `next_sp` is
+        //    the sp *after* this op, so the operands — already read into
+        //    registers in step 1 — are freed here too. This must run after the
+        //    load (which still reads them) and before the result allocation (so
+        //    the result can reuse a freed operand's register).
+        let dst_gp = self.take_dst_reg(ir, plan, lhs, lhs_gp, extra_pinned, dst);
         // An operand not yet proven a fixnum is only speculatively an integer,
         // so guard it; the guard then *proves* it a fixnum, so refine its
         // abstract type in place (keeping the resident) — a later integer op on
@@ -268,10 +253,6 @@ impl AbstractFrame {
         } else {
             ir.integer_binop_reg(kind, dst_gp, lhs_gp, rhs_gp, deopt);
         }
-        // The op left garbage in `rhs_gp`: forget that it cached `rhs`.
-        if rhs_clobbered {
-            self.gp_regfile.invalidate(rhs);
-        }
         if let Some(dst) = dst {
             // Define first (this clears any stale resident of `dst` via `clear`),
             // then bind the result register.
@@ -292,14 +273,11 @@ impl AbstractFrame {
         imm: i32,
     ) {
         let (lhs_gp, lhs_guard) = self.gp_ensure(ir, lhs, &[]);
-        let lhs_dirty = self.gp_regfile.dirty_reg_of(lhs).is_some();
+        // Plan and reserve the result register before the snapshot, then
+        // snapshot, then clear — the same three steps as `binop_integer_gp`.
+        let plan = self.plan_dst_reg(ir, lhs, lhs_gp, true, &[], dst);
         let deopt = ir.new_deopt(self);
-        if let Some(dst) = dst {
-            self.gp_regfile.invalidate(dst);
-        }
-        let next_sp = self.next_sp();
-        self.gp_regfile.free_above_sp(next_sp);
-        let dst_gp = self.binop_dst_reg(ir, lhs, lhs_gp, lhs_dirty, &[]);
+        let dst_gp = self.take_dst_reg(ir, plan, lhs, lhs_gp, &[], dst);
         if lhs_guard {
             ir.push(AsmInst::GuardClass(lhs_gp, INTEGER_CLASS, deopt));
             self.refine_S_fixnum(lhs);
@@ -317,45 +295,81 @@ impl AbstractFrame {
         }
     }
 
-    /// Choose the result register for an `Add`/`Sub`-family op that computes
-    /// in place in the dst position.
+    /// Plan the result register of an integer op, **before** its deopt
+    /// snapshot, and make room for it. Returns whether the op computes in
+    /// place in `lhs_gp`; otherwise a distinct register is reserved (any
+    /// eviction that requires is spilled *now*, so the snapshot taken next
+    /// lists no register the result will overwrite — see
+    /// `GpRegFile::reserve`). The decision reads the file as it will be after
+    /// the post-snapshot clearing (`invalidate(dst)`, `free_above_sp`).
     ///
-    /// * `lhs` **clean** (or already unbound — a dead-after temp freed by
-    ///   `free_above_sp`, a dst-aliasing operand dropped by `invalidate`, or
-    ///   a constant's load register): compute in place in `lhs_gp`. A live
-    ///   clean resident transfers its register to the result with no data
-    ///   move (its stack home is current, so nothing is lost); the slot
-    ///   simply drops to `S`.
-    /// * `lhs` **dirty**: the deopt write-back re-homes `lhs` *from
-    ///   `lhs_gp`*, and the op would clobber that register before the
+    /// In place (`in_place_ok` only — `Mul`/`Div` never qualify) when:
+    /// * `lhs` is **clean** (or unbound — a dead-after temp, a dst-aliasing
+    ///   operand, or a constant's load register): a live clean resident
+    ///   transfers its register to the result with no data move (its stack
+    ///   home is current, so nothing is lost); the slot simply drops to `S`.
+    ///   A **dirty** `lhs` is re-homed *from `lhs_gp`* by the deopt
+    ///   write-back, and the op would clobber that register before the
     ///   overflow side-exit — the interpreter would then re-execute the op
-    ///   with a corrupted operand. Compute in a distinct register instead
-    ///   (the lowering's `mov dst, lhs` preserves the operand register for
-    ///   the side exit).
-    fn binop_dst_reg(
+    ///   with a corrupted operand — so it gets a distinct register (the
+    ///   lowering's `mov dst, lhs` preserves the operand register).
+    /// * `lhs_gp` will hold nothing but `lhs`: a register **shared** with
+    ///   other slots (copies of `lhs` whose stores are still owed) carries
+    ///   their only copy, so it must survive.
+    /// * `lhs_gp` carries no other live operand (`x + x`: lhs and rhs share
+    ///   one register — clobbering it in place would corrupt the rhs read).
+    fn plan_dst_reg(
         &mut self,
         ir: &mut AsmIr,
         lhs: SlotId,
         lhs_gp: GP,
-        lhs_dirty: bool,
+        in_place_ok: bool,
         extra_pinned: &[GP],
+        dst: Option<SlotId>,
+    ) -> bool {
+        let next_sp = self.next_sp();
+        let in_place = in_place_ok
+            && self.gp_regfile.dirty_reg_of(lhs).is_none()
+            && !extra_pinned.contains(&lhs_gp)
+            && self.gp_regfile.will_hold_at_most(lhs_gp, lhs, next_sp, dst);
+        if !in_place {
+            let mut pinned = vec![lhs_gp];
+            pinned.extend_from_slice(extra_pinned);
+            for (reg, slot) in self.gp_regfile.reserve(&pinned, next_sp, dst) {
+                ir.reg2stack(reg, slot);
+            }
+        }
+        in_place
+    }
+
+    /// The post-snapshot half of [`Self::plan_dst_reg`]: drop the stale cache
+    /// of `dst` and the popped temporaries, then hand out the planned result
+    /// register — `lhs_gp` itself (in place), or a register `reserve` left
+    /// free, so no spill lands after the snapshot.
+    fn take_dst_reg(
+        &mut self,
+        ir: &mut AsmIr,
+        in_place: bool,
+        lhs: SlotId,
+        lhs_gp: GP,
+        extra_pinned: &[GP],
+        dst: Option<SlotId>,
     ) -> GP {
-        // Never compute in place in a register that also carries another live
-        // operand (`x + x`: lhs and rhs share one register — clobbering it
-        // in place would corrupt the rhs read).
-        if !lhs_dirty && !extra_pinned.contains(&lhs_gp) {
-            if self.gp_regfile.is_free(lhs_gp) {
-                return lhs_gp;
-            }
-            if self.gp_regfile.reg_of(lhs) == Some(lhs_gp) {
-                self.gp_regfile.invalidate(lhs);
-                return lhs_gp;
-            }
+        if let Some(dst) = dst {
+            self.gp_regfile.invalidate(dst);
+        }
+        let next_sp = self.next_sp();
+        self.gp_regfile.free_above_sp(next_sp);
+        if in_place {
+            debug_assert!(self.gp_regfile.will_hold_at_most(lhs_gp, lhs, next_sp, None));
+            self.gp_regfile.invalidate(lhs);
+            return lhs_gp;
         }
         let mut pinned = vec![lhs_gp];
         pinned.extend_from_slice(extra_pinned);
-        let (gp, spill) = self.gp_regfile.alloc_reg(&pinned);
-        if let Some((reg, slot)) = spill {
+        let (gp, spills) = self.gp_regfile.alloc_reg(&pinned);
+        debug_assert!(spills.is_empty(), "reserve() must have made room before the snapshot");
+        for (reg, slot) in spills {
             ir.reg2stack(reg, slot);
         }
         gp
@@ -383,8 +397,8 @@ impl AbstractFrame {
         // as `movabs gp, 0x3` rather than materializing it to a slot and reading
         // it back). The value is a known fixnum, so it needs no guard.
         if let Some(v) = self.fixnum_literal_value(slot) {
-            let (gp, spill) = self.gp_regfile.alloc_reg(pinned);
-            if let Some((reg, s)) = spill {
+            let (gp, spills) = self.gp_regfile.alloc_reg(pinned);
+            for (reg, s) in spills {
                 ir.reg2stack(reg, s);
             }
             ir.lit2reg(v, gp);
@@ -394,8 +408,8 @@ impl AbstractFrame {
         // Not resident and not a constant: put the value at its canonical stack
         // home (a no-op for an `S` slot; materializes a boxed float), then load it.
         self.write_back_slot(ir, slot);
-        let (gp, spill) = self.gp_regfile.alloc_reg(pinned);
-        if let Some((reg, s)) = spill {
+        let (gp, spills) = self.gp_regfile.alloc_reg(pinned);
+        for (reg, s) in spills {
             ir.reg2stack(reg, s);
         }
         ir.stack2reg(slot, gp);

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1752,16 +1752,31 @@ impl SlotState {
                 self.set_Sf(dst, x, guarded);
             }
             LinkMode::S(guarded) => {
-                // A live GP resident holds `src`'s value in a register; copy it
-                // from there rather than reading a stale stack home (mirrors
-                // `load`'s resident-aware `S` arm).
-                if let Some(reg) = self.gp_regfile.reg_of(src) {
-                    ir.reg2stack(reg, dst);
-                } else {
-                    ir.stack2reg(src, GP::Rax);
-                    ir.reg2stack(GP::Rax, dst);
-                }
+                // The copy is free: `dst` joins `src`'s register as a dirty
+                // holder and no store is emitted now. The store to `dst`'s
+                // home is owed at the register's eviction or the next flush —
+                // and dropped if `dst` dies first (a `ret`, a popped
+                // temporary). A chain `v2 = v1; v3 = v2; …` thus costs nothing
+                // per link instead of a load/store pair each, with each
+                // link's load waiting on the previous link's store. When
+                // `src` is not resident it is loaded (clean) into a fresh
+                // register first, so `src` and `dst` share it from here on.
+                let reg = match self.gp_regfile.reg_of(src) {
+                    Some(reg) => reg,
+                    None => {
+                        let (reg, spills) = self.gp_regfile.alloc_reg(&[]);
+                        for (r, s) in spills {
+                            ir.reg2stack(r, s);
+                        }
+                        ir.stack2reg(src, reg);
+                        self.gp_regfile.bind(reg, src, /* dirty */ false);
+                        reg
+                    }
+                };
+                // Define first (this drops any stale resident of `dst` via
+                // `clear`), then bind the shared register.
                 self.def_S_guarded(dst, guarded);
+                self.gp_regfile.bind(reg, dst, /* dirty */ true);
             }
             LinkMode::C(v) => {
                 self.def_C(dst, v);

--- a/monoruby/tests/copy_propagation.rs
+++ b/monoruby/tests/copy_propagation.rs
@@ -1,0 +1,231 @@
+//! Local-variable copies in the JIT: `%dst = %src` shares `src`'s GP register
+//! instead of storing through the stack home (`GpRegFile` holds a set of
+//! slots per register). Every case below mixes copies with the things that
+//! must still see the right value: in-place integer ops on a shared
+//! register, `Mul`/`Div` clobbering an operand register, overflow / type
+//! deopts with copies outstanding, calls and allocations (flushes), loop
+//! back-edges, and non-fixnum values riding in the register.
+
+extern crate monoruby;
+use monoruby::tests::*;
+
+/// Wrap `body` in a method called enough times for the method JIT, and
+/// return the last result.
+fn jit(body: &str) -> String {
+    format!(
+        r##"
+        def __f(x)
+          {body}
+        end
+        r = nil
+        40.times {{ |i| r = __f(i) }}
+        r
+        "##
+    )
+}
+
+#[test]
+fn copy_chains_of_fixnums() {
+    // The 30k_variables shape: chains of copies between integer ops.
+    run_test(&jit(
+        r##"
+        v0 = x
+        v1 = (v0 + 8) & 4095
+        v2 = v1
+        v3 = v2
+        v4 = v3
+        v5 = v4 ^ v1
+        v6 = v5
+        v7 = v6
+        v8 = (v7 + v3) & 4095
+        v9 = v8
+        v10 = v9
+        [v10, v9, v6, v2, v0]
+        "##,
+    ));
+}
+
+#[test]
+fn in_place_op_on_a_shared_register() {
+    // `a += 1` must not clobber `b`, which shares `a`'s register.
+    run_test(&jit(
+        r##"
+        a = x
+        b = a
+        a += 1
+        c = b
+        b -= 3
+        [a, b, c]
+        "##,
+    ));
+    run_test(&jit(
+        r##"
+        a = x + 1
+        b = a
+        a = a + a
+        [a, b]
+        "##,
+    ));
+}
+
+#[test]
+fn mul_and_div_clobber_a_shared_operand() {
+    run_test(&jit(
+        r##"
+        a = x + 3
+        b = a
+        c = 7 * b
+        d = 1000 / b
+        e = b % 5
+        [a, b, c, d, e]
+        "##,
+    ));
+}
+
+#[test]
+fn deopt_with_copies_outstanding() {
+    // Overflow to Bignum after the copies: the side exit must re-home the
+    // copies from the shared register.
+    run_test(&jit(
+        r##"
+        a = x + 4611686018427387900
+        b = a
+        c = b
+        d = c + 10
+        [a, b, c, d]
+        "##,
+    ));
+    // Type deopt: the copied value is not a fixnum after all.
+    run_test(&jit(
+        r##"
+        a = x > 30 ? 1.5 : x
+        b = a
+        c = b
+        d = c + 1
+        [a, b, c, d]
+        "##,
+    ));
+}
+
+#[test]
+fn eviction_under_pressure_before_an_overflow_deopt() {
+    // plb2/bedcov's `splitmix32`: with the copy `z = x` keeping `x` resident
+    // (dirty) for the whole body, the second multiply — which overflows to a
+    // Bignum — needs a result register and must evict `x`'s. That eviction
+    // has to be spilled *before* the deopt snapshot; a snapshot still naming
+    // the evicted register would store the multiply's garbage into `x`.
+    run_test(
+        r##"
+        def splitmix32(x)
+          x = (x + 0x9e3779b9) & 0xffffffff
+          z = x
+          z = (z ^ (z >> 16)) * 0x21f0aaad & 0xffffffff
+          z = (z ^ (z >> 15)) * 0x735a2d97 & 0xffffffff
+          return z ^ (z >> 15), x
+        end
+        x = 11
+        i = 0
+        r = nil
+        while i < 200
+          r, x = splitmix32(x)
+          i += 1
+        end
+        [r, x]
+        "##,
+    );
+    // The same pressure without a copy: three live results plus an operand
+    // fill the four-register file, so the overflowing op evicts a live local.
+    run_test(&jit(
+        r##"
+        a = x * 3 + 1
+        b = a * 5 + 2
+        c = b * 7 + 3
+        d = c * 0x3fffffffffffff + 4
+        [a, b, c, d]
+        "##,
+    ));
+}
+
+#[test]
+fn copies_across_calls_and_allocations() {
+    run_test(&jit(
+        r##"
+        a = x
+        b = a
+        s = "z" * 3
+        arr = [b, a]
+        c = b
+        arr << c.to_s
+        [a, b, c, s, arr]
+        "##,
+    ));
+}
+
+#[test]
+fn copies_of_non_fixnum_values() {
+    run_test(&jit(
+        r##"
+        a = x.odd? ? nil : "str"
+        b = a
+        c = b
+        f = 2.5
+        g = f
+        h = g + 1.0
+        s = :sym
+        t = s
+        [a, b, c, g, h, t]
+        "##,
+    ));
+}
+
+#[test]
+fn copies_in_loops_and_branches() {
+    run_test(&jit(
+        r##"
+        acc = 0
+        i = 0
+        while i < 20
+          a = i
+          b = a
+          c = b
+          if i.even?
+            a = c + 1
+          else
+            b = a * 2
+          end
+          acc += a + b + c
+          i += 1
+        end
+        [acc, a, b, c]
+        "##,
+    ));
+    run_test(
+        r##"
+        acc = 0
+        i = 0
+        while i < 100
+          v = i
+          w = v
+          u = w
+          acc += u ^ (v + 1)
+          i = u + 1
+        end
+        acc
+        "##,
+    );
+}
+
+#[test]
+fn copy_of_a_call_result_and_self_return() {
+    run_test(&jit(
+        r##"
+        a = x.succ
+        b = a
+        c = b + 1
+        s = "q"
+        d = s.freeze
+        e = d
+        [a, b, c, e]
+        "##,
+    ));
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -158,6 +158,7 @@
 09c5d14600ee6e1cc49a870b8ecd0fea	["zero", "one", "two", "three-six", "three-six", "three-six", "three-six", "seven", "eight", "nine", "ten-fourteen", "ten-fourteen", "ten-fourteen", "ten-fourteen", "ten-fourteen", "fifteen", "sixteen", "seventeen", "above eighteen", "above eighteen", "zero", "one", "two", "three-six", "three-six", "three-six", "three-six", "seven", "eight", "nine", "ten-fourteen", "ten-fourteen", "ten-fourteen", "ten-fourteen", "ten-fourteen", "fifteen", "sixteen", "seventeen", "above eighteen", "above eighteen", "zero", "one", "two", "three-six", "three-six", "three-six", "three-six", "seven", "eight", "nine"]	res = []\n      50.times do |x|\n        case x % 20\n        when 0\n       
 09da60f0b8af936f2576e6fce8f5b2ce	[["one", nil, 1], "uno", [1, "uno"], [1, 1, nil, [true]], [2, 1, 2, nil], 10, [2, 10, 2]]	def drive(n)\n              r = nil\n              n.times { r = yiel
 09dbda92a05db85d6ad08cef7673aa9d	["extended:C"]	$res = []\n        module M\n          def self.extended(base)\n          
+09e1a701e3fe1cd8ef94aa693e0b655b	[1.5, 1.5, 1.5, 2.5]	def __f(x)\n          \n        a = x > 30 ? 1.5 : x\n        b = a\n      
 0a0748b8809f0e8d7f80297870a4da1e	[200000, 0, 999]	a = []\n            200000.times { |i| a << [(i * 7919) % 1000] }\n  
 0a0f30d8ebe55e1e0abe73391dfb071f	[true, true, true, true, 2]	(o=Object.new; def o.to_path; "/tmp/mono_tp_#{Process.pid}"; end; p2=Object.new;
 0a113daaabe1d4a623096c5f5d1b9ad3	"/home/user/monoruby"	File.expand_path("..")
@@ -197,6 +198,7 @@
 0c59ef50cf993e559eee5d6f90c6a39e	[1, 1, 8, [2, 3, 4], 1, 2, 4, nil, 9, 9, 8, [9, 3, 4], 0, 2, 4, nil, 9, 3, 8, [9, 3, 4], 1, 2, 4, nil, 9, 4, 8, [9, 2, 4], 2, 2, 4, nil, 9, 5, 8, [9, 2, 3], 3, 2, 4, nil, 9, 6, 8, [9, 2, 3], 4, 2, 4, nil, 9, 7, 8, [9, 2, 3], 5, 2, 4, nil, 9, 8, 8, [9, 2, 3], 6, 2, 4, nil, 9, 9, 7, [9, 2, 3], 7, 2, 4, nil, 9, 9, 7, [9, 2, 3], 8, 2, 4, nil, 9, 2, 7, [9, 2, 3], 9, 2, 4, nil, 9, 3, 7, [9, 10, 3], 10, 2, 4, nil, 9, 4, 7, [9, 10, 11], 11, 2, 4, nil, 9, 5, 7, [9, 10, 11], 12, 2, 4, nil, 9, 6, 7, [9, 10, 11], 13, 2, 4, nil, 9, 7, 7, [9, 10, 11], 14, 2, 4, nil, 9, 9, 15, [9, 10, 11], 15, 2, 4, nil, 9, 9, 15, [9, 10, 11], 16, 2, 4, nil, 9, 10, 15, [9, 10, 11], 17, 2, 4, nil, 9, 11, 15, [9, 18, 11], 18, 2, 4, nil, 9, 12, 15, [9, 18, 19], 19, 2, 4, nil, 9, 13, 15, [9, 18, 19], 20, 2, 4, nil, 9, 14, 15, [9, 18, 19], 21, 2, 4, nil, 9, 15, 15, [9, 18, 19], 22, 2, 4, nil, 9, 9, 23, [9, 18, 19], 23, 2, 4, nil, 9, 9, 23, [9, 18, 19], 24, 2, 4, nil, 9, 18, 23, [9, 18, 19], 25, 2, 4, nil, 9, 19, 23, [9, 26, 19], 26, 2, 4, nil, 9, 20, 23, [9, 26, 27], 27, 2, 4, nil, 9, 21, 23, [9, 26, 27], 28, 2, 4, nil, [9, 9, 26, 27, 28, 29, 22, 23], {a: 29, "b" => 2, 3 => 4}]	def drive\n              a = [1, 2, 3, 4, 5, 6, 7, 8]\n              
 0c73d03517bb4f3119910e3eaaaec7c7	"[]\\n"	ENV["SPAWN_T2"] = "parent"\n            r, w = IO.pipe\n            P
 0c83f321648f3f64690fb94178ec7665	"/home/user/monoruby/monoruby"	Dir.pwd
+0cace142624c1e6cb89f728eba20c289	[39, 39, 39, "zzz", [39, 39, "39"]]	def __f(x)\n          \n        a = x\n        b = a\n        s = "z" * 3\n 
 0cc1878ea30baafb813863f3ce8b91b6	[90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90]	def real(a, *r) = yield(a + r.sum)\n        def g(...) = real(...)\n     
 0cebe4bdba51d916fafb772a61e36f04	42	x = 42\n            binding.local_variable_get(:x)\n            
 0cf52da8cfa0528dc273b8d510378aad	["not_myobj", false]	class MyObj\n          def !\n            "not_myobj"\n          end\n     
@@ -781,6 +783,7 @@
 3c027e2e1ae3889315fbc61098871eaa	3	class MyNum; def to_int; 2; end; end\nn = MyNum.new\n[1,2,3,4,5].delete_at(n)
 3c08d84242fa705f6035b733b22c106c	"no-shebang\\n"	require "tmpdir"\n            Dir.mktmpdir do |d|\n              path
 3c2bfd6217c4e85fafe2bf1e3baa05d5	""	eval("/a+?*/").match("")[0]
+3c317b41d6a90f7b882850a676d924f0	[40, 36, 39]	def __f(x)\n          \n        a = x\n        b = a\n        a += 1\n      
 3c3e9df720bcfc9e16e5388ec370e1a6	3.15	class Foo; def to_int; 2; end; end\n            3.14159.ceil(Foo.new
 3c69555cfc9c304438892b113e9bb012	[[:@@inherited, :@@own], [:@@own]]	parent = Class.new\n            parent.class_variable_set(:@@inherit
 3c7f081b962e4c7272b51d99d568feb4	["outer", "outer", "outer", "outer", "nil"]	def brk_while(log)\n          outer = StandardError.new "outer"\n        
@@ -836,6 +839,7 @@
 40e716c7328738b3fe988089e88cf750	[false, "d"]	File.open("Cargo.toml") do |f|\n              f.read\n              f
 40ec27ae46c638a3a6280b2acf09bfed	["SocketError", true, 0, ["AF_INET", "127.0.0.1", "127.0.0.1"], true, "127.0.0.1"]	require "socket"\n            res = []\n            # unknown host ->
 410e76b670dd81753a10505bf18e9a4e	[true, ["String", "Comparable", "Object", "Kernel", "BasicObject"], true, false, "b", "c", "c", true, true, true, false, true, false, -1, nil, "b", "a"]	[String.include?(Comparable), String.ancestors.map(&:to_s),\n         "b
+41196e2784709a38db16b2ac20d45c21	[47, 47, 0, 47, 39]	def __f(x)\n          \n        v0 = x\n        v1 = (v0 + 8) & 4095\n     
 4127f9d58f69e19b5bcf5c3c3cefe969	[true, true, false, :fired]	Thread.handle_interrupt(StandardError => :never) do\n              c
 41308fa046142fe3ed9d2bce06bdeb37	[4, 8, 91, 7, 73, 117, 58, 13, 85, 68, 80, 114, 111, 116, 111, 50, 7, 104, 105, 6, 58, 6, 69, 84, 64, 6]	class UDProto2\n              def initialize(s); @s = s; end\n       
 41709673073e0a9bac7681363b4962df	"語本日"	"日本語".reverse
@@ -1142,6 +1146,7 @@
 573fe669ac971343defbd1cde20dc915	["MONORUBY_ENV_TEST_KEY", nil]	ENV["MONORUBY_ENV_TEST_KEY"] = "uniq_value_5678"\n            r = EN
 576157356419a5741dbdbde29df95789	true	GC.stat.values.all? { |v| v.is_a?(Integer) }
 57bd29081de5740463b29a1c3ee0ef00	"US-ASCII"	s = "hello".dup.force_encoding("US-ASCII")\n              s[/(ll)/
+57c833a5c1b734fc7100669600389b9b	[nil, nil, nil, 2.5, 3.5, :sym]	def __f(x)\n          \n        a = x.odd? ? nil : "str"\n        b = a\n  
 57f002dbbc2a38d20a751f8e1d4218fe	[255, 15, 240, -1, 15, -16, 42, 0, 42, 42, -43, 244837815148286, 304366200, 244837510782086]	def or_a; 0xFF | 0x0F; end\n            def and_a; 0xFF & 0x0F; end\n
 57f22a05e8acf18b24e3a1c7b3e4f9a8	[false, :c, false, :cf, :c]	class A; end\n            class B; end\n            class C; end\n    
 5802c597582fbeab79b6c6ee6bfe6fed	[true, false]	a = ["a","b","c"]\n        \n\n            [a.include?("b"), a.include
@@ -1356,6 +1361,7 @@
 68f4361ccb18fadb55264f42091b2bc7	42	x = 42\n            x\n        
 690f7a9479d83c4f5efc9942963213df	["bc", "bc"]	class C; def to_str; "bc"; end; end; o = C.new\n"abcabc".scan(o)
 6918db71780c28b00e597c253bde368e	"default"	GC.config[:implementation]
+69191e68bd5e02ec97d535fd37c3ff3e	652	acc = 0\n        i = 0\n        while i < 100\n          v = i\n          w
 691b2c56eea7b2b314d5eb00cd44238a	nil	def f; end; f
 693bb18ddab0f71baad7547f17a5170e	true	File.executable?("/bin/sh")
 693f5aa61446e94a059879fc0e8410e4	C	class C\n        end\n        \n\n        a = 1\n        C.class_eval do |m|
@@ -1447,6 +1453,7 @@
 704d452b80d83d3bcdabb9fc21dfd71c	["boom", 1, "KwErr", "KwErr"]	class KwErr < StandardError\n              attr_reader :extra\n      
 704e725b4b5d761ef261e9bd0491038b	0.75	Rational(3, 4).to_f
 705519c630a831804749a02887790307	[true, true, true]	module M; class N; CONST = 1; end; end\n            \n\n            [\n
+70656cec0a7d05dbe074e523b3789ac3	[4611686018427387939, 4611686018427387939, 4611686018427387939, 4611686018427387949]	def __f(x)\n          \n        a = x + 4611686018427387900\n        b = a
 7068324754662230dd6cba5af8947f71	"hel"	class Foo; def to_str; "lo"; end; end\n            "hello".chomp(Foo
 7073b2cf059ea135845fa20451762fce	[1, 2, 3]	class E\n              def initialize(a); @a = a; end\n              
 707b7fd02add3d39fff2a8fb60b17cde	["hello", "text"]	klass = Class.new do\n          def hello; "hello"; end\n          def se
@@ -1793,6 +1800,7 @@
 8a6b94b64e2a0b0af3908b52f147185f	true	class S\n        end\n        class C < S\n        end\n        S === C.new
 8a806116e8db9855524e6f7e79e47938	[nil, 2, 9999999999999999999999999999999]	[[].max, [1,2,-42].max, [-42.4242, 100, 999999999999999999999999999
 8ab7255cc645f88bcc12b9b985e76688	[[:protected_foo, :public_foo], [:protected_foo, :public_foo], [:private_foo], [:private_foo]]	class Foo\n          private;   def private_foo()   end\n          protec
+8ac618ade447bc8197083d4232e91f3a	[42, 42, 294, 23, 2]	def __f(x)\n          \n        a = x + 3\n        b = a\n        c = 7 * b
 8ac98985ac612f0703d37bf0737bc3e8	["ABいう", true]	s = "あいう"\n            s.bytesplice(0, 3, "AB".force_encoding("ASCII
 8ad0bb005e97f639e1a5c706a270ed11	[true, false, true, true, true, true]	class W\n            include Comparable\n            attr_accessor :x\n 
 8aff130d4cf4e00d7d7b4435b5691762	[true, "hi"]	require 'tmpdir'\n            path = File.join(Dir.tmpdir, "mrb_fifo
@@ -2461,6 +2469,7 @@ bd72323eccae40b197ebea1283639273	[nil, 42]	a = []\n        a << $std\n        $s
 bd7a26e1f462e26d42e9543689bc3430	3862152.611328125	def calc(n, vals)\n          a = 0.0; b = 1.0; c = 2.0; d = 3.0\n        
 bd9970837b8009b39aca5efafe329d8e	["true", "5", "", "foo"]	[true.to_s, 5.to_s, nil.to_s, :foo.to_s]
 bd9f54fa26238d51503216b560dcfe9d	"M:C"	module M\n          def foo\n            "M:" + super\n          end\n     
+bdab5d25c3b4be158f0e7bd7de9daf97	[118, 592, 4147, 74705710618821783505]	def __f(x)\n          \n        a = x * 3 + 1\n        b = a * 5 + 2\n     
 bdd4254f72e55d63b4505c0909c9bd00	[6.5, 17.0]	def call_block\n      yield\n    end\n    def call_block_twice\n      yield\n   
 bde4f5647e4c5f426e0b6b9de2ad09ab	[[], [:it], [:_1, :_2, :_3], [:it], [], [], []]	[\n              binding.implicit_parameters,\n              proc { i
 bde9a54a7762ba3fd118c904ccaac5c2	[:rescued]	def boom; raise "no"; end\n            def test; [1].map { begin; bo
@@ -2663,6 +2672,7 @@ cb4478e73aab25c758637cb13389a676	true	Process.respond_to?(:exit!)
 cb6813c622f9c03c3a741e5ea65819a7	-1	class Integer; alias __orig :-; def -(o); __orig(o); end; end; 3 - 4
 cb7c9ec2433344c197fcd2854cff3c52	"abc"	"abc".center(3)
 cb9f3248f2f6bc5c98916096bf18af2d	[false, nil, nil]	class NilClass; def to_a; $flag = true; super; end; end\n        $flag =
+cba3d63bf788ac7a61926a8c9c04217f	[80, 40]	def __f(x)\n          \n        a = x + 1\n        b = a\n        a = a + a
 cba85401e6793856ca7879fbbe19af13	0	Process.euid
 cbc5428b9ea75e034300c93910733635	[10, 20, 30]	class C\n              attr_accessor :x,:y,:z\n            end\n      
 cbe2fdfe5524a2252322956fc39595d8	{}	M = Data.define(:amount, :unit)\nM.new(1, "m").deconstruct_keys([:amount, :x, :un
@@ -2981,6 +2991,7 @@ e47239d7cd6ec89f4fe82f6a1a03800e	ArgumentError	class Integer; def <=>(o); :OVERR
 e47afc9bea872de2d1e41b256d5d2554	[true, 9, nil]	pid = fork { sleep 5 }\n            Process.kill("SIGKILL", pid)\n   
 e48337ae565a3904f3c01b8e583758d2	["C", "M2", "M1"]	module M1\n          def f\n            $res << "M1"\n          end\n      
 e4a701808e3a93ca91d9df6170eb2110	[["NestA::NestB", "NestA"], ["NestA::NestB", "NestA"], []]	module NestA\n              module NestB\n                def self.f;
+e4ae3916bef50df6a3becd07254df7c2	[3849074495, 2606176403]	def splitmix32(x)\n          x = (x + 0x9e3779b9) & 0xffffffff\n         
 e4b07dfb345d9091378925364fd0c790	[8, [1, 3, 5], 50, 3, 10]	def first_even(a); a.each { |x| break x if x % 2 == 0 }; end\n        de
 e4c3805b5eda733c2c3b305a068dc955	"Cargo.toml"	File.open("Cargo.toml") { |f| f.path }
 e4e344de107f90e3a04f591c1d83fb9a	nil	Inner = Struct.new(:b)\n        Outer = Struct.new(:a)\n        o = Outer
@@ -3157,6 +3168,7 @@ f2104384e6be9965ec5da4ad860b37f4	[1, 4, 2]	[IO::READABLE, IO::WRITABLE, IO::PRIO
 f212deed776e67ad2663d333efdef52c	true	b = binding\n            b.eval("z = 1")\n            b.local_variabl
 f216b4de4c4cc3516688e358d154cc58	[{k: 0}, 1, {a: 1, b: 0}, [:a, :b], [1, 0], false, true, {k: 1}, 1, {a: 1, b: 1}, [:a, :b], [1, 1], false, true, {k: 2}, 1, {a: 1, b: 2}, [:a, :b], [1, 2], false, true, {k: 3}, 1, {a: 1, b: 3}, [:a, :b], [1, 3], false, true, {k: 4}, 1, {a: 1, b: 4}, [:a, :b], [1, 4], false, true, {k: 5}, 1, {a: 1, b: 5}, [:a, :b], [1, 5], false, true, {k: 6}, 1, {a: 1, b: 6}, [:a, :b], [1, 6], false, true, {k: 7}, 1, {a: 1, b: 7}, [:a, :b], [1, 7], false, true, {k: 8}, 1, {a: 1, b: 8}, [:a, :b], [1, 8], false, true, {k: 9}, 1, {a: 1, b: 9}, [:a, :b], [1, 9], false, true, {k: 10}, 1, {a: 1, b: 10}, [:a, :b], [1, 10], false, true, {k: 11}, 1, {a: 1, b: 11}, [:a, :b], [1, 11], false, true, {k: 12}, 1, {a: 1, b: 12}, [:a, :b], [1, 12], false, true, {k: 13}, 1, {a: 1, b: 13}, [:a, :b], [1, 13], false, true, {k: 14}, 1, {a: 1, b: 14}, [:a, :b], [1, 14], false, true, {k: 15}, 1, {a: 1, b: 15}, [:a, :b], [1, 15], false, true, {k: 16}, 1, {a: 1, b: 16}, [:a, :b], [1, 16], false, true, {k: 17}, 1, {a: 1, b: 17}, [:a, :b], [1, 17], false, true, {k: 18}, 1, {a: 1, b: 18}, [:a, :b], [1, 18], false, true, {k: 19}, 1, {a: 1, b: 19}, [:a, :b], [1, 19], false, true]	res = []\n        20.times do |i|\n            h = {}\n            h[:k] =
 f25e578e126546527b49642021ac237a	[["US-ASCII", [65]], ["ASCII-8BIT", [65, 128]], ["ASCII-8BIT", [255]], ["UTF-8", [226, 128, 189]], ["EUC-JP", [65, 161, 161]], ["Windows-31J", [65, 177, 129, 64]], ["ASCII-8BIT", [0, 255]], ["ISO-8859-1", [65, 255]], ["UTF-16LE", 65, [65, 0]], ["UTF-16LE", 8253, [61, 32]], ["UTF-16LE", 66376, [0, 216, 72, 223]], ["UTF-16LE", "invalid codepoint 0xD800 in UTF-16LE"], ["UTF-16BE", 65, [0, 65]], ["UTF-16BE", 8253, [32, 61]], ["UTF-16BE", 66376, [216, 0, 223, 72]], ["UTF-16BE", "invalid codepoint 0xD800 in UTF-16BE"], ["UTF-32LE", 65, [65, 0, 0, 0]], ["UTF-32LE", 8253, [61, 32, 0, 0]], ["UTF-32LE", 66376, [72, 3, 1, 0]], ["UTF-32LE", "invalid codepoint 0xD800 in UTF-32LE"], ["UTF-32BE", 65, [0, 0, 0, 65]], ["UTF-32BE", 8253, [0, 0, 32, 61]], ["UTF-32BE", 66376, [0, 1, 3, 72]], ["UTF-32BE", "invalid codepoint 0xD800 in UTF-32BE"], ["RangeError", "256 out of char range"], ["RangeError", "-1 out of char range"], ["RangeError", "invalid codepoint 0x81 in EUC-JP"], ["RangeError", "invalid codepoint 0xA100 in EUC-JP"], ["RangeError", "invalid codepoint 0x80 in Windows-31J"], ["RangeError", "65536 out of char range"], ["RangeError", "16777216 out of char range"], ["RangeError", "256 out of char range"], ["RangeError", "4660 out of char range"], ["RangeError", "invalid codepoint 0xDFFF in UTF-16LE"], ["RangeError", "invalid codepoint 0x110000 in UTF-32BE"], ["RangeError", "256 out of char range"], ["RangeError", "1114112 out of char range"], ["RangeError", "bignum out of char range"]]	res = []\n        # US-ASCII: 7-bit stays, 128..255 widens to BINARY, pa
+f278d110b91e27cba6d94dd2fa48e555	[680, 19, 38, 19]	def __f(x)\n          \n        acc = 0\n        i = 0\n        while i < 2
 f27aef0e47e3354ce496c90299f462ea	[["x\\ny\\nz\\n"], ["x\\n", "y\\n", "z\\n"], ["x\\n", "y\\n", "z\\n"], "ASCII-8BIT"]	File.write("/tmp/mr_rlf4.txt", "x\\ny\\nz\\n")\n            r = []\n    
 f2899713941ee3ed54e30d3b5b785abc	[1, true]	module MSx; end\n            SX = Struct.new(:a)\n            s = SX.
 f2e470589175775eee4819e2df92057b	true	v = "MONORUBY_TEST_VAL"\n            r = ENV.send(:[]=, "MONORUBY_EN
@@ -3292,6 +3304,7 @@ fbb6a99a9e767f50065c0f1b714f7960	["RuntimeError", "boom", false]	f = Fiber.new {
 fbfbbb9d05ea7dc5ddb91d5f6aa274ad	"EUC-JP"	e = "あ".encode("EUC-JP"); "#{""}#{e}".encoding.to_s
 fc2292041cacaef7aa439e177107ed46	[42, 90, 15, "1/2", "7:8", "argerr"]	def a0; 42; end\n        def a1(x); x * 10; end\n        def a5(a, b, c, 
 fc22a4cd64bea4559dace662cad4cc26	[[1, 2]]	r = []; Enumerator.new { |y| y.yield 1, 2 }.each { |*a| r << a }; r
+fc2f16b93ce4cbb761bfc5c755d871c4	[40, 40, 41, "q"]	def __f(x)\n          \n        a = x.succ\n        b = a\n        c = b + 
 fc3371eaceedc6a0fdff24c1dffa8f49	[[], [nil, nil, nil], [:x, :x, :x], [0, 2, 4], [1, 2, 3], [4, 5], [nil, nil], [nil, nil]]	o = Object.new\n        def o.to_ary = [4, 5]\n        # to_ary returning
 fc3d5bf1ce71d212ebacaaf185815390	["RuntimeError", "parent 42", "parent 5"]	parent = Class.new { def m(a) = "parent #{a}" }\n        res = []\n      
 fc49adcb727ee87209fa4da1d578751d	["a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_", "a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_a1_b2_c3_"]	res = []\n        require "strscan"\n        20.times do\n            s = 


### PR DESCRIPTION
## Summary

`%dst = %src` was a load/store pair through the stack home, and `Mov` flushed the GP file first, ending every run of register-resident integer work. On a copy-heavy body (yjit-bench `30k_variables`: 100 locals per method, mostly `vN = vM`) that was ~300 memory ops per call, each copy's load waiting on the previous copy's store.

The fpr file has always let one xmm back several slots. `GpRegFile` now has the same shape: a holder set per allocatable register, each holder with its own dirty bit.

- `copy_slot`'s `S` arm binds `dst` **dirty** to `src`'s register (loading `src` clean into a fresh register first if it was not resident) and emits nothing. The store to `dst`'s home is owed at the register's eviction or the next flush, and dropped if `dst` dies first (a `ret`, a popped temporary). `Mov` no longer flushes for an `S`/`C` source.
- Eviction spills every dirty holder of the victim (`alloc_reg` returns the list; `evict_reg` is the shared primitive). `Mul`/`Div` evict the whole register they are about to destroy instead of syncing `rhs` alone.
- An op computes **in place** only in a register that will hold nothing but its `lhs` (`will_hold_at_most`); a register shared with copies carries their only value.
- The result register is **reserved before the deopt snapshot** (`plan_dst_reg` → `GpRegFile::reserve`, then `new_deopt`, then `take_dst_reg`). The snapshot is taken before the popped operands are cleared so the interpreter can re-read them; a victim evicted *after* it stayed listed in it, and an overflow side exit then stored the register, by then holding the result, into the victim's home. Copies made this latent ordering bug reachable (plb2 `bedcov`'s `splitmix32`: `z = x` kept `x` resident through the overflowing second multiply, and `x` came back a Float). It is fixed for the copy-free case as well.

`doc/regalloc_separation.md` §45 records the design.

## Results (x86-64, release)

| benchmark | master | this PR |
|---|---|---|
| 30k_variables (ms/iter) | 301 | 23 |
| 30k_methods (ms/iter) | 212 | 203 |
| fib / nbody / mandelbrot / nqueen / sudoku / bedcov / qsort / tarai / bf | flat (within noise; fib's generated code is byte-identical) | |

## Tests

- `tests/copy_propagation.rs`: copy chains between integer ops, in-place ops on a shared register, `Mul`/`Div` clobbering a shared operand, overflow and type deopts with copies outstanding, calls and allocations, loops and branches, non-fixnum values, a copied call result, and the `splitmix32` shape plus the copy-free pressure case for the snapshot ordering.
- `gp_alloc` unit tests for the many-holder file (sharing, eviction spills per dirty holder, rebinding one holder).
- Full `cargo test` with `stress-spill-pool` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_