### PR TITLE
GC: promote Time, Regexp and UnboundMethod — they hold no `Value`

### DIFF
--- a/doc/yjit_bench_slow_investigation_2026-09.md
+++ b/doc/yjit_bench_slow_investigation_2026-09.md
@@ -837,6 +837,88 @@ activerecord 253 → 250 ms（−1 %）、graphql −3 %、rack −1.5 %、psych
 > 昇格したクラスオブジェクトの下で superclass が解放されるので、gc-stress が
 > 最も効く形の検証になっている。
 
+### 8.6 minor GC が何を辿っているかの census と、残りの昇格不能型
+
+§8.5 のあと「他に何が昇格しないのか」を型別に測った。`mark_object` が実際に
+マークした数を minor GC ごとに集計する（old はシードマーク済みで早期 return する
+ので計上されない = そのまま「毎回辿り直しているもの」）。
+
+| 型 | erubi（計 6,608/minor） | activerecord（計 31,030/minor） | 昇格 |
+|---|---:|---:|---|
+| STRING | 608 | 9,699 | 可 |
+| OBJECT | 35 | 7,647 | 可 |
+| HASH | 46 | 3,906 | 可 |
+| **PROC** | **2,693 (41 %)** | **2,961 (9.5 %)** | **不可** |
+| **FRAME** | **2,692 (41 %)** | **2,880 (9.3 %)** | **不可** |
+| ARRAY | 61 | 2,016 | 可 |
+| TIME | 89 | 995 | 不可 |
+| REGEXP | 292 | 663 | 不可 |
+| RANGE / UMETHOD | 29 / 26 | 74 / 28 | 不可 |
+
+昇格しない型は 20 種（`TIME, RANGE, EXCEPTION, PROC, REGEXP, IO, METHOD, FIBER,
+ENUMERATOR, GENERATOR, COMPLEX, BINDING, UMETHOD, MATCHDATA, RATIONAL,
+ARITHMETIC_SEQUENCE, IO_BUFFER, THREAD, ARGF, FRAME`）だが、性質は 3 階層に分かれる。
+
+**A. `Value` を 1 本も持たない: TIME / REGEXP / UMETHOD**（実施済み）
+
+`mark_children` が `{}` なのは Bignum・ヒープ Float とこの 3 型だけ。中身も
+`DateTime` / `Arc<Regex>` + ソースバイト列 / `FuncId`+`ClassId`+`IdentId` で、
+`Value` を持たない。**元の厳しいルール（reference-free union kind）すら満たして
+いた**ので、許可リストへの入れ忘れ。バリアは 1 行も要らず、`is_promotable` への
+追加と `young_child_exists` の `false` を返す腕だけ（後者が無いと `_ => true` に
+落ちて昇格のたびに remembered set に入り、昇格しない場合より悪くなる）。
+
+マーク**個数**は減る:
+
+| ベンチ | before | after |
+|---|---:|---:|
+| erubi | REGEXP 291 / TIME 89 / UMETHOD 26 | 5 / 1 / 0 |
+| rack | 413 / 90 / 28 | 9 / 2 / 0 |
+| graphql | 298 / 88 / 25 | 13 / 4 / 1 |
+| activerecord | 658 / 975 / 28 | 24 / 870 / 1 |
+
+（activerecord の TIME が残るのは、本当に毎 GC 窓で ~870 個生成していて age 3 に
+届かないから。「昇格できないから残っている」のではない。）
+
+**ただし時間は 1〜2 % しか減らない**:
+
+| ベンチ | minor 1 回のマーク | マーク個数 |
+|---|---|---|
+| erubi | 1118 → 1095 µs (−2.1 %) | 6,626 → 6,176 (−6.8 %) |
+| activerecord | 2292 → 2282 µs (−0.4 %) | 30,472 → 29,946 (−1.7 %) |
+| rack | 1008 → 987 µs (−2.1 %) | 6,524 → 6,023 (−7.7 %) |
+| graphql | 1056 → 1034 µs (−2.1 %) | 7,971 → 7,561 (−5.1 %) |
+| psych-load | 1381 → 1387 µs (±0) | — |
+
+major の回数は変わらず（4/4, 4/4, 4/4, 3/3, 6/6）、合計マーク時間も誤差内。
+**個数が 7 % 減っても時間が 2 % しか減らないのは、この 3 型が葉だから** —
+`mark_children` が空なので、辿るコストはビットを立てるだけ。時間を食っているのは
+子を持つオブジェクトの traversal の方。効果は小さいが、新しい不変条件を 1 つも
+増やさない（保持する `Value` が無いので、将来の書き込み点に課す約束が無い）ので
+入れてある。
+
+**B. ストアが既にバリア済み / 構築後不変: RANGE / COMPLEX / RATIONAL**
+
+`RangeInner::initialize` は「Write barriers are the caller's responsibility」と
+明記され、`builtins/range.rs` が実際に `write_barrier(start)` / `(end)` を呼んで
+いる。必要なのは `young_child_exists` の腕だけ。ただし数が少ない（AR で 74/minor）
+ので未実施。
+
+**C. PROC / FRAME / BINDING / FIBER / THREAD — 本丸だが難易度が別物**
+
+erubi で 82 %、activerecord で 19 %。理由はコードに明記されている:
+
+> `FRAME`: *Deliberately NOT in `is_promotable`: frames are mutated without a
+> write barrier (dynvar stores), so like Proc/Binding/Fiber they stay young and
+> are re-walked on every minor GC.*
+
+CLASS は書き込み点が 4 か所だったが、フレームのスロットは**ローカル変数代入その
+もの**で書かれる — インタプリタと JIT 双方の、システム中で最もホットなパス。
+バリアを入れれば毎回のローカル代入にヘッダビット検査が乗るので、GC の削減と
+実行時コストのトレードオフになり、CLASS のような一方的な得ではない。加えて
+erubi の PROC 2,693/minor は「昇格できないから残っている」のか「本当に短命」なのか
+未切り分け（テンプレートが毎回ブロックを作っている）。着手前に寿命の実測が要る。
+
 残りは frozen 文字列プールと、`Store` の各表の単調増加そのもの。オブジェクト化が
 本当に必要になるのは「死んだ ISeq / 無名クラスの回収」の方で、これは性能ではなく
 メモリリーク（`iseqs` / `functions` / `constsite_info` が append-only）の課題として

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -1110,7 +1110,17 @@ impl alloc::GCBox for RValue {
             | ObjTy::STRUCT
             | ObjTy::HASH
             | ObjTy::CLASS
-            | ObjTy::MODULE => true,
+            | ObjTy::MODULE
+            // These three hold no `Value` at all — their payloads are a
+            // `DateTime`, an `Arc<Regex>` plus source bytes, and a
+            // `FuncId`/`ClassId`/`IdentId` triple. `mark_children` walks
+            // nothing for them (they are the only kinds besides Bignum and
+            // heap Float for which it is empty), so they satisfy even the
+            // strictest form of the rule: an ivar is the only reference
+            // they can ever gain, and that store is barriered.
+            | ObjTy::TIME
+            | ObjTy::REGEXP
+            | ObjTy::UMETHOD => true,
             _ => false,
         }
     }
