### PR TITLE
strscan: literal String patterns, in-place UTF-8 matching, and the onig_match study (§8.1)

### DIFF
--- a/doc/yjit_bench_slow_investigation_2026-09.md
+++ b/doc/yjit_bench_slow_investigation_2026-09.md
@@ -359,6 +359,10 @@ Fixnum ガードに Bignum 3.3 %、`Visitor#visit` の class-set ガード 2.4 %
 対策: `StringScanner` を Rust builtin にして、region を scanner に持たせ `onig_match`
 （アンカー付きの 1 回マッチ）を直接呼ぶ。CRuby の C 実装と同じ形。
 
+→ §8.1 で「Ruby 実装は残したまま、primitive だけを `onig_match` + region 再利用に
+する」形で検討した。2 倍速くなるが、`onigmo-regex` crate 側に region を受け取る API
+が要る。
+
 ### 5.7 例外・catch/throw（rack, activerecord）
 
 - `raise` は `MonorubyErr::new(String)` でメッセージ String を Rust ヒープに複製し、
@@ -526,6 +530,61 @@ activerecord の `respond_to?` 連打（`respond_to?(:to_ary)` などの未検�
   専用命令 + basic-op 検査に置き換えて解消。もう 1 つ、結果 temp を `push` する前に
   命令を emit すると JIT の抽象フレームがその temp を死んだスロットと見なして
   `load()` で panic する（`emit_call` は push してから emit している）。
+### 8.1 StringScanner（§5.6）の検討: Ruby 実装を残したまま primitive を差し替える
+
+graphql の lexer は 1 トークンあたり `skip` を 2〜3 回呼ぶ。`skip` 1 回の内訳を
+`perf`（`skip(/[_A-Za-z][_0-9A-Za-z]*/)` ヒットのみのループ、1 回 246 ns）で見ると:
+
+| 割合 | 何 |
+|---:|---|
+| 32 % | Onigmo 本体（`match_at` 17.6、`onig_search_gpos` 5.0、`forward_search_range` 4.5、`onig_region_clear` + memset 3.3、`mbclen` 1.9） |
+| 22 % | JIT された Ruby 側（`_match_len_at_pos` 12.8、`_anchored` 2.7、`pos=` 2.4、`skip` 1.3、呼び出し元 2.4） |
+| 20 % | Rust ヘルパ（`string_strscan_match` 6.6、`regex_view` 3.1、`captures_from_pos_no_save` 2.7、`Hash#[]`（`\A` 付き Regexp のキャッシュ引き）4.2、`Captures::get` 1.9、`coerce_to_regexp_or_string` 1.5） |
+| 9 % | malloc / free（`onig_region_new` / `onig_region_resize` / `onig_region_free`: `captures_from_pos` が呼ぶたびに region を確保・解放する） |
+
+つまり regex エンジン本体は 1/3 で、残りは「`\A(?:…)` でラップした Regexp を Hash から
+引いて `onig_search` に渡し、region を毎回 malloc する」周辺コスト。CRuby の C strscan は
+scanner が region を持ち、`onig_match`（scan 位置での 1 回マッチ）を直接呼ぶ。
+
+試したこと（2 段階）:
+
+1. **monoruby だけで閉じる変更**（このブランチ、コミット済み）: `__strscan_match` を
+   `(pattern, byte_pos, anchored)` にして、String パターンはリテラルのバイト比較
+   （prefix / 前方探索）を Rust で、Regexp は `\A(?:…)` 形を Ruby 側キャッシュから渡す。
+   非 ASCII の UTF-8 文字列もその場でマッチ（従来は rest をコピーして `String#match` に
+   落としていた）。`ascii_only?` 呼び出しと `@match_begin/@match_end` の ivar を削り、
+   MatchData fallback はバイト指向エンコーディング + 8bit 内容と EUC-JP 等だけに。
+   ついでに `getch` の多バイト文字対応と `StringScanner::Error` を追加。
+   **性能はほぼ中立**（`skip` ヒット 246 → 248 ns、graphql ±0）— Ruby 側の削減分は
+   ノイズに埋もれ、コストは Rust/Onigmo 側にあることが確認できた。
+2. **`onigmo-regex` に region 再利用 API を足す**（プロトタイプ、未マージ）:
+   `Regex::match_at_with_region(heystack, at, &mut Region)`（`onig_match`）と
+   `Regex::search_with_region`（`onig_search`）、`Region::new` を pub に。monoruby 側は
+   thread-local の `Region` を 1 つ持ち、Regexp パターンを *そのまま*（ラップせず）
+   `onig_match` で scan 位置にアンカーする。Ruby 側は `_anchored` を fallback 専用に
+   するだけ。
+
+   | マイクロ（ns/op） | 従来 | 1 | 2 | YJIT |
+   |---|---:|---:|---:|---:|
+   | `skip(/ident/)` ヒット | 246 | 248 | 126 | 158 |
+   | `skip(/ident/)` ミス | 160 | 157 | 86 | 151 |
+   | `scan(/ident/)` ヒット | 346 | 346 | 233 | 237 |
+   | `skip(/-?(…)(\.[0-9]+)?…/)` + `s[1]`（2 群） | 440 | 438 | 301 | 193 |
+   | lexer ループ（1 回、ms） | 6.2 | 6.1 | 3.5 | 2.9 |
+
+   graphql（交互 3 ラウンドの中央値）: 従来 54.8 / 54.6 / 54.6 ms → **2 で 41.8 / 41.8 / 42.7 ms
+   （−23 %）**、YJIT 31 ms。
+
+段階 2 は crate 側の変更（`sisshiki1969/onigmo-regex`）を先に取り込む必要があり、
+このセッションからは push できないので、パッチ 2 本（crate 側 `onigmo-regex-region-api.patch`
+と monoruby 側の差し替え `monoruby-strscan-followup-onig-match.patch`、どちらも段階 1 の
+上に当たる）を別途渡した。適用手順: crate に当てて push → monoruby で
+`cargo update -p onigmo-regex` → monoruby 側パッチを当てる → `cargo test --test strscan`。
+
+残る差（群あり 301 vs 193 ns）は群オフセットを Ruby の Array で返して `[]` を Ruby で
+引く分。scanner 側に region を持たせる（= Rust オブジェクト化）までやれば埋まるが、
+Ruby 実装を残す方針では次点。
+
 - 手元の CRuby は 4.0.6 で、`Float#ceil(15)` の結果が 4.0.2 と違う
   （`1.123456789.ceil(15)` → `1.123456789000001`）ため `float::tests::angle` が
   baseline でも失敗する。本変更とは無関係。

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -74,7 +74,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(STRING_CLASS, "scan", scan, 1);
     globals.define_builtin_func_with(STRING_CLASS, "match", string_match, 1, 2, false);
     globals.define_builtin_func_with(STRING_CLASS, "match?", string_match_, 1, 2, false);
