### PR TITLE
Take the basic-op licence in the leaf expansion, and decide equality on any immediate

### DIFF
--- a/monoruby/src/codegen/jitgen/compile/frameless.rs
+++ b/monoruby/src/codegen/jitgen/compile/frameless.rs
@@ -204,9 +204,19 @@ pub(super) enum LeafOp {
     /// `acc = acc <kind> operand`, fixnum arithmetic. Guards both operands
     /// and, for `Div`, the zero divisor.
     Bin(BinOpK, LeafValue),
-    /// `acc = acc <kind> operand`, fixnum comparison. Guards both operands;
-    /// the accumulator becomes a bool.
-    Cmp(CmpKind, LeafValue),
+    ///
+    /// `acc = acc <kind> operand`, comparison against a *tagged* value.
+    /// Guards both operands as the carried class; the accumulator becomes a
+    /// bool.
+    ///
+    /// The class is not always `Integer`. Both backends compare with a plain
+    /// register compare (`cmpq` / `cmp x, x`), which for `==` / `!=` is bit
+    /// equality — and bit equality *is* equality for every immediate:
+    /// `Symbol`, `nil`, `true`, `false` as well as fixnums. Ordering is a
+    /// fixnum-only reading of those bits, so the recogniser admits the other
+    /// classes for equality alone.
+    ///
+    Cmp(CmpKind, LeafValue, ClassId),
     /// `@name = acc`.
     Store(IdentId),
 }
