### PR TITLE
yjit-bench: investigate the slow activerecord/erubi/rack/graphql runs and land the low-cost fixes

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -78,6 +78,7 @@ Diagrams referenced by the above: [`fiber_state_diagram.svg`](fiber_state_diagra
 |---|---|---|---|
 | [`ruby_spec_skip_tags.md`](ruby_spec_skip_tags.md) | JA | reference | How the ruby/spec suite avoids hangs, and the audit that cut a coarse file-level skip list down to the handful that genuinely cannot run. |
 | [`optcarrot_opt_profile.md`](optcarrot_opt_profile.md) | JA | design record | Where `bin/optcarrot --opt` spends its time, measured with `perf` and `--features profile`, and the optimizations that came out of it. |
+| [`yjit_bench_slow_investigation_2026-09.md`](yjit_bench_slow_investigation_2026-09.md) | JA | design record | Why activerecord / erubi / rack / graphql run at half of CRuby+YJIT: steady-state `perf` breakdowns, deopt-log and PMC statistics, microbenchmarks isolating each runtime cost (String-keyed Hash, GC roots, arg-class-keyed PMC, StringScanner, exceptions), and a ranked plan. |
 
 ## Plans and history
 

--- a/doc/yjit_bench_slow_investigation_2026-09.md
+++ b/doc/yjit_bench_slow_investigation_2026-09.md
@@ -455,3 +455,52 @@ FFI: `fiddle|ffi_call|sqlite|classify_argument|libffi`）。
 このコンテナには `perf` が無いので `apt-get install linux-tools-generic` で入れ、カーネル版が
 違うため `/usr/lib/linux-tools/<ver>/perf` を直接叩いた（`perf_event_paranoid = 2` でも
 `-e cpu-clock` は採れる）。
+
+## 8. 実施した対策（2026-09-03、コスト順）
+
+§6 の案のうち実装コストの低いものから順に入れた。効果は同じ計測機で baseline
+（`750d04f`）と新ビルドを交互に 3 ラウンド走らせた中央値の最小値で比較
+（`MAX_TIME=30`、単発計測は ±10 % 揺れるので 1 回の差は信用しない）。
+
+| # | 施策 | 変更箇所 | マイクロベンチ | ベンチへの効果 |
+|---|---|---|---|---|
+| 1 | GC トリガーの下限を 8 → 32 ページ（≈ 13 万 RValue、8 MB） | `alloc.rs::PAGES_PER_GC_TRIGGER` | — | 下表 |
+| 2 | 汎用 `[]=`（VM と JIT の多相残余）に Hash の直接経路 | `runtime::set_index` | — | 下表 |
+| 3 | `"lit".freeze` を専用命令 `StringFreeze`（opcode 8）に。`String#freeze` を basic-op 表に追加し、未再定義ならインターン済み frozen リテラルを返す（CRuby の `opt_str_freeze`）。JIT は bop 依存を記録して plain literal load、再定義済みなら VM ヘルパが chilled コピーを作って再定義された `freeze` を呼ぶ | bytecodegen `gen_method_call`、`runtime::string_freeze_literal`、VM 両アーキ、TraceIR/JIT | `'abc'.freeze` 67.6 → 9.8 ns（YJIT 26）、`buf << 'lit'.freeze` 73 → 15.9 ns（YJIT 21） | pragma なしのコードのみ |
+| 4 | 引数クラスだけが変わる多相二項演算サイト（`children << node`）に、受信側クラスで分岐する 2-arm dispatch（直接呼び出し + 汎用ヘルパ）。それまでは毎回 `invoke_method` → グローバルメソッドキャッシュ | `compile/binary_op.rs::binary_recv_dispatch` | `ary << x`（4 クラス）57 → 4.5 ns、`<<` のグローバルキャッシュ引き 300 万回 → 0 | 下表 |
+
+施策 1〜3 を入れた時点（v2）:
+
+| ベンチ | baseline（3 回の中央値） | v2 | 差 |
+|---|---:|---:|---:|
+| erubi | 318 / 310 / 311 ms | 317 / 318 / 310 ms | ±0 % |
+| rack | 94 / 91 / 90 ms | 84 / 89 / 91 ms | −6.7 % |
+| graphql | 61 / 61 / 59 ms | 59 / 53 / 58 ms | −10 % |
+| activerecord | 329 / 341 / 340 ms | 318 / 292 / 311 ms | −11 % |
+
+施策 1〜4 を全部入れた最終ビルド（v3、コミット `265aa91`）:
+
+| ベンチ | baseline（3 回の中央値） | v3 | 差 |
+|---|---:|---:|---:|
+| erubi | 337 / 316 / 310 ms | 308 / 318 / 334 ms | ±0 % |
+| rack | 88 / 92 / 98 ms | 84 / 81 / 82 ms | −8 % |
+| graphql | 61 / 60 / 62 ms | 54 / 53 / 52 ms | −13 % |
+| activerecord | 334 / 328 / 319 ms | 309 / 301 / 293 ms | −8 % |
+
+（v2 → v3 で graphql がさらに 3 % 前後縮んだのが施策 4 の分。activerecord は
+ノイズの範囲。）フルテストは 3688 passed / 1 failed で、失敗は下記の既存の
+`Float#ceil` 差分のみ。
+
+- erubi は GC 回数が 1/4 になっても速くならなかった（施策 1 単体の単発計測では
+  erubi −13 % に見えたが、交互 3 ラウンドでは差なし。ヒープが 6 → 8 MB になって
+  キャッシュ局所性が落ちる分と相殺していると見ている）。GC のコストの本体は
+  ルート走査（§5.1）なので、次はルートの世代別化が必要。
+- 施策 3 の設計メモ: 最初は「レシーバだけを frozen リテラルにして `freeze` 呼び出し
+  は残す」形で入れたが、`String#freeze` を再定義したコードが frozen なレシーバを
+  受け取る（CRuby は chilled なコピーを渡す）ので、テストで CRuby と食い違った。
+  専用命令 + basic-op 検査に置き換えて解消。もう 1 つ、結果 temp を `push` する前に
+  命令を emit すると JIT の抽象フレームがその temp を死んだスロットと見なして
+  `load()` で panic する（`emit_call` は push してから emit している）。
+- 手元の CRuby は 4.0.6 で、`Float#ceil(15)` の結果が 4.0.2 と違う
+  （`1.123456789.ceil(15)` → `1.123456789000001`）ため `float::tests::angle` が
+  baseline でも失敗する。本変更とは無関係。

--- a/doc/yjit_bench_slow_investigation_2026-09.md
+++ b/doc/yjit_bench_slow_investigation_2026-09.md
@@ -1,0 +1,457 @@
+# yjit-bench で monoruby が遅い 4 ベンチ (activerecord / erubi / rack / graphql) の原因調査
+
+調査日 2026-09-03。対象コミットは `750d04f`（master, "Boot rubygems lazily" #1240 直後）。
+[ベンチマークポータル](https://sisshiki1969.github.io/monoruby/)の x86-64 最新スナップショット
+（`c295e69`, 2026-09-02）で monoruby が CRuby+YJIT の半分前後の速度しか出ていない 4 本に
+ついて、どこで時間を使っているかを `perf` / `--features profile` / `--features deopt` /
+`--features jit-log` / マイクロベンチで測り、monoruby 固有のボトルネックを切り分けた記録。
+
+計測機は x86-64 / Linux（Xeon 2.1 GHz 4 vCPU, L2 8 MiB, L3 260 MiB）。比較対象は
+rbenv でビルドした CRuby 4.0.6（`--yjit`）。ベンチ本体は
+[Shopify/yjit-bench](https://github.com/Shopify/yjit-bench) `e73823e`（2026-08-31）を
+`harness-warmup` で走らせ、後半半分の反復の中央値を使う（CI の `bench.yml` と同じ条件）。
+gem のバージョンは rack 3.2.3 / graphql 2.5.11 / erubi 1.13.1 / activerecord 8.1.1 +
+sqlite3 2.7.3。
+
+---
+
+## 1. 結論（先に要点）
+
+4 本の遅さは JIT が吐くコードの質ではなく、**ランタイム側（Rust の builtin・GC・
+アロケータ・呼び出しキャッシュの設計）に集中**している。perf のセルフ時間では JIT
+コード本体はどのベンチでも 15〜20 % しかなく、残りは Rust 側の Hash / String /
+アロケータ / GC / 正規表現 / FFI である。
+
+monoruby 固有で CRuby+YJIT より明確に遅いと確認できた要素（マイクロベンチ §4）:
+
+| 要素 | monoruby | YJIT | 倍率 | 効くベンチ |
+|---|---:|---:|---:|---|
+| String キーの Hash リテラル `{"content-type" => "text/plain"}` | 155 ns | 60 ns | **2.6x** | rack（レスポンスヘッダ）, activerecord |
+| `ary << x` で `x` のクラスが混在（PMC が引数クラスでキーされる） | 84 ns | 66 ns（単相は 3.6 ns → 23x） | — | graphql, activerecord |
+| `catch` / `throw` | 580 ns | 218 ns | **2.7x** | activerecord（callbacks） |
+| `raise` / `rescue` | 1288 ns | 746 ns | 1.7x | rack, activerecord |
+| `StringScanner` による字句解析（Ruby 実装） | 692 µs | 438 µs | 1.6x | graphql |
+| `Array#map(&:sym)` | 1556 ns | 926 ns | 1.7x | 全般 |
+| String キー Hash（20 キー）`h["k"]` / `h["k"] = v` | 256 / 369 ns | 202 / 250 ns | 1.3x / 1.5x | erubi, rack, activerecord |
+| `Hash#dup`（30 キー） | 395 ns | 306 ns | 1.3x | rack（`env.dup`） |
+| `'lit'.freeze`（`frozen_string_literal` なし） | 65 ns | 26 ns | 2.5x | （erubi は pragma 付きなので該当せず） |
+
+加えて、どのベンチにも共通に効いている構造的な要因:
+
+- **GC + アロケータで 20〜30 %**（malloc/free 13〜22 % self + GC が inclusive で 8〜14 %）。
+  ヒープが 22〜27 ページ（≈ 6 MB）と極端に小さく、erubi は 1 反復あたり 7.3 回、
+  activerecord は 3.8 回のマイナー GC が走る。毎回のマイナー GC がロードされた
+  **全 ISeq のリテラル・全クラスをルートとして再走査**するので、Rails 級のコード量では
+  ルート走査だけで固定費になる（`ISeqInfo::mark` が 1.4〜1.7 % self）。
+- **String キー Hash の検索**（`RandomState` = SipHash-1-3 を毎回計算、ハッシュ値の
+  キャッシュなし、String キーはインライン表現に入らず必ず boxed map）が erubi で 30 %、
+  rack で 18 %、activerecord で 13 %。
+- **VM（インタプリタ）側の `[]=` / `<<` はインラインキャッシュを使わず、毎回
+  `find_method` → グローバルメソッドキャッシュ**を引く（rack で `Hash#[]=` 780 万回、
+  activerecord で 1006 万回、graphql で `Array#<<` 712 万回）。
+- activerecord では **deopt の嵐**（60 秒で約 1,600 万回。`LazyAttributeSet#fetch_value`
+  の `type.deserialize(value)` サイトだけで 1,000 万回）。1 回の deopt は安い（≈ 15〜20 ns）
+  ので支配的ではないが、再コンパイルしても直らない単相ガードを出し続けるポリシー上の穴。
+- activerecord の sqlite3 は Fiddle 経由（`fiddle_invoke` + libffi + libsqlite3 で 12 %）。
+
+## 2. 再現結果
+
+| ベンチ | CRuby 4.0.6 --yjit | monoruby | 速度比 (YJIT 基準) | ポータル値 (`c295e69`) | monoruby `--no-jit` | CRuby interp |
+|---|---:|---:|---:|---:|---:|---:|
+| activerecord | 106 ms | 284 ms | 0.37x | 0.45x | 605 ms | 316 ms |
+| erubi | 181 ms | 275 ms | 0.66x | 0.55x | 511 ms | 230 ms |
+| graphql | 31 ms | 51 ms | 0.61x | 0.57x | 188 ms (参考) | 63 ms |
+| rack | 38 ms | 79 ms | 0.48x | 0.53x | 116 ms (参考) | 65 ms |
+
+- ポータルとの差は計測機の違い。傾向は一致する。
+- `--no-jit` は monoruby のインタプリタのみ。**rack / activerecord ではインタプリタが
+  CRuby のインタプリタより遅く、JIT を有効にしても CRuby のインタプリタに届かない**
+  （rack 79 ms vs 65 ms）。JIT の寄与（rack 116→79、activerecord 605→284）は CRuby の
+  YJIT の寄与（65→38、316→106）と同程度なので、差は JIT ではなくランタイムにある。
+- graphql / rack の `--no-jit` は他ジョブと並走中に測った参考値。
+- 起動（ベンチ計測の外側）: `Bundler.setup` + `require "rack"` が monoruby 0.47 s /
+  CRuby 0.17 s、`require "active_record"` が 846 ms / 101 ms。
+
+## 3. 時間の内訳（perf, 定常状態のセルフ時間）
+
+`--features perf` ビルドを `perf record -D 12000 -F 999 -e cpu-clock -g --call-graph=fp`
+（起動から 12 秒後にサンプリング開始 = ウォームアップ後のみ）で採り、シンボルを大まかに
+分類したもの。分類の正規表現は §7 の `categorize.rb`。
+
+| 区分 | rack | graphql | erubi | activerecord |
+|---|---:|---:|---:|---:|
+| JIT 生成コード + VM 領域の共有スタブ | 14.7 % | 20.4 % | 16.0 % | 21.2 % |
+| Hash（String digest / probe / insert） | 17.5 % | 4.6 % | **29.6 %** | 12.6 % |
+| malloc/free + RValue alloc | 17.1 % | 14.8 % | 13.1 % | **22.5 %** |
+| GC（mark / sweep, self） | 9.1 % | 6.3 % | 7.1 % | 8.4 % |
+| 正規表現（onigmo） | 7.2 % | **33.9 %** | 0 % | 0.2 % |
+| String 操作（連結・split・join・memmove） | 8.9 % | 2.5 % | **20.2 %** | 4.1 % |
+| メソッド探索・引数処理 | 8.4 % | 4.3 % | 2.7 % | 5.3 % |
+| FFI / libsqlite3 | 0 % | 0 % | 0 % | **12.4 %** |
+| kernel（page fault, smaps） | 4.3 % | 3.9 % | 2.3 % | 1.9 % |
+| その他 | 12.6 % | 9.2 % | 8.8 % | 10.8 % |
+| （参考）`execute_gc` の inclusive | 13.0 % | 8.1 % | 11.1 % | 13.6 % |
+
+「JIT 生成コード」のうち perf map で名前が付く JIT 本体は rack 5.1 % / graphql 19.4 % /
+erubi 16.0 % / activerecord 17.4 %。rack の残り 8 % は `monoruby-vm` 領域内の無名
+アドレス（gdb で逆アセンブルすると、メソッド呼び出しからの復帰シーケンス
+`VM+0x4005` と命令ハンドラ群）。完全に JIT 化されたマイクロベンチでも同じ領域に
+5〜6 % のセルフ時間が出るので、これはインタプリタ実行ではなく **JIT コードが共有する
+VM 領域内スタブ**（呼び出し復帰・エラー検査・GC ポール等）と解釈している。
+rack のリクエスト処理に含まれる Ruby メソッドは 1 リクエストあたり 30 個で、
+`jit-log` により全て JIT 済み・定常状態での再コンパイルはゼロと確認した。
+
+### 3.1 ベンチ別のホットスポット（上位シンボル、定常状態）
+
+**erubi**（`ErbRenderer#run_erb` の JIT ブロックが 11.7 % self、残りは builtin）
+
+| シンボル | self |
+|---|---:|
+| `hashbrown::HashTable::find`（`HashRef::get` の probe） | 11.5 % |
+| `hash::string_digest`（SipHash-1-3）+ `Sip13Rounds::write` | 9.3 % |
+| `HashRef::get` + `get_index_of_prehashed_with` + `Hashmap::index` | 7.1 % |
+| `runtime::concatenate_string_inner` + `append_piece`（`#{}` 補間） | 7.4 % |
+| `memmove` + `SmallVec::insert_from_slice`（`_buf << str`） | 7.8 % |
+| `GCBox::free` + `RurubyAlloc::alloc` + `Allocator::alloc` + `_int_malloc` | 8.4 % |
+| `Array#join` / `append_string` / `array_join` | 4.1 % |
+| `builtins::object::freeze` + `Object#freeze` ラッパ | 2.7 % |
+| `Executor::invoke_tos` + `to_s_is_refined` | 2.4 % |
+
+テンプレートは JSON 由来の 2,600 個の spec Hash（各 20 キー前後）に対する
+`spec["name"]` のような **String キーの `Hash#[]`** と、`_buf << '...'.freeze` /
+`_buf << (expr).to_s` の繰り返し。上の 3 行が前者に対応する。後者は pragma
+`frozen_string_literal: true` 付きで eval されるので monoruby でも速い（§4）。
+
+**rack**（`Rack::Static#call` 以下のミドルウェア連鎖が 51 % inclusive。
+`Rack::URLMap#call` 24 %、`Rack::Utils#clean_path_info` 18 %、`Proc#call`（アプリ本体）8 %）
+
+| シンボル | self / inclusive |
+|---|---:|
+| `Hashmap::index` + `HashRef::get` + `string_digest` + `Sip13` | 8.1 % incl. |
+| `String#split`（`clean_path_info`） | 8.1 % incl. |
+| `Regexp#match` + `captures_from_pos` + `onig_search`（`Rack::Utils` / `URI` / `Static`） | 8.3 % incl. |
+| `Hash#clone`（`env.dup`: `clone_body` + `deep_copy`） | 4.5 % incl. |
+| `runtime::set_index`（VM/JIT 汎用 `[]=` → `invoke_method` → グローバルキャッシュ） | 5.1 % incl. |
+| `String#gsub`（`URI::RFC2396_Parser#unescape`） | 3.5 % incl. |
+| `Executor::save_capture_special_variables`（`$~` の保存） | 3.3 % incl. |
+| `execute_gc`（`Root::mark` 5.8 % + sweep） | 13.0 % incl. |
+| `RurubyAlloc::alloc` + `Allocator::alloc` + `malloc`/`free` 系 | ≈ 12 % self |
+| `kernel::respond_to` | 1.0 % self |
+| `Codegen::chain_deopt_into` + `jit_module::handle_error`（`URLMap#call` ブロック内 `return`） | 1.6 % self |
+
+1 リクエストあたり CRuby 側の C 呼び出しは `Hash#[]` 18 回、`Hash#[]=` 5 回、
+`Hash#key?` 4 回、`respond_to?` 3 回、`Regexp#match` 2 回など。monoruby ではこれらの
+1 回あたりのコストと、レスポンスヘッダの Hash リテラル生成（§5.2）が積み上がる。
+
+**graphql**（`Lexer#advance` 55 % inclusive、うち `StringScanner#_match_len_at_pos` 48 %）
+
+| シンボル | self |
+|---|---:|
+| `match_at`（onigmo） | 17.5 % |
+| `JIT:<StringScanner#_match_len_at_pos>` | 4.6 % |
+| `JIT:<Lexer#advance>` | 3.5 % |
+| `string_strscan_match` | 2.2 % |
+| `onig_search_gpos` + `mbc_enc_len` + `onigenc_mbclen_approximate` + `onig_region_*` | ≈ 5 % |
+| `RubyMap::hash`（`_anchored` のキャッシュ引き）+ `GvarTable::lookup` | 3.3 % |
+| `RStringInner::regex_view` + `check_utf8` + `ascii_only` | 2.0 % |
+| malloc/free 系 + `GCBox::free` | ≈ 12 % |
+
+**activerecord**（`_load_from_sql` 30 %、`instantiate_instance_of` 29 %、
+`init_with_attributes` 23 % inclusive）
+
+| シンボル | self |
+|---|---:|
+| `malloc` + `_int_malloc` + `malloc_consolidate` + `_int_free` + `unlink_chunk` + `cfree` | 16.2 % |
+| `fiddle_invoke` + `ffi_call*` + `classify_argument` + `value_to_carg` + `bits_to_value` | 7.6 % |
+| `HashRef::get` + `string_digest` + `Sip13` + `get_index_of_prehashed_with` + `Hashmap::index` | 7.7 % |
+| `ISeqInfo::mark` + `mark_children` + `RValue::mark` + `Store::mark` + `ClassInfo::mark` | 5.2 % |
+| libsqlite3（`sqlite3VdbeExec` 他）+ `pthread_mutex_lock/unlock` | 5.2 % |
+| `RurubyAlloc::alloc` + `Allocator::alloc` + `GCBox::free` | 5.1 % |
+| `GlobalMethodCache::get` + `find_method` + `check_method_for_class_with_version` | 1.5 % |
+| `RStringInner::from_vec_scanned`（DB からの文字列生成） | 0.7 % |
+
+## 4. マイクロベンチによる切り分け
+
+`scratchpad` の `micro*.rb`（§7 に要点）。単位は ns/op、3 ラウンド目の値。**結果を捨てる
+式は CRuby がコンパイル時に消してしまう**（`"#{a}"` を捨てると CRuby はオブジェクトを
+1 つも作らず、`10M 回で GC 0 回`）ので、結果を使う形で測った値だけを載せる。
+「fsl」は `# frozen_string_literal: true` 付き。
+
+| 項目 | monoruby | YJIT | 備考 |
+|---|---:|---:|---|
+| `{"content-type" => "text/plain"}`（fsl） | 155 | 60 | **String キーは boxed map を毎回構築** |
+| `{"content-type" => .., "last-modified" => ..}`（fsl） | 162 | 61 | |
+| `{a: 1, b: 2}` | 54 | 60 | Symbol キーはインライン表現 |
+| `h["PATH_INFO"]`（fsl, 3 キー） | 35 | 34 | |
+| `h["name"]`（20 キー） | 256 | 202 | |
+| `h["name"] = i`（20 キー） | 369 | 250 | |
+| `h["name"]`（4 キー） | 145 | 143 | 小さい Hash では差なし |
+| `env.dup`（30 キー） | 395 | 306 | |
+| `[200, i, [i]]` | 47 | 82 | |
+| `s = "text/plain"`（fsl） | 9 | 26 | |
+| `s = 'abcdef'`（非 fsl, 複製あり） | 57 | 58 | |
+| `s = 'abcdef'.freeze`（fsl） | 16 | 25 | |
+| `s = 'abcdef'.freeze`（非 fsl） | 65 | 26 | 複製 + `Object#freeze` 呼び出し |
+| `buf << 'lit'.freeze`（fsl） | 30 | 44 | erubi の生成コードの形 |
+| `buf << v.to_s`（v は String） | 13 | 57 | |
+| `buf << i.to_s`（Integer） | 128 | 107 | |
+| `"<#{a}>"`（結果使用） | 107 | 130 | |
+| `a.map { "<a href=\"##{v}\">#{v}</a>" }.join(", ")`（10 要素） | 1959 | 2336 | |
+| `ary << obj`（単相） | 3.6 | 36 | |
+| `ary << obj`（引数が 2 クラス交互） | 83.5 | 66 | 単相の 23 倍 |
+| `ary << obj`（引数が 4 クラス） | 57 | 15 | |
+| `raise ArgumentError` / `rescue` | 1288 | 746 | |
+| `catch(:x) { ... throw :x }` | 580 | 218 | |
+| `StringScanner` で 2.7 KB を字句解析 | 692 µs | 438 µs | |
+| `%w[...8個].map(&:upcase)` | 1556 | 926 | |
+| `Time.httpdate(...)` | 3612 | 3060 | 両方 Ruby 実装 |
+| `ary.each { return x if ... }`（ブロック内 return） | 41 | 120 | |
+| 8 段のミドルウェア連鎖（葉がブロック内 return / 通常） | 206 / 131 | 249 / 137 | 差なし |
+| 6 クラスの megamorphic 呼び出し | 18.5 | 42 | deopt 自体は安い |
+| `Foo.new(a, b, c)` | 28 | 35 | |
+| `obj.respond_to?(:to_path)` | 1.8 | 70 | |
+| `1 << 63 <= i`（Bignum 比較） | 86 | 82 | |
+| `lambda { ... }.call(env)`（Rack アプリ相当） | 564 | 352 | 直接呼び出しでも 498 vs 318（Hash リテラル分） |
+
+検証して**否定した仮説**（記録として残す）:
+
+- 「rack は `Rack::URLMap#call` のブロック内 `return` が chain deopt を起こし、呼び出し元
+  ミドルウェアの後半が VM で走る」— 8 段連鎖のマイクロベンチで葉が `return` する場合と
+  しない場合の差は 75 ns、`--features profile` のグローバルキャッシュ計数（VM 実行なら
+  `Hash#[]=` が 8 倍になる）も同じだった。呼び出し元は JIT のまま。
+- 「文字列補間 `"#{a}"` が 5 倍遅い」— 結果を捨てるベンチの計測ミス。使うと monoruby の方が速い。
+- 「erubi は `'lit'.freeze` の複製が原因」— erubi の生成コードは `frozen_string_literal`
+  付きで eval され、その条件では monoruby の方が速い。非 pragma のコードにだけ効く。
+
+## 5. 原因の詳細と対策案
+
+### 5.1 GC とアロケータ（全ベンチで 20〜30 %）
+
+- `GC.stat` より: erubi 1 反復（285 ms）で 56 万オブジェクトを生成し 7.3 回 GC、
+  activerecord 1 反復（243 ms）で 44 万オブジェクト・3.8 回 GC。ヒープは 22〜27 ページ
+  （256 KB ページ、≈ 6 MB）で、`PAGES_PER_GC_TRIGGER = 8`, `GC_HEAP_FRACTION = 16`
+  （`alloc.rs`）のため約 3 万オブジェクトごとにマイナー GC が走る。
+- マイナー GC のルート走査が `Root::mark` → `Globals::mark` → `Store::mark` で
+  **全 ISeq のリテラルと jit_entry の const_map（`store/iseq.rs:448`）、全 ClassInfo** を
+  毎回なめる。Rails をロードすると ISeq は数万個あり、`ISeqInfo::mark` 1.4〜1.7 % +
+  `ClassInfo::mark` / `Store::mark` の固定費になる（CRuby は ISeq もヒープオブジェクトで
+  old 世代になり、マイナー GC では remembered set 経由でしか触らない）。
+- RValue の中身（String バッファ、Array/Hash の要素、hashbrown のテーブル）は glibc
+  malloc で、activerecord では `malloc` 系だけで 16 %（`Cargo.toml` の `mimalloc`
+  フィーチャのコメントにある通り 1 反復 58 万 alloc/free）。
+- 空きページを `madvise(MADV_DONTNEED)` で即返す（`alloc.rs::release_page`）ので、
+  短命オブジェクトが多いと再利用のたびにページフォルトが起きる（`do_user_addr_fault`
+  がマイクロベンチで 5〜6 %、ベンチで 2〜4 %）。
+- スレッドローカル `ALLOC` の `RefCell` 借用が 1 アロケーションごとに入る
+  （`LocalKey::with` が String 生成マイクロベンチで 6〜11 % self）。
+
+対策:
+1. ルートの世代別化: `Store`（ISeq リテラル・クラス）を old 扱いにして、マイナー GC では
+   リテラル追加・クラス変更時に remembered set へ入れたものだけを走査する。
+2. 初期ヒープ / トリガーを大きくする（`PAGES_PER_GC_TRIGGER` を 32〜64 に。RSS は
+   まだ CRuby より小さい）。
+3. `release_page` を遅延させる（直近 N 回の GC で再利用されたページは返さない）。
+4. `mimalloc` フィーチャの既定化を A/B で検討。JIT のインライン bump 割り当てが
+   使えない経路（Rust builtin からの `Value::string` 等）の `ALLOC.with` を薄くする。
+
+### 5.2 String キー Hash（erubi 30 %, rack 18 %, activerecord 13 %）
+
+- ハッシュ関数は `std::collections::hash_map::RandomState`（SipHash-1-3, `hash.rs:128`）。
+  `RStringInner` の `Hash` impl はバイト列をそのまま流し（`string.rs:879`）、ハッシュ値は
+  String 側にキャッシュされない。probe は rubymap（IndexMap）→ hashbrown の 2 段。
+- **String キーはインライン表現の対象外**（`is_inline_key` は packed 値のみ、
+  `hash.rs`）。そのため `{"content-type" => "text/plain"}` のようなリテラルは評価のたびに
+  `from_literal_pairs` → `RubyMap::with_capacity` + キーの SipHash + hashbrown の
+  テーブル確保を行う（155 ns vs CRuby 60 ns。CRuby は事前に作った frozen Hash を
+  `duphash` でコピーするだけ）。Symbol キーなら 54 ns で CRuby より速い。
+- 1 回の lookup は 20 キーの warm な Hash で 1.27x、小さい Hash では同等。erubi のように
+  数千個の Hash に対して cold にアクセスすると probe（`HashTable::find` 11.5 % self）が
+  支配的になる。
+
+対策（効果順）:
+1. String キーのリテラル Hash を ISeq 側にテンプレートとして持ち、評価時は
+   `clone_body`（entries + table の memcpy）だけにする（CRuby の `duphash` 相当）。
+2. 短い String 向けにハッシュ関数を差し替える（FxHash / wyhash。`String#hash` の値は
+   CRuby もプロセスごとに変わるので互換性の問題はない）。
+3. 8 エントリ以下の Hash は CRuby の ar_table 相当（ハッシュ値付き線形探索）にして
+   String キーもインライン表現に載せる。
+4. `Hash#[]` / `#[]=` の JIT インライン化で `hashindex` 呼び出し自体のオーバーヘッド
+   （`Value::unpack`, `is_compare_by_identity`, `frozen_hash_key` の分岐）を減らす。
+
+### 5.3 二項演算サイトのキャッシュが「受信側クラス × 引数クラス」でキーされる（graphql, activerecord）
+
+- `PolyCacheEntry.arg`（`globals/store.rs:1974`）: BinOp / Cmp / Index / StoreIndex サイトは
+  第 1 引数のクラスも記録し、JIT は `(recv, arg)` の組でガードする。Integer / Float の
+  算術にはこれが必要だが、`Array#<<` や `Hash#[]` のように**引数の型で振る舞いが変わらない
+  メソッド**まで引数クラスで多相化してしまう。
+- graphql は `children << node` で node クラスが十数種類あり（`polymorphic sites` 表の
+  CallId 34611 `<<` Array/Field | Array/InlineFragment | …）、サイトが megamorphic 扱いに
+  なって毎回スローパス（`Array#<<` のグローバルキャッシュ引き 712 万回 / 11 秒）。
+  activerecord でも `Array#<<` 511 万回、`Hash#[]=` 1006 万回。
+- マイクロベンチ: 単相 3.6 ns → 引数 2 クラス交互で 83.5 ns（23 倍）。
+
+対策: 受信側が `Integer` / `Float` 以外に解決したサイトは PMC を recv のみでキーし、JIT
+でも recv クラスのガードだけを出す（引数クラスは数値の fast path にだけ使う）。
+`Hash#[]` / `Hash#[]=` / `Array#<<` / `Array#[]` は builtin 直呼びに落とす。
+
+### 5.4 VM（インタプリタ）の `[]=` / `<<` / `respond_to?` がキャッシュを使わない（全般）
+
+- `runtime::set_index`（`codegen/runtime.rs:1874`）は Array + Fixnum 添字だけ fast path
+  で、それ以外（Hash 含む）は `vm.invoke_method(IdentId::_INDEX_ASSIGN, …)` →
+  `find_method` → `check_method_with_refinements` → `GlobalMethodCache::get`。
+  `<<` も `bop_entry!(shl_values …)` から同じ経路。JIT でも受信側が確定しないサイトは
+  この runtime を呼ぶ（rack で `set_index` が 5.1 % inclusive）。
+- `Kernel#respond_to?` builtin は毎回 `check_method` で探索し、未定義なら
+  `respond_to_missing?` を Ruby 呼び出しする（rack で `to_path` / `respond_to_missing?`
+  が各 260 万回）。
+
+対策: `set_index` / `get_index` / `shl` に Hash / Array 向けの builtin 直呼び fast path
+（BOP 再定義チェック付き）を足す。`respond_to?` は builtin 内にクラス × 名前 × バージョン
+のキャッシュを持つ。
+
+### 5.5 deopt ポリシーの穴（activerecord）
+
+`--features profile` の 60 秒（240 反復）での deopt 回数:
+
+| サイト | 回数 | 内容 |
+|---|---:|---|
+| `block in ActiveModel::LazyAttributeSet#fetch_value` [00019] `%3.deserialize(%2)` | 10,036,400 | 属性型ごとに受信側クラスが違う（Integer/String/Text/DateTime/…） |
+| `AcceptsMultiparameterTime::InstanceMethods#cast` [00001] `%2 = Hash` | 4,790,098 | 定数参照の const version ガード |
+| `ActiveRecord::Delegation::ClassMethods#create` [00006] `%4.new(...)` | 469,561 | Relation / CollectionProxy の 2 クラス |
+| `ActiveModel::Type::Integer#out_of_range?` [00004] `%3 <= %1` | 462,562 | `@max = 1 << 63` は常に Bignum |
+| `relation_class_for` / `type_casted_binds` / `derive_key` | 各 23 万 | Post / Comment の 2 クラス |
+
+`--features deopt` で 7 反復（62 万 deopt）の原因を分類すると、受信側クラスガード 67 %、
+Fixnum ガードに Bignum 3.3 %、`Visitor#visit` の class-set ガード 2.4 %、frame captured
+1.8 %、const version 0.3 %、class version 0.1 %。
+
+- `fetch_value` のサイトは deopt ログ上 **「Text を期待して DateTime が来た」14.2 万回と
+  「DateTime を期待して Text が来た」14.2 万回**が交互に並ぶ。再コンパイルのたびに
+  直近に観測した 1 クラスの単相ガードを出し直しているだけで、1 反復 ≈ 4.7 万回の
+  呼び出しが 1 回も JIT で完走していない。原因は `compile/method_call.rs` の
+  `RecvMissMode::Learn`（PMC に 2 クラス以上あれば多相パスは試したはずなので plain
+  deopt する ratchet）で、PIC（`PIC_WAYS = 4`）の容量を超えるサイト（属性型は 5 種以上）
+  では成り立たない。
+- `out_of_range?` は `Integer` のガードが Fixnum タグ検査なので Bignum が毎回落ちる
+  （コード中のコメントにある通り再コンパイルでは直らない）。`Integer#<=` の Bignum 側を
+  deopt ではなく汎用 `cmp` 呼び出しに落とせば済む。
+- 1 回の deopt は安い（megamorphic 6 クラスのマイクロベンチで 18.5 ns/呼び出し）ので
+  activerecord 全体では数 % と見積もられるが、VM 側で再実行される `super(value)` /
+  ブロック引数展開で `to_ary` / `to_a` が String に対して各 458 万回探索されるなど、
+  二次的な費用が乗る。
+
+対策: PIC の容量を超えたサイトは受信側クラスに依らない汎用呼び出し（`find_method` +
+インラインキャッシュ、deopt なし）を JIT に出す。Integer の Bignum 表現はガードではなく
+汎用パスへの分岐にする。
+
+### 5.6 StringScanner が Ruby 実装（graphql）
+
+`stdlib/strscan.rb` の `StringScanner` は Ruby で書かれ、`scan` / `skip` →
+`_match_len_at_pos` → `_anchored`（`\A(?:...)` でラップした Regexp を Hash から引く）→
+`String#ascii_only?` → `String#__strscan_match`（`builtins/string.rs:3472`）→
+`captures_from_pos_no_save` → onigmo `onig_search`（region の確保・解放を伴う）という
+段数を 1 トークンごとに踏む。graphql の lexer は 1 トークンあたり `skip` を 2〜3 回呼ぶので、
+`match_at` 本体（17.5 %）の周りに同じくらいのオーバーヘッドが付く
+（`_match_len_at_pos` 4.6 % + `string_strscan_match` 2.2 % + region / `regex_view` /
+`ascii_only` / `RubyMap::hash` ≈ 9 %）。`GvarTable::lookup` 1.6 % は `Lexer#advance` から
+の `get_global_var` で、JIT がグローバル変数を毎回テーブル引きしている。
+
+対策: `StringScanner` を Rust builtin にして、region を scanner に持たせ `onig_match`
+（アンカー付きの 1 回マッチ）を直接呼ぶ。CRuby の C 実装と同じ形。
+
+### 5.7 例外・catch/throw（rack, activerecord）
+
+- `raise` は `MonorubyErr::new(String)` でメッセージ String を Rust ヒープに複製し、
+  `Exception#initialize` へ `handle_keyword` / `coerce_hash_splat_args` を通して引数を渡し、
+  `ex_obj` / `_cause` で `IdentId::get_id`（文字列のインターン）を呼ぶ（マイクロベンチの
+  perf: `RurubyAlloc::alloc` 15 %, `handle_keyword` 4 %, `IdentId::get_id` 4 %,
+  `CallSiteInfo::clone` 1.6 %）。
+- `catch/throw` は 2.7 倍遅い。ActiveSupport の callbacks は `catch(:abort)` を使う。
+
+対策: `raise` 時のメッセージ複製とインターンをやめる（IdentId を定数化）、
+`Exception#initialize` の kwargs 経路を通さない、`throw` を例外オブジェクトを作らず
+`MonorubyErrKind::Throw` だけで巻き戻す。
+
+### 5.8 Fiddle 経由の sqlite3（activerecord 12 %）
+
+`gem/sqlite3` は Fiddle（`builtins/fiddle.rs::fiddle_invoke`）で libsqlite3 を呼ぶ。
+1 呼び出しごとに `value_to_carg` / libffi の `classify_argument` / `bits_to_value` と
+`SmallVec` の組み立てが走り、`sqlite3_column_*` を列ごとに呼ぶ `read_column` /
+`read_row` で積み上がる。CRuby の sqlite3 は C 拡張で直接呼ぶ。
+
+対策: `sqlite3` の hot path（`step` + 全列読み出し）を 1 回の Rust builtin にまとめる。
+
+### 5.9 その他
+
+- `'lit'.freeze`（pragma なし）: `TraceIr::Literal` は非 frozen リテラルを毎回
+  `deep_copy_lit` で複製し（`jitgen/compile.rs:408`）、`.freeze` は `Object#freeze` への
+  通常呼び出し。CRuby の `opt_str_freeze` 相当（bytecodegen で `"lit".freeze` を frozen
+  リテラルに畳む。`emit_frozen_string` はコマンドリテラルと `defined?` にしか使われて
+  いない）を足せば 65 → 16 ns。
+- `Array#map(&:upcase)`（Symbol#to_proc）が 1.7 倍遅い。`SymbolProcCache` はあるが
+  ブロック呼び出し経路が JIT の `yield` より重い。
+- `Hash#dup`（rack の `env.dup`）は `HashRef::clone_body` + `RValue::deep_copy` で 1.3 倍。
+- `Integer#to_s` を `<<` する形が 1.2 倍。
+- 起動（`Bundler.setup`, `require "active_record"`）が 3〜8 倍遅い。ベンチには含まれないが、
+  `Kernel#require` / gemspec の `eval` が VM で走る分。
+
+## 6. 優先順位（案）
+
+| 順 | 施策 | 効くベンチ | 見込み |
+|---|---|---|---|
+| 1 | §5.1 ルート走査の世代別化 + GC トリガー拡大 + ページ返却の遅延 | 全部 | GC inclusive 8〜14 % の大半 + page fault 分 |
+| 2 | §5.2 String キー Hash リテラルのテンプレート化、ハッシュ関数差し替え、小 Hash のインライン化 | rack, erubi, activerecord | Hash 系 13〜30 % の 2〜3 割、リテラル 155 → 60 ns |
+| 3 | §5.3 非数値 BinOp サイトの引数クラスキーを外す + `<<` / `[]` / `[]=` の直呼び | graphql, activerecord, rack | `<<` 84 → 4 ns |
+| 4 | §5.6 StringScanner の Rust 化 | graphql | 字句解析 1.6x → 1.0x |
+| 5 | §5.5 deopt ポリシー（PIC 超過時に汎用呼び出し、Bignum 分岐） | activerecord | 数 % + 二次費用 |
+| 6 | §5.4 VM 側 `[]=` / `<<` / `respond_to?` の fast path | rack, activerecord | グローバルキャッシュ引き 1000 万回 / 60 s |
+| 7 | §5.7 例外・throw の軽量化 | rack, activerecord | raise 1.7x / throw 2.7x → 1.0x |
+| 8 | §5.8 sqlite3 の行読み出しを builtin 化 | activerecord | FFI 12 % の半分 |
+| 9 | §5.9 `"lit".freeze` の畳み込み | pragma なしのコード全般 | 65 → 16 ns |
+
+## 7. 計測手順（再現用）
+
+```sh
+# CRuby 4.0.6
+rbenv install 4.0.6 && rbenv global 4.0.6 && gem install bigdecimal
+
+# yjit-bench
+git clone --depth 1 https://github.com/Shopify/yjit-bench.git ../yjit-bench
+cd ../yjit-bench/benchmarks/{activerecord,erubi,rack,graphql} && bundle install
+
+# 計測（LANG は必須: erubi の gem_specs.json に非 ASCII があり、US-ASCII だと CRuby が落ちる）
+export LANG=C.UTF-8
+cargo build --release
+ruby --yjit -Iharness-warmup benchmarks/rack/benchmark.rb
+MONORUBY_REPROBE=1 target/release/monoruby -Iharness-warmup benchmarks/rack/benchmark.rb
+
+# perf（JIT シンボルは /tmp/perf-<pid>.map に出る。-D で起動を除外）
+cargo build --release --features perf --target-dir target-perf
+perf record -D 12000 -F 999 -e cpu-clock -g --call-graph=fp -o rack.data -- \
+  target-perf/release/monoruby -Iharness-warmup benchmarks/rack/benchmark.rb
+perf report -i rack.data --no-children --sort sym --stdio -g none
+
+# deopt / 再コンパイル / PMC 統計（終了時に stderr へ）
+cargo build --release --features profile --target-dir target-profile
+MAX_TIME=60 target-profile/release/monoruby -Iharness-warmup benchmarks/activerecord/benchmark.rb 2> ar.prof
+
+# deopt 1 件ごとのガード種別と原因（出力が巨大なので短時間で）
+cargo build --release --features deopt --target-dir target-deopt
+MAX_TIME=12 MIN_ITERS=3 target-deopt/release/monoruby -Iharness-warmup benchmarks/activerecord/benchmark.rb 2> ar.deopt
+
+# JIT コンパイルイベント
+cargo build --release --features jit-log --target-dir target-jitlog
+```
+
+perf のセルフ時間の分類は、シンボル名に対する正規表現で行った（JIT: `^JIT:<|^monoruby-vm|invoker$|^0x`、
+Hash: `rvalue4hash|string_digest|Sip13|rubymap|hashbrown.*HashRef|builtins4hash|hashindex`、
+alloc: `_int_malloc|_int_free|^malloc$|cfree|malloc_consolidate|unlink_chunk|RurubyAlloc|Allocator.*5alloc|LocalKey.*4with|finish_grow`、
+GC: `4mark|mark_children|mark_contents|GCBox4free|gc_check_and_mark|Allocator.*2gc|drop_glue`、
+正規表現: `match_at|onig_|forward_search|mbc_enc_len|onigenc|regex|rmatch|captures|strscan`、
+String: `6string|concatenate_string|append_piece|memmove|memcmp|memset|invoke_tos|check_utf8|5split|4join|array_join`、
+dispatch: `find_method|GlobalMethodCache|check_method|invoke_method|4args|expand_array|handle_arguments|vm_get_constant|respond_to|IdentId6get_id|Value6unpack|8kernel`、
+FFI: `fiddle|ffi_call|sqlite|classify_argument|libffi`）。
+
+このコンテナには `perf` が無いので `apt-get install linux-tools-generic` で入れ、カーネル版が
+違うため `/usr/lib/linux-tools/<ver>/perf` を直接叩いた（`perf_event_paranoid = 2` でも
+`-e cpu-clock` は採れる）。

--- a/monoruby/src/alloc.rs
+++ b/monoruby/src/alloc.rs
@@ -418,10 +418,21 @@ const DATA_LEN: usize = 64 * (SIZE - 1);
 const THRESHOLD: usize = 64 * (SIZE - 2);
 
 /// Floor for the allocation budget between collections: pages filling to
-/// `THRESHOLD` before the arena requests a collection (~8 pages ≈ 32K
-/// `RValue`s, matching the old `>= 8` poll band that accumulated `+1` per
-/// page). Small heaps use exactly this; see [`GC_HEAP_FRACTION`].
-const PAGES_PER_GC_TRIGGER: u32 = 8;
+/// `THRESHOLD` before the arena requests a collection (32 pages ≈ 127K
+/// `RValue`s, 8 MB of cells). Small heaps use exactly this; see
+/// [`GC_HEAP_FRACTION`].
+///
+/// Was 8 (the old `>= 8` poll band). Every minor collection re-scans the
+/// whole root set — every ISeq's literals, every class — so on a program
+/// that has loaded a Rails-sized amount of code the fixed cost per
+/// collection dwarfs the young generation it reclaims: erubi ran 7.3
+/// collections per iteration, activerecord 3.8, on a 6 MB heap. Raising
+/// the floor to 32 measured graphql -8%, activerecord -6.5%, rack -2%
+/// (yjit-bench, x86-64, single runs on a machine that drifts ±10%; erubi
+/// did not move in a 3-round rerun) for +3..10 MB RSS, still below
+/// CRuby's on the same programs
+/// (see doc/yjit_bench_slow_investigation_2026-09.md §8).
+const PAGES_PER_GC_TRIGGER: u32 = 32;
 
 /// Above `PAGES_PER_GC_TRIGGER * GC_HEAP_FRACTION` pages in service, the
 /// budget instead scales with the heap: a collection is requested once

--- a/monoruby/src/builtins/gc.rs
+++ b/monoruby/src/builtins/gc.rs
@@ -777,15 +777,20 @@ mod tests {
             // mode rather than the trigger policy.
             return;
         }
+        // The budget floor is `PAGES_PER_GC_TRIGGER` (32) pages, so the
+        // large run has to hold more than `32 * GC_HEAP_FRACTION` (512)
+        // pages — about 2M cells — before the heap-scaled budget exceeds
+        // the floor; 4M single-element Arrays (~1000 pages) put the budget
+        // at ~60 pages against the small run's 32.
         run_test_once(
             r##"
             def churn(n) = n.times { |i| [i, i] }
             churn(50_000); GC.start
-            b = GC.count; churn(400_000); small = GC.count - b
-            keep = Array.new(1_500_000) { |i| [i] }
+            b = GC.count; churn(1_200_000); small = GC.count - b
+            keep = Array.new(4_000_000) { |i| [i] }
             GC.start
-            b = GC.count; churn(400_000); large = GC.count - b
-            [small > 0, large < small, keep.size == 1_500_000]
+            b = GC.count; churn(1_200_000); large = GC.count - b
+            [small > 0, large < small, keep.size == 4_000_000]
             "##,
         );
     }

--- a/monoruby/src/bytecodegen/encode.rs
+++ b/monoruby/src/bytecodegen/encode.rs
@@ -313,6 +313,11 @@ impl<'a> BytecodeGen<'a> {
                 let op1 = self.slot_id(&reg);
                 Bytecode::from_with_value(enc_wl(7, op1.0, 0), val)
             }
+            BytecodeInst::StringFreeze(reg, val) => {
+                // 8
+                let op1 = self.slot_id(&reg);
+                Bytecode::from_with_value(enc_wl(8, op1.0, 0), val)
+            }
             BytecodeInst::LoadConst {
                 dst,
                 base,

--- a/monoruby/src/bytecodegen/inst.rs
+++ b/monoruby/src/bytecodegen/inst.rs
@@ -54,6 +54,10 @@ pub(super) enum BytecodeInst {
     FrozenLiteral(BcReg, Value),
     /// Heap object (not frozen)
     Literal(BcReg, Value),
+    /// `"lit".freeze` (CRuby's `opt_str_freeze`): the interned frozen
+    /// literal while `String#freeze` is the builtin, otherwise a chilled
+    /// copy of the literal handed to the redefined `freeze`.
+    StringFreeze(BcReg, Value),
     Array(BcReg, Box<CallSite>),
     /// Concatenate the Array in `src` onto the Array in `dst` (used for the
     /// 2nd and later chunks of a chunked Array literal).

--- a/monoruby/src/bytecodegen/method_call.rs
+++ b/monoruby/src/bytecodegen/method_call.rs
@@ -58,6 +58,42 @@ impl<'a> BytecodeGen<'a> {
             UseMode2::Store(dst) => (Some(dst), false),
         };
         let old_temp = self.temp;
+        // `"lit".freeze` with no arguments, in a file without the
+        // `frozen_string_literal` pragma: CRuby's `opt_str_freeze`. One
+        // `StringFreeze` yields the interned frozen literal while
+        // `String#freeze` is the builtin — no per-evaluation copy, no call,
+        // the same object every time — and otherwise hands a chilled copy of
+        // the literal to the redefined method (`runtime::string_freeze_literal`
+        // consults the basic-op table). Under the pragma the literal already
+        // is the interned object and `Object#freeze` on it is a cheap no-op
+        // call, so there is nothing to fold.
+        if !safe_nav
+            && !self.frozen_string_literal()
+            && method == IdentId::FREEZE
+            && arglist.args.is_empty()
+            && arglist.kw_args.is_empty()
+            && arglist.hash_splat.is_empty()
+            && arglist.block.is_none()
+            && !arglist.forwarding
+            && !arglist.delegate_block
+            && !arglist.splat
+            && let Some(NodeKind::String(s)) = receiver.as_ref().map(|r| &r.kind)
+        {
+            let enc = self.source_encoding();
+            let v = self.store.intern_frozen_str(s.as_bytes(), enc);
+            let r: BcReg = dst.unwrap_or_else(|| self.sp().into());
+            // Push before emitting (as `emit_call` does): the instruction's
+            // recorded stack pointer has to cover its own result slot, or the
+            // JIT's abstract frame takes the temp for dead space.
+            if push_flag {
+                self.push();
+            }
+            self.emit(BytecodeInst::StringFreeze(r, v), loc);
+            if use_mode.is_ret() {
+                self.emit_ret(None)?;
+            }
+            return Ok(());
+        }
         let recv = match receiver {
             Some(receiver) => {
                 if receiver.kind == NodeKind::SelfValue {

--- a/monoruby/src/codegen.rs
+++ b/monoruby/src/codegen.rs
@@ -998,6 +998,7 @@ pub(crate) struct VmHandlers {
     pub condnotbr: CodePtr,            // 5, 13
     pub immediate: CodePtr,            // 6
     pub literal: CodePtr,              // 7
+    pub string_freeze: CodePtr,        // 8
     pub load_const: CodePtr,           // 10
     pub store_const: CodePtr,          // 11
     pub loop_start: CodePtr,           // 14
@@ -1129,6 +1130,7 @@ impl Codegen {
         self.dispatch[5] = h.condnotbr;
         self.dispatch[6] = h.immediate;
         self.dispatch[7] = h.literal;
+        self.dispatch[8] = h.string_freeze;
         self.dispatch[10] = h.load_const;
         self.dispatch[11] = h.store_const;
         self.dispatch[12] = h.condbr;

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -80,6 +80,7 @@ impl Codegen {
         let init_method = self.a64_op_init_method();
         let immediate = self.a64_op_immediate();
         let literal = self.a64_op_literal();
+        let string_freeze = self.a64_op_string_freeze();
         let mov = self.a64_op_mov();
         let ret = self.a64_op_ret();
         let add_rr = self.a64_op_iadd(false);
@@ -220,6 +221,7 @@ impl Codegen {
             condnotbr,
             immediate,
             literal,
+            string_freeze,
             load_const,
             store_const,
             loop_start,
@@ -1620,6 +1622,23 @@ impl Codegen {
             add x(PC.0), x(PC.0), #(16);
         );
         self.a64_fetch_and_dispatch();
+        p
+    }
+
+    /// op 8 `StringFreeze`: slot[`[pc+4]`] <- string_freeze_literal(vm,
+    /// globals, the literal Value at `[pc+8]`) -> Option (the redefined
+    /// `freeze` may raise). x86 `vm_string_freeze`.
+    pub(in crate::codegen) fn a64_op_string_freeze(&mut self) -> CodePtr {
+        let p = self.jit.get_current_address();
+        let raise = self.entry_raise.clone();
+        monoasm_arm64!(&mut self.jit,
+            mov x0, x(EXEC.0);
+            mov x1, x(GLOBALS.0);
+            ldr x2, [x(PC.0), #(8)];  // literal Value
+            mov x9, (runtime::string_freeze_literal as *const () as u64);
+            blr x9;
+        );
+        self.a64_checked_store_next(&raise);
         p
     }
 

--- a/monoruby/src/codegen/arch/x86_64/vmgen.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen.rs
@@ -369,6 +369,7 @@ impl Codegen {
             condnotbr: self.vm_condnotbr(&branch),
             immediate: self.vm_immediate(),
             literal: self.vm_literal(),
+            string_freeze: self.vm_string_freeze(),
             load_const: self.vm_load_const(),
             store_const: self.vm_store_const(),
             loop_start: self.vm_loop_start(),
@@ -977,6 +978,25 @@ impl Codegen {
             movq rax, (Value::value_deep_copy);
             call rax;
         };
+        self.vm_store_r15(GP::Rax);
+        self.fetch_and_dispatch();
+        label
+    }
+
+    /// op 8 `StringFreeze`: slot[:1] <- string_freeze_literal(vm, globals,
+    /// the literal Value at [pc - 8]) -> Option (the redefined `freeze` may
+    /// raise).
+    fn vm_string_freeze(&mut self) -> CodePtr {
+        let label = self.jit.get_current_address();
+        self.fetch_r15();
+        monoasm! { &mut self.jit,
+            movq rdx, [r13 - 8];
+            movq rdi, rbx;
+            movq rsi, r12;
+            movq rax, (runtime::string_freeze_literal);
+            call rax;
+        };
+        self.vm_handle_error();
         self.vm_store_r15(GP::Rax);
         self.fetch_and_dispatch();
         label

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -405,6 +405,23 @@ impl<'a> JitContext<'a> {
                 // Pure register/stack work.
                 self.restore_unfrozen(Some(dst));
             }
+            TraceIr::StringFreeze(dst, val) => {
+                if self.basic_op_assumable(STRING_CLASS, IdentId::FREEZE) {
+                    // The builtin `String#freeze`: the answer is the interned
+                    // literal itself, loaded like any frozen literal. The
+                    // recorded dependency evicts this body if `freeze` is
+                    // later redefined.
+                    self.record_bop_dep(STRING_CLASS, IdentId::FREEZE);
+                    state.def_lit2gp(ir, dst, val);
+                    self.restore_unfrozen(Some(dst));
+                } else {
+                    // Redefined: the interpreter's helper copies the literal
+                    // and calls whatever `freeze` is now. Rare enough that
+                    // an unconditional exit is the whole treatment.
+                    ir.deopt(state);
+                    return Ok(CompileResult::Cease);
+                }
+            }
             TraceIr::Literal(dst, val) => {
                 state.discard(dst);
                 let using_fpr = state.get_using_fpr(ir);

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -545,6 +545,106 @@ impl<'a> JitContext<'a> {
     }
 
     ///
+    /// Answer a polymorphic site whose receiver the VM only ever saw as one
+    /// (non-numeric) class with a two-arm dispatch around a direct call:
+    ///
+    /// ```text
+    ///         br_class_ne rdi, C -> slow
+    ///         <call C#op>                    (class-version guarded, no deopt)
+    ///         br merge
+    ///   slow: <generic helper>               (correct for *any* operand pair)
+    ///   merge:
+    /// ```
+    ///
+    /// The site is polymorphic in the inline cache's terms only: the pair
+    /// key changed because the *argument* did. The receiver-keyed dispatch
+    /// gives the one receiver class the call it would have had at a
+    /// monomorphic site, with the helper — not a deopt — behind it for a
+    /// receiver the VM never saw. Numeric receivers are left to the inline
+    /// arms above, which already handle their argument variance.
+    ///
+    /// Returns `false` (leaving *state* and *ir* untouched) when the site
+    /// does not qualify.
+    ///
+    #[allow(clippy::too_many_arguments)]
+    fn binary_recv_dispatch(
+        &mut self,
+        state: &mut AbstractState,
+        ir: &mut AsmIr,
+        binop: BinaryOp,
+        dst: Option<SlotId>,
+        lhs: SlotId,
+        rhs: SlotId,
+        case_semantics: bool,
+        bc_pos: BcIndex,
+    ) -> JitResult<bool> {
+        let Some(callid) = self.store.get_callsite_id(self.iseq_id(), bc_pos) else {
+            return Ok(false);
+        };
+        let op: IdentId = binop.into();
+        let mut recvs = self.store[callid].pmc.entries().iter().map(|e| e.recv);
+        let Some(recv_class) = recvs.next() else {
+            return Ok(false);
+        };
+        if recv_class == INTEGER_CLASS
+            || recv_class == FLOAT_CLASS
+            || !recvs.all(|c| c == recv_class)
+        {
+            return Ok(false);
+        }
+        let Some((fid, visibility)) = self.jit_check_method(recv_class, op) else {
+            return Ok(false);
+        };
+        // The ways out of `compile_method_call` that would leave the arm
+        // unfinished, hoisted (as `pic_groups` does) so the arm always lands
+        // on the merge.
+        if self.jit_visibility_blocks(callid, visibility)
+            || self.store[fid].possibly_capture_without_block()
+            || self.store[fid]
+                .is_iseq()
+                .is_some_and(|iseq| self.store[iseq].has_block_arg())
+        {
+            return Ok(false);
+        }
+        let is_func_call = self.store[callid].is_func_call();
+
+        let (entry, merge) = self.declare_merge(state, ir, &[lhs, rhs], dst);
+        let slow = self.label();
+
+        // ---- arm 1: the receiver class the VM saw, called directly.
+        let mut fast = entry.clone();
+        fast.load(ir, lhs, GP::Rdi);
+        ir.push(AsmInst::BrClassNe(GP::Rdi, recv_class, slow));
+        // Reaching the arm is the proof: `compile_method_call` sees a state
+        // that already knows the class and emits no receiver guard.
+        fast.guard_class_state(lhs, recv_class);
+        let outcome = self.with_arm(false, |this| {
+            this.compile_method_call(
+                &mut fast,
+                ir,
+                recv_class,
+                None,
+                fid,
+                visibility,
+                callid,
+                RecvMissMode::Plain,
+            )
+        })?;
+        debug_assert!(matches!(outcome, CompileResult::Continue));
+        self.end_arm(fast, ir, &merge, true);
+
+        // ---- arm 2: every other operand pair, through the generic helper.
+        ir.push(AsmInst::Label(slow));
+        let mut rest = entry.clone();
+        self.emit_generic_binary(&mut rest, ir, binop, lhs, rhs, case_semantics, is_func_call);
+        rest.def_rax2acc(ir, dst);
+        self.end_arm(rest, ir, &merge, false);
+
+        self.bind_merge(state, ir, merge);
+        Ok(true)
+    }
+
+    ///
     /// Lower a binary site: the shared skeleton behind `BinOp`, `BinCmp` and
     /// `BinCmpBr`.
     ///
@@ -682,6 +782,21 @@ impl<'a> JitContext<'a> {
 
         // ---- 5. The residual.
         if polymorphic {
+            // A site whose *argument* class varies while the receiver stays
+            // one class — `children << node` over a dozen node classes — is
+            // polymorphic only because the inline cache is keyed on the
+            // pair. Its receiver's operator has no guard-free inline arm
+            // (`Array#<<` is a builtin the bop table does not track), so it
+            // used to fall straight to the generic helper: `invoke_method`
+            // and a global-method-cache probe on every execution, twenty
+            // times a monomorphic call. Branch on the receiver into a direct
+            // call of the one method the VM saw instead, and let anything
+            // else take the helper.
+            if !matches!(mode, BinaryInlineMode::CmpBr { .. })
+                && self.binary_recv_dispatch(state, ir, binop, dst, lhs, rhs, case_semantics, bc_pos)?
+            {
+                return Ok(BinaryLowering::Emitted);
+            }
             // Any C-ABI call flushes at its `get_using_fpr` chokepoint; the
             // GP pool has to be spilled here because the helper clobbers it.
             state.flush_gp(ir);
@@ -1249,6 +1364,48 @@ mod tests {
             res = []
             600.times { |i| res << probe(vals[i % 4]) }
             [res.uniq.sort_by(&:to_s), probe(1 << 70), probe(2.5)]
+            "#,
+        );
+    }
+
+    /// A site polymorphic in the inline cache's terms only — one receiver
+    /// class, an argument that varies — takes the receiver-keyed dispatch
+    /// (`binary_recv_dispatch`): the observed class calls its method
+    /// directly, a receiver the VM never saw lands in the generic helper,
+    /// and a redefinition after warmup is caught by the class-version
+    /// guard.
+    #[test]
+    fn binop_arg_varying_site_dispatches_on_receiver() {
+        run_test(
+            r#"
+            def push(a, x) = a << x
+            a = []
+            200.times { |i| push(a, i.odd? ? "s" : :sym) }
+            s = +"str"
+            push(s, "x"); push(s, 33)
+            def plus(a, b) = a + b
+            r = []
+            100.times { |i| r << plus("a", i.odd? ? "b" : "c") }
+            def eq(a, b) = a == b
+            q = []
+            100.times { |i| q << eq([1], i.odd? ? [1] : "no") }
+            [a.size, a[0..3], s, push(1, 3), r.uniq, plus(1, 2), q.uniq]
+            "#,
+        );
+        // A redefinition is global, so this half runs once (the repeated
+        // form would see the redefined operator from its second pass on).
+        run_test_once(
+            r#"
+            def push(a, x) = a << x
+            a = []
+            100.times { |i| push(a, i.odd? ? "s" : :sym) }
+            class Array
+              alias push_orig push
+              def <<(x) = (push_orig(x, :tagged); self)
+            end
+            b = []
+            50.times { |i| push(b, i) }
+            [a.size, b.size, b.last(2)]
             "#,
         );
     }

--- a/monoruby/src/codegen/jitgen/trace_ir.rs
+++ b/monoruby/src/codegen/jitgen/trace_ir.rs
@@ -97,6 +97,9 @@ pub(crate) enum TraceIr {
 
     /// literal(%ret, value)
     FrozenLiteral(SlotId, Value),
+    /// `"lit".freeze`: the interned frozen literal while `String#freeze` is
+    /// the builtin (see `BytecodeInst::StringFreeze`).
+    StringFreeze(SlotId, Value),
     /// literal(%ret, value)
     Literal(SlotId, Value),
     Array {
@@ -390,6 +393,7 @@ impl TraceIr {
                 5 => TraceIr::CondBr(SlotId::new(op1_w), op1_l as i32, false, BrKind::BrIfNot),
                 6 => TraceIr::FrozenLiteral(SlotId::new(op1_w), Value::from_u64(op2)),
                 7 => TraceIr::Literal(SlotId::new(op1_w), Value::from_u64(op2)),
+                8 => TraceIr::StringFreeze(SlotId::new(op1_w), Value::from_u64(op2)),
                 10 | 18 => TraceIr::LoadConst(SlotId::new(op1_w), ConstSiteId(op1_l)),
                 11 => TraceIr::StoreConst(SlotId::new(op1_w), ConstSiteId(op1_l)),
                 12..=13 => TraceIr::CondBr(
@@ -902,6 +906,9 @@ impl TraceIr {
                 )
             }
             TraceIr::FrozenLiteral(reg, val) => format!("{:?} = {}", reg, val.debug(store)),
+            TraceIr::StringFreeze(reg, val) => {
+                format!("{:?} = {}.freeze", reg, val.debug(store))
+            }
             TraceIr::Literal(reg, val) => {
                 format!("{:?} = literal[{}]", reg, val.debug(store))
             }

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -1904,6 +1904,34 @@ pub(super) extern "C" fn set_index(
             }
         };
     }
+    if base_classid == HASH_CLASS
+        && !globals
+            .store
+            .basic_op_redefined_for(HASH_CLASS, IdentId::_INDEX_ASSIGN)
+    {
+        // `Hash#[]=` without a method lookup: the same steps as the
+        // `index_assign` builtin (the fresh-String-key dup/freeze, the
+        // frozen-receiver check, the insert). This is the path every
+        // interpreted `h[k] = v` on a Hash takes, and the residual arm of
+        // the JIT's polymorphic `[]=` dispatch; going through
+        // `invoke_method` here meant a global-method-cache probe per store
+        // (10M of them in an activerecord run).
+        let key = if base.as_hash().is_compare_by_identity() {
+            index
+        } else {
+            index.frozen_hash_key()
+        };
+        let res = base
+            .as_hash_mut(&globals.store)
+            .and_then(|mut h| h.insert(key, src, vm, globals));
+        return match res {
+            Ok(()) => Some(src),
+            Err(err) => {
+                vm.set_error(err);
+                None
+            }
+        };
+    }
     vm.invoke_method(
         globals,
         IdentId::_INDEX_ASSIGN,

--- a/monoruby/src/codegen/runtime.rs
+++ b/monoruby/src/codegen/runtime.rs
@@ -1871,6 +1871,34 @@ pub(super) extern "C" fn get_index(
     )
 }
 
+/// `StringFreeze` (`"lit".freeze`, CRuby's `opt_str_freeze`): while
+/// `String#freeze` is the builtin the answer is `lit` itself — the interned
+/// frozen literal, no copy, no call. Once it has been redefined the literal
+/// is copied (chilled, as a plain literal evaluation would produce) and the
+/// redefined `freeze` is called on the copy, exactly as the unfolded form
+/// would have done.
+pub(super) extern "C" fn string_freeze_literal(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lit: Value,
+) -> Option<Value> {
+    if !globals
+        .store
+        .basic_op_redefined_for(STRING_CLASS, IdentId::FREEZE)
+    {
+        return Some(lit);
+    }
+    let mut copy = lit.dup();
+    copy.set_chilled_literal();
+    match vm.invoke_method_inner(globals, IdentId::FREEZE, copy, &[], None, None) {
+        Ok(v) => Some(v),
+        Err(err) => {
+            vm.set_error(err);
+            None
+        }
+    }
+}
+
 pub(super) extern "C" fn set_index(
     vm: &mut Executor,
     globals: &mut Globals,

--- a/monoruby/src/globals/store/basic_op.rs
+++ b/monoruby/src/globals/store/basic_op.rs
@@ -107,6 +107,11 @@ pub(crate) const BASIC_OP_DEFS: &[(ClassId, &str)] = &[
     (FLOAT_CLASS, "!"),
     (STRING_CLASS, "!"),
     (SYMBOL_CLASS, "!"),
+    // ---- `"lit".freeze`: the `StringFreeze` opcode (bytecodegen
+    // `gen_method_call`) answers the interned frozen literal without a
+    // call — CRuby's `opt_str_freeze` — and the JIT loads it as a plain
+    // literal (`compile.rs`, recorded as a bop dependency).
+    (STRING_CLASS, "freeze"),
     (COMPLEX_CLASS, "!"),
     (NIL_CLASS, "!"),
     (TRUE_CLASS, "!"),
@@ -460,6 +465,7 @@ mod tests {
             ("String", "==(o)", r#""a" == "b""#),
             ("String", "!=(o)", r#""a" != "b""#),
             ("String", "!", r#"!("a")"#),
+            ("String", "freeze", r#""a".freeze"#),
             ("Symbol", "==(o)", ":a == :b"),
             ("Symbol", "===(o)", ":a === :b"),
             ("Symbol", "!", "!(:a)"),

--- a/monoruby/src/id_table.rs
+++ b/monoruby/src/id_table.rs
@@ -266,6 +266,9 @@ impl IdentId {
     /// (`/encoding_override`). `String#encoding` probes it on every call,
     /// so it is interned up front rather than by name each time.
     pub const _ENCODING_OVERRIDE: IdentId = id!(96);
+    /// `freeze`: the `StringFreeze` opcode (`"lit".freeze`) asks the
+    /// basic-op table about `String#freeze` on every interpreted execution.
+    pub const FREEZE: IdentId = id!(97);
 
     // The special global variables whose assignment `write_special_check`
     // (globals/gvar.rs) validates or coerces. Deliberately a *consecutive*
@@ -552,6 +555,7 @@ impl IdentifierTable {
             table.set_id(name, id);
         }
         table.set_id("/encoding_override", IdentId::_ENCODING_OVERRIDE);
+        table.set_id("freeze", IdentId::FREEZE);
         table
     }
 

--- a/monoruby/tests/literal.rs
+++ b/monoruby/tests/literal.rs
@@ -529,6 +529,59 @@ fn command_literal_frozen_argument() {
 }
 
 #[test]
+fn string_literal_freeze_fold() {
+    // `"lit".freeze` loads the interned frozen template (CRuby's
+    // opt_str_freeze): frozen, and the same object on every evaluation.
+    run_test(
+        r##"
+        def f = 'abc'.freeze
+        a = f; b = f
+        [a.frozen?, a.equal?(b), a, 'abc'.freeze.equal?('abc'.freeze), 'xyz'.freeze.frozen?]
+        "##,
+    );
+    // Interpolated receivers and calls with arguments/blocks are not folded.
+    run_test(
+        r##"
+        x = 1
+        s = "a#{x}".freeze
+        t = "a#{x}".freeze
+        [s.frozen?, s.equal?(t), s]
+        "##,
+    );
+    // A redefined String#freeze still runs (and sees a frozen receiver).
+    run_test_once(
+        r##"
+        class String
+          def freeze = "redefined:#{frozen?}"
+        end
+        'abc'.freeze
+        "##,
+    );
+    // The result lands in a temp that the next instruction consumes: a
+    // binop rhs, a call argument, a receiver (the JIT's abstract frame must
+    // see the temp as live).
+    run_test(
+        r##"
+        def app(buf) = buf << 'hello '.freeze
+        def cat(buf) = buf.concat('world'.freeze)
+        def plus(a) = a + '!'.freeze
+        def recv = 'abc'.freeze.upcase
+        buf = String.new
+        app(buf); cat(buf)
+        [buf, plus(buf), recv, ('x'.freeze + 'y').frozen?]
+        "##,
+    );
+    // Under the pragma the literal is already the interned object.
+    run_test(
+        r##"
+        # frozen_string_literal: true
+        a = 'abc'.freeze
+        [a.frozen?, a.equal?('abc'), a.equal?('abc'.freeze)]
+        "##,
+    );
+}
+
+#[test]
 fn hash_index_assign_generic_path() {
     // `h[k] = v` on a Hash whose class the JIT cannot pin down takes
     // `runtime::set_index`: fresh String keys are dup'd and frozen, frozen

--- a/monoruby/tests/literal.rs
+++ b/monoruby/tests/literal.rs
@@ -527,3 +527,44 @@ fn command_literal_frozen_argument() {
         "#,
     );
 }
+
+#[test]
+fn hash_index_assign_generic_path() {
+    // `h[k] = v` on a Hash whose class the JIT cannot pin down takes
+    // `runtime::set_index`: fresh String keys are dup'd and frozen, frozen
+    // receivers raise, compare_by_identity keeps the caller's key, and a
+    // redefined `Hash#[]=` is honoured.
+    run_test(
+        r##"
+        def st(h, k, v) = (h[k] = v)
+        k = +"key"
+        h = {}
+        st(h, k, 1); k << "!"
+        r = [h.keys, h.keys[0].frozen?, h.keys[0].equal?(k)]
+        i = {}.compare_by_identity
+        ik = +"ik"
+        st(i, ik, 2); ik << "?"
+        r << i.keys[0].equal?(ik) << i[ik]
+        a = [1, 2]
+        st(a, 0, 9)
+        r << a
+        begin
+          st({}.freeze, :a, 1)
+        rescue => e
+          r << e.class
+        end
+        r
+        "##,
+    );
+    run_test_once(
+        r##"
+        class Hash
+          def []=(k, v)
+            "redef #{k}"
+          end
+        end
+        def st(h, k, v) = (h[k] = v)
+        [st({}, :a, 1), {}.size]
+        "##,
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -275,6 +275,7 @@
 1317901b03e325cdcbdb9c43a59b5785	[[[167, 65, 166, 110], "Big5"], [167, 65, 166, 110]]	require "tmpdir"\n        path = File.join(Dir.tmpdir, "mrb_bytes_magic_
 132388d4515c19d62c2dd3396854ec0f	[21, "xyy"]	def idapp(s, n)\n          i = 0\n          while i < n\n            t = (
 13323a8d5c81e35bcd4ad9f525e2542e	[true, 2, 9, 0]	h = Signal.list\n            [h.is_a?(Hash), h["INT"], h["KILL"], h[
+136d5b53ff9c773153c7fac5ff0b733b	[200, [:sym, "s", :sym, "s"], "strx!", 8, ["ac", "ab"], 3, [false, true]]	def push(a, x) = a << x\n            a = []\n            200.times { 
 138e62ffcfc71d0338a5247a729e81fb	[true, true]	[$:.equal?($LOAD_PATH), $:.equal?($-I)]\n        
 13ad4da7c9b738e48c91a58c2101c684	[false, true, false, false, true]	r, w = IO.pipe\n            res = [$stdout.sync, $stderr.sync, $stdi
 13c09eba52c55ecec3e82b015d3b4f59	[true, true, true]	C = Class.new\n            D = Class.new(C)\n            \n[C.new.clas
@@ -501,6 +502,7 @@
 2564e3ad2fe7fb1fdc5d2fa9b88997a2	"US-ASCII"	"\\x01".unpack("h")[0].encoding.to_s
 256686756b653a14cc54ed2fe66c19a5	"hello from Foo"	class Foo\n              def hello\n                "hello from Foo"\n
 259e0bc1539e3e941c430db4dd5e906c	"/home/user/monoruby/monoruby/a.rb"	class C\n          autoload :D, File.expand_path("j")\n          autoload
+25ab3bc8851895e51c03504e71ee2483	[true, false, "a1"]	x = 1\n        s = "a#{x}".freeze\n        t = "a#{x}".freeze\n        [s.
 25bf8c5753369088e3ee3a5e22313082	["Z", "\\n"]	tr = []\n            trace_var(:$/) { |v| tr << v }\n            $/ =
 25bfb835555c41988ae49ab62e4ae633	["ok", "ok", "ok", "ok", "ok", "abcok"]	class MTosInt; def to_s; 42; end; end\n            class MTosNil; de
 25f0534564d801243342b23debebc6f2	[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19], true, [0, 1, 2, 3, 4, 5, 6], [[0, "s0"], [1, "s1"], [2, "s2"], [3, "s3"], [4, "s4"], [5, "s5"]], [0, 1, 2], FrozenError]	def app(a, v) = a << v\n        def app_blk(a, v, &b) = a.<<(v, &b)\n    
@@ -1141,6 +1143,7 @@
 573a889f327b5f24c438d7517aacf15a	nil	"hello".byteindex("ll", 3)
 573fe669ac971343defbd1cde20dc915	["MONORUBY_ENV_TEST_KEY", nil]	ENV["MONORUBY_ENV_TEST_KEY"] = "uniq_value_5678"\n            r = EN
 576157356419a5741dbdbde29df95789	true	GC.stat.values.all? { |v| v.is_a?(Integer) }
+578de94984c2ccfde4e12e4b109f9b81	[1, 0]	class Hash\n          def []=(k, v)\n            "redef #{k}"\n          e
 57bd29081de5740463b29a1c3ee0ef00	"US-ASCII"	s = "hello".dup.force_encoding("US-ASCII")\n              s[/(ll)/
 57f002dbbc2a38d20a751f8e1d4218fe	[255, 15, 240, -1, 15, -16, 42, 0, 42, 42, -43, 244837815148286, 304366200, 244837510782086]	def or_a; 0xFF | 0x0F; end\n            def and_a; 0xFF & 0x0F; end\n
 57f22a05e8acf18b24e3a1c7b3e4f9a8	[false, :c, false, :cf, :c]	class A; end\n            class B; end\n            class C; end\n    
@@ -1199,6 +1202,7 @@
 5c54276df75bb39ec1d87961406e8d9a	"M:Base"	module M\n          def greet\n            "M:" + super\n          end\n   
 5c591e9ff73fb3eaf82f8472fbe461ed	:nme	class Float; def *(o); super(o); end; end\n                begin; 2.0 * 3; rescue
 5c78c8c1a1899c06122f988ae4e55650	true	module MNs; module Ext; end; end\n            o = Object.new\n       
+5c81b1416723d320008472f66e0573cc	[true, true, true]	def churn(n) = n.times { |i| [i, i] }\n            churn(50_000); GC
 5c9a399e6be0e655dcde007dc7ece9b8	true	r, w = IO.pipe\n            t = Thread.new { sleep 0.2 }\n           
 5c9bd2b9dbdb63097f4a4accca2a9df4	nil	def f(&p)\n            p.call\n        end\n        \n\n        f{}\n        
 5d03329e8ce3ae472df7fb2691c658f9	[3, :redefined]	a, b = 3, 9\n            r = []\n            50.times { r << [a, b].m
@@ -1319,6 +1323,7 @@
 65b60c5b39c342afed16c0ba169c3edc	20100	def target(x) = x + 1\n        s = 0\n        i = 0\n        while i < 200
 65d10140470d60de44657d841741db77	[0, 1, 2, 3, 4]	a = []\n            p = Proc.new {|x|\n                a << x\n       
 65f089c7f8670902b073a707f21a776d	["/p", nil]	m = Module.new { autoload :X, "/p" }\n            [m.autoload?("X"),
+660c0103d91b50d0c6f365cf1111c0c4	:OVERRIDDEN	class String; def freeze; :OVERRIDDEN; end; end; "a".freeze
 6622d68b20aa2154a49d5b127ef16dc7	:assigned	module MM\n          def self.const_missing(c); c; end\n        end\n     
 6640768cb0201ad9cc8cdbbc1ff67cd8	42	c = Class.new\n            c.class_exec do\n              define_meth
 664f853aae1b23342a7f3f6347677439	[nil, [:r]]	$clog = []\n            def craise; $clog << :r; raise "x"; end\n    
@@ -2243,6 +2248,7 @@ abff45e2e4ccefb2ed9daaa747abd7e9	[false, true, "ASCII-8BIT", "US-ASCII", "US-ASC
 ac05813546d64cee5c65087151515f0e	2	class C\n              class_variable_set(:@@a, 1)\n              cla
 ac1cd090922e2d287c49175ec16f5e26	[10.0, 11.0]	def call_block\n          yield\n        end\n        def q2(n)\n          
 ac297a4af1959cc67e21eec34a53aea8	"nil"	def t; end; (private).inspect
+ac2e43020ffe19b6c18c1104198f1e6e	[["key"], true, false, true, 2, [9, 2], FrozenError]	def st(h, k, v) = (h[k] = v)\n        k = +"key"\n        h = {}\n        
 ac3fd0f0d8305e489381e6ee6e5c07bd	[100, 100, 4950]	a=1\n            x=0\n            b=while a<2500 do\n            if a=
 ac462de061f87c41bfe50ec870af58fd	[false, true]	io = IO.popen("cat", "r+")\n            begin\n              io.close
 ac47b35a8659a773ec56fdd4d59752c6	"m1+m2"	m1 = Module.new do\n          def foo; "m1"; end\n        end\n        m2 
@@ -2345,6 +2351,7 @@ b48421b0d63a4f1dfbd01b42afbcbd69	[[true, "Other 2\\n", "File", true], [true, fal
 b4b8f74ab1ab36ffeaae5c220a83557e	[true, true]	m = Module.new do\n              eval <<-CODE\n                module
 b4da8c820c2dab4428659d300baa5cc4	[:foo]	$res = []\n            class C\n              def self.method_removed
 b4de022176f4c5de67942bada3f160da	[[Fold], [FoldRest], [FoldOpt], [Impure], 99, ArgumentError, ArgumentError, ArgumentError, Fold, 100]	$effects = []\n            class Fold\n              def initialize(x
+b4ebc0e6f5be99ec71ef0910baf89efa	"redefined:false"	class String\n          def freeze = "redefined:#{frozen?}"\n        end\n
 b4ebd9e4bda33219cab1ca52fb00c022	[[[1, 2, 3], [[:x, 10], [:y, 20]]]]	class C\n          def f(*args, **kw)\n            $res << [args, kw.sort
 b50aa88cac9a4ea0fd9adfd0ecc7d571	20	Random.urandom(0).size\n        Random.urandom(1).size\n        Random.ur
 b5186a1f8fc3fcc5d73748e08564545a	[1, 1]	->(a = 1, b = a) { [a, b] }.call
@@ -2391,6 +2398,7 @@ b8659d9eac8d9dda73d245a1976bcfbd	256	253.succ.succ.succ
 b8a21a20381c12eb8fd88a75578fcc20	["mm: probe [7]", "super: no superclass method 'probe'"]	res = []\n        klass = Class.new do\n          def method_missing(name
 b8a48c3aa1c3407546058fae28da4256	[false, false]	def foo; end\n            def bar; end\n            public :foo, :bar
 b8add92dc4f86330682dc9fa57fea596	"[nil, true]"	r, w = IO.pipe\n            pid = fork do\n              r.close\n    
+b8b5815c80c9b41df4ebb850776696ed	[100, 100, [49, :tagged]]	def push(a, x) = a << x\n            a = []\n            100.times { 
 b8d3738377245420bc2378da58f5f7d9	100	p = Proc.new { 100 }\n            define_method(:foo, p)\n           
 b8d68ef10028da6842a236893e45d2cb	:local_jump	begin\n              Thread.new { return }.value\n              :no_e
 b8e73ca465704ccb728ac104f9385e74	["str", 8]	def call_block\n      yield\n    end\n    def call_block_twice\n      yield\n   
@@ -2411,6 +2419,7 @@ ba14940825be38e026fae59620419fd4	42	class A\n          private\n          def se
 ba2759338f46738112684574d1873d91	["C", true, :overridden, "BetweenBAndC", "B", nil, "BetweenBAndC"]	module B; def overridden; "B"; end; end\n            module BetweenB
 ba33ae227745c6540c696d6d1939ee32	Complex	8.0.fdiv(Complex(2, 1)).class
 ba39d4e07d48704cbbd5237bda1f2e52	3	class C\n          def f(a = ($x = 3)); self; end\n        end\n        C.
+ba3e73d62c5db2b4428bbeab1207b07f	[true, false, true]	# frozen_string_literal: true\n        a = 'abc'.freeze\n        [a.froze
 ba4b2a427a6ae2a8c8e93903224a4e27	[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, true, :lexical, :lexical, :lexical, :lexical, :lexical, :lexical, :lexical, :lexical, :lexical, :lexical]	$r = []\n        # Constants stored directly in the singleton class.\n   
 ba4f1d7bb4ae928b997cbb3df7f887d9	nil	m = Module.new\n            m.name\n            
 ba4ff971390140cc452d6a37019cd25e	["hello", "hellohellohellohellohellohellohellohellohellohello"]	class Foo\n          def initialize(data)\n            @key = data\n      
@@ -2874,6 +2883,7 @@ dc3f2c1c601ee25acabb218a6cdbf2ba	"custom_argv0\\n"	r, w = IO.pipe\n            P
 dc46fc2af0d8cdf7f503978a0a044521	[{"a" => 100, "b" => 357, "c" => 300, "d" => 400}, {"a" => 100, "b" => 357, "c" => 300, "d" => 400}, {"a" => 100, "b" => 357, "c" => 300, "d" => 400}]	h1 = { "a" => 100, "b" => 200 }\n            h2 = { "b" => 246, "c" 
 dc4f9ee2cdc75359817229684847545b	[nil, nil, nil]	class C; def to_int; 3; end; end; o = C.new\nArray.new(o)
 dc8c0fed605309d0ac56a18fa4f96131	[1, -1, 2, -2]	class Foo\n              def a(x:); end\n              def b(x: 1); e
+dc8f64ca126f4f16403db76ca436887b	["hello world", "hello world!", "ABC", false]	def app(buf) = buf << 'hello '.freeze\n        def cat(buf) = buf.concat
 dca050e66a831044f8036e5e5e53de5e	[true, false]	class ModEvalBlockA; end\n            ModEvalBlockA.module_eval {\n  
 dca1fe10428b94607119699e4536affd	77	module Foo\n          def self.Bar; yield; end\n        end\n        Foo::
 dcb299cee36b3bcad2f0615af4c007af	true	File.exist?("../LICENSE-MIT")
@@ -3020,6 +3030,7 @@ e7c6302a9b297579c8e5ac35b76c1089	"1"	def foo \n          eval("a = 1", $b)\n    
 e7ca5b8d05bd3556a711daf23dfd10c6	nil	r, _w = IO.pipe\n            r.wait(IO::READABLE, 0)\n            
 e7ea0100557a89543a11511853510192	[{"alpha" => 3, "beta" => 2}, 3, 2, nil, true, false, 2]	h = {}\n        h["alpha"] = 1\n        h["beta"] = 2\n        h["alpha" +
 e832c1ba769618395a505bd13bd3d3b7	"hi"	mod = Module.new do\n          def greet; "hi"; end\n        end\n        
+e83df828ab1988d0aa930288164eeda1	[true, true, "abc", true, true]	def f = 'abc'.freeze\n        a = f; b = f\n        [a.frozen?, a.equal?(
 e841964d3dcfd7149202c80802373ee4	"Encoding::CompatibilityError"	(Regexp.new("".dup.force_encoding("US-ASCII"), Regexp::FIXEDENCODING) =~ "\\303\\2
 e845d4c714ee9e6cae44891a1b737bc6	[10, 11, 12]	class FwdD\n          attr_reader :a\n          def initialize(n)\n       
 e84e2a6f452bc8149fdee15dda638246	4	r = 0\n            20.times do\n              begin\n                r


### PR DESCRIPTION
## Summary

Investigation of why the four yjit-bench programs where monoruby runs at roughly half of CRuby+YJIT (activerecord 0.37x, rack 0.48x, graphql 0.61x, erubi 0.66x on this machine) spend their time, followed by the four cheapest fixes from the resulting plan. The full write-up, with steady-state `perf` breakdowns, `--features profile` / `--features deopt` statistics, JIT compile logs, the microbenchmarks isolating each runtime cost, the hypotheses that were tested and rejected, and a ranked plan for the rest, is `doc/yjit_bench_slow_investigation_2026-09.md` (indexed in `doc/README.md`).

The headline finding: the time is in the runtime, not in JIT-generated code (15–20 % in every benchmark). GC root scanning and allocation (20–30 %), String-keyed Hash lookup and literal construction, the `(receiver, argument)`-keyed binary-op cache making `Array#<<` megamorphic, the Ruby-level StringScanner, exceptions / `throw`, Fiddle-backed sqlite3, and a deopt policy that keeps re-emitting a monomorphic guard at PIC-overflowing sites.

## Changes (one commit each, in implementation-cost order)

1. **`gc`: collection budget floor 8 → 32 pages** (`alloc.rs::PAGES_PER_GC_TRIGGER`). Every minor GC re-scans the whole root set (every ISeq's literals, every class), so on a Rails-sized program the fixed cost per collection dwarfed the young generation it reclaimed (erubi: 7.3 GCs per iteration on a 6 MB heap). The budget-scaling GC test grows its large heap past the new floor.
2. **`runtime::set_index`: Hash fast path.** The interpreter's index-assign and the residual arm of the JIT's polymorphic `[]=` went through `invoke_method` and a global-method-cache probe per store (7.8M in a rack run, 10M in activerecord). `Hash#[]=` now takes the `index_assign` builtin's steps in place, behind the same basic-op check the Array arm consults.
3. **`"lit".freeze` → `StringFreeze` opcode (8)**, CRuby's `opt_str_freeze`. `String#freeze` joins `BASIC_OP_DEFS` (with its redefinition coverage case). While it is the builtin the interpreter's helper answers the interned frozen literal (no copy, no call) and the JIT loads it as a plain literal with a recorded bop dependency; once redefined, the helper hands a chilled copy to whatever `freeze` now is and the JIT side-exits. Both VM backends, TraceIR and JIT lowering are covered. `'abc'.freeze` 67.6 → 9.8 ns, `buf << 'lit'.freeze` 73 → 15.9 ns (YJIT: 26 / 21).
4. **JIT: receiver-keyed dispatch for argument-polymorphic binary sites** (`binary_recv_dispatch`). `children << node` over a dozen node classes is polymorphic only because the cache key is the class pair; it used to fall to the generic helper on every execution (7.1M global-cache probes in graphql, 5.1M in activerecord). When every recorded receiver is one non-numeric class, the residual branches on it into a direct class-version-guarded call, with the generic helper (not a deopt) behind it. `ary << x` with four argument classes: 57 → 4.5 ns.

## Measured effect

Interleaved 3-round yjit-bench comparison against the baseline (`750d04f`), min of medians, x86-64:

| benchmark | baseline | this PR | |
|---|---:|---:|---:|
| rack | 88 ms | 81 ms | −8 % |
| graphql | 60 ms | 52 ms | −13 % |
| activerecord | 319 ms | 293 ms | −8 % |
| erubi | 310 ms | 308 ms | ±0 % |

erubi did not move: its GC count drops 4x but the cost that matters is the root scan (§5.1 of the doc), so the next step there is generational treatment of the `Store` roots.

## Test plan

- [x] `cargo test` (full suite): 3688 passed, 1 failed — `float::tests::angle`, which fails on the baseline too because the local CRuby 4.0.6 answers `1.123456789.ceil(15)` as `1.123456789000001` (a 4.0.2 vs 4.0.6 difference, unrelated to this PR)
- [x] New tests: `string_literal_freeze_fold` (interned result, no fold for interpolated receivers, a redefined `String#freeze` sees a chilled copy, temps consumed by `<<` / `concat` / `+` / a receiver), `hash_index_assign_generic_path`, `binop_arg_varying_site_dispatches_on_receiver` (foreign receiver → helper, redefinition after warmup), `basic_op_redefinition_is_honored_per_pair` gains the `String#freeze` case
- [x] Semantics of each change checked against CRuby with the JIT on and `--no-jit`
- [ ] aarch64: the `a64_op_string_freeze` handler mirrors `a64_op_literal` + `a64_checked_store_next` but was not run here (no arm64 host); the macOS CI job covers it

Two things worth knowing from the detours (recorded in the doc and commit messages): the first receiver-only fold of `"lit".freeze` was observably different from CRuby under a redefined `String#freeze`, hence the opcode; and a bytecodegen instruction that produces a temp must `push` before `emit` (as `emit_call` does) or the JIT's abstract frame treats the temp as dead space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkoJG3qRpCRJ4nXDZH3mg9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkoJG3qRpCRJ4nXDZH3mg9)_