@@ -1157,7 +1167,16 @@ impl alloc::GCBox for RValue {
                     .as_rstring()
                     .shared_root()
                     .is_some_and(|root| is_young(root, alloc)),
-                ObjTy::BIGNUM | ObjTy::FLOAT => false,
+                // Reference-free payloads: nothing but `var_table` (checked
+                // above) can point anywhere. Without an arm here they would
+                // fall to the conservative `_ => true` below and be
+                // remembered on every promotion — which costs more than not
+                // promoting them at all.
+                ObjTy::BIGNUM
+                | ObjTy::FLOAT
+                | ObjTy::TIME
+                | ObjTy::REGEXP
+                | ObjTy::UMETHOD => false,
                 ObjTy::OBJECT => self
                     .as_object()
                     .iter()


### PR DESCRIPTION
Follow-up to #1256. That PR ended with a question — what else never promotes? — so I measured it: a census of the objects a minor GC actually marks (old ones are seed-marked and never counted, so this is exactly what gets re-traversed every collection).

| type | erubi (6.6k/minor) | activerecord (31k/minor) | promotes |
|---|---:|---:|---|
| STRING / OBJECT / HASH / ARRAY | 608 / 35 / 46 / 61 | 9699 / 7647 / 3906 / 2016 | yes |
| **PROC** | **2693 (41%)** | **2961 (9.5%)** | no |
| **FRAME** | **2692 (41%)** | **2880 (9.3%)** | no |
| TIME | 89 | 995 | no |
| REGEXP | 292 | 663 | no |
| RANGE / UMETHOD | 29 / 26 | 74 / 28 | no |

Twenty kinds never promote, but they are not alike. This PR does the tier that is free.

## Time, Regexp, UnboundMethod hold no `Value`

`mark_children` is empty for exactly five kinds — Bignum, heap Float, and these three — and the payloads confirm why:

* `TimeInner` — a `DateTime<FixedOffset>` / `DateTime<Utc>` enum
* `RegexpInner` — `Arc<Regex>`, `Arc<[u8]>` source bytes, encoding fields, a `bool`
* `UMethodInner` — `FuncId`, `ClassId`, three `IdentId`s

No outgoing `Value` at all, so they satisfy even the strictest form of the rule `is_promotable`'s own doc comment describes ("a reference-free union kind"). The only reference they can ever gain is an ivar, and that store is already barriered. **No new barrier, and no new invariant for a future writer to remember** — unlike #1256, there is no field here anyone could forget to barrier, because there are no fields.

They also get a `young_child_exists` arm alongside Bignum/Float. That is not cosmetic: without it they fall to the conservative `_ => true` and enter the remembered set on every promotion, which is worse than not promoting them at all.

They stop being re-marked:

| type | erubi | rack | graphql | activerecord |
|---|---|---|---|---|
| REGEXP | 291 → 5 | 413 → 9 | 298 → 13 | 658 → 24 |
| TIME | 89 → 1 | 90 → 2 | 88 → 4 | 975 → 870 |
| UMETHOD | 26 → 0 | 28 → 0 | 25 → 1 | 28 → 1 |

(activerecord keeps its Times because it really does allocate ~870 per collection window and they never reach age 3 — not because they were stuck young.)

## The time saved is small, and the reason is the interesting part

| bench | minor mark | marked/minor |
|---|---|---|
| erubi | 1118 → 1095 µs (−2.1%) | 6626 → 6176 (−6.8%) |
| activerecord | 2292 → 2282 µs (−0.4%) | 30472 → 29946 (−1.7%) |
| rack | 1008 → 987 µs (−2.1%) | 6524 → 6023 (−7.7%) |
| graphql | 1056 → 1034 µs (−2.1%) | 7971 → 7561 (−5.1%) |
| psych-load | 1381 → 1387 µs (±0) | ±0 |

Major count is unchanged (4/4, 4/4, 4/4, 3/3, 6/6) and total mark time is within noise.

Object count falls 5–8% but time only 1–2%, **because these are leaves**: `mark_children` is empty, so walking one costs a bit set, not a traversal. What costs is objects whose children have to be scanned. I would not land this for the number — I am landing it because it costs nothing to maintain and the allowlist was simply missing them.

## What is left, for the record

* **Range / Complex / Rational** — stores are already barriered (`RangeInner::initialize` documents that the caller owns the barrier, and `builtins/range.rs` calls it), so they need only a `young_child_exists` arm. Not done here: ~74/minor on activerecord.
* **Proc / Frame / Binding / Fiber / Thread** — 82% of erubi's minor traversal and the real prize, but a different order of problem. The `FRAME` constant already says why: *"frames are mutated without a write barrier (dynvar stores)"*. Frame slots are written by ordinary local-variable assignment, in both the interpreter and JIT-emitted code, so a barrier there is a trade-off against the hottest path in the system rather than a free win. It also is not yet established whether erubi's 2693 Procs/minor are stuck young or genuinely short-lived (the template allocates a block per render) — that wants measuring first.

`doc/yjit_bench_slow_investigation_2026-09.md` §8.6 records the census and all three tiers.

## Verification

`gc-debug` and `gc-stress` together — a collection at every safepoint, with #1256's clean-`ClassInfo` assertion checked on every minor: 2618 lib tests, no assertion, no dead-object report. Ordinary suite 3730 passed / 1 failed (the pre-existing `float::tests::angle`, a local CRuby 4.0.6 vs 4.0.2 difference in `Float#ceil(15)`). Rebased onto current master and re-verified there.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkoJG3qRpCRJ4nXDZH3mg9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkoJG3qRpCRJ4nXDZH3mg9)_