@@ -362,8 +372,13 @@ pub(super) fn leaf_expr_body(store: &Store, iseq_id: ISeqId) -> Option<LeafBody>
                 ic,
                 polymorphic,
             } => {
-                saw_fixnums(ic, polymorphic)?;
-                let chain = extend(&slots, lhs, rhs, LeafOp::Cmp(kind, LeafValue::Param(0)))?;
+                let class = cmp_operand_class(ic, polymorphic, kind)?;
+                let chain = extend(
+                    &slots,
+                    lhs,
+                    rhs,
+                    LeafOp::Cmp(kind, LeafValue::Param(0), class),
+                )?;
                 slots.insert(dst, chain);
             }
             TraceIr::StoreIvar(src, name, _) => {
@@ -418,11 +433,51 @@ pub(super) fn leaf_expr_body(store: &Store, iseq_id: ISeqId) -> Option<LeafBody>
 /// class, so a fixnum-only expansion would exit on the others.
 ///
 fn saw_fixnums(ic: Option<(ClassId, ClassId)>, polymorphic: bool) -> Option<()> {
+    cmp_operand_class(ic, polymorphic, CmpKind::Lt).filter(|c| *c == INTEGER_CLASS)?;
+    Some(())
+}
+
+///
+/// The class both operands of a comparison were observed to have, when the
+/// expansion can decide that comparison with a register compare.
+///
+/// For `==` / `!=` / `===` the compare is bit equality, which is equality
+/// for every immediate — so `Symbol`, `nil`, `true` and `false` join
+/// `Integer` here. `graphql`'s parser is the motivating shape:
+///
+/// ```ruby
+/// def at?(expected_token_name)
+///   @token_name == expected_token_name
+/// end
+/// ```
+///
+/// — 74 call sites, on the hot path of every parse, and an `Integer`-only
+/// gate turned every one of them away.
+///
+/// Ordering reads those same bits as a signed number, which is only the
+/// right answer for a tagged fixnum (`Symbol#<` compares the *names*, via
+/// `Comparable`), so the other classes are admitted for equality alone.
+///
+fn cmp_operand_class(
+    ic: Option<(ClassId, ClassId)>,
+    polymorphic: bool,
+    kind: CmpKind,
+) -> Option<ClassId> {
+    // A polymorphic site saw more than one operand class, so a
+    // single-class guard would exit on the others.
     if polymorphic {
         return None;
     }
-    match ic {
-        Some((INTEGER_CLASS, INTEGER_CLASS)) => Some(()),
+    // An empty cache means the VM never reached the instruction, which is
+    // no evidence either way.
+    let (lhs, rhs) = ic?;
+    if lhs != rhs {
+        return None;
+    }
+    let equality = matches!(kind, CmpKind::Eq | CmpKind::Ne | CmpKind::TEq);
+    match lhs {
+        INTEGER_CLASS => Some(lhs),
+        NIL_CLASS | TRUE_CLASS | FALSE_CLASS | SYMBOL_CLASS if equality => Some(lhs),
         _ => None,
     }
 }
@@ -468,7 +523,7 @@ fn extend(
     }
     chain.0.push(match op {
         LeafOp::Bin(kind, _) => LeafOp::Bin(kind, operand),
-        LeafOp::Cmp(kind, _) => LeafOp::Cmp(kind, operand),
+        LeafOp::Cmp(kind, _, class) => LeafOp::Cmp(kind, operand, class),
         _ => return None,
     });
     Some(chain)

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -1378,17 +1378,24 @@ impl<'a> JitContext<'a> {
         // exit: the class-version guard fires, the body recompiles, and the
         // recompiled body emits the same unconditional fast path again —
         // `frameless_leaf_bodies_bop_redefine` is the regression.
-        let mut bop_deps: Vec<IdentId> = Vec::new();
+        let mut bop_deps: Vec<(ClassId, IdentId)> = Vec::new();
         for op in &body.ops {
             let name: IdentId = match *op {
                 frameless::LeafOp::Bin(kind, _) => kind.into(),
-                frameless::LeafOp::Cmp(kind, _) => kind.into(),
+                frameless::LeafOp::Cmp(kind, _, _) => kind.into(),
                 _ => continue,
             };
-            if !self.basic_op_assumable(INTEGER_CLASS, name) {
+            // The class the guards will prove, so the licence is the tight
+            // one: a `Symbol` comparison needs `Symbol#==` unredefined, not
+            // `Integer#==`.
+            let class = match *op {
+                frameless::LeafOp::Cmp(_, _, class) => class,
+                _ => INTEGER_CLASS,
+            };
+            if !self.basic_op_assumable(class, name) {
                 return false;
             }
-            bop_deps.push(name);
+            bop_deps.push((class, name));
         }
 
         // Resolve every ivar name the body mentions, up front.
@@ -1397,7 +1404,7 @@ impl<'a> JitContext<'a> {
             let name = match *op {
                 frameless::LeafOp::Load(frameless::LeafValue::SelfIvar(name))
                 | frameless::LeafOp::Bin(_, frameless::LeafValue::SelfIvar(name))
-                | frameless::LeafOp::Cmp(_, frameless::LeafValue::SelfIvar(name))
+                | frameless::LeafOp::Cmp(_, frameless::LeafValue::SelfIvar(name), _)
                 | frameless::LeafOp::Store(name) => name,
                 _ => {
                     ivars.push(None);
@@ -1476,10 +1483,15 @@ impl<'a> JitContext<'a> {
                     ir.integer_binop_reg(kind, GP::Rax, GP::Rax, GP::Rcx, deopt);
                     acc_immediate = true;
                 }
-                frameless::LeafOp::Cmp(kind, operand) => {
+                frameless::LeafOp::Cmp(kind, operand, class) => {
                     recv_live &= !emit_value(ir, state, arg_slots, operand, ivars[i], GP::Rcx);
-                    ir.push(AsmInst::GuardClass(GP::Rax, INTEGER_CLASS, deopt));
-                    ir.push(AsmInst::GuardClass(GP::Rcx, INTEGER_CLASS, deopt));
+                    // Both backends compare with a plain register compare, so
+                    // the guarded class decides what that compare *means*:
+                    // bit equality for an immediate, a signed read of the
+                    // tagged bits for a fixnum. The recogniser admits the
+                    // non-fixnum classes for equality only.
+                    ir.push(AsmInst::GuardClass(GP::Rax, class, deopt));
+                    ir.push(AsmInst::GuardClass(GP::Rcx, class, deopt));
                     // The comparison zeroes rax before reading its operands,
                     // so the accumulator has to step aside first.
                     ir.reg_move(GP::Rax, GP::Rsi);
@@ -1506,8 +1518,8 @@ impl<'a> JitContext<'a> {
                 }
             }
         }
-        for name in bop_deps {
-            self.record_bop_dep(INTEGER_CLASS, name);
+        for (class, name) in bop_deps {
+            self.record_bop_dep(class, name);
         }
         state.def_reg2acc(ir, GP::Rax, dst);
         state.unset_side_effect_guard();
@@ -4070,6 +4082,63 @@ mod tests {
               def ==(o); :redefined_eq; end
             end
             res << run(c, 500)
+            res
+            "#,
+        );
+    }
+
+    /// Equality on the immediates. Both backends compare with a plain
+    /// register compare, which for `==` / `!=` is bit equality — and bit
+    /// equality *is* equality for a `Symbol`, `nil`, `true` or `false`, not
+    /// only for a fixnum. The motivating shape is graphql's parser:
+    ///
+    /// ```ruby
+    /// def at?(expected_token_name)
+    ///   @token_name == expected_token_name
+    /// end
+    /// ```
+    ///
+    /// — 74 call sites on the hot path of every parse, which an
+    /// `Integer`-only gate turned away.
+    ///
+    /// Ordering reads the same bits as a signed number, which is only right
+    /// for a tagged fixnum (`Symbol#<` compares the names through
+    /// `Comparable`), so the non-fixnum classes are admitted for equality
+    /// alone — `sym_lt` below is the case that must still go through a real
+    /// call, and it is checked against a receiver whose answer the bit
+    /// ordering would get wrong.
+    #[test]
+    fn frameless_leaf_bodies_immediate_eq() {
+        run_test(
+            r#"
+            class P
+              def initialize(t); @t = t; end
+              def at?(x);   @t == x; end
+              def not?(x);  @t != x; end
+              def teq?(x);  @t === x; end
+              def is_nil;   @t == nil; end
+              def is_true;  @t == true; end
+              def is_false; @t == false; end
+              def sym_lt(x); @t < x; end
+            end
+            res = []
+            sym = P.new(:ident)
+            400.times { sym.at?(:ident); sym.not?(:other); sym.teq?(:ident); sym.is_nil }
+            res << sym.at?(:ident) << sym.at?(:other)
+            res << sym.not?(:other) << sym.not?(:ident)
+            res << sym.teq?(:ident) << sym.teq?(:other)
+            res << sym.is_nil << sym.is_true << sym.is_false
+            # a Symbol the bit ordering would order the other way round:
+            # :a < :b by name, but their ids run the other direction only
+            # by accident, so this pins the answer rather than the reason
+            res << P.new(:a).sym_lt(:b) << P.new(:b).sym_lt(:a)
+
+            nl = P.new(nil);   400.times { nl.is_nil };   res << nl.is_nil << nl.at?(nil)
+            tr = P.new(true);  400.times { tr.is_true };  res << tr.is_true << tr.is_false
+            fa = P.new(false); 400.times { fa.is_false }; res << fa.is_false << fa.is_true
+            # the guard fires: a receiver whose ivar is not the observed class
+            st = P.new("s"); res << st.at?("s") << st.at?(:s)
+            res << P.new(1).at?(1) << P.new(1).at?(:one)
             res
             "#,
         );

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -1369,6 +1369,28 @@ impl<'a> JitContext<'a> {
                 _ => Some(None),
             }
         };
+        // The arithmetic and the comparison below are emitted as machine
+        // instructions with no runtime check, which is only licensed while
+        // the operator is still the built-in one. Take that licence for
+        // every operator the body uses *before* emitting anything, and
+        // record the dependency after, so `set_bop_redefine` evicts this
+        // body. Without it a redefinition is not repairable by any side
+        // exit: the class-version guard fires, the body recompiles, and the
+        // recompiled body emits the same unconditional fast path again —
+        // `frameless_leaf_bodies_bop_redefine` is the regression.
+        let mut bop_deps: Vec<IdentId> = Vec::new();
+        for op in &body.ops {
+            let name: IdentId = match *op {
+                frameless::LeafOp::Bin(kind, _) => kind.into(),
+                frameless::LeafOp::Cmp(kind, _) => kind.into(),
+                _ => continue,
+            };
+            if !self.basic_op_assumable(INTEGER_CLASS, name) {
+                return false;
+            }
+            bop_deps.push(name);
+        }
+
         // Resolve every ivar name the body mentions, up front.
         let mut ivars: Vec<Option<IvarId>> = Vec::with_capacity(body.ops.len());
         for op in &body.ops {
@@ -1483,6 +1505,9 @@ impl<'a> JitContext<'a> {
                     });
                 }
             }
+        }
+        for name in bop_deps {
+            self.record_bop_dep(INTEGER_CLASS, name);
         }
         state.def_reg2acc(ir, GP::Rax, dst);
         state.unset_side_effect_guard();
@@ -3992,6 +4017,59 @@ mod tests {
             # the guards fire: a non-fixnum ivar, and a non-fixnum argument
             res << P.new(1.5).pos << p5.gt(4.5) << p5.eq("5")
             res << (begin; p5.gt("x"); rescue ArgumentError, TypeError => e; e.class; end)
+            res
+            "#,
+        );
+    }
+
+    /// The expansion emits the arithmetic and the comparison as machine
+    /// instructions with no runtime check, which Ruby licenses only while
+    /// the operator is still the built-in one. Redefining it has to take
+    /// the licence back.
+    ///
+    /// A side exit cannot do that on its own: the class-version guard every
+    /// definition bumps does fire, but the body then *recompiles* and emits
+    /// the same unconditional fast path, so the answer goes stale again on
+    /// the next entry. The observable shape is a redefinition that appears
+    /// to take and then stops: 500 calls after `Integer#*` is redefined
+    /// answered `[:redefined_mul, 6]` — the compiled body drifting back to
+    /// the machine multiply — where CRuby answers `[:redefined_mul]`.
+    ///
+    /// So the expansion takes `basic_op_assumable` before emitting and
+    /// records the dependency after, which is what makes `set_bop_redefine`
+    /// evict it.
+    #[test]
+    fn frameless_leaf_bodies_bop_redefine() {
+        run_test_once(
+            r#"
+            class C
+              def initialize; @a = 3; @n = 1; end
+              def dbl; @a * 2; end
+              def add; @a + 1; end
+              def eq;  @n == 1; end
+            end
+            # The loop keeps the caller compiled across the redefinition, so
+            # the expansion is re-entered rather than left behind at the
+            # first deopt. `<` and `+=` drive the loop, so the body uses `*`
+            # and `==`, which the redefinition below can take without
+            # breaking the loop itself.
+            def run(c, n)
+              out = []
+              i = 0
+              while i < n
+                out << [c.dbl, c.eq]
+                i += 1
+              end
+              out.uniq
+            end
+            c = C.new
+            run(c, 500)
+            res = [run(c, 50)]
+            class Integer
+              def *(o); :redefined_mul; end
+              def ==(o); :redefined_eq; end
+            end
+            res << run(c, 500)
             res
             "#,
         );

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -1446,6 +1446,7 @@
 6e572d93b20a8692a4e7ddd298baa9ee	true	class Foo\n              def bind; binding; end\n            end\n    
 6e7aebe2556be39faee23d7b63bd31d6	[false, false, false, false, false]	S = Struct.new(:a, :b, :c)\n            \n\n            s = S.new(1, 2
 6eadac74beac0aa21a211ec67fcdc95d	["0.514e1", "0.114e1", "0.628e1", "0.45e1", "0.7e1", "0.3e0"]	require "rubygems"\n        require "bigdecimal"\n        a = BigDecimal(
+6ebe2eb5165b0355e2d3ceeb9e154145	[[[6, true]], [[:redefined_mul, :redefined_eq]]]	class C\n              def initialize; @a = 3; @n = 1; end\n         
 6ec1acc4c17516bb23420e702e9103d2	[:done, true, 64]	def make_enum\n              Enumerator.new { |y| sleep 0.05; y << :
 6ee39a1116ff8eda1d78eddc45c1b5a3	[2020, 1, 2, 3, 32400, 32400]	t = Time.new(2020, 1, 2, 3, 4, 5, "+09:00")\n        [t.year, t.month, t
 6ee8709f21799482d6bff0182f48702d	"/\\n"	r, w = IO.pipe\n            Process.wait Process.spawn("pwd", chdir:

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -1747,6 +1747,7 @@
 846556768cd567bd24d3916bd92ff7db	[false, false, true, [true, true, false], true, false, false, ["NameError", "'a' is not an implicit parameter"], ["TypeError", "1 is not a symbol nor a string"]]	def try; yield; rescue => e; [e.class.to_s, e.message]; end\n       
 846653c25256021e7ac217987b6ab247	[nil, true]	r, w = IO.pipe\n            pid = fork { r.close; Signal.trap("TERM"
 8479b8263b2031ca390cec82e34d1347	"yes-shname\\n"	env = Object.new\n            def env.to_hash = {"VIA_TO_HASH" => "y
+84b7526c4266744e31975a2bbd3771af	[true, false, true, false, true, false, false, false, false, true, false, true, true, true, false, true, false, true, false, true, false]	class P\n              def initialize(t); @t = t; end\n              
 84d91589fff917e43c1d88cde1f37516	[false, false, false, [:include, :TypeError], [:extend, :TypeError], [:r_include, :TypeError], [:r_prepend, :TypeError]]	r = Module.new { refine(String) { } }.refinements[0]\n            ou
 84f4b6da4f67b5e0629d3c8cdef84518	"A"	class A\n              def who; self.class.name; end\n            end
 85019cb4cb8a7b9dda94fc30fc53ddb9	""	class EmptyStr\n                  def to_str; ""; end\n          


### PR DESCRIPTION
Two commits. **The first is a correctness fix to #1247 / #1254**; the second is the widening I set out to do, which is what turned the bug up.

## 1. The basic-op licence (a bug fix)

`frameless`'s expansion emits its arithmetic and its comparison as machine instructions with no runtime check. Ruby licenses that only while the operator is still the built-in one, and #1247 / #1254 never asked: no `basic_op_assumable` before emitting, no `record_bop_dep` after.

A side exit cannot repair this on its own, which is what makes it a bug rather than a slow path. The class-version guard every definition bumps *does* fire, so the first call after a redefinition is correct — but the body then recompiles and emits the same unconditional fast path, and the answer goes stale again on the next entry. The observable shape is a redefinition that appears to take and then stops:

```ruby
class C; def initialize; @a = 3; end; def dbl; @a * 2; end; end
run(c, 500)                                          # warm the caller
class Integer; def *(o); :redefined_mul; end; end
run(c, 500).uniq
```

| | result |
|---|---|
| CRuby | `[:redefined_mul]` |
| monoruby (master) | `[:redefined_mul, 6]` — drifts back to the machine multiply |

`opt_eq_assumable` in `compile/binary_op.rs` documents exactly this failure for the immediate-`==` fast path; the leaf expansion had reproduced it.

Every operator the body uses now takes the licence before anything is emitted — declining the whole expansion if any is unavailable, so a partly-licensed body emits nothing — and records its dependency after, so `set_bop_redefine` evicts the body. `frameless_leaf_bodies_bop_redefine` is the regression, verified to fail without the fix and pass with it.

## 2. Equality on any immediate

Both backends compare with a plain register compare (`cmpq` / `cmp x, x`), so for `==` / `!=` / `===` the instruction the expansion already emits **is** bit equality — and bit equality is equality for every immediate, not only for a tagged fixnum. The gate admitted `Integer`/`Integer` and nothing else.

The shape this was found on is graphql's parser:

```ruby
def at?(expected_token_name)
  @token_name == expected_token_name
end
```

74 call sites, on the hot path of every parse. It is the shape `frameless` was built for — `def gt(x) = @a > x` with a different operator — and only the class check stood between it and the expansion.

The change is the class, not the comparison: the recogniser carries the observed operand class on the op, and the emitter guards both operands as *that* class before the same compare. Nothing new is lowered on either arch. Ordering stays fixnum-only, because reading those bits as a signed number is a fixnum-only reading (`Symbol#<` compares the names through `Comparable`), and the licence tightens with it — a `Symbol` comparison now needs `Symbol#==` unredefined rather than `Integer#==`.

## Results, and what they are not

| | master | this PR |
|---|---|---|
| `def at?(x) = @t == x` (Symbol) | 15.0–16.0 ns | **4.6–4.9 ns** (3.2x) |

Three consistent runs, tight loop, direct calls. The 3.2x is larger than the frame overhead alone because the generic `Symbol#==` dispatch goes with it.

**graphql as a whole does not move.** Four alternating pairs came out at 271 ms either way, on a host whose own spread on that benchmark is ±15 %. `symbol::eq` was 1.39 % of self time before, so a percent or two is all there was to win here. The microbenchmark is the honest measure of what changed; the benchmark is the honest measure of how much it mattered. I am shipping it because it is correct, tested, and strictly removes work — not because it moved a benchmark.

## How this came about

I was surveying frame merging (predicate + `jit-log` report, on `claude/frame-merge-stage1`, not part of this PR) to size the work before building it. The survey said the cheap stage — no calls in the merged body, which needs no new soundness argument — covers 1.5 % of specialized call sites on erubi, 3.4 % on rack, 1.5 % on activerecord, and that its entire real-world catch was `Parser#at?`. Reading why *that* had not already been expanded found the `Integer`-only gate, and reading the gate's neighbour `opt_eq_assumable` found the missing licence.

## Tests

- `frameless_leaf_bodies_bop_redefine` — `*` and `==` redefined under a warm caller, driving the loop with `<` / `+=` so the redefinition cannot break the loop it is observed from.
- `frameless_leaf_bodies_immediate_eq` — `==` / `!=` / `===` on Symbol, nil, true and false receivers and arguments; the guards firing on a receiver of another class; and `<` on Symbols still going through a real call.

Full `cargo test` with `stress-spill-pool` passes (76 binaries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_