### PR TITLE
strscan: anchor with onig_match into a reused region (graphql −24 %)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 [[package]]
 name = "onigmo-regex"
 version = "0.1.0"
-source = "git+https://github.com/sisshiki1969/onigmo-regex.git#4db1266bf96c2c99c94e84f63e5b3717f78638be"
+source = "git+https://github.com/sisshiki1969/onigmo-regex.git#4513d0af352dbe8ec1c61625d47f62442cbde0fb"
 dependencies = [
  "bindgen 0.71.1",
  "cc",

--- a/doc/yjit_bench_slow_investigation_2026-09.md
+++ b/doc/yjit_bench_slow_investigation_2026-09.md
@@ -557,29 +557,24 @@ scanner が region を持ち、`onig_match`（scan 位置での 1 回マッチ�
    ついでに `getch` の多バイト文字対応と `StringScanner::Error` を追加。
    **性能はほぼ中立**（`skip` ヒット 246 → 248 ns、graphql ±0）— Ruby 側の削減分は
    ノイズに埋もれ、コストは Rust/Onigmo 側にあることが確認できた。
-2. **`onigmo-regex` に region 再利用 API を足す**（プロトタイプ、未マージ）:
+2. **`onigmo-regex` に region 再利用 API を足す**（crate 側マージ済み、monoruby 側も適用）:
    `Regex::match_at_with_region(heystack, at, &mut Region)`（`onig_match`）と
    `Regex::search_with_region`（`onig_search`）、`Region::new` を pub に。monoruby 側は
    thread-local の `Region` を 1 つ持ち、Regexp パターンを *そのまま*（ラップせず）
-   `onig_match` で scan 位置にアンカーする。Ruby 側は `_anchored` を fallback 専用に
-   するだけ。
+   `onig_match` で scan 位置にアンカーする。`\A(?:…)` のラップ Regexp も、その Hash
+   キャッシュ引きも、マッチごとの region 確保・解放も消える。Ruby 側の変更は
+   `_anchored` を fallback 専用にするだけで、`StringScanner` は Ruby のまま。
 
    | マイクロ（ns/op） | 従来 | 1 | 2 | YJIT |
    |---|---:|---:|---:|---:|
-   | `skip(/ident/)` ヒット | 246 | 248 | 126 | 158 |
-   | `skip(/ident/)` ミス | 160 | 157 | 86 | 151 |
-   | `scan(/ident/)` ヒット | 346 | 346 | 233 | 237 |
-   | `skip(/-?(…)(\.[0-9]+)?…/)` + `s[1]`（2 群） | 440 | 438 | 301 | 193 |
-   | lexer ループ（1 回、ms） | 6.2 | 6.1 | 3.5 | 2.9 |
+   | `skip(/ident/)` ヒット | 246 | 234 | 127 | 158 |
+   | `skip(/ident/)` ミス | 160 | 147 | 83 | 151 |
+   | `scan(/ident/)` ヒット | 346 | 362 | 222 | 237 |
+   | `skip(/-?(…)(\.[0-9]+)?…/)` + `s[1]`（2 群） | 440 | 430 | 301 | 193 |
+   | lexer ループ（1 回、ms） | 6.2 | 5.8 | 3.7 | 2.9 |
 
-   graphql（交互 3 ラウンドの中央値）: 従来 54.8 / 54.6 / 54.6 ms → **2 で 41.8 / 41.8 / 42.7 ms
-   （−23 %）**、YJIT 31 ms。
-
-段階 2 は crate 側の変更（`sisshiki1969/onigmo-regex`）を先に取り込む必要があり、
-このセッションからは push できないので、パッチ 2 本（crate 側 `onigmo-regex-region-api.patch`
-と monoruby 側の差し替え `monoruby-strscan-followup-onig-match.patch`、どちらも段階 1 の
-上に当たる）を別途渡した。適用手順: crate に当てて push → monoruby で
-`cargo update -p onigmo-regex` → monoruby 側パッチを当てる → `cargo test --test strscan`。
+   graphql（交互 3 ラウンドの中央値）: 段階 1 まで（`479b011`）53.3 / 55.4 / 53.4 ms →
+   **段階 2 で 40.9 / 40.4 / 41.3 ms（−24 %）**、YJIT 31 ms。
 
 残る差（群あり 301 vs 193 ns）は群オフセットを Ruby の Array で返して `[]` を Ruby で
 引く分。scanner 側に region を持たせる（= Rust オブジェクト化）までやれば埋まるが、

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -3459,11 +3459,11 @@ fn string_match(
 /// position (CRuby strscan's default `fixed_anchor: false` semantics).
 /// A String pattern is literal bytes, as in CRuby's C strscan:
 /// `anchored` selects a prefix test versus a forward byte search. A
-/// Regexp pattern is searched as given — the Ruby side passes its
-/// `\A(?:…)`-wrapped form for the anchored scan family (see
-/// `RegexpInner::strscan_match` for the `onig_match` route this is
-/// meant to take once the regex crate exposes a reusable region).
-/// Returns
+/// Regexp pattern goes to `onig_match` at the scan position when
+/// `anchored` — no `\A(?:…)` wrapper regex is ever built — and to a
+/// forward `onig_search` otherwise; the registers land in one
+/// thread-local Onigmo region reused across calls, so a group-less hit
+/// costs no allocation at all. Returns
 /// - nil — no match;
 /// - an Integer — the byte end of a whole-match starting at offset 0
 ///   with no capture groups (the common lexer case — the value is a
@@ -3483,6 +3483,10 @@ fn string_strscan_match(
     lfp: Lfp,
     _: BytecodePtr,
 ) -> Result<Value> {
+    thread_local! {
+        static STRSCAN_REGION: std::cell::RefCell<onigmo_regex::Region> =
+            std::cell::RefCell::new(onigmo_regex::Region::new());
+    }
     let byte_pos = match lfp.arg(1).coerce_to_int_i64(vm, globals)? {
         pos if pos >= 0 => pos as usize,
         _ => return Ok(Value::nil()),
@@ -3532,38 +3536,35 @@ fn string_strscan_match(
     let Some(sub) = given.get(byte_pos..) else {
         return Ok(Value::nil());
     };
-    // The engine sees only `sub`, so the caller's `\A(?:…)`-wrapped form
-    // anchors at the scan position. Onigmo's `onig_match` with a reused
-    // region (no wrapper regex, no region allocation per match) needs an
-    // `onigmo-regex` API taking a caller-owned `Region`; until the crate
-    // grows one this goes through `captures_from_pos`, which allocates
-    // its region per call.
-    let Some(caps) = re.captures_from_pos_no_save(sub, 0)? else {
-        return Ok(Value::nil());
-    };
-    if caps.len() == 1 {
-        // Group-less pattern: a single Fixnum carries the whole
-        // register set when the match starts at the scan position
-        // (always true for the anchored scan family).
-        let m = caps.get(0).unwrap();
-        if m.start() == 0 {
-            return Ok(Value::integer(m.end() as i64));
+    STRSCAN_REGION.with(|region| {
+        let mut region = region.borrow_mut();
+        if !re.strscan_match(sub, anchored, &mut region)? {
+            return Ok(Value::nil());
         }
-    }
-    let mut spans = Vec::with_capacity(caps.len() * 2);
-    for m in caps.iter() {
-        match m {
-            Some(m) => {
-                spans.push(Value::integer(m.start() as i64));
-                spans.push(Value::integer(m.end() as i64));
-            }
-            None => {
-                spans.push(Value::nil());
-                spans.push(Value::nil());
+        let n = region.len();
+        if n == 1 {
+            // Group-less pattern: a single Fixnum carries the whole
+            // register set when the match starts at the scan position
+            // (always true for the anchored scan family).
+            if let Some((0, e)) = region.pos(0) {
+                return Ok(Value::integer(e as i64));
             }
         }
-    }
-    Ok(Value::array_from_vec(spans))
+        let mut spans = Vec::with_capacity(n * 2);
+        for i in 0..n {
+            match region.pos(i) {
+                Some((b, e)) => {
+                    spans.push(Value::integer(b as i64));
+                    spans.push(Value::integer(e as i64));
+                }
+                None => {
+                    spans.push(Value::nil());
+                    spans.push(Value::nil());
+                }
+            }
+        }
+        Ok(Value::array_from_vec(spans))
+    })
 }
 
 ///

--- a/monoruby/src/value/rvalue/regexp.rs
+++ b/monoruby/src/value/rvalue/regexp.rs
@@ -1440,6 +1440,27 @@ impl RegexpInner {
             .map_err(|err| MonorubyErr::regexerr(format!("Capture failed. {:?}", err)))
     }
 
+    /// `StringScanner` primitive: match `sub` (the byte suffix at the scan
+    /// position, already a valid engine view) either anchored at its start
+    /// (`onig_match`) or as a forward search (`onig_search`), recording the
+    /// registers into the caller's reusable `region`. Returns whether it
+    /// matched; the caller reads the offsets (relative to `sub`) from the
+    /// region. Never touches `$~`.
+    pub(crate) fn strscan_match(
+        &self,
+        sub: &str,
+        anchored: bool,
+        region: &mut onigmo_regex::Region,
+    ) -> Result<bool> {
+        let r = if anchored {
+            self.regex.match_at_with_region(sub.as_bytes(), 0, region)
+        } else {
+            self.regex.search_with_region(sub.as_bytes(), 0, region)
+        };
+        r.map(|r| r.is_some())
+            .map_err(|err| MonorubyErr::regexerr(format!("Capture failed. {:?}", err)))
+    }
+
     /// Like `match_one` but returns only a boolean and does NOT set `$~`.
     pub(crate) fn match_pred(
         re: &RegexpInner,

--- a/monoruby/stdlib/strscan.rb
+++ b/monoruby/stdlib/strscan.rb
@@ -268,14 +268,11 @@ class StringScanner
     matched.to_s
   end
 
-  # `\A`-anchored counterparts of caller Regexp patterns, built once per
-  # distinct pattern instead of on every scan; identity-keyed (a regex
-  # literal is the same object on every evaluation, so a lexer's fixed
-  # pattern set hits after the first scan). String patterns never come
-  # here: the primitive treats them as literal bytes (CRuby's C strscan
-  # does too), and only the MatchData fallback needs their escaped
-  # Regexp forms. All caches are size-capped so callers that generate
-  # patterns dynamically cannot grow them without bound.
+  # `\A`-anchored counterparts of caller patterns for the MatchData
+  # fallback path only (the primitive anchors natively), built once per
+  # distinct pattern; identity-keyed for Regexps, value-keyed via the
+  # escaped form for Strings. All caches are size-capped so callers that
+  # generate patterns dynamically cannot grow them without bound.
   ANCHORED_RE = {}.compare_by_identity
   ANCHORED_STR = {}
   PLAIN_STR = {}
@@ -327,13 +324,12 @@ class StringScanner
   #
   # `__strscan_match` matches the byte suffix in place (a group-less hit
   # is a bare Fixnum) and answers `false` only for a subject it cannot
-  # view in place, which takes the MatchData fallback. The engine sees
-  # only the suffix, so the cached `\A(?:…)` form of a Regexp pattern
-  # anchors at the scan position; a String pattern is a literal prefix.
+  # view in place, which takes the MatchData fallback. The primitive
+  # anchors natively at the scan position (`onig_match` on the suffix);
+  # a String pattern is a literal prefix.
   def _match_len_at_pos(pattern, advance)
     @prev_pos = @pos
-    probe = pattern.is_a?(String) ? pattern : _anchored(pattern)
-    spans = @str.__strscan_match(probe, @pos, true)
+    spans = @str.__strscan_match(pattern, @pos, true)
     return _fallback_at_pos(pattern, advance) if false == spans
     @match_md = nil
     @match_spans = spans


### PR DESCRIPTION
Stage 2 of the StringScanner work from `doc/yjit_bench_slow_investigation_2026-09.md` §8.1, now that the `onigmo-regex` side is merged. `StringScanner` stays in Ruby.

## Change

`onigmo-regex` now exposes `Regex::match_at_with_region` (`onig_match`) and `Regex::search_with_region` (`onig_search`), both taking a caller-owned `Region`. `String#__strscan_match` uses them:

- a Regexp pattern is anchored **natively** at the scan position, instead of being matched as a `\A(?:…)`-wrapped copy — so neither the wrapper Regexp nor its identity-keyed Hash lookup happens per scan;
- the registers land in **one thread-local region** reused across calls, removing the Onigmo region malloc/free that `captures_from_pos` did on every match (~9 % of a scan in the profile).

`StringScanner` itself only changes in that `_anchored` is now used solely by the MatchData fallback (subjects the engine cannot view in place: byte-oriented with 8-bit content, EUC-JP / Shift_JIS, broken UTF-8). `cargo update -p onigmo-regex` picks up the merged crate.

## Measurements (same machine, release)

| micro (ns/op) | before §8.1 | master (`479b011`) | this PR | YJIT |
|---|---:|---:|---:|---:|
| `skip(/ident/)` hit | 246 | 234 | **127** | 158 |
| `skip(/ident/)` miss | 160 | 147 | **83** | 151 |
| `scan(/ident/)` hit | 346 | 362 | **222** | 237 |
| two-group `skip` + `s[1]` | 440 | 430 | **301** | 193 |
| graphql lexer loop (ms) | 6.2 | 5.8 | **3.7** | 2.9 |

graphql (yjit-bench harness-warmup, 3 interleaved rounds, medians): master 53.3 / 55.4 / 53.4 ms → **40.9 / 40.4 / 41.3 ms, −24 %**. YJIT is 31 ms.

The remaining gap on the group case (301 vs 193 ns) is the group offsets being returned as a Ruby Array and indexed from Ruby; closing it would mean putting the region in the scanner (i.e. a Rust object), which the "keep it in Ruby" constraint rules out for now.

## Tests

`cargo test --test strscan`: 11/11 (the anchor-semantics, literal-String-pattern, in-place UTF-8, register-state and fallback tests added in #1248 all cover this path unchanged). Full `cargo test --no-fail-fast`: 2403 passed / 1 failed — the pre-existing `float::tests::angle` (`Float#ceil(15)` differs on the local CRuby 4.0.6 vs the 4.0.2 oracle), unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkoJG3qRpCRJ4nXDZH3mg9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkoJG3qRpCRJ4nXDZH3mg9)_