### PR TITLE
x86-64: nil-fill a method's slots two at a time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -438,7 +438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -794,7 +794,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "monoasm"
 version = "0.1.0"
-source = "git+https://github.com/sisshiki1969/monoasm.git?branch=claude%2Fmovups#d9f2d07f333c8f89c29881bfff1ad0961889553f"
+source = "git+https://github.com/sisshiki1969/monoasm.git?branch=aarch#e577fb19a52a44af23caa55e02fc8568f52b7ef5"
 dependencies = [
  "chrono",
  "libc",
@@ -808,7 +808,7 @@ dependencies = [
 [[package]]
 name = "monoasm_macro"
 version = "0.1.0"
-source = "git+https://github.com/sisshiki1969/monoasm.git?branch=claude%2Fmovups#d9f2d07f333c8f89c29881bfff1ad0961889553f"
+source = "git+https://github.com/sisshiki1969/monoasm.git?branch=aarch#e577fb19a52a44af23caa55e02fc8568f52b7ef5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1283,7 +1283,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1480,7 +1480,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "monoasm"
 version = "0.1.0"
-source = "git+https://github.com/sisshiki1969/monoasm.git?branch=aarch#12c4fe932435f738f9322461ef53a497b0280ae3"
+source = "git+https://github.com/sisshiki1969/monoasm.git?branch=claude%2Fmovups#d9f2d07f333c8f89c29881bfff1ad0961889553f"
 dependencies = [
  "chrono",
  "libc",
@@ -808,7 +808,7 @@ dependencies = [
 [[package]]
 name = "monoasm_macro"
 version = "0.1.0"
-source = "git+https://github.com/sisshiki1969/monoasm.git?branch=aarch#12c4fe932435f738f9322461ef53a497b0280ae3"
+source = "git+https://github.com/sisshiki1969/monoasm.git?branch=claude%2Fmovups#d9f2d07f333c8f89c29881bfff1ad0961889553f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/monoruby/Cargo.toml
+++ b/monoruby/Cargo.toml
@@ -91,8 +91,8 @@ mimalloc = { version = "0.1", optional = true }
 clap = { version = "4.6.1", features = ["derive"] }
 rustyline = "18.0.0"
 paste = "1.0.15"
-monoasm_macro = { git = "https://github.com/sisshiki1969/monoasm.git", branch = "aarch" }
-monoasm = { git = "https://github.com/sisshiki1969/monoasm.git", branch = "aarch" }
+monoasm_macro = { git = "https://github.com/sisshiki1969/monoasm.git", branch = "claude/movups" }
+monoasm = { git = "https://github.com/sisshiki1969/monoasm.git", branch = "claude/movups" }
 onigmo-regex = { git = "https://github.com/sisshiki1969/onigmo-regex.git" }
 ruby-prism = { git = "https://github.com/sisshiki1969/prism.git", branch = "monoruby-vendored" }
 monoruby-attr = { path = "../monoruby_attr" }

--- a/monoruby/Cargo.toml
+++ b/monoruby/Cargo.toml
@@ -91,8 +91,8 @@ mimalloc = { version = "0.1", optional = true }
 clap = { version = "4.6.1", features = ["derive"] }
 rustyline = "18.0.0"
 paste = "1.0.15"
-monoasm_macro = { git = "https://github.com/sisshiki1969/monoasm.git", branch = "claude/movups" }
-monoasm = { git = "https://github.com/sisshiki1969/monoasm.git", branch = "claude/movups" }
+monoasm_macro = { git = "https://github.com/sisshiki1969/monoasm.git", branch = "aarch" }
+monoasm = { git = "https://github.com/sisshiki1969/monoasm.git", branch = "aarch" }
 onigmo-regex = { git = "https://github.com/sisshiki1969/onigmo-regex.git" }
 ruby-prism = { git = "https://github.com/sisshiki1969/prism.git", branch = "monoruby-vendored" }
 monoruby-attr = { path = "../monoruby_attr" }

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -870,6 +870,13 @@ pub struct Codegen {
     ///   live x30 around the `bl`).
     ///
     alloc_cell: DestLabel,
+    /// A 16-byte constant holding `NIL_VALUE` twice, so a method prologue
+    /// can nil-fill its slots two at a time with `movups` (see
+    /// `Codegen::init_func`). Laid down as four `const_i32`, not two
+    /// `const_i64`: monoasm aligns every 8-byte constant to 16 bytes
+    /// individually, so a pair of them would not be contiguous.
+    #[cfg(target_arch = "x86_64")]
+    nil_pair: DestLabel,
     pub(crate) specialized_info: Vec<SpecializedPatchEntry>,
     pub(crate) specialized_base: usize,
     /// The const-version snapshot word of the unit currently being compiled:
@@ -1260,6 +1267,16 @@ impl Codegen {
         let switch_to_scheduler = jit.switch_to_scheduler();
         let scheduler_resume = jit.scheduler_resume();
 
+        #[cfg(target_arch = "x86_64")]
+        let nil_pair = {
+            let label = jit.const_align8();
+            for _ in 0..2 {
+                jit.const_i32(NIL_VALUE as i32);
+                jit.const_i32((NIL_VALUE >> 32) as i32);
+            }
+            label
+        };
+
         let mut codegen = Self {
             jit,
             class_version_addr,
@@ -1274,6 +1291,8 @@ impl Codegen {
             chain_deopt_table: HashMap::default(),
             chain_cont_stub: entry_panic.clone(),
             alloc_cell: entry_panic.clone(),
+            #[cfg(target_arch = "x86_64")]
+            nil_pair,
             specialized_info: Vec::new(),
             specialized_base: 0,
             unit_const_version: None,

--- a/monoruby/src/codegen/arch/x86_64/compile/init_method.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/init_method.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+/// Slot count from which the prologue's nil fill switches to 16-byte
+/// `movups` stores. Below it the scalar form is at least as small and
+/// avoids occupying an xmm register plus the pattern load; a method with
+/// a handful of locals is also where the fill is not worth measuring.
+const SIMD_FILL_MIN: usize = 6;
+
 impl Codegen {
     ///
     /// Initialize function stack frame.
@@ -25,19 +31,47 @@ impl Codegen {
         let l1 = self.jit.label();
         // fill nil to non-argument locals and temporary registers.
         let clear_len = reg_num - arg_num;
-        if clear_len > 2 {
+        // Frame offset of the `i`-th slot of the cleared run. The run
+        // descends — slot `i + 1` sits 8 bytes *below* slot `i` — so a
+        // 16-byte store addressed at slot `i + 1` covers the pair
+        // (`i + 1`, `i`).
+        let ofs = |i: usize| -> i32 { RBP_LOCAL_FRAME + (arg_num + i) as i32 * 8 + LFP_ARG0 };
+        if clear_len >= SIMD_FILL_MIN {
+            // Two slots per store. The pattern is a shared rip-relative
+            // constant (`Codegen::nil_pair`), so nothing is read back from
+            // the frame we are about to write — a 16-byte load of two
+            // just-stored 8-byte words would stall on store forwarding and
+            // give most of the saving back.
+            let nil_pair = self.nil_pair.clone();
+            monoasm!( &mut self.jit,
+                movups xmm0, [rip + nil_pair];
+            );
+            let mut i = 0;
+            while i + 1 < clear_len {
+                monoasm!( &mut self.jit,
+                    movups [rbp - (ofs(i + 1))], xmm0;
+                );
+                i += 2;
+            }
+            // Odd tail.
+            if i < clear_len {
+                monoasm!( &mut self.jit,
+                    movq [rbp - (ofs(i))], (NIL_VALUE);
+                );
+            }
+        } else if clear_len > 2 {
             monoasm!( &mut self.jit,
                 movq rax, (NIL_VALUE);
             );
             for i in 0..clear_len {
                 monoasm!( &mut self.jit,
-                    movq [rbp - (RBP_LOCAL_FRAME + (arg_num + i) as i32 * 8 + LFP_ARG0)], rax;
+                    movq [rbp - (ofs(i))], rax;
                 );
             }
         } else {
             for i in 0..clear_len {
                 monoasm!( &mut self.jit,
-                    movq [rbp - (RBP_LOCAL_FRAME + (arg_num + i) as i32 * 8 + LFP_ARG0)], (NIL_VALUE);
+                    movq [rbp - (ofs(i))], (NIL_VALUE);
                 );
             }
         }


### PR DESCRIPTION
Depends on sisshiki1969/monoasm#12 (`x64: add MOVUPS`), now merged — the pin is back on `branch = "aarch"` at the merge commit.

## Summary

A JIT method prologue clears every non-argument slot with one 8-byte store each, so a body with many locals pays a store per local before it runs anything. Since copy propagation (#1242) took yjit-bench `30k_variables` from 518 ns to 38 ns per call, that fill is now **40%** of what is left — about 15 ns of the 38 for its 100 locals.

Fill pairs instead. The cleared run descends, so a 16-byte store addressed at slot `i+1` covers the pair `(i+1, i)`. `movups` is the form to use: frame slots are only 8-byte aligned, so `movaps` would fault on half the pairs, and an unaligned 16-byte store that stays inside a cache line costs the same anyway.

Two details worth calling out:

- The pattern comes from **one shared rip-relative constant** (`Codegen::nil_pair`), not from the frame itself. Seeding two slots and reading them back as 16 bytes is tempting but stalls on store forwarding, giving most of the saving back.
- That constant is four `const_i32`, **not** two `const_i64` — monoasm's `resolve_constants` aligns every 8-byte constant to 16 bytes individually, so a pair of them has 8 bytes of padding between.

Below `SIMD_FILL_MIN` (6) slots the scalar form is kept: it is no larger there and leaves xmm0 alone. Clobbering xmm0 in a prologue is safe — the FP register pool starts at xmm2, and xmm0/xmm1 are C-call scratch that never hold a value across a Ruby call.

For a 24-slot frame the prologue's fill block goes from 23 stores / 147 bytes to 11 `movups` + 1 `movq` / 83 bytes.

## Results (x86-64, release)

| | master | this PR |
|---|---|---|
| fill of 47 slots (ns/call) | 11.6 | 7.7 |
| fill of 97 slots (ns/call) | 20.7 | 13.7 |
| 30k_variables (ms/iter) | 22 | 17 |

`fib`, `nbody`, `mandelbrot`, `nqueen`, `sudoku`, `bedcov`, `matmul`, `qsort`, `tarai`, `bf` and `aobench` are all within noise; `30k_methods` and `30k_ifelse` are unchanged (few locals per method).

## Tests

Full `cargo test` with `stress-spill-pool` passes (76 binaries). The fill is exercised by every JIT-compiled method in the suite; the emitted prologue was checked against the scalar version slot by slot with `--features emit-asm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM