### PR TITLE
Expand leaf accessor and counter bodies without a frame

### DIFF
--- a/doc/stack_frame.md
+++ b/doc/stack_frame.md
@@ -164,3 +164,55 @@ accumulator: `GP_ALLOC_POOL` is empty, and the local allocator in
 `jitgen/gp_alloc.rs` assigns general-purpose registers per basic block
 instead, so a compiled body's values live in whatever caller-saved register
 it picked.
+
+## Negative result: moving META / SVAR to the callee
+
+The caller writes the whole header, including the two words that depend only
+on the callee — `meta` (`store[fid].meta()`) and the `svar` zero sentinel.
+They are the same at every call site of a given method, so they look like an
+obvious thing to write once in the callee instead: 24 bytes off each of a
+program's call sites, in exchange for 17 bytes added once per method.
+
+This was implemented and measured, and it is **slower**. The x86-64 form
+was: `Codegen::init_func` writes both words at `rbp - RBP_LOCAL_FRAME` (the
+same addresses the caller reached at `rsp - RSP_LOCAL_FRAME`), and a call
+site drops them exactly when it dispatches straight to the callee's compiled
+entry — the same `get_jit_entry` lookup `AsmInst::Call` performs, resolved in
+the same lowering so the two cannot disagree. Block-style callees were
+excluded: `define_method` re-tags a block's `LFP_META` with
+`Meta::PROC_METHOD_MASK` at call time, and a body rewriting the word from its
+own compile-time copy would drop that bit.
+
+Measured against the same tree, interleaved runs (x86-64, release):
+
+| benchmark | delta |
+|---|---|
+| fib | +4% |
+| 30k_methods | −5 to −10% |
+| tarai | −5.8% |
+| bedcov | −5.5% |
+| sudoku | −3.6% |
+| qsort | −3.3% |
+| 30k_ifelse | −3% |
+| aobench | −2.5% |
+| nbody, mandelbrot, bf, 30k_variables | flat |
+
+Two reasons, and both generalise:
+
+* **The size win is much smaller than the call-site arithmetic suggests.**
+  A `movabs` for the 64-bit `Meta` is 10 of the 17 bytes added per method,
+  and these programs have nearly as many methods as call sites (30k_methods:
+  ~31k sites over 30k methods). The net was ~6% of the JIT code, not the
+  ~19% the caller-side saving alone implies. The trade only pays where call
+  sites outnumber methods by a wide margin — which is what `fib` is, and why
+  `fib` is the one benchmark that improved.
+* **Placement matters more than count.** The stores moved from the caller,
+  where they issue well ahead of the `call` and drain from the store buffer
+  while the caller finishes its own work, to the head of the callee, where
+  they are serialized behind `push rbp` / `mov rbp, rsp` / `sub rsp` and
+  compete with the entry poll's load — on a taken branch, at the exact point
+  the front end is refilling.
+
+So the header stays where it is. A future attempt at trimming the call
+sequence should target words that can be *dropped* rather than moved, or
+move work off the callee's entry rather than onto it.

--- a/monoruby/src/codegen/jitgen/compile/frameless.rs
+++ b/monoruby/src/codegen/jitgen/compile/frameless.rs
@@ -1,10 +1,12 @@
-//! Frame-free expansion of the constructor idiom.
+//! Frame-free expansion of the small-body idioms.
 //!
-//! `def initialize(a, b) = (@a = a; @b = b)` is the single most common
-//! method body in object-heavy Ruby, and today it costs a full method
-//! frame to run three `mov`s. This module recognises that body and lets
-//! [`compile_method_call`](JitContext::compile_method_call) emit the
-//! stores straight into the caller, with no frame pushed at all.
+//! `def initialize(a, b) = (@a = a; @b = b)` and `def inc = @count += 1`
+//! are the most common method bodies in object-heavy Ruby, and today each
+//! costs a full method frame to run a handful of `mov`s. This module
+//! recognises them — [`ivar_store_body`] the constructor, [`leaf_expr_body`]
+//! the accessor/counter — and lets
+//! [`compile_method_call`](JitContext::compile_method_call) emit the body
+//! straight into the caller, with no frame pushed at all.
 //!
 //! # How this differs from the other two folds
 //!
@@ -20,15 +22,19 @@
 //! a frozen guard, and a deopt is fine because it rebuilds from the
 //! *caller's* frame state, which is the one that exists. What the callee
 //! must not do is *need a frame of its own*: no call or `yield` (a
-//! callee's callee walks `cfp` and would find the caller's frame), nothing
-//! that can raise or appear in a backtrace, no `binding`, no `super`, no
-//! access to an `outer` frame.
+//! callee's callee walks `cfp` and would find the caller's frame), no
+//! `binding`, no `super`, no access to an `outer` frame.
 //!
-//! Restricting the body to `StoreIvar` from a parameter slot, plus the
-//! `Ret`, buys all of that at once: every instruction is a move between
-//! things the caller already holds. The frozen guard is the one side exit,
-//! and it is hoisted ahead of the stores so the expansion is all-or-nothing
-//! (see [`ivar_store_body`] for why that matters).
+//! Raising is not on that list either, as long as the raise is reached by a
+//! *guard*. `x / 0` deopts to the call instruction in both backends, and
+//! the interpreter then performs the whole call — building the real frame
+//! and raising `ZeroDivisionError` from it, with the backtrace that frame
+//! gives it. What the guards buy is not "cannot raise" but **nothing has
+//! happened yet**: the expansion is all-or-nothing, so an exit can hand the
+//! entire call back. Both recognisers therefore hoist every guard ahead of
+//! every store — the frozen guard in [`ivar_store_body`], and in
+//! [`leaf_expr_body`] the single store is required to be the last
+//! instruction before the `Ret`.
 
 use super::*;
 use crate::bytecodegen::BinOpK;
@@ -240,8 +246,13 @@ impl Chain {
 /// come after every exit. Requiring a single `StoreIvar` immediately before
 /// the `Ret` buys that outright; anything else is declined.
 ///
-/// `Div` and `Rem` are excluded for the same reason in reverse: they raise
-/// `ZeroDivisionError`, which needs a frame to raise *from*.
+/// `Div` needs no special treatment: a zero divisor is *already* a deopt in
+/// both backends (x86-64 stamps `_divide_by_zero` and jumps to the exit,
+/// aarch64 does `cbz x(r), deopt`), so it lands on the call instruction like
+/// every other guard and the interpreter raises `ZeroDivisionError` from the
+/// real frame it then builds — backtrace and all. `Rem` is the one exclusion,
+/// and for a lowering reason rather than a semantic one: `BinOpK::Rem` is
+/// `unreachable!()` in the register form of the integer binop.
 ///
 pub(super) fn leaf_expr_body(store: &Store, iseq_id: ISeqId) -> Option<LeafBody> {
     let iseq = &store[iseq_id];
@@ -296,7 +307,10 @@ pub(super) fn leaf_expr_body(store: &Store, iseq_id: ISeqId) -> Option<LeafBody>
                 rhs,
                 ..
             } if !after_store => {
-                if !matches!(kind, BinOpK::Add | BinOpK::Sub | BinOpK::Mul) {
+                if !matches!(
+                    kind,
+                    BinOpK::Add | BinOpK::Sub | BinOpK::Mul | BinOpK::Div
+                ) {
                     return None;
                 }
                 let lhs = slots.get(&lhs)?.clone();

--- a/monoruby/src/codegen/jitgen/compile/frameless.rs
+++ b/monoruby/src/codegen/jitgen/compile/frameless.rs
@@ -31,6 +31,7 @@
 //! (see [`ivar_store_body`] for why that matters).
 
 use super::*;
+use crate::bytecodegen::BinOpK;
 
 ///
 /// Where a callee parameter's value lives, as seen from the frame being
@@ -160,5 +161,184 @@ pub(super) fn ivar_store_body(store: &Store, iseq_id: ISeqId) -> Option<IvarStor
     Some(IvarStoreBody {
         stores,
         ret: ret?,
+    })
+}
+
+///
+/// One value a frame-free leaf body can reach for.
+///
+/// All three are things the *caller* already holds: an argument in one of
+/// its slots, an inline ivar of the receiver it is about to send to, or a
+/// constant. None of them needs a frame to name.
+///
+#[derive(Clone, Copy, Debug)]
+pub(super) enum LeafValue {
+    /// The callee's parameter `i` (0-based), i.e. its `SlotId(i + 1)`.
+    Param(u16),
+    /// `@name` of the receiver.
+    SelfIvar(IdentId),
+    /// A fixnum literal.
+    Fixnum(Value),
+}
+
+///
+/// A body that computes one value by folding operands into an accumulator,
+/// optionally stores it to an ivar, and returns it.
+///
+/// `@count += 1`, `@a * 2`, `@sum + x`, `@a` — the small readers, writers
+/// and counters that make up most of the leaf methods in object-heavy Ruby,
+/// and today cost a full frame each.
+///
+/// The chain is deliberately *left-linear*: every step's right operand is a
+/// leaf. That keeps the expansion to two registers, and it is the shape
+/// bytecodegen produces for these expressions anyway.
+///
+pub(super) struct LeafBody {
+    /// The value the accumulator starts at.
+    pub base: LeafValue,
+    /// Folded in left to right: `acc = acc <kind> operand`.
+    pub steps: Vec<(BinOpK, LeafValue)>,
+    /// When set, the accumulator is stored to this ivar before returning.
+    pub store: Option<IdentId>,
+}
+
+/// The longest accumulator chain that is still worth expanding. Each step
+/// is two guards plus an arithmetic instruction in the caller, repeated at
+/// every site that calls this method.
+const MAX_STEPS: usize = 3;
+
+/// What a callee slot holds, as an accumulator chain under construction.
+#[derive(Clone)]
+struct Chain {
+    base: LeafValue,
+    steps: Vec<(BinOpK, LeafValue)>,
+}
+
+impl Chain {
+    fn leaf(base: LeafValue) -> Self {
+        Self {
+            base,
+            steps: vec![],
+        }
+    }
+}
+
+///
+/// Recognise a leaf body of the [`LeafBody`] shape.
+///
+/// The frame conditions are [`ivar_store_body`]'s, and for the same
+/// reasons: no `outer`, plain positional parameters, a single basic block,
+/// and an instruction set with no call, no `yield`, nothing that raises and
+/// nothing that appears in a backtrace.
+///
+/// # Why the store must come last
+///
+/// Every guard this body needs — the operand class checks, the overflow
+/// check, the frozen check — side-exits to the *call* instruction, and the
+/// interpreter then performs the whole call itself. That is only sound
+/// while nothing has happened yet, so the one effect a body may have has to
+/// come after every exit. Requiring a single `StoreIvar` immediately before
+/// the `Ret` buys that outright; anything else is declined.
+///
+/// `Div` and `Rem` are excluded for the same reason in reverse: they raise
+/// `ZeroDivisionError`, which needs a frame to raise *from*.
+///
+pub(super) fn leaf_expr_body(store: &Store, iseq_id: ISeqId) -> Option<LeafBody> {
+    let iseq = &store[iseq_id];
+    if iseq.outer.is_some() {
+        return None;
+    }
+    let func = &store[iseq.func_id()];
+    if !func.meta().is_simple() || iseq.block_param().is_some() {
+        return None;
+    }
+    let pos_num = func.params().total_positional_args();
+    if pos_num > u16::MAX as usize {
+        return None;
+    }
+    if iseq.bb_info.len() != 1 {
+        return None;
+    }
+    let BasicBlockInfoEntry { begin, end, .. } = iseq.bb_info[BasicBlockId(0)];
+
+    // Parameters arrive in `SlotId(1) ..= SlotId(pos_num)`; `SlotId(0)` is self.
+    let mut slots: HashMap<SlotId, Chain> = HashMap::default();
+    for i in 0..pos_num {
+        slots.insert(
+            SlotId::new(i as u16 + 1),
+            Chain::leaf(LeafValue::Param(i as u16)),
+        );
+    }
+
+    let mut store_to: Option<(IdentId, SlotId)> = None;
+    let mut ret: Option<SlotId> = None;
+    for idx in begin..=end {
+        // A store is the body's one effect, so nothing that can side-exit
+        // may follow it. `Ret` is all that is allowed to.
+        let after_store = store_to.is_some();
+        match TraceIr::from_pc(iseq.get_pc(idx), store) {
+            TraceIr::InitMethod(..) if !after_store => {}
+            TraceIr::FrozenLiteral(dst, v) | TraceIr::Literal(dst, v) if !after_store => {
+                v.try_fixnum()?;
+                slots.insert(dst, Chain::leaf(LeafValue::Fixnum(v)));
+            }
+            TraceIr::LoadIvar(dst, name, _) if !after_store => {
+                slots.insert(dst, Chain::leaf(LeafValue::SelfIvar(name)));
+            }
+            TraceIr::Mov(dst, src) if !after_store => {
+                let chain = slots.get(&src)?.clone();
+                slots.insert(dst, chain);
+            }
+            TraceIr::BinOp {
+                kind,
+                dst: Some(dst),
+                lhs,
+                rhs,
+                ..
+            } if !after_store => {
+                if !matches!(kind, BinOpK::Add | BinOpK::Sub | BinOpK::Mul) {
+                    return None;
+                }
+                let lhs = slots.get(&lhs)?.clone();
+                let rhs = slots.get(&rhs)?;
+                // Left-linear only: a nested right operand would need a
+                // third register and a spill slot to evaluate.
+                if !rhs.steps.is_empty() {
+                    return None;
+                }
+                let operand = rhs.base;
+                if lhs.steps.len() >= MAX_STEPS {
+                    return None;
+                }
+                let mut chain = lhs;
+                chain.steps.push((kind, operand));
+                slots.insert(dst, chain);
+            }
+            TraceIr::StoreIvar(src, name, _) if !after_store => {
+                store_to = Some((name, src));
+            }
+            // A basic block ends at its terminator, so this runs last.
+            TraceIr::Ret(slot) => ret = Some(slot),
+            _ => return None,
+        }
+    }
+
+    let ret = ret?;
+    // When the body stores, it must return the very value it stored — the
+    // expansion computes the accumulator once.
+    if let Some((_, src)) = store_to
+        && src != ret
+    {
+        return None;
+    }
+    let chain = slots.remove(&ret)?;
+    // A body that only hands back a parameter is `ISeqHint`'s business.
+    if chain.steps.is_empty() && store_to.is_none() && matches!(chain.base, LeafValue::Param(_)) {
+        return None;
+    }
+    Some(LeafBody {
+        base: chain.base,
+        steps: chain.steps,
+        store: store_to.map(|(name, _)| name),
     })
 }

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -852,19 +852,20 @@ impl<'a> JitContext<'a> {
                     // never one the constructor recogniser would take.
                     if let Some(leaf) = frameless::leaf_expr_body(&self.store, iseq) {
                         let callee_pos = self.store[func_id].params().total_positional_args();
-                        let arg_slots: Option<Vec<frameless::ArgSlot>> = (simple_fold
-                            && pos_num == callee_pos)
-                            .then(|| {
-                                (0..callee_pos)
-                                    .map(|i| frameless::ArgSlot::Own(args + i))
-                                    .collect()
-                            });
-                        if let Some(arg_slots) = arg_slots
-                            && self.expand_leaf_body(
+                        // Plain positional arguments in this frame's own
+                        // slots. A `...` forward leaves its positionals in
+                        // the *caller's* window instead, which only the
+                        // constructor expansion below reads; a forwarding
+                        // callee is not `simple_fold`, so it falls through
+                        // to it rather than being handled here.
+                        if simple_fold && pos_num == callee_pos {
+                            let arg_slots: Vec<SlotId> =
+                                (0..callee_pos).map(|i| args + i).collect();
+                            if self.expand_leaf_body(
                                 state, ir, recv_class, recv, dst, &leaf, &arg_slots,
-                            )
-                        {
-                            return Ok(CompileResult::Continue);
+                            ) {
+                                return Ok(CompileResult::Continue);
+                            }
                         }
                     }
                     if let Some(body) = frameless::ivar_store_body(&self.store, iseq) {
@@ -1323,7 +1324,7 @@ impl<'a> JitContext<'a> {
         recv: SlotId,
         dst: Option<SlotId>,
         body: &frameless::LeafBody,
-        arg_slots: &[frameless::ArgSlot],
+        arg_slots: &[SlotId],
     ) -> bool {
         // Every ivar below is resolved against `recv_class`, so the site
         // must have proven the receiver *is* that class. A set-guarded
@@ -1383,7 +1384,7 @@ impl<'a> JitContext<'a> {
         fn emit_value(
             ir: &mut AsmIr,
             state: &mut AbstractState,
-            arg_slots: &[frameless::ArgSlot],
+            arg_slots: &[SlotId],
             v: frameless::LeafValue,
             ivarid: Option<IvarId>,
             reg: GP,
@@ -1394,12 +1395,7 @@ impl<'a> JitContext<'a> {
                     dst: reg,
                 }),
                 frameless::LeafValue::Fixnum(val) => ir.lit2reg(val, reg),
-                frameless::LeafValue::Param(i) => match arg_slots[i as usize] {
-                    frameless::ArgSlot::Own(slot) => state.load(ir, slot, reg),
-                    frameless::ArgSlot::Caller(slot) => {
-                        ir.push(AsmInst::LoadCallerSlot { slot, dst: reg })
-                    }
-                },
+                frameless::LeafValue::Param(i) => state.load(ir, arg_slots[i as usize], reg),
             }
         }
 
@@ -3521,7 +3517,10 @@ mod tests {
     /// conditional store (a guard would have to prove something about a
     /// path that stores nothing), a body that calls, one that stores twice,
     /// one whose store is not last, a `%` (`BinOpK::Rem` has no register
-    /// form to lower to), and a body reading a second object's ivar.
+    /// form to lower to), and a body reading a second object's ivar. Then
+    /// the two declines that depend on the *receiver* rather than the body:
+    /// a class whose instances have no inline ivar slots, and an ivar with
+    /// no `IvarId` to resolve.
     #[test]
     fn frameless_leaf_bodies_decline() {
         run_test(
@@ -3542,6 +3541,27 @@ mod tests {
             100.times { d.cond(1); d.calls; d.two; d.early; d.rem(3); d.other(d) }
             res << d.cond(-1) << d.cond(3) << d.calls << d.two << d.early
             res << d.rem(4) << d.other(d) << d.n << d.m
+
+            # A receiver whose instances are not plain objects has no inline
+            # ivar slots to read at a fixed offset.
+            class S < String
+              def initialize(x); super(x); @n = 5; end
+              def inc; @n += 1; end
+            end
+            s = S.new("x")
+            100.times { s.inc }
+            res << s.inc << s
+
+            # An ivar no instance of the class was ever assigned has no
+            # `IvarId` to resolve, so the body cannot be expanded against it.
+            class U
+              def initialize; @a = 1; end
+              def unset; @never; end
+              def bump; @never2 = (@a += 1); end
+            end
+            u = U.new
+            100.times { u.unset; u.bump }
+            res << u.unset << u.bump << u.instance_variables
             res
             "#,
         );

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -3570,30 +3570,65 @@ mod tests {
     /// A zero divisor is a guard like any other: it exits to the call
     /// instruction, and the interpreter performs the whole call — so the
     /// `ZeroDivisionError` is raised from the frame it builds, and carries
-    /// that frame's backtrace. The frame the expansion skipped has to
-    /// appear in it, which is the whole point.
+    /// that frame's backtrace.
+    ///
+    /// The deopt fabricates neither a frame nor a position: it restores the
+    /// caller at the call instruction and hands the call back, so the
+    /// frames and the lines within them are the ones the unexpanded path
+    /// produces. That is what is asserted — every frame, with its line as
+    /// an offset from a `__LINE__` marker so the comparison does not depend
+    /// on where the harness places the snippet — for a plain call, a call
+    /// inside a block, and a call under a JIT-compiled loop. `Integer#/` is
+    /// dropped because CRuby lists that builtin frame and monoruby reports
+    /// no builtin frame at all, expanded or not.
     #[test]
     fn frameless_leaf_bodies_divide() {
         run_test(
             r#"
+            BASE = __LINE__
             class Q
               def initialize(n); @n = n; end
-              def div(x); @n / x; end
+              def div(x)
+                @n / x
+              end
               def half; @n / 2; end
+              # The store is after the division, so a zero divisor must
+              # leave it undone — that is what lets the exit hand the whole
+              # call back.
+              def store_after(x); @m = @n / x; end
+              attr_reader :m
+            end
+            def in_block(q, d)
+              [d].each { |v| q.div(v) }
+            end
+            def in_loop(q, d)
+              i = 0
+              i += 1 while i < 200
+              q.div(d)
+            end
+            def trace(e)
+              e.backtrace.reject { |l| l.include?("Integer#/") }.map { |l|
+                l =~ /:(\d+):in (.+)/ ? [$1.to_i - BASE, $2] : l
+              }
             end
             q = Q.new(100)
             res = []
-            200.times { q.div(3); q.half }
+            200.times { q.div(3); q.half; in_block(q, 3); in_loop(q, 3) }
             res << q.div(3) << q.div(7) << q.half
             # floor division, not truncation
             res << Q.new(-7).div(2) << Q.new(7).div(-2)
             e = (begin; q.div(0); rescue ZeroDivisionError => x; x; end)
-            res << e.class << e.message
-            # The frame the expansion skipped must be in the backtrace.
-            # Not `backtrace.first`: CRuby also lists the `Integer#/`
-            # builtin frame above it, which monoruby does not report for any
-            # builtin, expanded or not.
-            res << e.backtrace.any? { |l| l.include?("Q#div") }
+            res << e.class << e.message << trace(e)
+            # `Array#each` is a C frame in CRuby and Ruby-level in monoruby,
+            # so the block case compares only the frames below it.
+            e = (begin; in_block(q, 0); rescue ZeroDivisionError => x; x; end)
+            res << trace(e).first(2)
+            e = (begin; in_loop(q, 0); rescue ZeroDivisionError => x; x; end)
+            res << trace(e)
+            200.times { q.store_after(4) }
+            before = q.m
+            e = (begin; q.store_after(0); rescue ZeroDivisionError => x; x; end)
+            res << trace(e) << before << q.m << (q.m == before)
             res
             "#,
         );

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -845,6 +845,28 @@ impl<'a> JitContext<'a> {
                     // pushing a frame to run three `mov`s. Same gate as the
                     // folds above, because it needs the same thing they do —
                     // an argument shape that binds without `ArgumentError`.
+                    // Frame-free expansion of the leaf idiom (`@count += 1`,
+                    // `@a * 2`, `@sum + x`, `@a`): the accumulator chain runs
+                    // in the caller's registers, and every guard exits to the
+                    // call instruction. Tried first — a body it recognises is
+                    // never one the constructor recogniser would take.
+                    if let Some(leaf) = frameless::leaf_expr_body(&self.store, iseq) {
+                        let callee_pos = self.store[func_id].params().total_positional_args();
+                        let arg_slots: Option<Vec<frameless::ArgSlot>> = (simple_fold
+                            && pos_num == callee_pos)
+                            .then(|| {
+                                (0..callee_pos)
+                                    .map(|i| frameless::ArgSlot::Own(args + i))
+                                    .collect()
+                            });
+                        if let Some(arg_slots) = arg_slots
+                            && self.expand_leaf_body(
+                                state, ir, recv_class, recv, dst, &leaf, &arg_slots,
+                            )
+                        {
+                            return Ok(CompileResult::Continue);
+                        }
+                    }
                     if let Some(body) = frameless::ivar_store_body(&self.store, iseq) {
                         let callee_pos = self.store[func_id].params().total_positional_args();
                         // Where each callee parameter lives in *this* frame.
@@ -1272,6 +1294,145 @@ impl<'a> JitContext<'a> {
     }
 
     ///
+    ///
+    /// Emit a recognised leaf body ([`frameless::leaf_expr_body`]) as the
+    /// caller's own instructions — no frame pushed, no call made.
+    ///
+    /// Returns `false` (having emitted nothing) when the receiver class
+    /// cannot serve the body's ivars inline, in which case the caller falls
+    /// through to the ordinary call.
+    ///
+    /// # Where the guards exit to
+    ///
+    /// Every guard here — each operand's fixnum check, each arithmetic
+    /// overflow check, the frozen check before a store — side-exits to the
+    /// deopt taken at the *call* instruction, so the interpreter re-performs
+    /// the whole call and produces whatever the real body would have,
+    /// including any exception, from a real frame. That is sound only
+    /// because nothing has happened yet when a guard fires: the recogniser
+    /// admits a single `StoreIvar` and only as the last thing before the
+    /// `Ret`, so every exit precedes the one effect.
+    ///
+    fn expand_leaf_body(
+        &mut self,
+        state: &mut AbstractState,
+        ir: &mut AsmIr,
+        recv_class: ClassId,
+        recv: SlotId,
+        dst: Option<SlotId>,
+        body: &frameless::LeafBody,
+        arg_slots: &[frameless::ArgSlot],
+    ) -> bool {
+        // Every ivar below is resolved against `recv_class`, so the site
+        // must have proven the receiver *is* that class. A set-guarded
+        // dispatch arm has only proven membership in a set of classes that
+        // share this `func_id` — and two classes sharing a method need not
+        // agree on where its ivars live: a subclass that assigns one of its
+        // own first shifts every inherited slot. Reading `@n` at the
+        // parent's index would then hit whatever the subclass put there.
+        if state.class(recv) != Some(recv_class) {
+            return false;
+        }
+        // Only `RValue`s with the object layout have inline ivar slots at a
+        // fixed offset; anything else goes through the heap table, which
+        // needs `using_fpr` bookkeeping and a possible reallocation call.
+        if !self.store[recv_class].is_object_ty_instance() {
+            return false;
+        }
+        // Resolve every ivar before emitting anything, so a body that is
+        // only partly expandable emits nothing at all. A miss means the
+        // class reaching this site is not the one the body was written for
+        // (a subclass whose own initializer never ran); decline rather than
+        // recompile — the ordinary call is correct.
+        let resolve = |this: &Self, name: IdentId| -> Option<IvarId> {
+            this.store[recv_class]
+                .get_ivarid(name)
+                .filter(|ivarid| ivarid.is_inline())
+        };
+        let ivar_of = |this: &Self, v: frameless::LeafValue| -> Option<Option<IvarId>> {
+            match v {
+                frameless::LeafValue::SelfIvar(name) => resolve(this, name).map(Some),
+                _ => Some(None),
+            }
+        };
+        let Some(base_ivar) = ivar_of(self, body.base) else {
+            return false;
+        };
+        let mut step_ivars = Vec::with_capacity(body.steps.len());
+        for &(_, operand) in &body.steps {
+            let Some(ivarid) = ivar_of(self, operand) else {
+                return false;
+            };
+            step_ivars.push(ivarid);
+        }
+        let store_ivar = match body.store {
+            Some(name) => match resolve(self, name) {
+                Some(ivarid) => Some(ivarid),
+                None => return false,
+            },
+            None => None,
+        };
+
+        state.flush_gp(ir);
+        // The receiver, for every inline ivar access and the frozen guard.
+        state.load(ir, recv, GP::Rdi);
+        let deopt = ir.new_deopt(state);
+
+        fn emit_value(
+            ir: &mut AsmIr,
+            state: &mut AbstractState,
+            arg_slots: &[frameless::ArgSlot],
+            v: frameless::LeafValue,
+            ivarid: Option<IvarId>,
+            reg: GP,
+        ) {
+            match v {
+                frameless::LeafValue::SelfIvar(_) => ir.push(AsmInst::LoadIVarInline {
+                    ivarid: ivarid.unwrap(),
+                    dst: reg,
+                }),
+                frameless::LeafValue::Fixnum(val) => ir.lit2reg(val, reg),
+                frameless::LeafValue::Param(i) => match arg_slots[i as usize] {
+                    frameless::ArgSlot::Own(slot) => state.load(ir, slot, reg),
+                    frameless::ArgSlot::Caller(slot) => {
+                        ir.push(AsmInst::LoadCallerSlot { slot, dst: reg })
+                    }
+                },
+            }
+        }
+
+        emit_value(ir, state, arg_slots, body.base, base_ivar, GP::Rax);
+        for (i, &(kind, operand)) in body.steps.iter().enumerate() {
+            emit_value(ir, state, arg_slots, operand, step_ivars[i], GP::Rcx);
+            // Neither operand is statically typed here — the receiver's
+            // class is known but its ivars' contents are not, and a
+            // parameter is whatever the caller passed.
+            ir.push(AsmInst::GuardClass(GP::Rax, INTEGER_CLASS, deopt));
+            ir.push(AsmInst::GuardClass(GP::Rcx, INTEGER_CLASS, deopt));
+            ir.integer_binop_reg(kind, GP::Rax, GP::Rax, GP::Rcx, deopt);
+        }
+
+        if let Some(ivarid) = store_ivar {
+            // A step's result is a proven fixnum, so it needs no write
+            // barrier; a bare value (`def set(x) = @a = x`) may be a heap
+            // object and does.
+            let wb = body.steps.is_empty() && !matches!(body.base, frameless::LeafValue::Fixnum(_));
+            // Re-materialize the receiver: the arithmetic above went
+            // through rax/rcx, but a parameter load may have gone through
+            // rdi's slot machinery.
+            state.load(ir, recv, GP::Rdi);
+            ir.guard_frozen(deopt);
+            ir.push(AsmInst::StoreIVarInline {
+                src: GP::Rax,
+                ivarid,
+                wb,
+            });
+        }
+        state.def_reg2acc(ir, GP::Rax, dst);
+        state.unset_side_effect_guard();
+        true
+    }
+
     /// Emit a recognised constructor body ([`frameless::ivar_store_body`])
     /// as the caller's own instructions — no frame pushed, no call made.
     ///
@@ -3284,6 +3445,133 @@ mod tests {
             end
             30.times { t("hello"); t(:HUP); t(nil); t(0) }
             [t("hello"), t(:HUP), t(nil), t(0)]
+            "#,
+        );
+    }
+
+    /// Frame-free expansion of the leaf idiom
+    /// ([`frameless::leaf_expr_body`]): a counter, a reader, arithmetic on
+    /// an ivar and on a parameter, and a plain writer. Every one of these
+    /// runs in the caller with no frame, so the results have to match the
+    /// interpreter exactly — including the values the guards send back to
+    /// it.
+    #[test]
+    fn frameless_leaf_bodies() {
+        run_test(
+            r#"
+            class L
+              def initialize; @n = 0; @a = 3; @s = "x"; end
+              def inc; @n += 1; end
+              def dec; @n -= 2; end
+              def dbl; @a * 2; end
+              def add(x); @a + x; end
+              def chain(x); @a + x * 1; end
+              def get; @a; end
+              def obj; @s; end
+              def set(x); @a = x; end
+            end
+            l = L.new
+            res = []
+            60.times { l.inc }
+            60.times { l.dec }
+            res << l.inc << l.dbl << l.add(4) << l.chain(2) << l.get << l.obj
+            res << l.set(9) << l.get << l.dbl
+            res
+            "#,
+        );
+    }
+
+    /// The guards the expansion hoists must send control back to the call
+    /// instruction, where the interpreter performs the real call. Each case
+    /// below makes one of them fire after the site is hot: a non-fixnum
+    /// ivar, a non-fixnum argument, a fixnum overflow into Bignum, and a
+    /// frozen receiver (which must raise `FrozenError` from a real frame).
+    #[test]
+    fn frameless_leaf_bodies_deopt() {
+        run_test(
+            r#"
+            class L
+              def initialize(n, a); @n = n; @a = a; end
+              def inc; @n += 1; end
+              def add(x); @a + x; end
+              attr_reader :n, :a
+            end
+            res = []
+            l = L.new(0, 1)
+            100.times { l.inc; l.add(1) }
+            # the ivar stops being a fixnum
+            f = L.new(1.5, 1)
+            res << (begin; f.inc; rescue => e; e.class; end) << f.n
+            # the argument stops being a fixnum
+            res << l.add(2.5) << (begin; l.add("s"); rescue TypeError => e; e.class; end)
+            # overflow out of the fixnum range
+            b = L.new(4611686018427387903, 1)
+            res << b.inc << b.n.class
+            # a frozen receiver must raise, from a real frame
+            fr = L.new(1, 1).freeze
+            res << (begin; fr.inc; rescue FrozenError => e; e.class; end) << fr.n
+            res
+            "#,
+        );
+    }
+
+    /// Shapes the recogniser must decline, each for its own reason: a
+    /// conditional store (a guard would have to prove something about a
+    /// path that stores nothing), a body that calls, one that stores twice,
+    /// one whose store is not last, a division (it can raise
+    /// `ZeroDivisionError`, which needs a frame), and a body reading a
+    /// second object's ivar.
+    #[test]
+    fn frameless_leaf_bodies_decline() {
+        run_test(
+            r#"
+            class D
+              def initialize; @n = 5; @m = 5; end
+              def cond(x); @n = x if x > 0; @n; end
+              def calls; helper + @n; end
+              def helper; 1; end
+              def two; @n += 1; @m += 1; end
+              def early; @n = 1; @m + 1; end
+              def div(x); @n / x; end
+              def other(o); @n + o.n; end
+              attr_reader :n, :m
+            end
+            d = D.new
+            res = []
+            100.times { d.cond(1); d.calls; d.two; d.early; d.div(1); d.other(d) }
+            res << d.cond(-1) << d.cond(3) << d.calls << d.two << d.early
+            res << d.div(2) << d.other(d) << d.n << d.m
+            res << (begin; d.div(0); rescue ZeroDivisionError => e; e.class; end)
+            res
+            "#,
+        );
+    }
+
+    /// The expansion resolves ivar names against the *receiver's* class, so
+    /// a subclass whose slot numbering diverges must still land in the
+    /// right slot — and a subclass that redefines the method must not be
+    /// expanded with the parent's body.
+    #[test]
+    fn frameless_leaf_bodies_subclass() {
+        run_test(
+            r#"
+            class P
+              def initialize; @n = 1; end
+              def inc; @n += 1; end
+              attr_reader :n
+            end
+            class Skew < P
+              def initialize; @z = 100; @n = 1; end
+              attr_reader :z
+            end
+            class Over < P
+              def inc; @n += 10; end
+            end
+            res = []
+            objs = [P.new, Skew.new, Over.new]
+            100.times { objs.each { |o| o.inc } }
+            res << objs.map { |o| o.n } << Skew.new.z
+            res
             "#,
         );
     }

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -1311,7 +1311,9 @@ impl<'a> JitContext<'a> {
     /// including any exception, from a real frame. That is sound only
     /// because nothing has happened yet when a guard fires: the recogniser
     /// admits a single `StoreIvar` and only as the last thing before the
-    /// `Ret`, so every exit precedes the one effect.
+    /// `Ret`, so every exit precedes the one effect. A zero divisor is one
+    /// of those exits, so `x / 0` raises `ZeroDivisionError` from the frame
+    /// the interpreter builds, with the backtrace that frame gives it.
     ///
     fn expand_leaf_body(
         &mut self,
@@ -3518,9 +3520,8 @@ mod tests {
     /// Shapes the recogniser must decline, each for its own reason: a
     /// conditional store (a guard would have to prove something about a
     /// path that stores nothing), a body that calls, one that stores twice,
-    /// one whose store is not last, a division (it can raise
-    /// `ZeroDivisionError`, which needs a frame), and a body reading a
-    /// second object's ivar.
+    /// one whose store is not last, a `%` (`BinOpK::Rem` has no register
+    /// form to lower to), and a body reading a second object's ivar.
     #[test]
     fn frameless_leaf_bodies_decline() {
         run_test(
@@ -3532,16 +3533,47 @@ mod tests {
               def helper; 1; end
               def two; @n += 1; @m += 1; end
               def early; @n = 1; @m + 1; end
-              def div(x); @n / x; end
+              def rem(x); @n % x; end
               def other(o); @n + o.n; end
               attr_reader :n, :m
             end
             d = D.new
             res = []
-            100.times { d.cond(1); d.calls; d.two; d.early; d.div(1); d.other(d) }
+            100.times { d.cond(1); d.calls; d.two; d.early; d.rem(3); d.other(d) }
             res << d.cond(-1) << d.cond(3) << d.calls << d.two << d.early
-            res << d.div(2) << d.other(d) << d.n << d.m
-            res << (begin; d.div(0); rescue ZeroDivisionError => e; e.class; end)
+            res << d.rem(4) << d.other(d) << d.n << d.m
+            res
+            "#,
+        );
+    }
+
+    /// A zero divisor is a guard like any other: it exits to the call
+    /// instruction, and the interpreter performs the whole call — so the
+    /// `ZeroDivisionError` is raised from the frame it builds, and carries
+    /// that frame's backtrace. The frame the expansion skipped has to
+    /// appear in it, which is the whole point.
+    #[test]
+    fn frameless_leaf_bodies_divide() {
+        run_test(
+            r#"
+            class Q
+              def initialize(n); @n = n; end
+              def div(x); @n / x; end
+              def half; @n / 2; end
+            end
+            q = Q.new(100)
+            res = []
+            200.times { q.div(3); q.half }
+            res << q.div(3) << q.div(7) << q.half
+            # floor division, not truncation
+            res << Q.new(-7).div(2) << Q.new(7).div(-2)
+            e = (begin; q.div(0); rescue ZeroDivisionError => x; x; end)
+            res << e.class << e.message
+            # The frame the expansion skipped must be in the backtrace.
+            # Not `backtrace.first`: CRuby also lists the `Integer#/`
+            # builtin frame above it, which monoruby does not report for any
+            # builtin, expanded or not.
+            res << e.backtrace.any? { |l| l.include?("Q#div") }
             res
             "#,
         );

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -46,6 +46,7 @@
 029c3ebe189781d0b649df411808dfee	[[[:a, 1], 0], [[:b, 2], 1]]	r = []; ({a: 1, b: 2}).each.with_index { |v, i| r << [v, i] }; r
 02a7d510f273964ead93e757431a554c	[3, 2, 1]	base = Class.new { def foo(ary); ary << 1; end }\n            child 
 02b9efd8d2189aaacb0d22c54cae5e92	[2000, 0, 999]	a = []\n            2000.times { |i| a << [(i * 7919) % 1000] }\n    
+02bcd011adb4bb84d0653542d5cc1dbf	[33, 14, 50, -4, -4, ZeroDivisionError, "divided by 0", [[4, "'Q#div'"], [27, "'<main>'"]], [[4, "'Q#div'"], [9, "'block in Object#in_block'"]], [[4, "'Q#div'"], [14, "'Object#in_loop'"], [33, "'<main>'"]]]	BASE = __LINE__\n            class Q\n              def initialize(n)
 02c396b429bf65fdf9a120d44cc103f5	true	src = Module.new { def t1; end }\n            m = Module.new do\n    
 02c6f5d297eadcc0a5026d7c20a2e18c	["a", {b: "b"}]	T = Struct.new(:a, :b)\n            \n\n            s = T.new("a", b: 
 02cb9b2aa7a2eb9ebb2690e1cb412b25	200000	io = IO.popen("sleep 0.05; cat > /dev/null", "w")\n            t = T
@@ -804,6 +805,7 @@
 3dbebf67556767ed46ca1b15b5c6014b	0	("" <=> "".dup.force_encoding("ISO-2022-JP"))\n            
 3dde798cc9545abe28c98d1ee6dfbc9a	[:wrapped, :real, 12]	class Base; def real(x); x * 3; end; end\n            class Sub < Ba
 3dea6009f2f1cee6ca57430c6241a099	"ASCII-8BIT"	s = "abcdef".dup.force_encoding("US-ASCII")\n              arg = "
+3dedec9b4f9d9d254f018b5a0e31acb1	[33, 14, 50, -4, -4, ZeroDivisionError, "divided by 0", [[4, "'Q#div'"], [32, "'<main>'"]], [[4, "'Q#div'"], [14, "'block in Object#in_block'"]], [[4, "'Q#div'"], [19, "'Object#in_loop'"], [38, "'<main>'"]], [[10, "'Q#store_after'"], [42, "'<main>'"]], 25, 25, true]	BASE = __LINE__\n            class Q\n              def initialize(n)
 3df82d5f32bc7def3d0d985cd7071aa8	:ok	res = :ok; if false; a = [1, 2]; a[] = 9; end; res
 3dfe78bc67c9d66d2fdd2e9ab6b354e7	[1, 9, 10, 7, 107]	class A\n              def initialize(h) @a = h end\n              de
 3e1d53f944590acbe759e3fddf0d6b76	60000	S = Struct.new(:a, :b, :c)\n            \n\n            s = S.new(10, 

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -1189,6 +1189,7 @@
 5b44a248a61dc40383d51a96cc748f88	14	[2, 3, 4, 5].inject {|result, item| result + item }
 5b46729462de0ea516438e53f745a399	[4.5, 5.5, 4.75]	def call_block\n      yield\n    end\n    def call_block_twice\n      yield\n   
 5b723a2cb7483967f04b7359c4f52ccd	[11, 11, 5, 3, 8, nil, nil, nil]	class C; attr_accessor :m; end\n\n        res = []\n        o = C.new\n        o.m =
+5b746dc2feb736ef4fb8f1d37beb7a7c	[-59, 6, 7, 5, 3, "x", 9, 9, 18]	class L\n              def initialize; @n = 0; @a = 3; @s = "x"; end
 5b774769e16c7084451c9d4b9f9b0acd	[[[:missing, :later]], [:from_base]]	class Base; end\n        class Sub < Base\n          def method_missing(n
 5b79cfb335c3c10194e188b3310b2096	["RuntimeError", "msg", false]	root = Fiber.current\n            fiber = Fiber.new { root.transfer;
 5b81f105b406bdc1f8f48edc118fcd74	[{a: 1, b: 2, c: 3}]	def f(*x)\n            x\n        end\n        \n\n            f(a:1, **{b:2
@@ -1402,6 +1403,7 @@
 6b82ebaaa0df8e456b952c1649290d36	["INT-NE", "RAW-B", false, true, true, true, true]	class Integer; def !=(o); "INT-NE"; end; end\n        class CustomEqB; d
 6bab7203c03f2793f901298b3357f169	true	"abc".force_encoding("ISO-8859-5").encoding == Encoding::ISO_8859_5
 6bc256a131cd947b4c256d4afa639789	["y", Encoding::ConverterNotFoundError, Encoding::ConverterNotFoundError, [254, 255, 0, 97, 0, 10, 0, 98], "UTF-16", [[254, 255, 0, 97, 0, 10, 0, 98]], true, Encoding::ConverterNotFoundError]	(a="\\x79".dup.force_encoding(Encoding::BINARY).encode(Encoding::Emacs_Mule); b=(
+6beb6eff7e6eb2f2c46d4560e26595f7	[1, 3, 4, 106, 107, 0, 2, 1, 106, ZeroDivisionError]	class D\n              def initialize; @n = 5; @m = 5; end\n         
 6c331f471496111694ecb08afb04cab9	[1, 2, 3]	v = []\n            t = Thread.new { v << 1; sleep; v << 3 }\n       
 6c6bac9e1206b463f412a2b2d96f020e	[3, 1]	class Integer; def <=>(o) = (o.to_i - to_i); end\n[3, 1, 2].minmax
 6c8169ed67889ab883af159b5e32ee14	[[:reader_splat, 2, :struct_reader_arg, 3], 3]	class AccCov\n          attr_reader :x\n          attr_writer :y\n        
@@ -1912,6 +1914,7 @@
 93e6ef7313e6853be460ee30b0736410	[true, 5]	pid = fork { exit 5 }\n            w = Process.detach(pid)\n         
 940e03901c8843bf06aca61f6ac64658	true	pid = Process.fork { exit 0 }\n            pid.is_a?(Integer)\n      
 94317fffff39c9093268791671c631b0	[true, false, 1, -1, nil, true, false, true, false, false, true, false, false, true]	require "rubygems"\n        require "bigdecimal"\n        res = []\n      
+9441f2118acd3193fe370775231fdcac	[[101, 101, 1001], 100]	class P\n              def initialize; @n = 1; end\n              def
 9455609d2dcf2780b3bf58180504fb90	["a", nil, "b"]	ENV["MONORUBY_ENV_TEST_VA1"] = "a"\n            ENV["MONORUBY_ENV_TE
 948c8ebc5838aacb75bb4ad2c54cd528	[true, true, true]	[Process.respond_to?(:exit),\n             Process.respond_to?(:abor
 9491706684975503cce7f8dd96dffe40	:OVERRIDDEN	class NilClass; def !; :OVERRIDDEN; end; end; !(nil)
@@ -2859,6 +2862,7 @@ da20ef8164c16f9d050189c7530ccdda	13	case 4\n        when 0\n          a = 10\n  
 da337801ffb5841d6913419d4806674b	[[1, 2, 3], [1, 2, 3], 1, 3, [1, 3]]	a = [3, 1, 2]\n            [\n              a.sort { |x, y| (x <=> y)
 da4116da4a0b35a76e2faef0a98c7685	[42, 300]	$m = 0\n        def h\n          [1].each do |x|\n            begin\n      
 da424b8ae2f6063fa60766fab8bac34a	false	t = Thread.new { sleep(2**62) }\n            Thread.pass while t.sta
+da52e290ddf3ec3f474fa3a4bb76acdd	[2.5, 2.5, 3.5, TypeError, 4611686018427387904, Integer, FrozenError, 1]	class L\n              def initialize(n, a); @n = n; @a = a; end\n   
 da5e06d1fe5eed1ee4258f71a99b2332	0	a = "abc".dup.force_encoding("UTF-8")\n              b = "abc".dup
 da64841b8187b9d8951f84703a56f5e9	[true, false]	$x = []\n            path = "/tmp/monoruby_test_mkdir_#{Process.pid}
 da6b246283b4f211581ca1d5eb140461	"a b\\n"	IO.popen(["echo", "a b"]) { |io| io.read }\n            

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -335,6 +335,7 @@
 1821c10c6ad04de6330183a77e1e0216	["Binding", 41, 42, 41]	x = 41\n            b = binding\n            b2 = b.dup\n            b
 182caa69fa07777b5c852ab6d6cd523b	[:@b]	class Foo\n              def initialize\n                @a = 1\n     
 1838df795bd9fd01b3bfa47259229043	1.0	class Float; def <=>(o) = (o.to_f - to_f); end\n[3.0, 1.0, 2.0].max
+183dd8bff258c6f71986a8a730a5a952	[1, 3, 4, 106, 107, 1, 2, 1, 106]	class D\n              def initialize; @n = 5; @m = 5; end\n         
 185001d9a1904b3f91e65a1932e2bf0b	[11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11]	def g(a) = yield(a * 2)\n        def f(...) = g(...)\n        \n\n        $
 18507817da0f9cab02fe974f7701f74a	[[3.0, 2.0, 1.0], 3.0, 1.0, [3.0, 1.0], [1.7976931348623157e+308, 1.0]]	class Float; def <=>(o) = (o.to_f - to_f); end\n        [[3.0, 1.0, 2.0]
 186a15eac97b7392435d31cc9d7e59de	70	class Coercible\n              def to_proc\n                proc { |x
@@ -786,6 +787,7 @@
 3c317b41d6a90f7b882850a676d924f0	[40, 36, 39]	def __f(x)\n          \n        a = x\n        b = a\n        a += 1\n      
 3c3e9df720bcfc9e16e5388ec370e1a6	3.15	class Foo; def to_int; 2; end; end\n            3.14159.ceil(Foo.new
 3c69555cfc9c304438892b113e9bb012	[[:@@inherited, :@@own], [:@@own]]	parent = Class.new\n            parent.class_variable_set(:@@inherit
+3c6e88bd378792f73dc8dc3eec400a99	[33, 14, 50, -4, -4, ZeroDivisionError, "divided by 0", true]	class Q\n              def initialize(n); @n = n; end\n              
 3c7f081b962e4c7272b51d99d568feb4	["outer", "outer", "outer", "outer", "nil"]	def brk_while(log)\n          outer = StandardError.new "outer"\n        
 3c8c62dfbc6ab8e4b391463cee4bdbb0	[true, true]	require "io/wait"\n            [IO.instance_method(:wait_readable).i
 3c8d308b1dc06f94ef88b63745ff08be	[false, true, [:a, :b], nil]	t = Thread.new {}.join\n            t.thread_variable_set(:a, 1)\n   
@@ -1614,6 +1616,7 @@
 7bf72e6eb4c2c593bd81eb7b98dcafb0	:OVERRIDDEN	class Integer; def <=>(o); :OVERRIDDEN; end; end; 1 <=> 2
 7bfe1905c8cfcd84d8d0ad738c459253	[1, 2, 3, 4, 1, 2]	def f(x,y,a:100,b:200,c:300,d:400)\n              [a,b,c,d,x,y]\n    
 7c1f60d60806a84dcf3a11a88bdef692	TypeError	("a" =~ "b" rescue $!.class)
+7c1f7443b2cfe560bb72a1a104c6e345	[33, 14, 50, -4, -4, ZeroDivisionError, "divided by 0", "'Integer#/'"]	class Q\n              def initialize(n); @n = n; end\n              
 7c28dee19aa27309293f956968134d84	"HELLOd"	s = "hello world"; s.bytesplice(0...-1, "HELLO"); s
 7c3a942bb1335abaf415dc95e59e5dfd	[0, 1, 2, 3, 4, 5, "break:5", "done: main"]	def bar(&b)\n      10.times &b\n      $i << "done: bar"\n    end\n\n    def foo(
 7c486608085102bd6bffa726334867ac	[true, true, true, "warned", [1, 2]]	res = []\n        f = -> *a { a.last }\n        res << f.ruby2_keywords.e

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -1564,6 +1564,7 @@
 77b00e5257cfe366d9ad6a60194785e2	[true, false, true, false]	x = 1\n            b = binding\n            [\n              b.local_v
 77be5f23f43f53c251e9965e79fe7154	true	class MyStr\n              def to_str\n                "llo"\n        
 77c54f817439de91d7af1ba0fc2f7703	2.0	[1.0, 1e100, 1.0, -1e100].sum
+77d2a482539b819352ff3c3c016f211c	[1, 3, 4, 106, 107, 1, 2, 1, 106, 106, "x", nil, 102, [:@a, :@never2]]	class D\n              def initialize; @n = 5; @m = 5; end\n         
 77d8bf3df315e6839b43925962f505ad	[5, ["\\n", "\\n", "\\n", "plain\\n"], true]	path = "/tmp/mono_cov_puts_#{Process.pid}"\n            begin\n      
 77e87f734b11d0483e6b3360a59c3d1a	["-", "+", "~", "-", "+", "~"]	class C\n          def -@\n            "-"\n          end\n            \n   
 77ef6df0c04f7f116f5f35aaaea42fca	[7, 7, true]	b = binding\n            b.local_variable_set(:foo, 7)\n            [


### PR DESCRIPTION
First step of the inlining plan: widen `frameless` from one recognised body shape to a general leaf-body predicate, using the deopt argument its own doc already makes.

## Summary

`frameless` recognises the constructor idiom `def initialize(a, b) = (@a = a; @b = b)` and emits its stores as the caller's own instructions. Its doc explains why that is sound, and the argument generalises well past a store from a parameter:

> Not "the body cannot side-exit" — a deopt is fine because it rebuilds from the *caller's* frame state, which is the one that exists. What the callee must not do is *need a frame of its own*.

So this widens the recogniser to any single-block leaf body that folds operands into one accumulator: `@count += 1`, `@a * 2`, `@sum + x`, `@n / 2`, `@a`, `@a = x`. It interprets the block symbolically and admits ivar loads, fixnum literals, parameters, `Add`/`Sub`/`Mul`/`Div`, and at most one `StoreIvar` — which must be the last thing before the `Ret`. The chain is left-linear, so the expansion runs in two registers and needs no slots.

`@count += 1` becomes a class-version guard, a receiver-class guard, an inline ivar load, two fixnum guards, an add with its overflow check, a frozen guard and an inline store — no frame, no call, no callee prologue.

### What the guards actually buy

Not "the body cannot raise" but that **nothing has happened yet** when one fires, so an exit can hand the entire call back to the interpreter. Division makes the distinction concrete: a zero divisor is *already* a deopt in both backends (x86-64 stamps `_divide_by_zero` and jumps to the exit; aarch64 does `cbz x(r), deopt`), so it lands on the call instruction like every other guard and the interpreter raises `ZeroDivisionError` from the real frame it then builds.

Nothing shifts in the backtrace, because the deopt fabricates neither a frame nor a position — it restores the caller at the call instruction and hands the call back, so the interpreter reaches the division through the ordinary path. Measured, as relative line offsets, for a plain call, a call inside a block, and a call under a JIT-compiled loop:

```
plain:      [[4, "'Q#div'"], [26, "'<main>'"]]
in block:   [[4, "'Q#div'"], [9, "'block in Object#in_block'"]]
under loop: [[4, "'Q#div'"], [14, "'Object#in_loop'"], [30, "'<main>'"]]
```

identical across CRuby, monoruby with the expansion, and monoruby `--no-jit` without it.

`Rem` is the one arithmetic exclusion, for a lowering reason rather than a semantic one: `BinOpK::Rem` is `unreachable!()` in the register form of the integer binop.

## A bug this found

The receiver's class must be **statically proven**, not merely guarded as a member of a set. A set-guarded dispatch arm proves only that the receiver's class shares this `func_id`, and two classes sharing a method need not agree on where its ivars live: a subclass that assigns one of its own first shifts every inherited slot, so reading `@n` at the parent's index returns whatever the subclass put there. Without the `state.class(recv) != Some(recv_class)` check, the polymorphic site in `frameless_leaf_bodies_subclass` produced `[101, 14, 1001]` where CRuby gives `[101, 101, 1001]`. The constructor path is unaffected — it is compiled per `self_class`, so its class is always resolved.

## Results (x86-64, release)

| | master | this PR |
|---|---|---|
| leaf call (`inc` / `get` / `add`) | 6.1–6.5 ns | **2.4–2.7 ns** |
| binarytrees, 6 alternating pairs | 210.5 ms mean | 202.2 ms mean (−4%, 6/6 pairs) |

`fib`, `nbody`, `mandelbrot`, `nqueen`, `sudoku`, `bedcov`, `matmul`, `qsort`, `tarai`, `bf`, `aobench`, `blurhash`, `lee` and the `30k_*` set are unchanged. That is expected: this reaches leaves only, and a 30-deep call chain has one leaf in it. The chain itself is what a general inliner has to remove — see the plan below.

## Tests

Five cases in `method_call::tests`:

- `frameless_leaf_bodies` — counter, decrementer, reader, arithmetic on an ivar and on a parameter, chained arithmetic, an object-valued reader, a writer.
- `frameless_leaf_bodies_deopt` — each guard fired after the site is hot: a non-fixnum ivar, a non-fixnum argument, an overflow into Bignum, and a frozen receiver (which must raise `FrozenError` from a real frame).
- `frameless_leaf_bodies_divide` — floor division including both negative-operand roundings, the three backtraces above frame-by-frame with line numbers, and a body whose store follows the division (the raise must leave the store undone).
- `frameless_leaf_bodies_decline` — the shapes that must not expand: a conditional store, a body that calls, two stores, a store that is not last, a `%`, a read of another object's ivar, a class whose instances have no inline ivar slots, and an ivar with no `IvarId` to resolve.
- `frameless_leaf_bodies_subclass` — the skewed-slot case above.

Full `cargo test` with `stress-spill-pool` passes (76 binaries).

### Noted in passing, not addressed here

Two pre-existing backtrace divergences from CRuby, both reproducing on master with no expansion involved, and both excluded from the comparison above rather than fixed:

- monoruby omits builtin frames entirely: `a / b` with `b == 0` gives `["'Object#plain'", "'<main>'"]` where CRuby also lists `'Integer#/'`.
- `Array#each` is a C frame in CRuby (attributed to the call site) and Ruby-level in monoruby (`<internal:array>`).

## Where this sits

This is step (a) of the staging discussed for general inlining. (b) is single-level frame merging for a callee that may side-exit *after* an effect, which needs the first real frame materialization at deopt; (c) is multi-level with an inlining budget. This step deliberately needs no materialization — every exit lands on the call instruction — and puts the effect/guard ordering analysis into production first, since (b) builds on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM