### PR TITLE
Gate the leaf expansion on the inline cache, and admit effects and comparisons

### DIFF
--- a/monoruby/src/codegen/jitgen/compile/frameless.rs
+++ b/monoruby/src/codegen/jitgen/compile/frameless.rs
@@ -188,43 +188,71 @@ pub(super) enum LeafValue {
 }
 
 ///
-/// A body that computes one value by folding operands into an accumulator,
-/// optionally stores it to an ivar, and returns it.
+/// One step of a frame-free leaf body, applied in order to a single
+/// accumulator.
 ///
-/// `@count += 1`, `@a * 2`, `@sum + x`, `@a` — the small readers, writers
-/// and counters that make up most of the leaf methods in object-heavy Ruby,
-/// and today cost a full frame each.
+/// The accumulator model is what keeps the expansion to two registers and
+/// no stack slots, and it is not a restriction bytecodegen fights: these
+/// bodies are single expressions, so their bytecode already threads one
+/// value through one temporary.
 ///
-/// The chain is deliberately *left-linear*: every step's right operand is a
-/// leaf. That keeps the expansion to two registers, and it is the shape
-/// bytecodegen produces for these expressions anyway.
+#[derive(Clone, Copy, Debug)]
+pub(super) enum LeafOp {
+    /// `acc = value`. Needs no guard — every [`LeafValue`] is something the
+    /// caller can name outright.
+    Load(LeafValue),
+    /// `acc = acc <kind> operand`, fixnum arithmetic. Guards both operands
+    /// and, for `Div`, the zero divisor.
+    Bin(BinOpK, LeafValue),
+    /// `acc = acc <kind> operand`, fixnum comparison. Guards both operands;
+    /// the accumulator becomes a bool.
+    Cmp(CmpKind, LeafValue),
+    /// `@name = acc`.
+    Store(IdentId),
+}
+
+impl LeafOp {
+    /// Whether this op can side-exit. The ordering rule is stated in terms
+    /// of these: none may follow a [`LeafOp::Store`].
+    fn guards(&self) -> bool {
+        matches!(self, LeafOp::Bin(..) | LeafOp::Cmp(..))
+    }
+}
+
+///
+/// A body that computes one value through an accumulator, storing to ivars
+/// along the way, and returns it.
+///
+/// `@count += 1`, `@a * 2`, `@sum + x`, `@a > 0`, `@a`, `@n = 1; @m = 2` —
+/// the small readers, writers, counters and predicates that make up most of
+/// the leaf methods in object-heavy Ruby, and today cost a full frame each.
 ///
 pub(super) struct LeafBody {
-    /// The value the accumulator starts at.
-    pub base: LeafValue,
-    /// Folded in left to right: `acc = acc <kind> operand`.
-    pub steps: Vec<(BinOpK, LeafValue)>,
-    /// When set, the accumulator is stored to this ivar before returning.
-    pub store: Option<IdentId>,
+    /// Applied in order; the accumulator's final value is returned.
+    pub ops: Vec<LeafOp>,
 }
 
-/// The longest accumulator chain that is still worth expanding. Each step
-/// is two guards plus an arithmetic instruction in the caller, repeated at
+/// The most ops a body may have and still be expanded. Each guarding op is
+/// two guards plus an arithmetic instruction in the caller, repeated at
 /// every site that calls this method.
-const MAX_STEPS: usize = 3;
+const MAX_OPS: usize = 8;
 
-/// What a callee slot holds, as an accumulator chain under construction.
+/// What a callee slot holds: the op sequence that computes it.
 #[derive(Clone)]
-struct Chain {
-    base: LeafValue,
-    steps: Vec<(BinOpK, LeafValue)>,
-}
+struct Chain(Vec<LeafOp>);
 
 impl Chain {
     fn leaf(base: LeafValue) -> Self {
-        Self {
-            base,
-            steps: vec![],
+        Self(vec![LeafOp::Load(base)])
+    }
+
+    /// The value this chain is, when it is a bare [`LeafValue`] — the only
+    /// form admitted as an operand, which is what keeps the accumulator
+    /// chain left-linear and the register need at two.
+    fn as_value(&self) -> Option<LeafValue> {
+        match self.0[..] {
+            [LeafOp::Load(v)] => Some(v),
+            _ => None,
         }
     }
 }
@@ -237,14 +265,21 @@ impl Chain {
 /// and an instruction set with no call, no `yield`, nothing that raises and
 /// nothing that appears in a backtrace.
 ///
-/// # Why the store must come last
+/// # Why no guard may follow a store
 ///
 /// Every guard this body needs — the operand class checks, the overflow
-/// check, the frozen check — side-exits to the *call* instruction, and the
-/// interpreter then performs the whole call itself. That is only sound
-/// while nothing has happened yet, so the one effect a body may have has to
-/// come after every exit. Requiring a single `StoreIvar` immediately before
-/// the `Ret` buys that outright; anything else is declined.
+/// check, the zero-divisor check, the frozen check — side-exits to the
+/// *call* instruction, and the interpreter then performs the whole call
+/// itself. That is only sound while **nothing has happened yet**, so the
+/// body's effects have to come after every exit.
+///
+/// That is the rule, and it is weaker than "one store, immediately before
+/// the `Ret`", which is what the first version required. A body may store
+/// as many times as it likes (`def reset = (@n = 0; @m = 0)`) as long as no
+/// guarding op follows the first store; the hoisted frozen guard covers
+/// every one of them, since nothing between them can call out and freeze
+/// the receiver. What is declined is a guard *after* an effect — that exit
+/// could no longer hand the call back, because part of it already ran.
 ///
 /// `Div` needs no special treatment: a zero divisor is *already* a deopt in
 /// both backends (x86-64 stamps `_divide_by_zero` and jumps to the exit,
@@ -281,22 +316,23 @@ pub(super) fn leaf_expr_body(store: &Store, iseq_id: ISeqId) -> Option<LeafBody>
         );
     }
 
-    let mut store_to: Option<(IdentId, SlotId)> = None;
+    // Stores are the body's effects, so they are emitted where the body puts
+    // them rather than folded into a slot's chain. `ops` is what has been
+    // committed to the accumulator so far; a slot's chain is spliced onto it
+    // when the slot is finally used.
+    let mut ops: Vec<LeafOp> = vec![];
     let mut ret: Option<SlotId> = None;
     for idx in begin..=end {
-        // A store is the body's one effect, so nothing that can side-exit
-        // may follow it. `Ret` is all that is allowed to.
-        let after_store = store_to.is_some();
         match TraceIr::from_pc(iseq.get_pc(idx), store) {
-            TraceIr::InitMethod(..) if !after_store => {}
-            TraceIr::FrozenLiteral(dst, v) | TraceIr::Literal(dst, v) if !after_store => {
+            TraceIr::InitMethod(..) => {}
+            TraceIr::FrozenLiteral(dst, v) | TraceIr::Literal(dst, v) => {
                 v.try_fixnum()?;
                 slots.insert(dst, Chain::leaf(LeafValue::Fixnum(v)));
             }
-            TraceIr::LoadIvar(dst, name, _) if !after_store => {
+            TraceIr::LoadIvar(dst, name, _) => {
                 slots.insert(dst, Chain::leaf(LeafValue::SelfIvar(name)));
             }
-            TraceIr::Mov(dst, src) if !after_store => {
+            TraceIr::Mov(dst, src) => {
                 let chain = slots.get(&src)?.clone();
                 slots.insert(dst, chain);
             }
@@ -305,31 +341,40 @@ pub(super) fn leaf_expr_body(store: &Store, iseq_id: ISeqId) -> Option<LeafBody>
                 dst: Some(dst),
                 lhs,
                 rhs,
-                ..
-            } if !after_store => {
+                ic,
+                polymorphic,
+            } => {
                 if !matches!(
                     kind,
                     BinOpK::Add | BinOpK::Sub | BinOpK::Mul | BinOpK::Div
                 ) {
                     return None;
                 }
-                let lhs = slots.get(&lhs)?.clone();
-                let rhs = slots.get(&rhs)?;
-                // Left-linear only: a nested right operand would need a
-                // third register and a spill slot to evaluate.
-                if !rhs.steps.is_empty() {
-                    return None;
-                }
-                let operand = rhs.base;
-                if lhs.steps.len() >= MAX_STEPS {
-                    return None;
-                }
-                let mut chain = lhs;
-                chain.steps.push((kind, operand));
+                saw_fixnums(ic, polymorphic)?;
+                let chain = extend(&slots, lhs, rhs, LeafOp::Bin(kind, LeafValue::Param(0)))?;
                 slots.insert(dst, chain);
             }
-            TraceIr::StoreIvar(src, name, _) if !after_store => {
-                store_to = Some((name, src));
+            TraceIr::BinCmp {
+                kind,
+                dst: Some(dst),
+                lhs,
+                rhs,
+                ic,
+                polymorphic,
+            } => {
+                saw_fixnums(ic, polymorphic)?;
+                let chain = extend(&slots, lhs, rhs, LeafOp::Cmp(kind, LeafValue::Param(0)))?;
+                slots.insert(dst, chain);
+            }
+            TraceIr::StoreIvar(src, name, _) => {
+                // The stored value's chain is committed here, so its guards
+                // land ahead of this store — and of every later one.
+                let chain = slots.get(&src)?.clone();
+                commit(&mut ops, chain)?;
+                ops.push(LeafOp::Store(name));
+                // The slot now *is* the accumulator: a later use of it (the
+                // `ret` of `@n += 1`, say) must not recompute the chain.
+                slots.insert(src, Chain(vec![]));
             }
             // A basic block ends at its terminator, so this runs last.
             TraceIr::Ret(slot) => ret = Some(slot),
@@ -337,22 +382,94 @@ pub(super) fn leaf_expr_body(store: &Store, iseq_id: ISeqId) -> Option<LeafBody>
         }
     }
 
-    let ret = ret?;
-    // When the body stores, it must return the very value it stored — the
-    // expansion computes the accumulator once.
-    if let Some((_, src)) = store_to
-        && src != ret
+    let chain = slots.remove(&ret?)?;
+    commit(&mut ops, chain)?;
+    // A body that only hands back a parameter is `ISeqHint`'s business.
+    if let [LeafOp::Load(LeafValue::Param(_))] = ops[..] {
+        return None;
+    }
+    if ops.len() > MAX_OPS {
+        return None;
+    }
+    // The rule: nothing that can side-exit may follow an effect.
+    let first_store = ops.iter().position(|op| matches!(op, LeafOp::Store(_)));
+    if let Some(i) = first_store
+        && ops[i..].iter().any(LeafOp::guards)
     {
         return None;
     }
-    let chain = slots.remove(&ret)?;
-    // A body that only hands back a parameter is `ISeqHint`'s business.
-    if chain.steps.is_empty() && store_to.is_none() && matches!(chain.base, LeafValue::Param(_)) {
+    Some(LeafBody { ops })
+}
+
+///
+/// Require that the VM has actually seen this operation on two fixnums.
+///
+/// The expansion is *all* fixnum: it guards both operands as `Integer` and
+/// lowers to the integer register forms. Taking it at a site the VM has only
+/// ever run on Floats does not produce a wrong answer — the guard exits and
+/// the interpreter performs the call — but it replaces a working specialized
+/// call with a guaranteed deopt on every execution, which is worse than not
+/// expanding at all. Float-heavy code (`app_aobench.rb`'s vector methods) is
+/// full of exactly these small bodies, so the inline cache is the difference
+/// between a win and a regression there.
+///
+/// An empty cache means the VM never reached the instruction, which is no
+/// evidence either; a polymorphic site means it saw more than one operand
+/// class, so a fixnum-only expansion would exit on the others.
+///
+fn saw_fixnums(ic: Option<(ClassId, ClassId)>, polymorphic: bool) -> Option<()> {
+    if polymorphic {
         return None;
     }
-    Some(LeafBody {
-        base: chain.base,
-        steps: chain.steps,
-        store: store_to.map(|(name, _)| name),
-    })
+    match ic {
+        Some((INTEGER_CLASS, INTEGER_CLASS)) => Some(()),
+        _ => None,
+    }
+}
+
+///
+/// Splice `chain` onto the ops committed so far.
+///
+/// An empty chain means the slot already *is* the accumulator (it was just
+/// stored), so there is nothing to recompute. Otherwise the chain must start
+/// by loading the accumulator afresh — a chain that continued from some
+/// other slot's value would need that value still to be in the accumulator,
+/// which only the empty case guarantees.
+///
+fn commit(ops: &mut Vec<LeafOp>, chain: Chain) -> Option<()> {
+    if chain.0.is_empty() {
+        return Some(());
+    }
+    if !matches!(chain.0[0], LeafOp::Load(_)) {
+        return None;
+    }
+    ops.extend(chain.0);
+    Some(())
+}
+
+///
+/// Build the chain for `lhs <op> rhs`, where `op`'s operand field is a
+/// placeholder to be filled with `rhs`'s value.
+///
+/// The right operand must be a bare [`LeafValue`]: a nested one would need a
+/// third register and a slot to evaluate into, and bytecodegen does not
+/// produce it for these bodies anyway.
+///
+fn extend(
+    slots: &HashMap<SlotId, Chain>,
+    lhs: SlotId,
+    rhs: SlotId,
+    op: LeafOp,
+) -> Option<Chain> {
+    let operand = slots.get(&rhs)?.as_value()?;
+    let mut chain = slots.get(&lhs)?.clone();
+    if chain.0.is_empty() {
+        return None;
+    }
+    chain.0.push(match op {
+        LeafOp::Bin(kind, _) => LeafOp::Bin(kind, operand),
+        LeafOp::Cmp(kind, _) => LeafOp::Cmp(kind, operand),
+        _ => return None,
+    });
+    Some(chain)
 }

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -1358,29 +1358,38 @@ impl<'a> JitContext<'a> {
                 _ => Some(None),
             }
         };
-        let Some(base_ivar) = ivar_of(self, body.base) else {
-            return false;
-        };
-        let mut step_ivars = Vec::with_capacity(body.steps.len());
-        for &(_, operand) in &body.steps {
-            let Some(ivarid) = ivar_of(self, operand) else {
-                return false;
+        // Resolve every ivar name the body mentions, up front.
+        let mut ivars: Vec<Option<IvarId>> = Vec::with_capacity(body.ops.len());
+        for op in &body.ops {
+            let name = match *op {
+                frameless::LeafOp::Load(frameless::LeafValue::SelfIvar(name))
+                | frameless::LeafOp::Bin(_, frameless::LeafValue::SelfIvar(name))
+                | frameless::LeafOp::Cmp(_, frameless::LeafValue::SelfIvar(name))
+                | frameless::LeafOp::Store(name) => name,
+                _ => {
+                    ivars.push(None);
+                    continue;
+                }
             };
-            step_ivars.push(ivarid);
-        }
-        let store_ivar = match body.store {
-            Some(name) => match resolve(self, name) {
-                Some(ivarid) => Some(ivarid),
+            match resolve(self, name) {
+                Some(ivarid) => ivars.push(Some(ivarid)),
                 None => return false,
-            },
-            None => None,
-        };
+            }
+        }
 
         state.flush_gp(ir);
         // The receiver, for every inline ivar access and the frozen guard.
         state.load(ir, recv, GP::Rdi);
         let deopt = ir.new_deopt(state);
 
+        ///
+        /// Emit one operand into `reg`.
+        ///
+        /// Returns whether rdi (the receiver) may have been clobbered. Only
+        /// a parameter load can do it: the slot may hold an unboxed float,
+        /// and boxing it calls out. The ivar load and the literal write
+        /// their destination and nothing else.
+        ///
         fn emit_value(
             ir: &mut AsmIr,
             state: &mut AbstractState,
@@ -1388,43 +1397,81 @@ impl<'a> JitContext<'a> {
             v: frameless::LeafValue,
             ivarid: Option<IvarId>,
             reg: GP,
-        ) {
+        ) -> bool {
             match v {
-                frameless::LeafValue::SelfIvar(_) => ir.push(AsmInst::LoadIVarInline {
-                    ivarid: ivarid.unwrap(),
-                    dst: reg,
-                }),
-                frameless::LeafValue::Fixnum(val) => ir.lit2reg(val, reg),
-                frameless::LeafValue::Param(i) => state.load(ir, arg_slots[i as usize], reg),
+                frameless::LeafValue::SelfIvar(_) => {
+                    ir.push(AsmInst::LoadIVarInline {
+                        ivarid: ivarid.unwrap(),
+                        dst: reg,
+                    });
+                    false
+                }
+                frameless::LeafValue::Fixnum(val) => {
+                    ir.lit2reg(val, reg);
+                    false
+                }
+                frameless::LeafValue::Param(i) => {
+                    state.load(ir, arg_slots[i as usize], reg);
+                    true
+                }
             }
         }
 
-        emit_value(ir, state, arg_slots, body.base, base_ivar, GP::Rax);
-        for (i, &(kind, operand)) in body.steps.iter().enumerate() {
-            emit_value(ir, state, arg_slots, operand, step_ivars[i], GP::Rcx);
-            // Neither operand is statically typed here — the receiver's
-            // class is known but its ivars' contents are not, and a
-            // parameter is whatever the caller passed.
-            ir.push(AsmInst::GuardClass(GP::Rax, INTEGER_CLASS, deopt));
-            ir.push(AsmInst::GuardClass(GP::Rcx, INTEGER_CLASS, deopt));
-            ir.integer_binop_reg(kind, GP::Rax, GP::Rax, GP::Rcx, deopt);
-        }
-
-        if let Some(ivarid) = store_ivar {
-            // A step's result is a proven fixnum, so it needs no write
-            // barrier; a bare value (`def set(x) = @a = x`) may be a heap
-            // object and does.
-            let wb = body.steps.is_empty() && !matches!(body.base, frameless::LeafValue::Fixnum(_));
-            // Re-materialize the receiver: the arithmetic above went
-            // through rax/rcx, but a parameter load may have gone through
-            // rdi's slot machinery.
-            state.load(ir, recv, GP::Rdi);
-            ir.guard_frozen(deopt);
-            ir.push(AsmInst::StoreIVarInline {
-                src: GP::Rax,
-                ivarid,
-                wb,
-            });
+        // The accumulator lives in rax; rcx holds each op's right operand.
+        // Tracked alongside it: whether rax is known to hold an immediate,
+        // which is what decides the write barrier on a store.
+        let mut acc_immediate = false;
+        // The frozen guard is hoisted to the first store and covers every
+        // later one — nothing between them can call out and freeze the
+        // receiver.
+        let mut frozen_guarded = false;
+        // rdi still holds the receiver, so a store needs no reload.
+        let mut recv_live = true;
+        for (i, op) in body.ops.iter().enumerate() {
+            match *op {
+                frameless::LeafOp::Load(v) => {
+                    recv_live &= !emit_value(ir, state, arg_slots, v, ivars[i], GP::Rax);
+                    acc_immediate = matches!(v, frameless::LeafValue::Fixnum(_));
+                }
+                frameless::LeafOp::Bin(kind, operand) => {
+                    recv_live &= !emit_value(ir, state, arg_slots, operand, ivars[i], GP::Rcx);
+                    // Neither operand is statically typed here — the
+                    // receiver's class is known but its ivars' contents are
+                    // not, and a parameter is whatever the caller passed.
+                    ir.push(AsmInst::GuardClass(GP::Rax, INTEGER_CLASS, deopt));
+                    ir.push(AsmInst::GuardClass(GP::Rcx, INTEGER_CLASS, deopt));
+                    ir.integer_binop_reg(kind, GP::Rax, GP::Rax, GP::Rcx, deopt);
+                    acc_immediate = true;
+                }
+                frameless::LeafOp::Cmp(kind, operand) => {
+                    recv_live &= !emit_value(ir, state, arg_slots, operand, ivars[i], GP::Rcx);
+                    ir.push(AsmInst::GuardClass(GP::Rax, INTEGER_CLASS, deopt));
+                    ir.push(AsmInst::GuardClass(GP::Rcx, INTEGER_CLASS, deopt));
+                    // The comparison zeroes rax before reading its operands,
+                    // so the accumulator has to step aside first.
+                    ir.reg_move(GP::Rax, GP::Rsi);
+                    ir.integer_cmp_reg(kind, None, GP::Rsi, GP::Rcx);
+                    acc_immediate = true;
+                }
+                frameless::LeafOp::Store(_) => {
+                    if !recv_live {
+                        state.load(ir, recv, GP::Rdi);
+                        recv_live = true;
+                    }
+                    if !frozen_guarded {
+                        ir.guard_frozen(deopt);
+                        frozen_guarded = true;
+                    }
+                    ir.push(AsmInst::StoreIVarInline {
+                        src: GP::Rax,
+                        ivarid: ivars[i].unwrap(),
+                        // A guarded arithmetic result or a fixnum literal
+                        // needs no write barrier; a bare value
+                        // (`def set(x) = @a = x`) may be a heap object.
+                        wb: !acc_immediate,
+                    });
+                }
+            }
         }
         state.def_reg2acc(ir, GP::Rax, dst);
         state.unset_side_effect_guard();
@@ -3518,9 +3565,9 @@ mod tests {
     /// path that stores nothing), a body that calls, one that stores twice,
     /// one whose store is not last, a `%` (`BinOpK::Rem` has no register
     /// form to lower to), and a body reading a second object's ivar. Then
-    /// the two declines that depend on the *receiver* rather than the body:
-    /// a class whose instances have no inline ivar slots, and an ivar with
-    /// no `IvarId` to resolve.
+    /// a guard after an effect, and the two declines that depend on the
+    /// *receiver* rather than the body: a class whose instances have no
+    /// inline ivar slots, and an ivar with no `IvarId` to resolve.
     #[test]
     fn frameless_leaf_bodies_decline() {
         run_test(
@@ -3534,13 +3581,17 @@ mod tests {
               def early; @n = 1; @m + 1; end
               def rem(x); @n % x; end
               def other(o); @n + o.n; end
+              # A guard *after* an effect: `@n` is already written when the
+              # `+` overflow check could fire, so that exit could no longer
+              # hand the whole call back.
+              def late(x); @n = x; @m = x + 1; end
               attr_reader :n, :m
             end
             d = D.new
             res = []
-            100.times { d.cond(1); d.calls; d.two; d.early; d.rem(3); d.other(d) }
+            100.times { d.cond(1); d.calls; d.two; d.early; d.rem(3); d.other(d); d.late(2) }
             res << d.cond(-1) << d.cond(3) << d.calls << d.two << d.early
-            res << d.rem(4) << d.other(d) << d.n << d.m
+            res << d.rem(4) << d.other(d) << d.late(5) << d.n << d.m
 
             # A receiver whose instances are not plain objects has no inline
             # ivar slots to read at a fixed offset.
@@ -3629,6 +3680,124 @@ mod tests {
             before = q.m
             e = (begin; q.store_after(0); rescue ZeroDivisionError => x; x; end)
             res << trace(e) << before << q.m << (q.m == before)
+            res
+            "#,
+        );
+    }
+
+    /// Several effects in one body. The rule is that no *guard* may follow
+    /// an effect, not that there be only one effect, so `@n = 1; @m = 2`
+    /// expands: one hoisted frozen guard covers both stores, since nothing
+    /// between them can call out and freeze the receiver.
+    ///
+    /// Covered alongside it: the write barrier, which a guarded arithmetic
+    /// result or a fixnum literal does not need but a bare parameter does —
+    /// so a store of a heap object has to keep the receiver's card marked,
+    /// which the young-object collection at the end checks.
+    #[test]
+    fn frameless_leaf_bodies_multi_store() {
+        run_test(
+            r#"
+            class M
+              def initialize; @a = 0; @b = 0; @c = 0; end
+              def two;   @a = 1; @b = 2; end
+              def reset; @a = 0; @b = 0; @c = 0; end
+              def calc(x); @a = x * 2; @b = @a; end
+              def objs(x); @a = x; @b = x; end
+              attr_reader :a, :b, :c
+            end
+            m = M.new
+            res = []
+            300.times { m.two; m.reset; m.calc(3); m.objs("s") }
+            res << m.two << [m.a, m.b]
+            res << m.reset << [m.a, m.b, m.c]
+            res << m.calc(4) << [m.a, m.b]
+            # a heap object through the same path: the store needs the write
+            # barrier, so force a collection and read it back
+            res << m.objs([1, 2]) << [m.a, m.b]
+            GC.start
+            res << [m.a, m.b]
+            # a frozen receiver still raises, from a real frame, and with
+            # neither store performed
+            f = M.new.freeze
+            res << (begin; f.two; rescue FrozenError => e; e.class; end) << [f.a, f.b]
+            res
+            "#,
+        );
+    }
+
+    /// The expansion is all-fixnum — it guards both operands as `Integer`
+    /// and lowers to the integer register forms — so it must only be taken
+    /// where the VM has actually seen fixnums. Float-ivar bodies are the
+    /// counter-case, and they are everywhere in numeric code: expanding
+    /// `def scaled = @x * 2` on a `Float` `@x` answers correctly (the guard
+    /// exits and the interpreter performs the call) but exits on *every*
+    /// execution, which is strictly worse than the specialized call it
+    /// replaced. Measured on a tight loop, gating on the inline cache is
+    /// worth ~2x on these bodies.
+    ///
+    /// This test pins the answers; what it cannot pin is the absence of the
+    /// exit, so the shapes are listed here to keep them exercised.
+    #[test]
+    fn frameless_leaf_bodies_float_ivars() {
+        run_test(
+            r#"
+            class F
+              def initialize(x, y); @x = x; @y = y; end
+              def scaled; @x * 2; end
+              def sum;    @x + @y; end
+              def gt;     @x > 1.0; end
+              def bump;   @x += 1; end
+              attr_reader :x
+            end
+            f = F.new(1.5, 2.5)
+            res = []
+            300.times { f.scaled; f.sum; f.gt; f.bump }
+            res << f.scaled << f.sum << f.gt << f.bump << f.x
+            # the same bodies on Integer receivers still answer correctly
+            i = F.new(3, 4)
+            300.times { i.scaled; i.sum; i.gt; i.bump }
+            res << i.scaled << i.sum << i.gt << i.bump << i.x
+            # and a body the VM saw on both is polymorphic, so neither
+            # expansion is taken
+            m = [F.new(1.5, 2.5), F.new(3, 4)]
+            300.times { m.each { |o| o.sum } }
+            res << m.map { |o| o.sum }
+            res
+            "#,
+        );
+    }
+
+    /// Comparisons: the accumulator becomes a bool, so the expansion has to
+    /// step it out of rax first (the lowering zeroes rax before reading its
+    /// operands). All seven `CmpKind`s, on an ivar and on a parameter, plus
+    /// the guard firing on a non-fixnum operand.
+    #[test]
+    fn frameless_leaf_bodies_compare() {
+        run_test(
+            r#"
+            class P
+              def initialize(n); @n = n; end
+              def pos;    @n > 0; end
+              def gt(x);  @n > x; end
+              def ge(x);  @n >= x; end
+              def lt(x);  @n < x; end
+              def le(x);  @n <= x; end
+              def eq(x);  @n == x; end
+              def ne(x);  @n != x; end
+              def scaled_gt(x); @n * 2 > x; end
+            end
+            p5 = P.new(5)
+            res = []
+            300.times { p5.pos; p5.gt(1); p5.ge(5); p5.lt(9); p5.le(5); p5.eq(5); p5.ne(1); p5.scaled_gt(3) }
+            res << p5.pos << P.new(-1).pos << P.new(0).pos
+            res << p5.gt(4) << p5.gt(5) << p5.ge(5) << p5.ge(6)
+            res << p5.lt(6) << p5.lt(5) << p5.le(5) << p5.le(4)
+            res << p5.eq(5) << p5.eq(6) << p5.ne(5) << p5.ne(6)
+            res << p5.scaled_gt(9) << p5.scaled_gt(10)
+            # the guards fire: a non-fixnum ivar, and a non-fixnum argument
+            res << P.new(1.5).pos << p5.gt(4.5) << p5.eq("5")
+            res << (begin; p5.gt("x"); rescue ArgumentError, TypeError => e; e.class; end)
             res
             "#,
         );

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -490,6 +490,7 @@
 23f3838afb92bd57e15d229dd0d1deb0	"method"	defined?(__ENCODING__.name)
 23fb14c94b631d93c9694feb48994552	[RuntimeError, true]	class BlockRaiser\n              def self.raise_in_thread(*args, &bl
 23fb7df204a374180f0628ebb762f0dd	[[:deprecated, :experimental, :performance, :strict_unused_block], false, true, false, false, true, true, nil, false, false, false, true]	res = []\n            res << Warning.categories\n            res << W
+2409ce9d3bc696017834648d7c8c2579	[2, [1, 2], 0, [0, 0, 0], 8, [8, 8], [1, 2], [[1, 2], [1, 2]], [[1, 2], [1, 2]], FrozenError, [0, 0]]	class M\n              def initialize; @a = 0; @b = 0; @c = 0; end\n 
 24196e0cebd247d987469fb63b77ec33	:OVERRIDDEN	class Complex; def *(o); :OVERRIDDEN; end; end; Complex(1,2) * Complex(3,4)
 245e848f69575fb36810ea7f6796973c	TypeError	(GC.stat(7) rescue $!.class)
 246af9040a3d2f43e9ddf823ee30471c	true	(0x8000_0000_0000_0000 + 39) > (0x8000_0000_0000_0000 + 39 + 0.0)
@@ -1528,6 +1529,7 @@
 740f2927c51791b1cce95ad716cea114	[[], [[], :blk]]	class ZpBase\n          def q(*a) = a\n          def r(*a) = [a, block_gi
 7416b95f5e87edec12c271dfa849a210	[200, [:body, :ensure_start, :ensure]]	def baz\n              $x = []\n              $x << :body\n           
 74265315f293e83823e6e37edea00c74	[true, true, true, true, true, 1.0, 42, nil, nil]	srand(42)\n            a = rand\n            srand(42)\n            [\n
+7427c64af89bec062257a676328a3d4f	[603.0, 304.0, true, 302.5, 302.5, 606, 307, true, 304, 304, [4.0, 7]]	class F\n              def initialize(x, y); @x = x; @y = y; end\n   
 742cf7259eae88dd4512794b3c9d16ad	[:i, :j]	def m; [1].each { |i| j = i * 2; return local_variables.sort }; end; m
 7441660ef7a2d951150dad613bc4907b	[:x, :x=, :y, :y=]	$added = []\n        class Module\n          alias_method :orig_method_ad
 7483001417ab19fd0c97c04334cd3e4a	[-1.0, -0.5, 0.0, 0.5, 1.0]	def test\n          res = []\n          i = 0\n          lo  = -2.0\n      
@@ -2988,6 +2990,7 @@ e1c2cb8e9e01d860acf3a63296e8f6a3	[nil, nil]	s = "\\303".dup.force_encoding(Encod
 e1d0e1049ee5298bcdc5c96d04a37dd7	[false, false, true]	res = [$DEBUG, $-d]\n        $DEBUG = true\n        res << $-d\n        $D
 e1dc59a25b246ef8aaa68515e60ea4a0	true	Process.getrlimit(Process::RLIMIT_STACK).is_a?(Array)
 e1e049bcd24042f78171ca96d4da9c05	false	class Foo\n              def bar; end\n            end\n            \n\n
+e1f68fed705933ee21e8053af4092c30	[true, false, false, true, false, true, false, true, false, true, false, true, false, false, true, true, false, true, true, false, ArgumentError]	class P\n              def initialize(n); @n = n; end\n              
 e216ce1e2b8ed4cd8ceaebfdb111d6fc	"US-ASCII"	("abc %s".dup.force_encoding("US-ASCII") % "x").encoding.to_s
 e221d27f16787b87dfe9fecfc65c5962	[600.0, 150.0]	def call_block\n          yield\n        end\n        def d2(k)\n          
 e226e478267e4a855c4aa2949e8e83a5	30	def add(x, y); x + y; end\n            m = method(:add)\n            
@@ -3208,6 +3211,7 @@ f27aef0e47e3354ce496c90299f462ea	[["x\\ny\\nz\\n"], ["x\\n", "y\\n", "z\\n"], ["
 f2899713941ee3ed54e30d3b5b785abc	[1, true]	module MSx; end\n            SX = Struct.new(:a)\n            s = SX.
 f2e470589175775eee4819e2df92057b	true	v = "MONORUBY_TEST_VAL"\n            r = ENV.send(:[]=, "MONORUBY_EN
 f2f61ae8dbed2bff4eb6e1bb603b94d5	5	(..5).max
+f30aa4d203b608f35977d0b328b100ae	[2, 3, 4, 4, 5, 1, 2, 6, 5, 6, 106, "x", nil, 102, [:@a, :@never2]]	class D\n              def initialize; @n = 5; @m = 5; end\n         
 f3176371966e0240a645893d31e35731	[1, 2]	module M\n              def a; 1; end\n              def b; 2; end\n  
 f329ce2071115a197fe643cb17ed55d7	[]	S = Struct.new(:a, :b, :c)\n            \n\n            s = S.new(1, 2
 f3438f2eabc960c10ac335f28ee99149	[7, true]	def m\n              y = 7\n              binding\n            end\n   


### PR DESCRIPTION
Follow-up to #1247. Two changes to `leaf_expr_body`, found together while widening it — **the first is a fix to what #1247 shipped**.

## 1. The inline-cache gate (a fix)

The expansion is all-fixnum: it guards both operands as `Integer` and lowers to the integer register forms. #1247 took it without ever asking what the VM had actually seen at that instruction.

On a `Float` ivar the answer stays correct — the guard exits and the interpreter performs the call — but it exits on **every** execution, so a working specialized call is replaced by a guaranteed deopt. Numeric code is full of exactly these bodies.

Measured on a tight loop (direct calls, three consecutive runs, all consistent). Master here is #1247 as merged; the only difference for these bodies is the gate:

| | master (#1247) | this PR |
|---|---|---|
| `def scaled = @x * 2` (Float `@x`) | 10.5–12.6 ns | **5.76–5.82 ns** |
| `def sum = @x + @y` (Float) | 13.3–16.4 ns | **6.05–6.29 ns** |

The site must have a monomorphic `Integer`/`Integer` cache. An empty cache (the VM never reached the instruction) is no evidence either way, and also declines.

This shows up in real code. Diffing the `--features profile` deopt report for `app_aobench.rb` between the two builds — the whole diff:

```
< (2967) block (2 levels) in Scene#ambient_occlusion  [:00135]  10  %13 = %13 + %14  [Float][Float]
< +   Float   336
> +   Float   337
```

Master deopts 10 times at a `Float + Float` that it expanded and this PR declines. Everything else in the report is identical.

## 2. The widening

The rule was always *nothing that can side-exit may follow an effect* — an exit hands the whole call back, which is sound only while nothing has happened yet. What the code required was stricter: exactly one store, immediately before the `Ret`. Those are not the same, so the recogniser now works on an op list and checks the actual rule.

That admits:

- **Several effects in one body** — `def reset = (@a = 0; @b = 0)`. One hoisted frozen guard covers every store, since nothing between them can call out and freeze the receiver.
- **Comparisons** — `def pos = @n > 0`. The accumulator becomes a bool, and has to step out of rax first because the comparison lowering zeroes rax before reading its operands.

| | master | this PR |
|---|---|---|
| `def two = (@n = 1; @m = 2)` | 3.71–4.04 ns | **1.76–1.83 ns** (2.2x) |
| `def pos = @a > 0` | 3.85–4.19 ns | **2.06–2.15 ns** (1.9x) |
| `def gt(x) = @a > x` | 3.66–4.20 ns | **2.16–2.26 ns** (1.8x) |

Also drops the receiver reloads between stores: only a parameter load can clobber rdi (its slot may hold an unboxed float, and boxing calls out), so the reload is emitted only after one. `def two` is 11 instructions with no frame and no call.

## Why this shape rather than frame merging

The plan after #1247 was single-level frame merging. I measured its ceiling first — the frame overhead of a specialized call is **2.2 ns (2.4x)**, ~18 instructions plus call/ret — and then checked what eliding the frame would take:

1. **Slot addressing is rbp-fixed.** `rbp_local(slot) = RBP_LOCAL_FRAME + slot*8 + LFP_SELF`, 81 call sites. A merged window needs a per-frame base at every one.
2. **GC rooting goes through the cfp chain.** Values in a frame not on the chain are invisible to the collector. The frameless expansion is safe because its values live in the *caller's* slots and registers; a callee window off-chain is not, so the callee could never allocate or reach a safepoint — and Float boxing allocates.
3. **Some stores are LFP-relative** (`[r14 - slot]`, for a frame that was captured and relocated).

So this PR takes the same 2.2 ns on a wider body set without opening obstacle 2, which is a correctness hazard of exactly the kind `gc-stress` exists to find. It also produces the effect/guard ordering analysis that frame merging would need anyway.

## Tests

Three new cases in `method_call::tests`, plus the guard-after-effect decline added to the existing one:

- `frameless_leaf_bodies_multi_store` — several effects, the hoisted frozen guard, write-barrier elision for immediates and its retention for a heap object (checked across a `GC.start`), and a frozen receiver leaving *both* stores undone.
- `frameless_leaf_bodies_compare` — all seven `CmpKind`s on an ivar and on a parameter, plus the guards firing on non-fixnum operands.
- `frameless_leaf_bodies_float_ivars` — the Float bodies the gate declines, on Float, Integer and polymorphic receivers.
- `frameless_leaf_bodies_decline` — now also `def late(x) = (@n = x; @m = x + 1)`, where the `+` overflow check would fire after `@n` was written.

Full `cargo test` with `stress-spill-pool` passes (76 binaries).

## On measurement

The microbenchmarks above are trustworthy — tight loop, direct calls, same process, three consistent runs. The **whole-benchmark** numbers on my host are not: across two runs of the standard suite every benchmark flipped sign (matmul −6.7% → +23%, nqueen +9.7% → −8.4%), and `app_aobench.rb` ranged 4.79–5.81 s on the *same* binary.

Rather than keep chasing that, I compared the two builds' deopt profiles instead (above): machine-independent, and it shows this PR doing strictly *less* deopting than master on aobench. Worth a confirming wall-clock run on a quiet machine, but there is no mechanism left by which it would be slower there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM