### PR TITLE
GC: keep one collection's allocation budget resident (object-new −35 %)

### DIFF
--- a/monoruby/src/alloc.rs
+++ b/monoruby/src/alloc.rs
@@ -498,15 +498,28 @@ const OLD_OBJECT_FLOOR: usize = 16384;
 
 /// How many salvaged (all-dead) pages stay resident for reuse before the
 /// rest are handed back to the OS: `1/FREE_PAGE_RESERVE_FRACTION` of the
-/// pages in service, and never fewer than `FREE_PAGE_RESERVE_MIN`.
+/// pages in service, never fewer than `FREE_PAGE_RESERVE_MIN`, and never
+/// less than one collection's allocation budget (`gc_trigger_pages`).
 ///
 /// A page that empties out used to sit on `free_pages` forever, so a
 /// workload's *peak* heap stayed resident: lee's collector needed 22
 /// pages for its live set while the arena kept ~115 touched (30 MB RSS
-/// for 5.5 MB of objects). The reserve covers the growth between two
-/// collections (the trigger budget is `1/GC_HEAP_FRACTION` of the pages
-/// in service), so a steady-state heap reuses resident pages and only a
-/// heap that shrank pays the page faults of re-touching released ones.
+/// for 5.5 MB of objects). The reserve has to cover the growth between
+/// two collections, otherwise the mutator re-faults the pages it just
+/// released: what it allocates between collections is exactly
+/// `gc_trigger_pages`, so that is the floor. The fraction alone was only
+/// equal to it while the budget was `1/GC_HEAP_FRACTION` of the pages in
+/// service — once `PAGES_PER_GC_TRIGGER` became the binding term (a heap
+/// whose live set is small next to its allocation rate), the reserve fell
+/// to `FREE_PAGE_RESERVE_MIN` while the budget stayed at 32 pages, and
+/// every cycle handed back ~30 pages only to fault them in again. On a
+/// 20M-`Object.new` loop that was 282K page faults and 794 ms; with the
+/// budget as the floor, 5.4K faults and 456 ms.
+///
+/// The floor is bounded by the budget, not by the peak heap, so the
+/// original problem does not come back: a program keeps at most one
+/// collection's worth of pages resident (8 MB at
+/// `PAGES_PER_GC_TRIGGER`), and only if it actually salvaged that many.
 const FREE_PAGE_RESERVE_FRACTION: usize = 8;
 const FREE_PAGE_RESERVE_MIN: usize = 2;
 
@@ -1969,7 +1982,9 @@ impl<T: GCBox> Allocator<T> {
 
     /// The salvaged pages kept resident: see [`FREE_PAGE_RESERVE_FRACTION`].
     fn free_page_reserve(&self) -> usize {
-        (self.page_count() / FREE_PAGE_RESERVE_FRACTION).max(FREE_PAGE_RESERVE_MIN)
+        (self.page_count() / FREE_PAGE_RESERVE_FRACTION)
+            .max(FREE_PAGE_RESERVE_MIN)
+            .max(self.gc_trigger_pages() as usize)
     }
 
     /// Hand every salvaged page beyond the reserve back to the OS. The


### PR DESCRIPTION
Fixes the `object-new*` regression that started at #1245, and speeds up every yjit-bench benchmark I measured.

## The regression

Building each of the last ten commits and running the three benchmarks against them puts the step at `7b6c9e7` (#1245), which raised `PAGES_PER_GC_TRIGGER` from 8 to 32:

| bench | 750d04f | a6d6c3e | dc6e5bf | a29690f | **7b6c9e7** | 7687208 | b853ca1 | 479b011 | efcd763 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| object-new | 27.3 | 27.8 | 27.0 | 27.4 | **29.7** | 29.0 | 30.1 | 30.1 | 30.1 |
| object-new-initialize | 29.6 | 28.7 | 28.5 | 28.3 | **30.7** | 31.8 | 32.8 | 33.0 | 30.7 |
| object-new-no-escape | 55.7 | 55.7 | 57.1 | 57.0 | **61.2** | 62.1 | 61.0 | 62.5 | 60.4 |

## Cause

`free_page_reserve` keeps `1/FREE_PAGE_RESERVE_FRACTION` of the pages in service (floored at 2) after a sweep and releases the rest with `madvise(MADV_DONTNEED)`. #1238 sized it to cover what the mutator allocates before the next collection — true while a collection's budget was itself a fraction of the heap.

Raising the trigger floor broke that pairing. For a heap whose live set is small next to its allocation rate (`object-new` retains 665 objects), `page_count` collapses after each sweep, so the reserve is `FREE_PAGE_RESERVE_MIN` = 2 pages while `gc_trigger_pages()` is 32. Every cycle hands ~30 pages back to the OS and immediately faults them in again.

`perf stat` on a 20M-`Object.new` loop:

| | task-clock | page-faults |
|---|---:|---:|
| trigger 8 | 700 ms | 191,515 |
| trigger 32 | 798 ms | 282,482 |

Note the GC count *falls* (24 → 7) while the loop gets slower: with a 665-object live set marking is free, and the only thing that changes is how much fresh memory the mutator cycles through.

## Fix

Make the budget the floor of the reserve:

```rust
fn free_page_reserve(&self) -> usize {
    (self.page_count() / FREE_PAGE_RESERVE_FRACTION)
        .max(FREE_PAGE_RESERVE_MIN)
        .max(self.gc_trigger_pages() as usize)
}
```

Bounded by the budget rather than by the peak heap, so what the fraction was introduced to fix (a workload's whole peak staying resident — lee: 22 live pages, ~115 touched) does not come back.

Same loop: 282K page faults → 5.4K, 794 ms → 456 ms.

## Benchmarks (yjit-bench harness-warmup, 3 interleaved rounds, medians)

| bench | HEAD | this PR | diff | RSS |
|---|---:|---:|---:|---|
| object-new | 29.9 / 31.5 / 29.9 ms | 19.7 / 20.6 / 19.4 | **−35 %** | 32 → 40 MB |
| object-new-initialize | 32.3 / 32.3 / 31.4 | 22.1 / 22.5 / 22.9 | **−30 %** | 32 → 39 MB |
| object-new-no-escape | 61.9 / 62.6 / 63.1 | 37.7 / 38.7 / 37.4 | **−40 %** | 32 → 39 MB |
| graphql | 41.3 / 40.1 / 43.3 | 39.9 / 38.3 / 38.0 | −5.3 % | 65 → 73 MB |
| erubi | 304.9 / 302.5 / 304.8 | 315.7 / 293.7 / 291.4 | −3.7 % | 72 → 76 MB |
| rack | 75.7 / 74.3 / 75.3 | 71.8 / 75.9 / 72.5 | −3.4 % | 64 → 72 MB |
| activerecord | 232.1 / 234.8 / 223.9 | 228.5 / 218.6 / 221.2 | −2.4 % | 143 → 150 MB |

RSS grows by at most one budget (8 MB), and only for a program that actually salvaged that many pages: `puts "hi"` goes 19.8 → 19.9 MB peak.

I also measured simply lowering the trigger again, as the alternative: at 8 it is object-new −12 %, rack −5 % but graphql **+8 %** and activerecord **+6 %**; at 16, object-new −9 %, graphql still +9 %. That is a real trade-off, whereas fixing the reserve improves both ends.

## Tests

Full `cargo test --no-fail-fast`: 2403 passed / 1 failed — the pre-existing `float::tests::angle` (`Float#ceil(15)` differs on the local CRuby 4.0.6 vs the 4.0.2 oracle), unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkoJG3qRpCRJ4nXDZH3mg9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkoJG3qRpCRJ4nXDZH3mg9)_