### PR TITLE
Hash: bucket with a seeded mixer instead of SipHash-1-3 (erubi −12 %)

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -78,6 +78,7 @@ Diagrams referenced by the above: [`fiber_state_diagram.svg`](fiber_state_diagra
 |---|---|---|---|
 | [`ruby_spec_skip_tags.md`](ruby_spec_skip_tags.md) | JA | reference | How the ruby/spec suite avoids hangs, and the audit that cut a coarse file-level skip list down to the handful that genuinely cannot run. |
 | [`optcarrot_opt_profile.md`](optcarrot_opt_profile.md) | JA | design record | Where `bin/optcarrot --opt` spends its time, measured with `perf` and `--features profile`, and the optimizations that came out of it. |
+| [`hash_optimization.md`](hash_optimization.md) | JA | design record | What one `Hash#[]` actually costs: the three representations (inline / boxed / identity-keyed), the vm-free prehashed probe, the optimizations landed so far with their measurements, and a ranked list of what is left. |
 | [`yjit_bench_slow_investigation_2026-09.md`](yjit_bench_slow_investigation_2026-09.md) | JA | design record | Why activerecord / erubi / rack / graphql run at half of CRuby+YJIT: steady-state `perf` breakdowns, deopt-log and PMC statistics, microbenchmarks isolating each runtime cost (String-keyed Hash, GC roots, arg-class-keyed PMC, StringScanner, exceptions), and a ranked plan. |
 
 ## Plans and history

--- a/doc/hash_optimization.md
+++ b/doc/hash_optimization.md
@@ -1,0 +1,251 @@
+# Hash の実装と最適化
+
+Ruby プログラムは Hash を「オブジェクトのフィールド袋」として使うので、
+`[]` / `[]=` / `key?` / `fetch` はアプリケーションのもっとも内側のループに
+現れる。yjit-bench の erubi では実行時間の 29 %、rack で 18 %、
+activerecord で 13 % が Hash 参照だった
+（[`yjit_bench_slow_investigation_2026-09.md`](yjit_bench_slow_investigation_2026-09.md) §5.2）。
+
+この文書は、現在の Hash がどういう表現とどういう探索経路を持っているかを
+まとめ、そこに入れた最適化を計測とともに記録し、残っているコストと次の
+候補を優先順位付きで並べる。個々の API の意味論ではなく「1 回の参照に何が
+起きるか」に焦点を当てる。
+
+---
+
+## 1. 3 つの表現
+
+Hash の表現は `RValue` ヘッダの型別メタデータバイト（`Metadata::ty_flags`）に
+入っている。48 バイトのペイロードを表現の判別に使わないので、小さい Hash は
+ペイロード全部をデータに使える。
+
+| ビット | 意味 |
+|---|---|
+| 0-2 | 表現: 0..=3 = その数のペアを inline 保持、7 = boxed |
+| 3 | `ruby2_keywords` フラグ |
+| 4-5 | inline hash の反復深度（飽和カウンタ。boxed は `BoxedHash::iter_lev`） |
+| 6 | inline hash が `compare_by_identity` |
+
+ゼロバイト（`Header::new` の既定値）がそのまま空の inline hash として妥当で、
+`dup` / `clone`（`Header::newborn`）はこのバイトを保存するので、表現はヘッダと
+一緒に移動する。
+
+### 1.1 inline 表現（≤ 3 ペア）
+
+`HashBody::inline` に `(key, value)` を 3 組、セルの中に直接持つ。**ヒープ確保
+ゼロ**、探索は 3 要素の線形走査。`is_inline_key`（`rvalue/hash.rs`）が許すキーは:
+
+- **packed immediate**（Fixnum / Symbol / nil / true / false / flonum）—
+  同一性がそのまま内容なので、比較はビット比較で足り、プローブ時に再計算した
+  ダイジェストが挿入時のものと食い違うことがない。
+- **frozen String** — String の `eql?` はエンコーディング規則込みのバイト比較で
+  （再定義された `String#eql?` / `#hash` はどちらの表現でも参照しない）、frozen
+  なら探索中に内容が変わらない。
+
+リテラルのキーも `h["k"] = v` の格納キー（`Value::frozen_hash_key` が
+コピーして freeze する）も frozen なので、**String キーの小さな Hash リテラルは
+boxed map を作らない**。
+
+`compare_by_identity` な inline hash は id 走査だけなので、任意のキー（可変な
+ヒープオブジェクトを含む）を保持できる（`IDENT_BIT`）。
+
+4 ペア目、ヒープキー、デフォルト値、`compare_by_identity` のいずれかが来ると
+`promote` が boxed へ移す。
+
+### 1.2 boxed 表現
+
+`BoxedHash` は `Box<RubyMap<Option<Value>, Value>>`（`compare_by_identity` なら
+`Option<IdentKey>` キーの別インスタンス）とデフォルト値／デフォルト proc、
+反復深度、tombstone 数を持つ。
+
+`rubymap` は順序保持マップ（hashbrown のインデックステーブル + エントリ Vec）
+で、Ruby の挿入順序保持セマンティクスをそのまま表現する。反復中の `delete` は
+エントリを **tombstone**（キーを `None`）にして位置を保ち、`Option<Value>` の
+niche によりキーワードがゼロなら死んだエントリ、という判定が機械語からも
+できる。反復が終わった後の最初の変更操作が `compact_if_dirty` で詰める。
+
+### 1.3 探索経路
+
+```
+JIT: Hash#[]  ──inline gen (hash_index)──►  hashindex(vm, globals, recv, key)
+                                                  │
+VM:  Hash#[]  ──builtin index───────────────────►  Hashmap::index
+                                                  │  （ミス時のみ default / default_proc）
+                                                  ▼
+                                             HashRef::get
+                                        ┌─────────┴─────────┐
+                                    inline 走査        boxed プローブ
+                                                  ┌────────┴────────┐
+                                          packed_digest      string_digest
+                                          （vm 不要）        + string_key_eq（vm 不要）
+                                                  └────────┬────────┘
+                                                  IndexMapCore::get_index_of_prehashed*
+```
+
+要点は **prehashed probe**: packed キーと String キーは Ruby コードを一切
+起動せずにダイジェストと `eql?` を決められるので、`vm` / `globals` を触らない
+専用経路を通る。汎用経路（`RubyMap::hash`）とバケットが一致することは
+`packed_digest` / `string_digest` のドキュメントコメントが不変条件として
+書いている。
+
+### 1.4 機械語が直接歩く部分
+
+`Hash#size` / `#__key_at` / `#__value_at` / `#__entry_count` / `#__live_at` /
+`#__get_or_key` / `#default` / `#default=` / `#compare_by_identity?` は JIT が
+表現を直接歩く機械語として出る。焼き込むオフセットは手計算せず
+`HASH_INLINE_PAIRS_OFFSET` などのレイアウト定数（`offset_of!` 由来）と
+`rubymap::EntriesLayout` のプローブから取る。3 ペア以下の Hash リテラルは
+JIT がセルを bump 確保してヘッダとペアを直接書き込む（`emit_alloc_cell`）。
+
+`Hash#each` / `each_key` / `each_value` はこれらのプリミティブの上に Ruby で
+書かれている（`builtins/hash.rb`）ので、ホットな呼び出しサイトではメソッドと
+ブロックの両方がインライン展開される。
+
+---
+
+## 2. 入れた最適化
+
+効果は同じ計測機で交互ラウンドの中央値の最小値で比較している（単発は ±10 %
+揺れる）。「純ルックアップ」は同じループからルックアップだけ抜いた時間を
+差し引いた値。
+
+| # | 施策 | 変更箇所 | 効果 |
+|---|---|---|---|
+| 1 | ≤3 ペアの packed キー Hash を inline 表現に（ヒープ確保ゼロ、JIT がセルを直接書く） | `rvalue/hash.rs`、JIT の literal 経路 | Symbol キーリテラル生成が boxed の 1/2 以下 |
+| 2 | 定数 Hash リテラルをテンプレート化し、評価ごとに複製（#1232） | `bytecodegen/expression.rs::from_literal_pairs` | 評価ごとの挿入ループが消える |
+| 3 | 汎用 `[]=`（VM と JIT の多相残余）に Hash の直接経路（#1245） | `codegen/runtime.rs::set_index` | rack −8 %、graphql −13 %、activerecord −8 %（他の 3 施策込み） |
+| 4 | frozen String キーを inline 表現に許可（#1246） | `rvalue/hash.rs::is_inline_key` | `{"content-type" => "text/plain"}` 生成 134 → 57 ns（YJIT 60）、`h["k"]` 50 → 23 ns、`h["k"] = v` 40 → 22 ns。rack −7 %、activerecord −13.5 % |
+| 5 | バケット用ハッシュを SipHash-1-3 から seeded ミキサーへ（本ブランチ） | `rubymap/src/hasher.rs` | 下表。erubi −12.4 %、graphql −4.1 % |
+
+施策 5 の背景: `RubyMap` は std の `RandomState`（SipHash-1-3）を既定の
+ハッシャに継いでいて、`perf` で見るとルックアップ 1 回の **1/3** がそこだった
+（String キーで `string_digest` 18.7 % + `SipHasher13::write` 13.9 %、Symbol キーで
+`packed_digest` 24.6 % + 11.7 %）。CRuby の `st_hash` は seeded な非暗号ミキサー
+なので、同じトレードを取った。プロセス単位の乱数シード（`RandomState` から
+1 度引くので新規依存なし）+ wyhash 系の multiply-fold。シードを秘匿することが
+hash-flooding を抑える根拠で、混ぜ方自体は乗算 2 回。Ruby から見える
+`Object#hash` は従来どおり `HASH_STATE` 側なので変わらない。
+
+### 純ルックアップのコスト（1 回、ns。18 エントリの Hash）
+
+| キー | 施策 4 まで | 施策 5 後 | CRuby 4.0.6 + YJIT |
+|---|---:|---:|---:|
+| String 4 バイト | 42.8 | **33.7** | 17.5 |
+| String 19 バイト | 49.1 | **37.7** | 18.5 |
+| String ミス | 42.0 | **30.7** | 16.7 |
+| Symbol | 39.0 | **25.7** | 16.1 |
+| Integer | 52.1 | **39.5** | 16.4 |
+
+ハッシュ品質のサニティチェック: 20 万エントリで 4096 刻みの整数キー（弱い
+ミキサーが破綻する典型ケース）は 94.2 → 88.8 ns と悪化しない。
+
+---
+
+## 3. 残っているコスト
+
+施策 5 後の `h["name"]` / `h[:name]` ループの `perf` セルフ時間:
+
+| | String キー | Symbol キー |
+|---|---:|---:|
+| IndexMap / hashbrown の probe | 31.6 % | 32.6 % |
+| `HashRef::get`（2 インスタンス化の合計） | 25.0 % | 19.7 % |
+| `Hashmap::index` | 10.4 % | 13.6 % |
+| ダイジェスト（`RubyHasher`） | 7.8 % | 8.9 % |
+| `hashindex` builtin | 7.2 % | 6.3 % |
+| `memcmp`（キー比較） | 7.7 % | — |
+
+ハッシュは 33 % → 8 % まで落ち、いまの支配項は **probe と 4 段のディスパッチ**
+（`hashindex` → `Hashmap::index` → `HashRef::get` → `IndexMapCore`）である。
+
+---
+
+## 4. 今後のアイデア（効果の見込み順）
+
+### 4.1 Integer / Float キーの二重ハッシュを外す（小・確度高）
+
+`Value::ruby_hash_packed` の Fixnum / Float アームは、`Integer#hash` /
+`Float#hash` が返す**値**を作るために内側で `seeded_hasher()`（std の
+`DefaultHasher` = SipHash）を丸ごと 1 回回し、その結果を外側のマップハッシャに
+流している。これは `Array#hash` / `Hash#hash` が要素を混ぜるときに Ruby レベルの
+`#hash` 結果と一致させるための要請で、**バケッティングには要らない**。上表で
+Integer キーだけ Symbol キーより 14 ns 遅い（39.5 vs 25.7）のがそのコスト。
+
+構造ハッシュ用（Ruby から見える `#hash` 値）とバケッティング用を分ければ、
+Integer キーの参照が Symbol キーと同じところまで来るはず。
+
+### 4.2 probe を JIT でインライン展開する（大・最大の残り）
+
+いまは `Hash#[]` のインライン生成が `hashindex` への直接呼び出しまでしか
+やらない（メソッドフレームは省くが、そこから先は Rust）。受信側が
+`Hash` ちょうどで boxed 表現だと分かっている呼び出しサイトなら、
+ダイジェスト → インデックステーブル引き → エントリ比較を機械語で出せる。
+上の内訳の probe 32 % + ディスパッチ 42 % のかなりの部分が対象で、YJIT との
+残差（33.7 vs 17.5 ns）を埋める本命。`gen_hash_entry_at` が既に
+`rubymap::EntriesLayout` からエントリ配列を歩いているので、必要なレイアウト
+知識は揃っている。
+
+### 4.3 呼び出しサイトのキーセット・インラインキャッシュ（中・要検証）
+
+erubi の 322 個の spec Hash は **すべて同じ 18 個のキーを同じ順序で持つ**
+（同じ JSON 形状から作られる）。`spec["name"]` のような「リテラルキー ×
+同形状の Hash」という組み合わせは、テンプレートエンジンや JSON 処理では
+支配的なパターンである。呼び出しサイトに「このキーセットならインデックスは
+これ」を憶えさせられれば、probe そのものを飛ばせる。CRuby のオブジェクト
+shape に相当する仕組みを Hash に持ち込むことになるので、キーセットの同一性を
+安く判定する仕掛け（挿入順の版番号など）の設計が要る。
+
+### 4.4 ディスパッチ段数を減らす（小〜中）
+
+`hashindex` → `Hashmap::index` → `HashRef::get` → `IndexMapCore` の 4 段で、
+それぞれが `vm` / `globals` を引き回している。`Hashmap::index` はミス時の
+default 処理のためだけに 1 段あり、`HashRef::get` は表現の分岐をしている。
+表現の分岐を呼び出し側に持ち上げて boxed 専用の入口を用意すれば数 ns 縮む
+見込み。4.2 を先にやると自然に消える部分もある。
+
+### 4.5 frozen String にダイジェストをキャッシュ（小）
+
+施策 5 の前は有力だったが、ハッシュが 8 % まで落ちた今は上積みが小さい。
+長いキー（パスや URL）を多用するコードでは効くので、`RStringInner` に
+4 バイトの空きができたときの候補として残す。frozen なら無効化が不要という
+性質は変わらない。
+
+### 4.6 inline 表現の拡張（要検討）
+
+48 バイトのペイロードにペア 3 組でちょうど埋まっている。4 組以上にするには
+`RValue` を大きくするかキー・値を別配列にするかで、どちらも Hash 以外の
+すべてのオブジェクトに影響する。erubi の Hash は 18 ペアなので、この方向で
+救えるワークロードは限られる。
+
+### 4.7 RValue の中身のアロケータ（別件だが Hash に効く）
+
+boxed Hash の実体（インデックステーブルとエントリ Vec）は glibc malloc
+経由で、activerecord では malloc/free 系だけで 15 % を占める。`mimalloc`
+フィーチャの既定化 A/B は Hash に限らない話だが、Hash の生成・成長が多い
+ワークロードにはここが効く。
+
+---
+
+## 5. 計測手順（再現用）
+
+```sh
+# ビルド
+cargo build --release
+cargo build --release --features perf --target-dir target-perf   # perf 用シンボル
+
+# 純ルックアップのマイクロ（baseline を引く）
+target/release/monoruby bench_hash.rb
+
+# 内訳
+perf record -F 999 -e cpu-clock -g --call-graph=fp -o h.data -- \
+  target-perf/release/monoruby h_str.rb
+perf report -i h.data --stdio --no-children --sort symbol -g none
+
+# ベンチ（交互ラウンド。単発は信用しない）
+cd ../yjit-bench && export LANG=C.UTF-8
+MAX_TIME=25 RESULT_JSON_PATH=out.json \
+  /path/to/monoruby -Iharness-warmup benchmarks/erubi/benchmark.rb
+```
+
+マイクロは必ず「同じループからルックアップを抜いたもの」を baseline として
+測り、その差を見る。monoruby と CRuby ではループ自体のコストが 10 倍違う
+（2.5 ns 対 23 ns）ので、生の時間を並べると比較にならない。

--- a/monoruby/src/value/rvalue/hash.rs
+++ b/monoruby/src/value/rvalue/hash.rs
@@ -125,7 +125,7 @@ pub const HASH_DEAD_OFFSET: usize = RVALUE_OFFSET_KIND + std::mem::offset_of!(Bo
 /// `IdentKey`, a transparent wrapper, so in practice the two agree and
 /// generated code need not branch on the discriminant.
 pub fn hash_entries_layout() -> Option<rubymap::EntriesLayout> {
-    type S = std::collections::hash_map::RandomState;
+    type S = rubymap::RubyRandomState;
     let by_value = rubymap::entries_layout::<Option<Value>, Value, (), (), (), S>()?;
     let by_ident = rubymap::entries_layout::<Option<IdentKey>, Value, (), (), (), S>()?;
     (by_value == by_ident).then_some(by_value)

--- a/rubymap/src/hasher.rs
+++ b/rubymap/src/hasher.rs
@@ -1,0 +1,195 @@
+//! The default hasher for [`RubyMap`](crate::RubyMap) / [`RubySet`](crate::RubySet).
+//!
+//! A Ruby `Hash` probes its table on every `[]`, `[]=`, `key?` and
+//! `fetch`, so the digest is on the hottest path a hash has. The
+//! standard library's [`RandomState`](std::collections::hash_map::RandomState)
+//! runs SipHash-1-3, which measured about a third of the cost of a whole
+//! lookup (`perf` on a `h["name"]` loop: `string_digest` 18.7 % +
+//! `SipHasher13::write` 13.9 %). CRuby does not pay that: its `st_hash`
+//! is a seeded, non-cryptographic mixer.
+//!
+//! This is the same trade: a wyhash-style multiply-fold seeded from a
+//! process-wide random value. Keeping the seed secret is what bounds
+//! hash-flooding — an attacker who cannot predict it cannot pick
+//! colliding keys ahead of time — while the mixing itself is a couple of
+//! multiplies rather than a cryptographic permutation.
+
+use std::hash::{BuildHasher, Hasher};
+
+/// Multiply-fold: the low and high halves of a 128-bit product, xored.
+/// One of these diffuses every input bit across the whole output.
+#[inline(always)]
+fn fold(a: u64, b: u64) -> u64 {
+    let r = (a as u128).wrapping_mul(b as u128);
+    (r as u64) ^ ((r >> 64) as u64)
+}
+
+/// Odd, high-entropy multipliers (wyhash's).
+const P0: u64 = 0xa0761d6478bd642f;
+const P1: u64 = 0xe7037ed1a0b428db;
+const P2: u64 = 0x8ebc6af09c88c6e3;
+
+#[inline(always)]
+fn read8(bytes: &[u8]) -> u64 {
+    u64::from_le_bytes(bytes[..8].try_into().unwrap())
+}
+
+#[inline(always)]
+fn read4(bytes: &[u8]) -> u64 {
+    u32::from_le_bytes(bytes[..4].try_into().unwrap()) as u64
+}
+
+/// The `BuildHasher` half: just the process seed.
+#[derive(Clone, Copy, Debug)]
+pub struct RubyRandomState {
+    seed: u64,
+}
+
+impl RubyRandomState {
+    /// A state on the process-wide random seed — the same one for every
+    /// map, as [`RandomState`](std::collections::hash_map::RandomState)
+    /// keys per process rather than per instance.
+    pub fn new() -> Self {
+        Self { seed: seed() }
+    }
+}
+
+impl Default for RubyRandomState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The process seed, taken once from the standard library's own random
+/// source (`RandomState` is seeded by the OS) so this crate needs no
+/// randomness dependency of its own.
+fn seed() -> u64 {
+    use std::sync::OnceLock;
+    static SEED: OnceLock<u64> = OnceLock::new();
+    *SEED.get_or_init(|| {
+        let s = std::collections::hash_map::RandomState::new();
+        s.hash_one(0x5ee_du64) | 1
+    })
+}
+
+impl BuildHasher for RubyRandomState {
+    type Hasher = RubyHasher;
+
+    #[inline]
+    fn build_hasher(&self) -> RubyHasher {
+        RubyHasher { h: self.seed }
+    }
+}
+
+/// The running digest. Every `write_*` folds its input into `h`; the
+/// final [`finish`](Hasher::finish) folds once more so the result
+/// avalanches even for a single small write (a Symbol key is one
+/// `write_u64`).
+#[derive(Clone, Copy, Debug)]
+pub struct RubyHasher {
+    h: u64,
+}
+
+impl RubyHasher {
+    #[inline(always)]
+    fn add(&mut self, v: u64) {
+        self.h = fold(self.h ^ v, P0);
+    }
+}
+
+impl Hasher for RubyHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        fold(self.h, P2)
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        // Length first: it separates "ab" from "a" + "b" across two
+        // writes, which `Hash` implementations that stream fields rely on.
+        self.add(bytes.len() as u64);
+        let mut b = bytes;
+        while b.len() >= 16 {
+            let lo = read8(b) ^ P1;
+            let hi = read8(&b[8..]) ^ P2;
+            self.add(fold(lo, hi));
+            b = &b[16..];
+        }
+        match b.len() {
+            0 => {}
+            1..=3 => {
+                let mut v = 0u64;
+                for (i, &c) in b.iter().enumerate() {
+                    v |= (c as u64) << (8 * i);
+                }
+                self.add(v);
+            }
+            4..=7 => {
+                // Overlapping 4-byte reads cover 4..=7 without a branch
+                // per length.
+                self.add(read4(b) | (read4(&b[b.len() - 4..]) << 32));
+            }
+            _ => {
+                // 8..=15, likewise with overlapping 8-byte reads.
+                self.add(read8(b));
+                self.add(read8(&b[b.len() - 8..]));
+            }
+        }
+    }
+
+    #[inline]
+    fn write_u8(&mut self, n: u8) {
+        self.add(n as u64);
+    }
+
+    #[inline]
+    fn write_u16(&mut self, n: u16) {
+        self.add(n as u64);
+    }
+
+    #[inline]
+    fn write_u32(&mut self, n: u32) {
+        self.add(n as u64);
+    }
+
+    #[inline]
+    fn write_u64(&mut self, n: u64) {
+        self.add(n);
+    }
+
+    #[inline]
+    fn write_usize(&mut self, n: usize) {
+        self.add(n as u64);
+    }
+
+    #[inline]
+    fn write_u128(&mut self, n: u128) {
+        self.add(n as u64);
+        self.add((n >> 64) as u64);
+    }
+
+    #[inline]
+    fn write_i8(&mut self, n: i8) {
+        self.add(n as u64);
+    }
+
+    #[inline]
+    fn write_i16(&mut self, n: i16) {
+        self.add(n as u64);
+    }
+
+    #[inline]
+    fn write_i32(&mut self, n: i32) {
+        self.add(n as u64);
+    }
+
+    #[inline]
+    fn write_i64(&mut self, n: i64) {
+        self.add(n as u64);
+    }
+
+    #[inline]
+    fn write_isize(&mut self, n: isize) {
+        self.add(n as u64);
+    }
+}

--- a/rubymap/src/hasher.rs
+++ b/rubymap/src/hasher.rs
@@ -198,8 +198,17 @@ impl Hasher for RubyHasher {
 mod tests {
     use super::*;
 
+    /// A fixed seed, so the statistical assertions below are the same
+    /// run to run. The process seed is exercised separately by
+    /// `state_is_stable_within_the_process`.
+    fn fixed() -> RubyRandomState {
+        RubyRandomState {
+            seed: 0x0123_4567_89ab_cdef,
+        }
+    }
+
     fn digest(f: impl FnOnce(&mut RubyHasher)) -> u64 {
-        let mut h = RubyRandomState::default().build_hasher();
+        let mut h = fixed().build_hasher();
         f(&mut h);
         h.finish()
     }
@@ -240,20 +249,35 @@ mod tests {
     /// One flipped bit anywhere in the input changes the digest, and
     /// changes it in the high bits too — hashbrown takes its control byte
     /// from the top 7, so a mixer that only diffuses downward would
-    /// cluster.
+    /// cluster there while looking fine overall.
+    ///
+    /// The control byte is only 7 bits wide, so two unrelated digests
+    /// share it once in 128 by chance: the bound is on the *rate*, not
+    /// on every flip. A mixer that left the high bits alone would keep
+    /// them equal for nearly every flip and blow well past it.
     #[test]
     fn one_bit_changes_the_whole_digest() {
         let base = [0x11u8; 24];
         let h0 = of(&base);
+        let mut same_control = 0;
+        let flips = base.len() * 8;
         for byte in 0..base.len() {
             for bit in 0..8 {
                 let mut probe = base;
                 probe[byte] ^= 1 << bit;
                 let h1 = of(&probe);
                 assert_ne!(h0, h1, "byte {byte} bit {bit}");
-                assert_ne!(h0 >> 57, h1 >> 57, "control bits, byte {byte} bit {bit}");
+                if h0 >> 57 == h1 >> 57 {
+                    same_control += 1;
+                }
             }
         }
+        // Chance alone gives flips/128 (1.5 of 192); 10 % is far above
+        // that and far below the ~100 % of an undiffused high half.
+        assert!(
+            same_control * 10 <= flips,
+            "control bits unchanged for {same_control} of {flips} flips"
+        );
     }
 
     /// Sequential and strided integers are the classic way a weak mixer
@@ -312,3 +336,4 @@ mod tests {
         assert_eq!(a.hash_one("key"), c.hash_one("key"));
     }
 }
+

--- a/rubymap/src/hasher.rs
+++ b/rubymap/src/hasher.rs
@@ -193,3 +193,122 @@ impl Hasher for RubyHasher {
         self.add(n as u64);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn digest(f: impl FnOnce(&mut RubyHasher)) -> u64 {
+        let mut h = RubyRandomState::default().build_hasher();
+        f(&mut h);
+        h.finish()
+    }
+
+    fn of(bytes: &[u8]) -> u64 {
+        digest(|h| h.write(bytes))
+    }
+
+    /// Every length branch of `write`: empty, the 1..=3 byte-at-a-time
+    /// arm, the overlapping 4-byte and 8-byte arms, and the 16-byte loop
+    /// with each possible tail.
+    #[test]
+    fn write_covers_every_length_branch() {
+        let buf: Vec<u8> = (0u8..=63).collect();
+        let mut seen = std::collections::HashSet::new();
+        for len in 0..buf.len() {
+            // Distinct lengths of distinct content must not collide; a
+            // branch that dropped its bytes would show up here.
+            assert!(seen.insert(of(&buf[..len])), "collision at len {len}");
+        }
+    }
+
+    /// The length is mixed in, so a split write is not the same as the
+    /// concatenation — `Hash` implementations that stream several fields
+    /// depend on that.
+    #[test]
+    fn length_separates_split_writes() {
+        let concat = of(b"ab");
+        let split = digest(|h| {
+            h.write(b"a");
+            h.write(b"b");
+        });
+        assert_ne!(concat, split);
+        assert_ne!(of(b"ab"), of(b"ab\0"));
+        assert_ne!(of(b""), of(b"\0"));
+    }
+
+    /// One flipped bit anywhere in the input changes the digest, and
+    /// changes it in the high bits too — hashbrown takes its control byte
+    /// from the top 7, so a mixer that only diffuses downward would
+    /// cluster.
+    #[test]
+    fn one_bit_changes_the_whole_digest() {
+        let base = [0x11u8; 24];
+        let h0 = of(&base);
+        for byte in 0..base.len() {
+            for bit in 0..8 {
+                let mut probe = base;
+                probe[byte] ^= 1 << bit;
+                let h1 = of(&probe);
+                assert_ne!(h0, h1, "byte {byte} bit {bit}");
+                assert_ne!(h0 >> 57, h1 >> 57, "control bits, byte {byte} bit {bit}");
+            }
+        }
+    }
+
+    /// Sequential and strided integers are the classic way a weak mixer
+    /// falls over: the low bits pick the bucket, so a mixer that leaves
+    /// them alone piles every stride into one.
+    #[test]
+    fn integer_keys_spread_over_buckets() {
+        for stride in [1u64, 8, 4096, 1 << 20] {
+            let mut buckets = [0usize; 64];
+            for i in 0..4096u64 {
+                let h = digest(|h| h.write_u64(i.wrapping_mul(stride)));
+                buckets[(h % 64) as usize] += 1;
+            }
+            // 4096 keys over 64 buckets is 64 each; allow a wide margin
+            // and still catch clustering.
+            let (min, max) = (
+                *buckets.iter().min().unwrap(),
+                *buckets.iter().max().unwrap(),
+            );
+            assert!(min >= 20 && max <= 160, "stride {stride}: {min}..{max}");
+        }
+    }
+
+    /// Every `write_*` the `Hash` derive can reach, so a key type that
+    /// streams anything other than `u64` still digests.
+    #[test]
+    fn every_write_method_digests() {
+        let mut seen = std::collections::HashSet::new();
+        assert!(seen.insert(digest(|h| h.write_u8(1))));
+        assert!(seen.insert(digest(|h| h.write_u16(2))));
+        assert!(seen.insert(digest(|h| h.write_u32(3))));
+        assert!(seen.insert(digest(|h| h.write_u64(4))));
+        assert!(seen.insert(digest(|h| h.write_u128(5))));
+        assert!(seen.insert(digest(|h| h.write_usize(6))));
+        assert!(seen.insert(digest(|h| h.write_i8(-1))));
+        assert!(seen.insert(digest(|h| h.write_i16(-2))));
+        assert!(seen.insert(digest(|h| h.write_i32(-3))));
+        assert!(seen.insert(digest(|h| h.write_i64(-4))));
+        assert!(seen.insert(digest(|h| h.write_isize(-5))));
+        // The 128-bit write folds both halves in, so the high half is
+        // not dropped.
+        assert_ne!(
+            digest(|h| h.write_u128(1)),
+            digest(|h| h.write_u128(1 | (1 << 64)))
+        );
+    }
+
+    /// One seed per process: two states digest alike, and a state
+    /// survives being cloned into a map.
+    #[test]
+    fn state_is_stable_within_the_process() {
+        let a = RubyRandomState::new();
+        let b = RubyRandomState::default();
+        assert_eq!(a.hash_one(0x1234u64), b.hash_one(0x1234u64));
+        let c = a;
+        assert_eq!(a.hash_one("key"), c.hash_one("key"));
+    }
+}

--- a/rubymap/src/lib.rs
+++ b/rubymap/src/lib.rs
@@ -59,10 +59,10 @@
 //! ### Alternate Hashers
 //!
 //! [`IndexMap`] and [`RubySet`] have a default hasher type
-//! [`S = RandomState`][std::collections::hash_map::RandomState],
-//! just like the standard `HashMap` and `HashSet`, which is resistant to
-//! HashDoS attacks but not the most performant. Type aliases can make it easier
-//! to use alternate hashers:
+//! [`S = RubyRandomState`][crate::RubyRandomState]: a seeded,
+//! non-cryptographic mixer rather than the standard library's SipHash-1-3
+//! (see `hasher.rs` for why, and what the seed does and does not buy).
+//! Type aliases can make it easier to use alternate hashers:
 //!
 //! ### Rust Version
 //!
@@ -98,11 +98,13 @@ use alloc::vec::{self, Vec};
 
 #[macro_use]
 mod macros;
+mod hasher;
 mod util;
 
 pub mod map;
 pub mod set;
 
+pub use crate::hasher::{RubyHasher, RubyRandomState};
 pub use crate::map::RubyMap;
 pub use crate::set::RubySet;
 pub use ruby_traits::{Equivalent, RubyEql, RubyHash, RubySymEql, RubySymHash};

--- a/rubymap/src/map.rs
+++ b/rubymap/src/map.rs
@@ -24,7 +24,7 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use ruby_traits::{RubyEql, RubyHash, RubySymEql, RubySymHash};
 
-use std::collections::hash_map::RandomState;
+use crate::hasher::RubyRandomState;
 
 use self::core::IndexMapCore;
 use crate::util::{third, try_simplify_range};
@@ -73,7 +73,7 @@ use crate::{Bucket, Entries, Equivalent, GetDisjointMutError, HashValue};
 /// assert_eq!(letters[&'u'], 1);
 /// assert_eq!(letters.get(&'y', &mut (), &mut ()).unwrap(), None);
 /// ```
-pub struct RubyMap<K, V, E = (), G = (), R = (), S = RandomState> {
+pub struct RubyMap<K, V, E = (), G = (), R = (), S = RubyRandomState> {
     pub(crate) core: IndexMapCore<K, V, E, G, R>,
     hash_builder: S,
 }
@@ -1635,7 +1635,7 @@ where
     }
 }
 
-impl<K, V, E, G, R> RubyMap<K, V, E, G, R, RandomState>
+impl<K, V, E, G, R> RubyMap<K, V, E, G, R, RubyRandomState>
 where
     K: RubyHash<E, G, R> + RubyEql<E, G, R>,
 {

--- a/rubymap/src/set.rs
+++ b/rubymap/src/set.rs
@@ -9,7 +9,7 @@ mod tests;
 pub use self::iter::{Drain, IntoIter, Iter};
 pub use self::slice::Slice;
 
-use std::collections::hash_map::RandomState;
+use crate::hasher::RubyRandomState;
 
 use crate::util::try_simplify_range;
 use alloc::boxed::Box;
@@ -71,7 +71,7 @@ type Bucket<T> = super::Bucket<T, ()>;
 /// assert!(letters.contains(&'u', &mut (), &mut ()).unwrap());
 /// assert!(!letters.contains(&'y', &mut (), &mut ()).unwrap());
 /// ```
-pub struct RubySet<T, E = (), G = (), R = (), S = RandomState> {
+pub struct RubySet<T, E = (), G = (), R = (), S = RubyRandomState> {
     pub(crate) map: RubyMap<T, (), E, G, R, S>,
 }
 
@@ -977,7 +977,7 @@ where
     }
 }
 
-impl<T, E, G, R> RubySet<T, E, G, R, RandomState>
+impl<T, E, G, R> RubySet<T, E, G, R, RubyRandomState>
 where
     T: RubyEql<E, G, R> + RubyHash<E, G, R>,
 {


### PR DESCRIPTION
Follows up §5.2 of `doc/yjit_bench_slow_investigation_2026-09.md` — Hash lookups are 29 % of erubi, 18 % of rack, 13 % of activerecord. Two commits: the change, and a document recording where a lookup's time actually goes.

## What a lookup was spending its time on

`perf` on an `h["name"]` loop, before this PR:

| | String key | Symbol key |
|---|---:|---:|
| digest (SipHash-1-3) | **32.6 %** | **36.3 %** |
| IndexMap / hashbrown probe | 28.2 % | 18.4 % |
| `HashRef::get` | 12.0 % | 11.7 % |
| `Hashmap::index` | 8.0 % | 9.4 % |
| `hashindex` builtin | 5.8 % | 5.0 % |
| memcmp | 5.2 % | — |

A Symbol key is just as slow as a String key, so this was never String-specific: `RubyMap` inherited the standard library's `RandomState`, so every `[]`, `[]=`, `key?` and `fetch` ran SipHash-1-3. CRuby does not pay that — its `st_hash` is a seeded, non-cryptographic mixer.

## Change

`rubymap::RubyRandomState`: a wyhash-style multiply-fold seeded from one process-wide random value (drawn from `RandomState` itself, so no new dependency). It becomes `RubyMap` / `RubySet`'s default `S`, so the general and the prehashed (vm-free) probes move together in one place. `Object#hash` and friends still answer from `HASH_STATE` and are unchanged.

Keeping the seed secret is what bounds hash-flooding — an attacker who cannot predict it cannot pick colliding keys ahead of time — while the mixing is a couple of multiplies rather than a cryptographic permutation. That is the same trade CRuby makes.

## Measurements

Pure lookup cost (loop time minus the same loop without the lookup), 18-entry hash, with CRuby 4.0.6 + YJIT for scale:

| key | before | after | YJIT |
|---|---:|---:|---:|
| String, 4 bytes | 42.8 ns | **33.7** | 17.5 |
| String, 19 bytes | 49.1 | **37.7** | 18.5 |
| String, miss | 42.0 | **30.7** | 16.7 |
| Symbol | 39.0 | **25.7** | 16.1 |
| Integer | 52.1 | **39.5** | 16.4 |

yjit-bench, 6 interleaved rounds, min of medians:

| bench | before | after | diff |
|---|---:|---:|---:|
| erubi | 385.3 ms | 337.7 | **−12.4 %** |
| graphql | 45.3 | 43.4 | −4.1 % |
| rack | 90.5 | 89.7 | −0.9 % |
| activerecord | 294.7 | 295.5 | +0.3 % |

Hash quality sanity check — a 200K-entry hash with keys strided by 4096, the classic way a weak mixer falls over: 94.2 → 88.8 ns per lookup, i.e. no clustering.

## `doc/hash_optimization.md`

The second commit adds a design record (JA, indexed in `doc/README.md`): the three representations and the flags byte that selects them, the vm-free prehashed probe, what the JIT walks in machine code, the five optimizations landed so far with their measurements, the post-change perf breakdown, and a ranked list of what is left. The top three of that list:

1. **The Integer/Float double hash.** `Value::ruby_hash_packed` runs a whole second SipHash (`seeded_hasher()`) inside itself to produce the value `Integer#hash` must return, then feeds that to the map's hasher. Bucketing does not need the Ruby-visible value — only insert/probe consistency. That is why Integer keys stay 14 ns behind Symbol keys (39.5 vs 25.7) even after this PR.
2. **Inlining the probe in the JIT.** `Hash#[]` inlines as far as a direct call to `hashindex`; everything past that is Rust. The probe plus the four dispatch layers are now ~75 % of a lookup, and this is what the remaining gap to YJIT (33.7 vs 17.5 ns) is made of.
3. **A key-set inline cache.** erubi's 322 spec hashes all carry the same 18 keys in the same order — the shape a template engine or a JSON payload produces.

## Tests

Full `cargo test --no-fail-fast`: 2403 passed / 1 failed — the pre-existing `float::tests::angle` (`Float#ceil(15)` differs on the local CRuby 4.0.6 vs the 4.0.2 oracle), unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkoJG3qRpCRJ4nXDZH3mg9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkoJG3qRpCRJ4nXDZH3mg9)_