### PR TITLE
Compare a String subclass Hash key with eql?, not with bytes

### DIFF
--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -1363,12 +1363,6 @@ impl<'a> JitContext<'a> {
                 .get_ivarid(name)
                 .filter(|ivarid| ivarid.is_inline())
         };
-        let ivar_of = |this: &Self, v: frameless::LeafValue| -> Option<Option<IvarId>> {
-            match v {
-                frameless::LeafValue::SelfIvar(name) => resolve(this, name).map(Some),
-                _ => Some(None),
-            }
-        };
         // The arithmetic and the comparison below are emitted as machine
         // instructions with no runtime check, which is only licensed while
         // the operator is still the built-in one. Take that licence for

--- a/monoruby/src/value.rs
+++ b/monoruby/src/value.rs
@@ -487,7 +487,19 @@ impl RubyEql<Executor, Globals, MonorubyErr> for Value {
                         (ObjTy::COMPLEX, ObjTy::COMPLEX) => {
                             lhs.as_complex().eql(rhs.as_complex(), vm, globals)?
                         }
-                        (ObjTy::STRING, ObjTy::STRING) => lhs.as_rstring() == rhs.as_rstring(),
+                        // Byte equality only between two *plain* Strings.
+                        // CRuby's `rb_any_cmp` gates its String
+                        // short-circuit on `RBASIC(a)->klass == rb_cString`
+                        // for both operands; a subclass falls through to
+                        // `rb_eql` below, so a redefined `eql?` on it is
+                        // observed. (`any_hash` has no such gate, so a
+                        // subclass still hashes by content — only the
+                        // comparison moves.)
+                        (ObjTy::STRING, ObjTy::STRING)
+                            if self.class() == STRING_CLASS && other.class() == STRING_CLASS =>
+                        {
+                            lhs.as_rstring() == rhs.as_rstring()
+                        }
                         (ObjTy::ARRAY, ObjTy::ARRAY) => {
                             let lhs_ary = lhs.as_array();
                             let rhs_ary = rhs.as_array();
@@ -2834,6 +2846,26 @@ impl Value {
             }
         } else {
             None
+        }
+    }
+
+    ///
+    /// [`Self::is_rstring_inner`] restricted to a String whose class is
+    /// exactly `String` — the condition under which a Hash may compare it
+    /// by bytes instead of dispatching `eql?` (see
+    /// `rvalue::hash::plain_string`).
+    ///
+    /// One `try_rvalue` for both questions: the type tag and the class sit
+    /// in the same header word, and this is on the hash-probe path.
+    ///
+    pub(crate) fn is_plain_rstring_inner(&self) -> Option<&RStringInner> {
+        let rv = self.try_rvalue()?;
+        // SAFETY: the type check ensures this RValue contains a string.
+        unsafe {
+            match rv.ty() {
+                ObjTy::STRING if rv.class() == STRING_CLASS => Some(rv.as_rstring()),
+                _ => None,
+            }
         }
     }
 

--- a/monoruby/src/value/rvalue/hash.rs
+++ b/monoruby/src/value/rvalue/hash.rs
@@ -180,6 +180,29 @@ fn string_digest<S: std::hash::BuildHasher>(hash_builder: &S, s: &RStringInner) 
 /// `String#eql?` it resolves to returns false for any non-String
 /// argument — a redefined `String#eql?` is no more observed here than a
 /// redefined `String#hash` is at insert time.)