-    globals.define_builtin_func(STRING_CLASS, "__strscan_match", string_strscan_match, 2);
+    globals.define_builtin_func(STRING_CLASS, "__strscan_match", string_strscan_match, 3);
     globals.define_builtin_func_with(STRING_CLASS, "index", string_index, 1, 2, false);
     globals.define_builtin_func_with(STRING_CLASS, "rindex", string_rindex, 1, 2, false);
     globals.define_builtin_funcs(STRING_CLASS, "length", &["size"], length, 0);
@@ -3446,10 +3446,10 @@ fn string_match(
 ///
 /// ### String#__strscan_match (monoruby internal)
 ///
-/// - __strscan_match(regexp, byte_pos) -> Integer | Array | nil
+/// - __strscan_match(pattern, byte_pos, anchored) -> Integer | Array | nil | false
 ///
 /// Allocation-lean scanning primitive backing the pure-Ruby
-/// `StringScanner` (`stdlib/strscan.rb`): match `regexp` against the
+/// `StringScanner` (`stdlib/strscan.rb`): match `pattern` against the
 /// byte suffix of self starting at `byte_pos` and hand back only the
 /// match registers. No MatchData is built and `$~` is NOT set — like
 /// CRuby's C strscan, which keeps its registers inside the scanner and
@@ -3457,17 +3457,25 @@ fn string_match(
 ///
 /// The engine sees only the suffix, so `\A` and `^` anchor at the scan
 /// position (CRuby strscan's default `fixed_anchor: false` semantics).
+/// A String pattern is literal bytes, as in CRuby's C strscan:
+/// `anchored` selects a prefix test versus a forward byte search. A
+/// Regexp pattern is searched as given — the Ruby side passes its
+/// `\A(?:…)`-wrapped form for the anchored scan family (see
+/// `RegexpInner::strscan_match` for the `onig_match` route this is
+/// meant to take once the regex crate exposes a reusable region).
 /// Returns
 /// - nil — no match;
 /// - an Integer — the byte end of a whole-match starting at offset 0
 ///   with no capture groups (the common lexer case — the value is a
 ///   packed Fixnum, so a hit allocates nothing);
 /// - an Array `[b0, e0, b1, e1, …]` of byte offsets relative to
-///   `byte_pos` (nil pairs for unmatched groups) otherwise.
+///   `byte_pos` (nil pairs for unmatched groups) otherwise;
+/// - false — the subject cannot be matched in place (a byte-oriented
+///   string with 8-bit content, EUC-JP / Shift_JIS text, broken UTF-8:
+///   anything whose engine view is not the byte buffer itself): the
+///   Ruby side falls back to `String#match` on a copy of the rest.
 ///
-/// Out-of-range or non-char-boundary positions return nil; the
-/// caller's `ascii_only?` gate makes every in-range byte position a
-/// boundary.
+/// Out-of-range or non-char-boundary positions return nil.
 #[monoruby_builtin]
 fn string_strscan_match(
     vm: &mut Executor,
@@ -3479,20 +3487,58 @@ fn string_strscan_match(
         pos if pos >= 0 => pos as usize,
         _ => return Ok(Value::nil()),
     };
-    let re = lfp.arg(0).coerce_to_regexp_or_string(vm, globals)?;
+    let anchored = lfp.arg(2).as_bool();
+    let pattern = lfp.arg(0);
     let self_ = lfp.self_val();
     let s = self_.as_rstring_inner();
-    let given = s.regex_view()?;
+    if let Some(pat) = pattern.is_rstring_inner() {
+        // Literal bytes: a prefix test, or a forward byte search.
+        let Some(sub) = s.as_bytes().get(byte_pos..) else {
+            return Ok(Value::nil());
+        };
+        let pat = pat.as_bytes();
+        let found = if anchored {
+            sub.starts_with(pat).then_some(0)
+        } else if pat.is_empty() {
+            Some(0)
+        } else {
+            sub.windows(pat.len()).position(|w| w == pat)
+        };
+        return Ok(match found {
+            None => Value::nil(),
+            Some(0) => Value::integer(pat.len() as i64),
+            Some(b) => Value::array_from_vec(vec![
+                Value::integer(b as i64),
+                Value::integer((b + pat.len()) as i64),
+            ]),
+        });
+    }
+    let Some(re) = pattern.is_regex() else {
+        return Err(MonorubyErr::argumenterr("pattern must be a Regexp or String"));
+    };
+    // In place only when the engine view *is* the byte buffer: ASCII-only
+    // content under any encoding, or valid UTF-8. Anything else takes the
+    // Ruby-side `String#match` fallback, which knows how to view those.
+    if !(s.is_ascii_only() || (s.encoding() == Encoding::Utf8 && s.is_valid_encoding())) {
+        return Ok(Value::bool(false));
+    }
+    let given = s.check_utf8()?;
     let Some(sub) = given.get(byte_pos..) else {
         return Ok(Value::nil());
     };
+    // The engine sees only `sub`, so the caller's `\A(?:…)`-wrapped form
+    // anchors at the scan position. Onigmo's `onig_match` with a reused
+    // region (no wrapper regex, no region allocation per match) needs an
+    // `onigmo-regex` API taking a caller-owned `Region`; until the crate
+    // grows one this goes through `captures_from_pos`, which allocates
+    // its region per call.
     let Some(caps) = re.captures_from_pos_no_save(sub, 0)? else {
         return Ok(Value::nil());
     };
     if caps.len() == 1 {
         // Group-less pattern: a single Fixnum carries the whole
         // register set when the match starts at the scan position
-        // (always true for the `\A`-anchored scan family).
+        // (always true for the anchored scan family).
         let m = caps.get(0).unwrap();
         if m.start() == 0 {
             return Ok(Value::integer(m.end() as i64));

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -3514,7 +3514,13 @@ fn string_strscan_match(
         });
     }
     let Some(re) = pattern.is_regex() else {
-        return Err(MonorubyErr::argumenterr("pattern must be a Regexp or String"));
+        // CRuby's strscan tries `to_str` on anything else and reports it
+        // as a String conversion failure.
+        return Err(MonorubyErr::no_implicit_conversion(
+            &globals.store,
+            pattern,
+            STRING_CLASS,
+        ));
     };
     // In place only when the engine view *is* the byte buffer: ASCII-only
     // content under any encoding, or valid UTF-8. Anything else takes the

--- a/monoruby/stdlib/strscan.rb
+++ b/monoruby/stdlib/strscan.rb
@@ -7,14 +7,18 @@
 #
 # Like CRuby's C strscan, the scanner keeps its match registers to
 # itself: a scan stores only byte offsets (via the allocation-lean
-# `String#__strscan_match` primitive on the ASCII fast path — a plain
-# Fixnum for group-less patterns), never builds a MatchData, and leaves
-# `$~` untouched. The accessors (`matched`, `[]`, `captures`, …)
-# materialize strings lazily from the registers. Non-ASCII subjects fall
-# back to a copied rest-slice matched with `String#match`, whose
-# MatchData then backs the same accessors.
+# `String#__strscan_match` primitive, matched in place on the byte
+# suffix at the scan position; a plain Fixnum for group-less patterns),
+# never builds a MatchData, and leaves `$~` untouched. The
+# accessors (`matched`, `[]`, `captures`, …) materialize strings lazily
+# from the registers. Byte-oriented subjects with 8-bit content (whose
+# engine view is a remapped copy) fall back to a copied rest-slice
+# matched with `String#match`, whose MatchData then backs the same
+# accessors.
 
 class StringScanner
+  class Error < StandardError; end
+
   def initialize(str)
     @str = str.is_a?(String) ? str : str.to_s
     @pos = 0
@@ -121,13 +125,13 @@ class StringScanner
 
   def getch
     return nil if eos?
-    ch = @str.byteslice(@pos, 1)
+    # One character (up to 4 bytes of UTF-8), not one byte.
+    ch = @str.byteslice(@pos, 4).chr
     @prev_pos = @pos
-    @pos += 1
+    @pos += ch.bytesize
     # A successful getch records the char as the whole match (CRuby).
     _clear_match
-    @match_spans = @match_end = ch.bytesize
-    @match_begin = 0
+    @match_spans = ch.bytesize
     ch
   end
 
@@ -137,14 +141,13 @@ class StringScanner
     @prev_pos = @pos
     @pos += 1
     _clear_match
-    @match_spans = @match_end = 1
-    @match_begin = 0
+    @match_spans = 1
     byte
   end
   alias getbyte get_byte
 
   def unscan
-    raise "unscan failed: previous match record not exist" unless matched?
+    raise Error, "unscan failed: previous match record not exist" unless matched?
     @pos = @prev_pos
     _clear_match
     self
@@ -152,14 +155,16 @@ class StringScanner
 
   # --- Match data ---
   #
-  # On the register (spans) path, @match_begin/@match_end are byte
-  # offsets of the whole match relative to the scan origin (@prev_pos),
-  # and group contents are byteslices of @str. On the fallback path the
+  # On the register path @match_spans is either an Integer (the byte end
+  # of a group-less whole match that starts at the scan origin
+  # @prev_pos) or an Array of byte offset pairs relative to @prev_pos;
+  # group contents are byteslices of @str. On the fallback path the
   # stored MatchData answers instead.
 
   def matched
     if @match_spans
-      @str.byteslice(@prev_pos + @match_begin, @match_end - @match_begin)
+      b = _match_begin
+      @str.byteslice(@prev_pos + b, _match_end - b)
     elsif @match_md
       @match_md[0]
     end
@@ -171,7 +176,7 @@ class StringScanner
 
   def matched_size
     if @match_spans
-      @match_end - @match_begin
+      _match_end - _match_begin
     elsif @match_md
       @match_md[0].bytesize
     end
@@ -191,7 +196,7 @@ class StringScanner
         end
       elsif n.is_a?(String) || n.is_a?(Symbol)
         name = n.to_s
-        idx = @match_re && @match_re.named_captures[name]&.last
+        idx = Regexp === @match_re && @match_re.named_captures[name]&.last
         raise IndexError, "undefined group name reference: #{name}" unless idx
         self[idx]
       elsif n.respond_to?(:to_int)
@@ -206,7 +211,7 @@ class StringScanner
 
   def pre_match
     if @match_spans
-      @str.byteslice(0, @prev_pos + @match_begin)
+      @str.byteslice(0, @prev_pos + _match_begin)
     elsif @match_md
       @str.byteslice(0, @pos - @match_md[0].bytesize)
     end
@@ -214,7 +219,7 @@ class StringScanner
 
   def post_match
     if @match_spans
-      @str.byteslice(@prev_pos + @match_end..-1)
+      @str.byteslice(@prev_pos + _match_end..-1)
     elsif @match_md
       @str.byteslice(@pos..-1)
     end
@@ -263,14 +268,14 @@ class StringScanner
     matched.to_s
   end
 
-  # `\A`-anchored counterparts of caller patterns, built once per
-  # distinct pattern instead of on every scan. Regexp patterns are
-  # identity-keyed (a regex literal is the same object on every
-  # evaluation, so a lexer's fixed pattern set hits after the first
-  # scan); String patterns are value-keyed via their escaped form
-  # (CRuby's C strscan treats them as literal bytes). All caches are
-  # size-capped so callers that generate patterns dynamically cannot
-  # grow them without bound.
+  # `\A`-anchored counterparts of caller Regexp patterns, built once per
+  # distinct pattern instead of on every scan; identity-keyed (a regex
+  # literal is the same object on every evaluation, so a lexer's fixed
+  # pattern set hits after the first scan). String patterns never come
+  # here: the primitive treats them as literal bytes (CRuby's C strscan
+  # does too), and only the MatchData fallback needs their escaped
+  # Regexp forms. All caches are size-capped so callers that generate
+  # patterns dynamically cannot grow them without bound.
   ANCHORED_RE = {}.compare_by_identity
   ANCHORED_STR = {}
   PLAIN_STR = {}
@@ -280,7 +285,7 @@ class StringScanner
   private
 
   def _clear_match
-    @match_spans = @match_md = @match_re = @match_begin = @match_end = nil
+    @match_spans = @match_md = @match_re = nil
   end
 
   def _group_count
@@ -290,6 +295,15 @@ class StringScanner
   # Group count across both representations (for `captures`).
   def _group_total
     @match_spans ? _group_count : @match_md.size
+  end
+
+  # Whole-match byte offsets relative to @prev_pos (register path).
+  def _match_begin
+    Integer === @match_spans ? 0 : @match_spans[0]
+  end
+
+  def _match_end
+    Integer === @match_spans ? @match_spans : @match_spans[1]
   end
 
   # Both match paths hand the engine only the rest of the string, so
@@ -305,39 +319,24 @@ class StringScanner
     end
   end
 
-  # Match the anchored form of `pattern` at the scan position and store
-  # the registers. Returns the byte length of the match, or nil.
+  # Match `pattern` at the scan position and store the registers.
+  # Returns the byte length of the match, or nil.
   #
-  # ASCII-only content (an O(1) check on the cached code range; byte and
-  # char offsets coincide) matches the byte suffix in place via
-  # `__strscan_match` — a group-less hit costs no allocation at all.
-  # Everything else copies the rest and matches it, as before.
+  # `__strscan_match` matches the byte suffix in place (a group-less hit
+  # is a bare Fixnum) and answers `false` only for a subject it cannot
+  # view in place, which takes the MatchData fallback. The engine sees
+  # only the suffix, so the cached `\A(?:…)` form of a Regexp pattern
+  # anchors at the scan position; a String pattern is a literal prefix.
   def _match_len_at_pos(pattern, advance)
-    anchored = _anchored(pattern)
     @prev_pos = @pos
-    if @str.ascii_only?
-      spans = @str.__strscan_match(anchored, @pos)
-      @match_md = nil
-      unless spans
-        @match_spans = @match_re = @match_begin = @match_end = nil
-        return nil
-      end
-      @match_spans = spans
-      @match_re = anchored
-      @match_begin = 0
-      len = @match_end = (Integer === spans ? spans : spans[1])
-    else
-      rest_str = @str.byteslice(@pos..-1)
-      m = rest_str&.match(anchored)
-      @match_spans = @match_re = nil
-      @match_md = m
-      unless m
-        @match_begin = @match_end = nil
-        return nil
-      end
-      @match_begin = 0
-      len = @match_end = m[0].bytesize
-    end
+    probe = pattern.is_a?(String) ? pattern : _anchored(pattern)
+    spans = @str.__strscan_match(probe, @pos, true)
+    return _fallback_at_pos(pattern, advance) if false == spans
+    @match_md = nil
+    @match_spans = spans
+    return nil unless spans
+    @match_re = pattern
+    len = Integer === spans ? spans : spans[1]
     @pos += len if advance
     len
   end
@@ -347,41 +346,47 @@ class StringScanner
   # position (== the number of bytes an advancing variant consumes), or
   # nil.
   def _match_forward_end(pattern, advance)
+    @prev_pos = @pos
+    spans = @str.__strscan_match(pattern, @pos, false)
+    return _fallback_forward(pattern, advance) if false == spans
+    @match_md = nil
+    @match_spans = spans
+    return nil unless spans
+    @match_re = pattern
+    end_pos = Integer === spans ? spans : spans[1]
+    @pos += end_pos if advance
+    end_pos
+  end
+
+  # MatchData fallbacks for subjects the primitive cannot match in
+  # place: copy the rest and match it, so `\A` anchors at the scan
+  # position.
+  def _fallback_at_pos(pattern, advance)
+    m = _fallback_match(_anchored(pattern))
+    return nil unless m
+    len = m[0].bytesize
+    @pos += len if advance
+    len
+  end
+
+  def _fallback_forward(pattern, advance)
     if pattern.is_a?(String)
       PLAIN_STR.clear if PLAIN_STR.size > CACHE_LIMIT
       pattern = PLAIN_STR[pattern] ||= Regexp.new(Regexp.escape(pattern))
     end
-    @prev_pos = @pos
-    if @str.ascii_only?
-      spans = @str.__strscan_match(pattern, @pos)
-      @match_md = nil
-      unless spans
-        @match_spans = @match_re = @match_begin = @match_end = nil
-        return nil
-      end
-      @match_spans = spans
-      @match_re = pattern
-      if Integer === spans
-        @match_begin = 0
-        end_pos = @match_end = spans
-      else
-        @match_begin = spans[0]
-        end_pos = @match_end = spans[1]
-      end
-    else
-      rest_str = @str.byteslice(@pos..-1)
-      m = rest_str&.match(pattern)
-      @match_spans = @match_re = nil
-      @match_md = m
-      unless m
-        @match_begin = @match_end = nil
-        return nil
-      end
-      end_pos = m.end(0)
-      @match_begin = end_pos - m[0].bytesize
-      @match_end = end_pos
-    end
+    m = _fallback_match(pattern)
+    return nil unless m
+    # Char == byte offsets on this path (a byte-oriented subject views
+    # one char per byte).
+    end_pos = m.end(0)
     @pos += end_pos if advance
     end_pos
+  end
+
+  def _fallback_match(re)
+    rest_str = @str.byteslice(@pos..-1)
+    m = rest_str&.match(re)
+    @match_spans = @match_re = nil
+    @match_md = m
   end
 end

--- a/monoruby/stdlib/strscan.rb
+++ b/monoruby/stdlib/strscan.rb
@@ -314,6 +314,9 @@ class StringScanner
       ANCHORED_STR.clear if ANCHORED_STR.size > CACHE_LIMIT
       ANCHORED_STR[pattern] ||= Regexp.new("\\A#{Regexp.escape(pattern)}")
     else
+      unless pattern.is_a?(Regexp)
+        raise TypeError, "no implicit conversion of #{pattern.class} into String"
+      end
       ANCHORED_RE.clear if ANCHORED_RE.size > CACHE_LIMIT
       ANCHORED_RE[pattern] ||= Regexp.new("\\A(?:#{pattern.source})", pattern.options)
     end

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -1311,6 +1311,7 @@
 63e644345315a92587e6531509cddace	true	require "json"\n            data = JSON.parse("{\\"name\\": \\"Nokogiri
 6400ae64c9910a3864a764454ee1737f	["SystemExit", true, 0]	begin\n              Process.exit(0)\n            rescue SystemExit =
 64304d338b2e1d9153798436746ba67c	[:plus, :lt, :bang, :aref, 3, true, false, 9]	class BopUser\n              def +(o); :plus; end\n              def 
+6453b5e2bc4a58561702b08638c14ead	["ab", 2, "ab", nil, "\\xFFc", "\\xFFc", 4, "c", 3, "d ef", "d", 1, "ef", "f", true, "ASCII-8BIT", "", nil, nil, "no implicit conversion of Integer into String", "no implicit conversion of Symbol into String"]	require "strscan"\n        r = []\n        b = StringScanner.new("ab\\xFFc
 646b6df81e3b78ea650391aa2912e6d4	["0.33333e1", "0.3333333333e1", "0.25e2"]	require "rubygems"\n        require "bigdecimal"\n        res = []\n      
 64745fd3594011f602b1ae98a52ab4ae	["Array", true, ["prompt>"], ["prompt>"]]	require "expect"\n            res = []\n            r, w = IO.pipe\n  
 64813a4dde67dc42192c53915b8c2dc5	true	M = Data.define(:amount, :unit)\nM.new(42, "km").frozen?

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -60,6 +60,7 @@
 03503f8bcb4632cbd04e4701371caab5	["File::Stat", 8, true]	path = "/tmp/monoruby_test_instat_#{Process.pid}_#{rand(100000)}"\n 
 035d992920dc2f7cc38dee107378052b	true	'he[[o'.gsub('[', ']'); $~.regexp == /\\[/
 0365d874d3091255ffafa6a537178e6a	nil	a=Object.new; a.instance_variable_get(:@i)
+0366a74fdcc076e9a2a06c94bbd26362	[nil, "a", ".", 2, 4, "b.", 2, "a.", "c a+b", "b.", nil, "c a+", "c a+", 8, "+", "a.b.c a", 1, 1, true, nil, false, "", 0, "", "a.b", IndexError]	require "strscan"\n        s = StringScanner.new("a.b.c a+b")\n        r 
 0379b90699980103ce98cdf1fd4b6457	[42, false, true]	class Foo\n          def !\n            42\n          end\n        end\n    
 03add114cdd6e1fb8f694172fc12ba42	[["method", "method"], [:se, :se]]	$dlog = []\n            def dse; $dlog << :se; 1; end\n            [[
 04053dc491e488a586338fcc5eed81e2	"hi"	c = Class.new\n            [1].each do |_|\n              c.class_eva
@@ -1363,6 +1364,7 @@
 681fd3ccba5816796a6f87e5163660da	["US-ASCII", "US-ASCII", "US-ASCII"]	s = "abc".dup.force_encoding("US-ASCII")\n              s.rpartiti
 6867d900d8bc23f027af9e908bfd1fbc	[File, "hello"]	path = "/tmp/mono_cov_file_new_#{Process.pid}"\n            begin\n  
 688b520eaa53b818c032ed84ebb90ba3	1234	Random.srand(1234)\n        Random.srand(4567)\n        
+688bcd73f28a1d32469337711f75b5af	["日本語", 9, 9, 3, 1, "text", "e", ["t", "e", "x", "t"], 14, " ü", 17, "日本語 text ", "nïcode 123", "nïcode 123", 10, "1", "2", "3", "3", true, nil, "本", "語", 9, "日", 3, "日", 3, "本", 3, "\\xE6", 4, "\\x9C\\xAC", 24]	require "strscan"\n        s = StringScanner.new("日本語 text ünïcode 123")
 68aaf8840f49575ccb7aee97d2c25227	true	__ENCODING__.equal?(Encoding::UTF_8)
 68acd2045cc595907a8dd13ac1cc06ac	[[:a, 10], [:b, 20], [:c, 30]]	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \ns.eac
 68c63ec13376de46973a48e77ab880cf	[]	Module.nesting
@@ -1487,6 +1489,7 @@
 71d85b9646b325d57ec9e46b0c5bd105	"hello"	class Foo; def to_str; "hello"; end; end\n            String.new(Foo
 71f4d67c2c270e965eaade7505c22804	[20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 0]	def count(n)\n              i = 0\n              c = 0\n              
 7223f396f3e66e954bb3f1b4f21a88a0	[[:a, :one, [0]], [:a, :two, [0]], [:a, :real, [0]], [:b, :one, [0]], [:b, :two, [0]], [:b_real, 0], [:a, :one, [1]], [:a, :two, [1]], [:a, :real, [1]], [:b, :one, [1]], [:b, :two, [1]], [:b_real, 1]]	class A\n          def method_missing(name, *args) = [:a, name, args]\n  
+722e9d91e8bf5b57493890d13ca6bbf4	["\\xFF", 1, "ab", "ab", "\\xFEcd", "\\xFEc", 5, 4, "d", "d", "d", true, "EUC-JP", 6, 1, "abc", "b", true]	require "strscan"\n        r = []\n        b = StringScanner.new("\\xFFab\\
 7235ebfc85831c502397c3cbb35ce813	Foo	class Foo\n              def bar; end\n            end\n            \n\n
 723ea63495140106ebdfae5448e3e464	80	class C\n          def f(a, b)\n            a + b\n          end\n        e
 7252f1c8ab400b2d14e205f52ce07f84	["warned", "silent", "warned", "silent", "warned", "warned"]	require "stringio"\n        res = []\n        capture = proc do |verbose,
@@ -1697,6 +1700,7 @@
 81a4893d8dc3fd03a6cb2cc3f973f7b0	[4, 8, 111, 58, 14, 69, 120, 99, 101, 112, 116, 105, 111, 110, 8, 58, 9, 109, 101, 115, 103, 73, 34, 6, 120, 6, 58, 6, 69, 84, 58, 7, 98, 116, 48, 58, 10, 64, 105, 118, 97, 114, 105, 12]	e = Exception.new("x")\n            e.instance_variable_set(:@ivar, 
 81e0c55d71a2b7b73cce48922e4bf66e	:OVERRIDDEN	class Integer; def /(o); :OVERRIDDEN; end; end; 3 / 4
 81eacd02531187a80cb90a83f0c4824c	[[130, 160], "Shift_JIS"]	Encoding.default_internal = Encoding::Shift_JIS\n              t =
+81f86732a80e26e9376730e005f7ae2b	["日本語", 9, 9, 3, 1, "text", "e", ["t", "e", "x", "t"], 14, " ü", 17, "日本語 text ", "nïcode 123", "nïcode 123", 10, "1", "2", "3", "3", true, nil, "\\x97", 2, "本", "語", 9]	require "strscan"\n        s = StringScanner.new("日本語 text ünïcode 123")
 81fd4c71c1be9be22bcbec82f890766a	[:method_missing, :method_missing]	class CM\n              def method_missing(name, *) = [__method__, _
 8200b7ed09f157ac5e736b20f1274721	[:custom, false, true, true, false]	class Baz\n          def !\n            :custom\n          end\n        end
 823812ee0e73bed95cbd8ff75188a377	[[65], [195, 168], nil]	File.write("/tmp/mr_gc3.txt", "A" + [0xC3, 0xA8].pack("C*").force_e
@@ -2330,6 +2334,7 @@ b1e95110d8ea3a01a8392d5fcde03380	[true, "nil"]	begin\n              raise Runtim
 b1f575a8d57c1ae9a8351ad21a875204	true	[true, false].include?(GC.auto_compact)
 b1fe8d72aed6bdfd75350fcc54ac6891	10	obj = Object.new\n            pr = Proc.new { |x| x * 2 }\n          
 b20a481ce0203a766d78c51b6ec17f1a	[[[ArgumentError, "comparison of Array with Array failed"], [ArgumentError, "comparison of String with 0 failed"]], [[ArgumentError, "comparison of Array with Array failed"], [ArgumentError, "comparison of String with 0 failed"]], [[ArgumentError, "comparison of Array with Array failed"], [ArgumentError, "comparison of String with 0 failed"]], [[ArgumentError, "comparison of Array with Array failed"], [ArgumentError, "comparison of String with 0 failed"]]]	a = [[1], [2]]\n            f = ->(m) { begin; a.send(m) { |x, y| ni
+b2246dc28e027cca7c95b52e7331237d	["ab", 3, "b", "b", nil, ["ab", "a", "b"], nil, false, nil, nil, nil, nil, "1", "1", 1, "ab", "2", 1, "2", "2", 3, false, "StringScanner::Error", "2", 3, nil, nil, false]	require "strscan"\n        s = StringScanner.new("ab12")\n        r = []\n
 b22bc514c07a095c143e3f7049f6dcd2	[true, false, false]	ensured = false\n            rescued = false\n            f = Fiber.n
 b2581c86d8fd4f38392d54c50df9db10	[5, 2, "hABlo", 2, "hABzz", "not opened for writing", 2, [0, 0, 104, 105], "not opened for writing", 1, 3, "x123"]	path = "/tmp/monoruby_test_iowrite_#{Process.pid}_#{rand(100000)}"\n
 b2795cc1ad41c83216d600a75460cd44	[nil, false, 19, nil, nil, 12, 17, :again, 18]	h = {}\n        20.times { |i| h["k#{i}"] = i }\n        h.delete("k3")\n 
@@ -2952,6 +2957,7 @@ e0378a5e80a453abed2cc017dde89a8c	[[:n, :n, :n], "wrong number of arguments (give
 e04102db31563efacf03513f5ddbcdd6	{"MONORUBY_ENV_TEST_SL1" => "x", "MONORUBY_ENV_TEST_SL2" => "y"}	ENV["MONORUBY_ENV_TEST_SL1"] = "x"\n            ENV["MONORUBY_ENV_TE
 e0430993ff49221b4ff142a12a2d9ee6	[1, [:gt, :lt, :gt, :lt]]	class C\n              attr_reader :calls\n              def initiali
 e051ec7a15469fca9105c948f78c2f26	[[:v], 50]	$nlr_log = []\n        def nlr_mid\n          yield\n        ensure\n      
+e08faf6442afb4dbe110fadb78630420	["ab", 3, "b", "b", nil, ["ab", "a", "b"], nil, false, nil, nil, nil, nil, "1", "1", 1, "ab", "2", 1, "2", "2", 3, false, StringScanner::Error, "2", 3, nil, nil, false]	require "strscan"\n        s = StringScanner.new("ab12")\n        r = []\n
 e093793f4006c99f09965c6fde38e86b	42	class Foo\n          def initialize\n            @x = 42\n          end\n  
 e0982ecc832e3a0a37c3aabbe59b1ec2	[{"name" => 100, "version" => 2, sym: 3, 4 => 5, 1.5 => 6, nil => 7, true => 8, false => 9, new: 200}, {"name" => 1, sym: 3, 4 => 5, 1.5 => 6, nil => 7, true => 8, false => 9}, {"name" => 1, "version" => 2, sym: 3, 4 => 5, 1.5 => 6, nil => 7, true => 8, false => 9}, false, false, nil, false, 9, 8, [true, true, true, true, true, true, true, true], [String, String, Symbol, Integer, Float, NilClass, TrueClass, FalseClass], true, 39]	def f; {"name" => 1, "version" => 2, sym: 3, 4 => 5, 1.5 => 6, nil 
 e09c62f66a3c3f3ed8999368ae421637	[true, [Errno::ENOENT, "No such file or directory @ rb_check_realpath_internal - /no_such_dir_zzq/x"], Errno::ELOOP, Errno::ELOOP]	(d="/tmp/mono_rp_#{Process.pid}"; Dir.mkdir(d); File.write("#{d}/file", ""); a=(

--- a/monoruby/tests/strscan.rs
+++ b/monoruby/tests/strscan.rs
@@ -219,3 +219,27 @@ fn strscan_register_state_across_calls() {
         "#,
     );
 }
+
+#[test]
+fn strscan_fallback_subjects_and_pattern_types() {
+    // A byte-oriented subject with 8-bit content cannot be viewed in
+    // place, so Regexp patterns take the MatchData fallback (String
+    // patterns stay literal bytes); a pattern that is neither raises the
+    // conversion TypeError CRuby reports.
+    run_test_once(
+        r#"
+        require "strscan"
+        r = []
+        b = StringScanner.new("ab\xFFcd ef".b)
+        r << b.scan(/ab/) << b.pos << b.matched << b.scan(/x/) << b.check_until(/c/) << b.scan_until(/c/) << b.pos
+        r << b.matched << b.pre_match.bytesize << b.post_match << b.scan("d") << b.skip(/\s/) << b.scan(/(e)(f)/) << b[2] << b.eos?
+        r << b.string.encoding.to_s
+        s = StringScanner.new("abc")
+        s.pos = 3
+        r << s.scan("") << s.scan("a") << s.scan_until("a")
+        r << (begin; s.scan(1); rescue TypeError => e; e.message; end)
+        r << (begin; s.scan_until(:a); rescue TypeError => e; e.message; end)
+        r
+        "#,
+    );
+}

--- a/monoruby/tests/strscan.rs
+++ b/monoruby/tests/strscan.rs
@@ -152,3 +152,70 @@ fn string_match_position_boundaries() {
         "#,
     );
 }
+
+#[test]
+fn strscan_literal_string_patterns() {
+    // String patterns are literal bytes for the anchored family and a
+    // literal byte search for the `_until` family; a name lookup on a
+    // String-pattern match has no groups to find.
+    run_test_once(
+        r#"
+        require "strscan"
+        s = StringScanner.new("a.b.c a+b")
+        r = []
+        r << s.scan(".") << s.scan("a") << s.scan(".") << s.skip("b.") << s.pos
+        r << s.matched << s.matched_size << s.pre_match << s.post_match << s[0] << s[1]
+        r << s.check_until("+") << s.scan_until("+") << s.pos << s.matched << s.pre_match
+        r << s.exist?("b") << s.skip_until("b") << s.eos? << s.scan_until("zz") << s.matched?
+        s.reset
+        r << s.scan_until("") << s.pos << s.scan("") << s.check("a.b")
+        r << (begin; s.scan("a"); s["x"]; rescue IndexError => e; e.class; end)
+        r
+        "#,
+    );
+}
+
+#[test]
+fn strscan_utf8_subjects_in_place() {
+    // Non-ASCII UTF-8 subjects are matched in place at a byte position;
+    // the registers stay byte offsets, so every accessor agrees with
+    // CRuby's byte-based scanner.
+    run_test_once(
+        r#"
+        require "strscan"
+        s = StringScanner.new("日本語 text ünïcode 123")
+        r = []
+        r << s.scan(/\S+/) << s.pos << s.matched_size << s.charpos
+        r << s.skip(/\s+/) << s.scan(/(t)(e)(x)(t)?/) << s[2] << s.captures << s.pos
+        r << s.scan_until(/ü/) << s.pos << s.pre_match << s.post_match
+        r << s.check_until(/\d+/) << s.skip_until(/(\d)(\d)/) << s[1] << s[2] << s.rest
+        r << s.scan(/\d/) << s.eos? << s.getch
+        s.pos = 3
+        r << s.scan(/本/) << s.scan(/語/) << s.pos
+        s.reset
+        r << s.getch << s.pos << s.matched << s.matched_size << s.getch << s.unscan.pos
+        r << s.get_byte << s.pos << s.peek(2) << s.rest_size
+        r
+        "#,
+    );
+}
+
+#[test]
+fn strscan_register_state_across_calls() {
+    // A failed match clears the registers; getch / get_byte record the
+    // char as the whole match; unscan restores the previous position.
+    run_test_once(
+        r#"
+        require "strscan"
+        s = StringScanner.new("ab12")
+        r = []
+        r << s.scan(/(a)(b)/) << s.size << s[-1] << s[2] << s[3] << s.values_at(0, 1, 2)
+        r << s.scan(/x/) << s.matched? << s.matched << s.size << s.captures << s[0]
+        r << s.getch << s.matched << s.matched_size << s.pre_match << s.post_match << s.size
+        r << s.get_byte << s.matched << s.unscan.pos << s.matched?
+        r << (begin; s.unscan; rescue => e; e.class.to_s; end)
+        r << s.scan(/\d+/) << s.unscan.pos << s.scan(/(\d)(\d)/) << s.captures << s.eos?
+        r
+        "#,
+    );
+}


### PR DESCRIPTION
Investigation of §5.6 of `doc/yjit_bench_slow_investigation_2026-09.md` (StringScanner, graphql) with the constraint of keeping `StringScanner` in Ruby. This PR lands the monoruby-only part; the part that actually makes it fast needs a small API in `onigmo-regex` and is delivered as two patches (see below and the new §8.1).

## What a `skip` costs today

perf on a `skip(/[_A-Za-z][_0-9A-Za-z]*/)` hit loop (246 ns/op): only ~32 % is the Onigmo matcher itself. ~22 % is the JIT-compiled Ruby, ~20 % Rust helpers (the `\A(?:…)`-wrapped Regexp cache lookup, `regex_view`, `coerce_to_regexp_or_string`, `Captures`), and ~9 % is malloc/free — `captures_from_pos` allocates and frees an Onigmo region on every match. CRuby's C strscan keeps one region in the scanner and calls `onig_match` at the scan position.

## This PR (monoruby only, performance-neutral)

`String#__strscan_match` becomes `(pattern, byte_pos, anchored)`:
- a String pattern is literal bytes in Rust (prefix test / forward byte search) instead of an escaped, cached Regexp;
- non-ASCII UTF-8 subjects are matched in place at their byte position instead of copying the rest into `String#match` (whose char-based `end(0)` was being added to a byte position);
- the `ascii_only?` gate and the `@match_begin` / `@match_end` registers are gone; the MatchData fallback remains only for subjects the engine cannot view in place (byte-oriented with 8-bit content, EUC-JP / Shift_JIS, broken UTF-8) and behaves as before.
- `getch` returns a whole character, and a failed `unscan` raises `StringScanner::Error` (CRuby).

Measured neutral: `skip` hit 246 → 248 ns, graphql ±0. That confirms the cost is on the Rust/Onigmo side, not in the Ruby code.

## The fast version (prototype, needs `onigmo-regex`)

Add to `onigmo-regex`: `Regex::match_at_with_region(heystack, at, &mut Region)` (`onig_match`), `Regex::search_with_region` (`onig_search`), and a public `Region::new`. monoruby then keeps one thread-local `Region`, passes the caller's Regexp unwrapped to `onig_match` on the byte suffix, and the Ruby side only uses `_anchored` for the fallback. Measured on the same machine (3 interleaved rounds for graphql):

| micro (ns/op) | before | this PR | + crate API | YJIT |
|---|---:|---:|---:|---:|
| `skip` hit | 246 | 248 | 126 | 158 |
| `skip` miss | 160 | 157 | 86 | 151 |
| `scan` hit | 346 | 346 | 233 | 237 |
| 2-group `skip` + `s[1]` | 440 | 438 | 301 | 193 |
| lexer loop (ms) | 6.2 | 6.1 | 3.5 | 2.9 |

graphql: 54.8 / 54.6 / 54.6 ms → **41.8 / 41.8 / 42.7 ms (−23 %)**; YJIT 31 ms.

The two patches (`onigmo-regex-region-api.patch` for the crate, `monoruby-strscan-followup-onig-match.patch` for monoruby, applying on top of this PR) were handed over in the session; this session cannot push to `sisshiki1969/onigmo-regex`. Order: apply + push the crate patch → `cargo update -p onigmo-regex` → apply the monoruby patch → `cargo test --test strscan`. Both were built and tested together here (10/10 strscan tests).

## Tests

- `tests/strscan.rs`: `strscan_literal_string_patterns` (anchored / `_until` with String patterns, name lookup on a String match), `strscan_utf8_subjects_in_place` (byte positions, groups, `_until`, multibyte `getch` / `get_byte`), `strscan_register_state_across_calls` (failed match clears registers, `getch` registers, `unscan`, `StringScanner::Error`).
- Full `cargo test --no-fail-fast`: 2398 passed / 1 failed (the pre-existing `float::tests::angle` on the local CRuby 4.0.6).

Pre-existing and untouched: binary subjects with `\xFF`-style patterns and EUC-JP subjects already diverge from CRuby on master (they go through `String#match`); this PR keeps their behavior byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkoJG3qRpCRJ4nXDZH3mg9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkoJG3qRpCRJ4nXDZH3mg9)_