+///
+/// # Plain-String keys
+///
+/// A Hash may compare a key by bytes instead of dispatching `eql?` only
+/// when it is a String **whose class is exactly `String`**.
+///
+/// CRuby draws the line in the same place, and only on the *equality*
+/// side. `rb_any_cmp`'s String short-circuit requires
+/// `RBASIC(a)->klass == rb_cString` of both operands, so a subclass falls
+/// through to `rb_eql` and a redefined `eql?` is observed; `any_hash` has
+/// no such check, so a subclass still hashes by content and lands in the
+/// bucket its bytes choose. Keeping the digest content-based and moving
+/// only the comparison reproduces both halves:
+///
+/// ```ruby
+/// class Sub < String; def eql?(o) = false; end
+/// h = {}; h[Sub.new("q")] = 1
+/// h[Sub.new("q")]   # nil — `eql?` decides, and says no
+/// h["q"]            # 1   — the bytes still chose the same bucket
+/// ```
+///
+/// The accessor that answers it is [`Value::is_plain_rstring_inner`].
+///
 fn string_key_eq(stored: &Option<Value>, k: Value, s: &RStringInner) -> bool {
     match stored {
         Some(sk) => sk.id() == k.id() || sk.is_rstring_inner().is_some_and(|si| si == s),
@@ -605,7 +628,7 @@ impl RubyHash<Executor, Globals, MonorubyErr> for HashmapInner {
 /// stale is exactly the behavior `Hash#rehash` exists for, and its
 /// `eql?` may be Ruby code.
 fn is_inline_key(k: Value) -> bool {
-    k.is_packed_value() || (k.is_rstring_inner().is_some() && k.is_frozen())
+    k.is_packed_value() || (k.is_plain_rstring_inner().is_some() && k.is_frozen())
 }
 
 /// The inline-pair match for a String probe: identity, then byte
@@ -736,7 +759,7 @@ impl<'a> HashRef<'a> {
         if self.is_ident_inline() || k.is_packed_value() {
             return pairs.iter().position(|(ek, _)| ek.id() == k.id());
         }
-        let s = k.is_rstring_inner()?;
+        let s = k.is_plain_rstring_inner()?;
         pairs
             .iter()
             .position(|(ek, _)| inline_string_key_eq(*ek, k, s))
@@ -756,8 +779,22 @@ impl<'a> HashRef<'a> {
         vm: &mut Executor,
         globals: &mut Globals,
     ) -> Result<Option<usize>> {
-        if self.is_ident_inline() || k.is_packed_value() || k.is_rstring_inner().is_some() {
+        if self.is_ident_inline() || k.is_packed_value() || k.is_plain_rstring_inner().is_some() {
             Ok(self.inline_pos_noobs(k))
+        } else if k.is_rstring_inner().is_some() {
+            // A String *subclass* probe. It can be `eql?` to a plain
+            // String key — the bytes are what chose the bucket — but the
+            // verdict is `eql?`'s to give, so scan with the dispatching
+            // comparison rather than by bytes. (`plain_string` keeps
+            // subclasses out of `is_inline_key`, so no *stored* inline key
+            // is one; only the probe can be.)
+            let pairs = self.inline_pairs().to_vec();
+            for (i, (ek, _)) in pairs.iter().enumerate() {
+                if k.eql(ek, vm, globals)? {
+                    return Ok(Some(i));
+                }
+            }
+            Ok(None)
         } else {
             k.calculate_hash(vm, globals)?;
             Ok(None)
@@ -876,7 +913,7 @@ impl<'a> HashRef<'a> {
                 if k.is_packed_value() {
                     let hash = packed_digest(m.hasher(), k);
                     m.get_prehashed(hash, &Some(k), vm, globals)?.copied()
-                } else if let Some(s) = k.is_rstring_inner() {
+                } else if let Some(s) = k.is_plain_rstring_inner() {
                     let hash = string_digest(m.hasher(), s);
                     m.get_prehashed_with(hash, |ek| string_key_eq(ek, k, s), vm, globals)?
                         .copied()
@@ -903,7 +940,7 @@ impl<'a> HashRef<'a> {
                 if k.is_packed_value() {
                     let hash = packed_digest(m.hasher(), k);
                     Ok(m.get_prehashed(hash, &Some(k), vm, globals)?.is_some())
-                } else if let Some(s) = k.is_rstring_inner() {
+                } else if let Some(s) = k.is_plain_rstring_inner() {
                     let hash = string_digest(m.hasher(), s);
                     Ok(m
                         .get_prehashed_with(hash, |ek| string_key_eq(ek, k, s), vm, globals)?
@@ -1394,7 +1431,7 @@ impl<'a> HashRefMut<'a> {
                     // is vm-free — so the whole probe is vm-free.
                     let hash = packed_digest(m.hasher(), k);
                     m.insert_prehashed(hash, Some(k), v);
-                } else if let Some(s) = k.is_rstring_inner() {
+                } else if let Some(s) = k.is_plain_rstring_inner() {
                     // A String key's digest and `eql?` are likewise
                     // vm-free: byte content only, dispatching neither
                     // `String#hash` nor `String#eql?` — exactly what the

--- a/monoruby/tests/hash_string_keys.rs
+++ b/monoruby/tests/hash_string_keys.rs
@@ -227,3 +227,48 @@ fn inline_string_key_ignores_redefined_string_hash() {
         "##,
     );
 }
+
+/// A String **subclass** key is compared by `eql?`, not by bytes.
+///
+/// CRuby's `rb_any_cmp` gates its String short-circuit on
+/// `RBASIC(a)->klass == rb_cString` for both operands, so a subclass falls
+/// through to `rb_eql` and a redefined `eql?` decides. Its `any_hash` has
+/// no such gate — a subclass still hashes by content — so the two keys
+/// land in the same bucket and the redefinition is what turns the lookup
+/// into a miss, rather than the bucket choice.
+///
+/// Both halves are checked here, and in both representations: `OnlyEql`
+/// misses (`eql?` said no) while `OnlyHash` and `Plain` hit (the bytes
+/// chose the bucket, and the default `eql?` agreed) — which is also why
+/// `h["q"]` finds the subclass-keyed entry in every case.
+#[test]
+fn string_subclass_key_dispatches_eql() {
+    run_test_once(
+        r##"
+        class OnlyHash < String; def hash; object_id; end; end
+        class OnlyEql  < String; def eql?(o); false; end; end
+        class Plain    < String; end
+        class Both     < String; def hash; 1; end; def eql?(o); true; end; end
+        res = []
+        [OnlyHash, OnlyEql, Plain, Both].each do |c|
+          # 1 pair exercises the inline representation, 18 the boxed map
+          [1, 18].each do |n|
+            h = {}
+            (1...n).each { |i| h["pad#{i}"] = i }
+            h[c.new("q")] = :hit
+            res << [c.to_s, n, h[c.new("q")], h["q"], h.key?(c.new("q")), h.size]
+          end
+        end
+        # the other direction: a plain String key, probed with a subclass
+        [1, 18].each do |n|
+          h = {}
+          (1...n).each { |i| h["pad#{i}"] = i }
+          h["q"] = :plain
+          res << ["stored-plain", n, h[Plain.new("q")], h[OnlyEql.new("q")]]
+        end
+        h = {"q" => 1}
+        res << ["delete", h.delete(Plain.new("q")), h.size]
+        res
+        "##,
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -1464,6 +1464,7 @@
 6f9a21b16eccd94c397c19f2c70977ab	[450.0, 1.5]	def call_block\n          yield\n        end\n        def c1\n          k =
 6f9e3eb9473b85b89a35086c448b5d42	true	obj = Object.new\n            begin; obj.nope_method; rescue NoMetho
 6fb70e1ac677ec5293ce90caf3afcdf5	true	Time.utc(2000,1,1,0,0,0,500000).subsec > 0
+6fbdf22dd19163ffa996600cbd775daa	[["OnlyHash", 1, :hit, :hit, true, 1], ["OnlyHash", 18, :hit, :hit, true, 18], ["OnlyEql", 1, nil, :hit, false, 1], ["OnlyEql", 18, nil, :hit, false, 18], ["Plain", 1, :hit, :hit, true, 1], ["Plain", 18, :hit, :hit, true, 18], ["Both", 1, :hit, :hit, true, 1], ["Both", 18, :hit, :hit, true, 18], ["stored-plain", 1, :plain, nil], ["stored-plain", 18, :plain, nil], ["delete", 1, 0]]	class OnlyHash < String; def hash; object_id; end; end\n        class On
 6fd7a2503b2b0d8020435a1135d8760a	["extended:Bar"]	$res = []\n        module Foo\n          def self.extended(base)\n        
 6ff6c6d86d977c8d2388dd6f11a63d5c	[4, 5, 7, 8]	r = []\n        10.times { |i| r << i if (i == 4)..(i == 5) or (i == 7).
 701afcadda9f90ae591de50be598f558	[[[false, 120], [true, 480]], false, true]	class T\n              def initialize = (@a = [1, 2.5, 3, 4.5, 1 << 


### PR DESCRIPTION
A Hash key that is a `String` **subclass** was compared by byte content, so a redefined `eql?` on it was never consulted:

```ruby
class Sub < String; def eql?(o) = false; end
h = {}; h[Sub.new("q")] = 1
h[Sub.new("q")]      # CRuby nil, monoruby 1
```

## Where CRuby draws the line

`rb_any_cmp` gates its String short-circuit on `RBASIC(a)->klass == rb_cString` for **both** operands; a subclass falls through to `rb_eql`, so `eql?` decides. Its `any_hash` has **no** such gate — a subclass still hashes by content.

Both halves matter, and they pull in opposite directions:

| | hashes by | compares by |
|---|---|---|
| plain `String` | content | bytes |
| `String` subclass | content | `eql?` |

So the two keys *do* land in the same bucket, and it is the redefinition that turns the lookup into a miss rather than the bucket choice. Gating only the hashing instead (my first attempt) makes `Sub` stop finding its own entry even with the default `eql?` — the four shapes in the test pin exactly this:

```
                    h[Sub.new("q")]   h["q"]
hash only               :hit           :hit     ← content still chose the bucket
eql? only               nil            :hit     ← eql? said no
neither                 :hit           :hit
both                    :hit           :hit
```

## The change

The digest stays content-based; only the comparison moves. Three places had the same unguarded short-circuit:

- **`Value::eql`'s `(STRING, STRING)` arm**, which every general probe reaches — now requires both classes to be exactly `String`, else falls through to the `eql?` dispatch already sitting below it.
- **the boxed map's vm-free fast path**, selected per probe key.
- **`is_inline_key`**, so a subclass is never *stored* inline — its equality is not answerable without the vm.

`inline_pos` grows the case that follows from that: a subclass **probe** against inline-stored plain Strings. It cannot take the byte scan, and it is not "a heap key that can never match" either — the bytes chose the bucket — so it scans the pairs with the dispatching comparison.

## Cost

None measurable. `Value::is_plain_rstring_inner` answers the type and the class from one `try_rvalue`, comparing a word the type check already loaded.

Pure-lookup micro (18-entry Hash, loop baseline subtracted), four alternating rounds:

| | master | this PR |
|---|---:|---:|
| String 12B | 36.8 | 38.1 |
| String 19B | 35.4 | 36.5 |
| String miss | 29.2 | 29.8 |
| Symbol | 24.1 | 23.6 |
| Integer | 40.2 | 34.6 |

The String rows move ~3 %, but `Symbol` and `Integer` — which this change cannot touch — move as much or more in the same runs, so the noise floor on this host is ±10-15 % and the String difference is not resolvable. Worth a confirming run on a quiet machine if the Hash path is under active tuning.

## Tests

`string_subclass_key_dispatches_eql` in `tests/hash_string_keys.rs`: all four redefinition shapes, in both representations (1 pair inline, 18 boxed), in both directions (subclass key probed with a plain String and vice versa), through `[]` / `key?` / `delete`. Verified to fail without the fix.

Full `cargo test` with `stress-spill-pool` passes (76 binaries).

Also drops a dead closure (`ivar_of`) left behind by #1254's refactor.

## How this came up

Investigating whether caching a frozen String's digest in `RStringInner` (`doc/hash_optimization.md` §4.5) is sound, since a redefined `String#hash` would invalidate a cache. It is sound — both implementations ignore a redefined `String#hash` for Hash bucketing — but checking that turned up this adjacent `eql?` divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_