### PR TITLE
Emit the Hash#[] probe as machine code for Symbol keys in a linear map

### DIFF
--- a/doc/hash_optimization.md
+++ b/doc/hash_optimization.md
@@ -173,7 +173,7 @@ Integer キーだけ Symbol キーより 14 ns 遅い（39.5 vs 25.7）のがそ
 構造ハッシュ用（Ruby から見える `#hash` 値）とバケッティング用を分ければ、
 Integer キーの参照が Symbol キーと同じところまで来るはず。
 
-### 4.2 probe を JIT でインライン展開する（大・最大の残り）
+### 4.2 probe を JIT でインライン展開する（大・最大の残り。**段階 1 実装済み**、2026-09-04）
 
 いまは `Hash#[]` のインライン生成が `hashindex` への直接呼び出しまでしか
 やらない（メソッドフレームは省くが、そこから先は Rust）。受信側が
@@ -183,6 +183,60 @@ Integer キーの参照が Symbol キーと同じところまで来るはず。
 残差（33.7 vs 17.5 ns）を埋める本命。`gen_hash_entry_at` が既に
 `rubymap::EntriesLayout` からエントリ配列を歩いているので、必要なレイアウト
 知識は揃っている。
+
+#### 段階分け
+
+`IndexMapCore` には 2 つの動作領域がある。**≤ 8 エントリ**（`AR_MAX`、CRuby の
+`RHASH_AR_TABLE_MAX_SIZE` と同じ）は `linear`、`indices` を作らず `entries` を
+線形走査して `entry.hash == hash` の一致だけキー比較する。それ以上は hashbrown
+の probe（上位 7 ビットで control byte を 16 個ずつ SIMD 比較 → 添字 →
+エントリ比較）。`Bucket { hash, key, value }` はハッシュ値を格納しているので、
+線形走査は「64 ビット比較 × N、当たったときだけキー比較」で済む。
+
+| 段階 | キー | 領域 | 状態 |
+|---|---|---|---|
+| 1 | packed のうちビットがそのままミキサーに入るもの（Symbol / nil / true / false） | 線形（≤ 8） | **実装済み** `AsmInst::HashProbePacked` |
+| 2 | 同上 | 索引（> 8）— hashbrown の group probe | 未 |
+| 3 | String — バイト列ダイジェスト + memcmp + `plain_string` 判定 | 両方 | 未（erubi の 18 エントリ・String キーはここ） |
+
+Integer キーは 4.1 の二重ハッシュ（SipHash を内側で 1 回回す）が解けるまで
+対象外。葉ヘルパで正しく計算はできるが、ヘルパ自体が現状のルックアップの
+大半のコストになる。
+
+#### 段階 1 の設計判断（2026-09-04）
+
+- **ダイジェストは葉ヘルパ `packed_digest_c`、probe は機械語。** fold は
+  64×64→128 の乗算だが、この JIT が使う x86-64 アセンブラ（monoasm）に
+  1 オペランド `mul` が**無い**（`div` / `idiv` はあり、`imul` は 2 オペランドの
+  下位 64 ビットのみ）。aarch64 には `umulh` がある。monoasm に足したら
+  ヘルパをその命令列に置き換えるだけで、他は変わらない。
+- **形の不一致は deopt ではなく builtin 呼び出し。** inline 表現・identity
+  マップ・索引領域はすべて `hashindex` への合流で、exit しない。最初は deopt に
+  していたが、この deopt は再コンパイルを起こさないので、大きな Symbol キー
+  Hash のサイトが**毎回 deopt**することになる（4.5 の ic ゲートで踏んだのと
+  同型）。builtin 呼び出しなら現状と同コストで退行しない。
+- **線形領域の miss は in-line で `nil`。** 走査を尽くしたら
+  `Option<Box<HashDefault>>`（null = default 値も proc も無し）を 1 ロード見て、
+  無ければ nil。builtin に落とすとダイジェストと走査をもう一度やり直すので、
+  最初の実装では miss が 16 → 30 ns に**退行**していた。
+- **`EntriesLayout` に `hash_offset` / `linear_offset` を追加**。`Bucket` は
+  niche を持つキー型で並び替わる（`Option<Value>` では value+0 / hash+8 /
+  key+16）ので、既存どおり実測で取る。
+
+#### 段階 1 の効果（6 エントリ・Symbol キー、純ルックアップ、交互 4 ラウンド）
+
+| | 従来 | 段階 1 |
+|---|---:|---:|
+| hit（先頭） | 16.3–18.1 | **6.3–9.7** |
+| hit（末尾） | 15.3–19.3 | **8.2–11.0** |
+| miss | 16.5–20.4 | **7.4–10.6** |
+| 18 エントリ Symbol（索引領域、fallback） | 18.7–26.0 | 15.5–21.2（退行なし） |
+
+hit 経路の call は `packed_digest_c` の 1 つだけになり、`hashindex` の call は
+miss 側にしか残らない（`emit-asm` で確認）。`tests/hash_probe_jit.rs` が
+hit / miss / default 値 / default proc / nil・true・false キー / tombstone /
+索引領域・inline 表現・identity マップへの委譲 / クラスガード / 線形↔索引の
+境界を跨ぐ成長 / 生きた状態の読み取りを CRuby と突き合わせる。
 
 ### 4.3 呼び出しサイトのキーセット・インラインキャッシュ（中・要検証）
 

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -1044,7 +1044,7 @@ fn hash_index(
     store: &Store,
     callid: CallSiteId,
     recv_class: Option<ClassId>,
-    _: Option<ClassId>,
+    idx_class: Option<ClassId>,
 ) -> bool {
     let Some(recv_class) = recv_class else {
         // The call site could not prove the receiver's class (a multi-class
@@ -1063,6 +1063,30 @@ fn hash_index(
     }
     state.load(ir, callsite.args, GP::Rcx);
     state.load(ir, callsite.recv, GP::Rdx);
+    // The probe in line, when the key is one of the immediates whose digest
+    // is its bits through the mixer (a fixnum's goes through SipHash first
+    // — `Value::ruby_hash_packed` — and stays on the call until that is
+    // split). The key's class comes from this site's inline cache, so it is
+    // guarded; the receiver's shape is checked inside the probe, and a shape
+    // it does not handle is answered by the builtin call, not by an exit.
+    if let (Some(layout), Some(kc)) = (hash_entries_layout(), idx_class)
+        && matches!(kc, SYMBOL_CLASS | NIL_CLASS | TRUE_CLASS | FALSE_CLASS)
+    {
+        let deopt = ir.new_deopt(state);
+        state.guard_class(ir, callsite.args, GP::Rcx, kc, deopt);
+        let using_fpr = state.get_using_fpr(ir);
+        ir.fpr_save(using_fpr);
+        ir.hash_probe_packed(
+            layout,
+            hashindex as *const () as u64,
+            packed_digest_c as *const () as u64,
+        );
+        ir.fpr_restore(using_fpr);
+        let error = ir.new_error(state);
+        ir.handle_error(error);
+        state.def_rax2acc(ir, callsite.dst);
+        return true;
+    }
     let using_fpr = state.get_using_fpr(ir);
     ir.fpr_save(using_fpr);
     ir.inline(|r#gen, _, _, _| r#gen.emit_call_2args(hashindex as *const () as u64));

--- a/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
@@ -752,6 +752,102 @@ impl Codegen {
         );
     }
 
+    ///
+    /// `Hash#[]` with the probe in line — see `AsmInst::HashProbePacked`.
+    /// The x86-64 sequence, register for register: hash in x2 (Rdx), key in
+    /// x1 (Rcx), result in x0 (Rax); x1 / x2 survive the probe for the miss
+    /// path's `emit_call_2args`. x3, x4, x9–x12 are scratch.
+    ///
+    pub(crate) fn gen_hash_probe_packed(
+        &mut self,
+        layout: rubymap::EntriesLayout,
+        hashindex: u64,
+        digest: u64,
+    ) {
+        let lp = self.jit.label();
+        let next = self.jit.label();
+        let exhausted = self.jit.label();
+        let miss = self.jit.label();
+        let done = self.jit.label();
+        let ty_flags = (RVALUE_OFFSET_TY + 1) as u32;
+        let boxed_rep = HASH_REP_BOXED as u32;
+        let map_ptr = HASH_CONTENT_MAP_OFFSET as u32;
+        let default_slot = HASH_DEFAULT_OFFSET as u32;
+        let linear_off = layout.linear_offset as u32;
+        let len_off = layout.len_offset as u32;
+        let ptr_off = layout.ptr_offset as u32;
+        let bucket_size = layout.bucket_size as u64;
+        let hash_off = layout.hash_offset as u32;
+        let key_off = layout.key_offset as u32;
+        let value_off = layout.value_offset as u32;
+        monoasm_arm64!(&mut self.jit,
+            ldrb w3, [x2, #(ty_flags)];
+            mov x9, (HASH_REP_MASK as u64);
+            and x3, x3, x9;
+            cmp x3, #(boxed_rep);
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &miss);
+        monoasm_arm64!(&mut self.jit,
+            ldr x4, [x2, #(map_ptr)];
+            ldrb w3, [x4, #(linear_off)];
+            cmp x3, #(0);
+        );
+        // A shape this probe does not handle is a call, not an exit — see
+        // the x86-64 twin.
+        self.jit.bcond_label(monoasm::Cond::Eq, &miss);
+        monoasm_arm64!(&mut self.jit,
+            // digest = packed_digest_c(key); keep x1 / x2 for the miss path.
+            stp x1, x2, [sp, #(-16)]!;
+            mov x0, x1;
+            mov x9, (digest);
+            str x30, [sp, #(-16)]!;
+            blr x9;
+            ldr x30, [sp], #(16);
+            ldp x1, x2, [sp], #(16);
+            mov x10, x0;                        // x10 = digest
+            ldr x4, [x2, #(map_ptr)];
+            ldr x11, [x4, #(ptr_off)];          // x11 = &entries[0]
+            ldr x9, [x4, #(len_off)];
+            mov x12, (bucket_size);
+            mul x9, x9, x12;
+            add x9, x9, x11;                    // x9 = one past the last entry
+        lp:
+            cmp x11, x9;
+        );
+        self.jit.bcond_label(monoasm::Cond::Hs, &exhausted);
+        monoasm_arm64!(&mut self.jit,
+            ldr x3, [x11, #(hash_off)];
+            cmp x3, x10;
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &next);
+        monoasm_arm64!(&mut self.jit,
+            ldr x3, [x11, #(key_off)];
+            cmp x3, x1;
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &next);
+        monoasm_arm64!(&mut self.jit,
+            ldr x0, [x11, #(value_off)];
+            b done;
+        next:
+            add x11, x11, x12;
+            b lp;
+        exhausted:
+            // Not present: nil in line unless a default value / proc exists
+            // (null `Option<Box<HashDefault>>` means neither) — see the
+            // x86-64 twin.
+            ldr x3, [x2, #(default_slot)];
+            cmp x3, #(0);
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &miss);
+        monoasm_arm64!(&mut self.jit,
+            mov x0, #(NIL_VALUE);
+            b done;
+        miss:
+        );
+        self.emit_call_2args(hashindex);
+        self.jit.bind_label(done);
+    }
+
     /// `Hash#__key_at` / `#__value_at`: hash in Rdx (x2), fixnum index in Rcx
     /// (x1), result Value in Rax (x0). aarch64 twin of the x86
     /// `gen_hash_entry_at`.

--- a/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
@@ -727,6 +727,110 @@ impl Codegen {
         }
     }
 
+    ///
+    /// `Hash#[]` with the probe in line — see `AsmInst::HashProbePacked`.
+    ///
+    /// ### in
+    /// - rdx: the hash
+    /// - rcx: the key, a bits-hashed immediate (class-guarded by the caller)
+    ///
+    /// ### out
+    /// - rax: the value on a hit; `hashindex`'s answer on a miss
+    ///
+    /// rdx and rcx survive the probe (the miss path needs them as
+    /// `hashindex`'s arguments); everything else caller-saved is scratch.
+    /// Total: a shape the probe does not handle is answered by the builtin,
+    /// never by an exit.
+    ///
+    pub(crate) fn gen_hash_probe_packed(
+        &mut self,
+        layout: rubymap::EntriesLayout,
+        hashindex: u64,
+        digest: u64,
+    ) {
+        let lp = self.jit.label();
+        let next = self.jit.label();
+        let exhausted = self.jit.label();
+        let miss = self.jit.label();
+        let done = self.jit.label();
+        let ty_flags = RVALUE_OFFSET_TY + 1;
+        let mask = HASH_REP_MASK as u64;
+        let boxed_rep = HASH_REP_BOXED as u64;
+        let map_ptr = HASH_CONTENT_MAP_OFFSET;
+        let default_slot = HASH_DEFAULT_OFFSET;
+        let linear_off = layout.linear_offset;
+        let len_off = layout.len_offset;
+        let ptr_off = layout.ptr_offset;
+        let bucket_size = layout.bucket_size;
+        let hash_off = layout.hash_offset;
+        let key_off = layout.key_offset;
+        let value_off = layout.value_offset;
+        monoasm! { &mut self.jit,
+            // The boxed representation only: inline pairs have no digests to
+            // compare, and the identity-keyed map is keyed differently.
+            movzxb rsi, [rdx + (ty_flags)];
+            andq rsi, (mask);
+            cmpq rsi, (boxed_rep);
+            jne  miss;
+            movq rdi, [rdx + (map_ptr)];
+            // Linear regime only (no indices table): the entries are the
+            // whole probe. Past that the table decides, which is stage 2.
+            // Either way the builtin answers correctly, so a shape this
+            // probe does not handle is a *call*, not an exit: a deopt here
+            // would not recompile, and a large Symbol-keyed Hash would then
+            // exit on every lookup — strictly worse than today.
+            movzxb rsi, [rdi + (linear_off)];
+            testq rsi, rsi;
+            jz   miss;
+            // digest = packed_digest_c(key). A leaf, but a C call: rdx / rcx
+            // are caller-saved, and the miss path still needs them.
+            pushq rdx;
+            pushq rcx;
+            movq rdi, rcx;
+            movq rax, (digest);
+            call rax;
+            popq rcx;
+            popq rdx;
+            movq r8, rax;                       // r8 = digest
+            movq rdi, [rdx + (map_ptr)];
+            movq r11, [rdi + (ptr_off)];        // r11 = &entries[0]
+            movq r9, [rdi + (len_off)];
+            movq rsi, (bucket_size);
+            imul r9, rsi;
+            addq r9, r11;                       // r9 = one past the last entry
+        lp:
+            cmpq r11, r9;
+            jae  exhausted;
+            cmpq r8, [r11 + (hash_off)];
+            jne  next;
+            // `Option<Value>` in `Value`'s NonZero niche: `Some(k)` is k's own
+            // bits, and a tombstone's `None` is the zero word, which no packed
+            // key equals.
+            cmpq rcx, [r11 + (key_off)];
+            jne  next;
+            movq rax, [r11 + (value_off)];
+            jmp  done;
+        next:
+            addq r11, (bucket_size);
+            jmp  lp;
+        exhausted:
+            // Not present. Without a default that *is* the answer, and the
+            // builtin would only redo the digest and the scan to say so;
+            // `Option<Box<HashDefault>>` is null when there is neither a
+            // default value nor a default proc.
+            movq rsi, [rdx + (default_slot)];
+            testq rsi, rsi;
+            jne  miss;
+            movq rax, (NIL_VALUE);
+            jmp  done;
+        miss:
+        }
+        // A default value / default proc, or a shape this probe does not
+        // handle: the builtin.
+        self.emit_call_2args(hashindex);
+        self.jit.bind_label(done);
+    }
+
     /// `Hash#__live_at`: hash in rdx, fixnum index in rcx, Ruby bool in rax —
     /// `true` iff the position is in range and the entry is not a tombstone.
     /// Total by construction, like `__key_at`. rsi and rdi are scratch.

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -187,6 +187,7 @@ impl Codegen {
             | AsmInst::HashLenFixnum { .. }
             | AsmInst::HashEntryAt { .. }
             | AsmInst::HashLiveAt { .. }
+            | AsmInst::HashProbePacked { .. }
             | AsmInst::HashCompareByIdentity { .. }
             | AsmInst::HashDefault { .. }
             | AsmInst::IsNilToBool { .. }

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1225,6 +1225,20 @@ impl AsmIr {
         self.inst.push(AsmInst::HashEntryAt { want_key, layout });
     }
 
+    /// See [`AsmInst::HashProbePacked`].
+    pub(crate) fn hash_probe_packed(
+        &mut self,
+        layout: rubymap::EntriesLayout,
+        hashindex: u64,
+        digest: u64,
+    ) {
+        self.inst.push(AsmInst::HashProbePacked {
+            layout,
+            hashindex,
+            digest,
+        });
+    }
+
     /// Emit `dst <- fixnum(String#bytesize)`: the fixnum-tagged byte length of
     /// the string receiver in `base`. Typed alternative to `inline`.
     pub(crate) fn string_len_fixnum(&mut self, dst: GP, base: GP) {
@@ -2071,6 +2085,32 @@ pub(super) enum AsmInst {
     /// construction, like `HashEntryAt` — no error edge, no fallback.
     HashLiveAt {
         layout: rubymap::EntriesLayout,
+    },
+    ///
+    /// `Rax <- Hash#[](Rcx)` for the hash in `Rdx`, with the probe emitted
+    /// as machine code: the boxed map's entries are scanned for the key's
+    /// digest and then its bits, and a hit reads the value straight out of
+    /// the entry. No Rust runs on a hit except the digest itself
+    /// (`digest`, a leaf). A miss answers `nil` in line when the Hash has
+    /// no default; a default value / default proc goes to `hashindex`,
+    /// which owns them — and so does a shape the probe does not handle (an
+    /// inline or identity-keyed representation, or a map past its linear
+    /// size, whose probe goes through the indices table). Total by
+    /// construction: nothing here exits, because a deopt would not
+    /// recompile and a large Symbol-keyed Hash would then exit on every
+    /// lookup.
+    ///
+    /// The key must already be class-guarded to one of the bits-hashed
+    /// immediates (`Symbol`, `nil`, `true`, `false`): a fixnum's digest
+    /// reduces through SipHash first (`Value::ruby_hash_packed`), which the
+    /// leaf would do correctly but not cheaply.
+    ///
+    HashProbePacked {
+        layout: rubymap::EntriesLayout,
+        /// `hashindex`'s address — the miss path.
+        hashindex: u64,
+        /// `packed_digest_c`'s address.
+        digest: u64,
     },
     /// `dst <- (src == nil) ? true : false` as a Ruby bool `Value` (`Object#nil?`).
     /// Typed replacement for the `emit_kernel_nil` closure. Uses `GP::Rsi` as a

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -1507,6 +1507,20 @@ impl Codegen {
                     },
                 );
             }
+            AsmInst::HashProbePacked {
+                layout,
+                hashindex,
+                digest,
+            } => {
+                self.lower_via_inline(
+                    store,
+                    labels,
+                    frame.base_stack_offset,
+                    move |cg, _, _, _| {
+                        cg.gen_hash_probe_packed(layout, hashindex, digest);
+                    },
+                );
+            }
             AsmInst::HashLiveAt { layout } => {
                 self.lower_via_inline(
                     store,

--- a/monoruby/src/value/rvalue/hash.rs
+++ b/monoruby/src/value/rvalue/hash.rs
@@ -157,6 +157,27 @@ fn packed_digest<S: std::hash::BuildHasher>(hash_builder: &S, k: Value) -> usize
     h.finish() as usize
 }
 
+///
+/// The bucketing digest of a packed key, for the JIT's inline probe.
+///
+/// A leaf: no vm, no allocation, nothing it can raise — so generated code
+/// calls it with the key in the first argument register and only its own
+/// caller-saved registers to protect. It is the same digest the map
+/// computed at insert time: the mixer is seeded per *process*
+/// (`RubyRandomState::new` reads one `OnceLock`), so one seed serves every
+/// map and every call site.
+///
+/// Why a call and not two multiplies in line: the fold is a 64×64→128
+/// multiply, and the x86-64 assembler this JIT emits through has no
+/// one-operand `mul`. When it does, this helper becomes the emitted
+/// sequence and nothing else changes.
+///
+pub(crate) extern "C" fn packed_digest_c(bits: u64) -> u64 {
+    let k = Value::from_u64(bits);
+    debug_assert!(k.is_packed_value());
+    packed_digest(&rubymap::RubyRandomState::new(), k) as u64
+}
+
 /// The boxed map's digest of a String key, computed without the vm: the
 /// same builder and the same digest stream as `RubyMap::hash(&Some(k))`
 /// for an `ObjTy::STRING` payload — `Value::ruby_hash`'s STRING arm

--- a/monoruby/tests/hash_probe_jit.rs
+++ b/monoruby/tests/hash_probe_jit.rs
@@ -1,0 +1,146 @@
+extern crate monoruby;
+use monoruby::tests::*;
+
+// `Hash#[]` with the probe emitted as machine code (`AsmInst::HashProbePacked`):
+// for a boxed map of at most eight entries and a key whose digest is its
+// bits through the mixer (Symbol, nil, true, false), the JIT scans the
+// entries in line — digest first, then the key's bits — and reads the
+// value out of the entry on a hit. Everything else is the builtin call, as
+// before. These pin the answers against CRuby for every shape the probe
+// can meet, including the ones it must hand back.
+
+/// The probe's home ground: a boxed (4+ pairs), linear (≤ 8) map with
+/// Symbol keys — hits, a miss, and the default value / default proc a miss
+/// must still reach through the builtin.
+#[test]
+fn hash_probe_symbol_keys_linear() {
+    run_test(
+        r##"
+        def run(h, k, n = 300)
+          r = nil; i = 0
+          while i < n; r = h[k]; i += 1; end
+          r
+        end
+        res = []
+        h = {a: 1, b: 2, c: 3, d: 4, e: 5}
+        res << run(h, :a) << run(h, :e) << run(h, :zz)
+        hd = Hash.new(:dflt); hd[:a] = 1; hd[:b] = 2; hd[:c] = 3; hd[:d] = 4
+        res << run(hd, :a) << run(hd, :nope)
+        hp = Hash.new { |hh, kk| "proc:#{kk}" }; hp[:a] = 1; hp[:b] = 2; hp[:c] = 3; hp[:d] = 4
+        res << run(hp, :a) << run(hp, :q)
+        res
+        "##,
+    );
+}
+
+/// The other bits-hashed immediates as keys.
+#[test]
+fn hash_probe_nil_true_false_keys() {
+    run_test(
+        r##"
+        def run(h, k, n = 300)
+          r = nil; i = 0
+          while i < n; r = h[k]; i += 1; end
+          r
+        end
+        hn = {nil => :n, true => :t, false => :f, a: 1}
+        [run(hn, nil), run(hn, true), run(hn, false), run(hn, :a), run(hn, :b)]
+        "##,
+    );
+}
+
+/// A deleted entry leaves a tombstone — `None` in the key slot, the zero
+/// word — which the scan must step over, never match, and never confuse
+/// with its neighbours.
+#[test]
+fn hash_probe_tombstones() {
+    run_test(
+        r##"
+        def run(h, k, n = 300)
+          r = nil; i = 0
+          while i < n; r = h[k]; i += 1; end
+          r
+        end
+        ht = {a: 1, b: 2, c: 3, d: 4, e: 5}
+        ht.delete(:c)
+        res = [run(ht, :c), run(ht, :d), run(ht, :e), run(ht, :a)]
+        ht.delete(:a); ht.delete(:e)
+        res << run(ht, :a) << run(ht, :b) << run(ht, :d) << run(ht, :e)
+        res
+        "##,
+    );
+}
+
+/// Shapes the probe hands to the builtin rather than answering itself —
+/// and must hand over as a *call*, never an exit, since a deopt would not
+/// recompile and the site would then exit on every lookup:
+/// a map past the linear size (indexed), the inline representation
+/// (≤ 3 pairs, no digests), and an identity-keyed map.
+#[test]
+fn hash_probe_hands_other_shapes_to_the_builtin() {
+    run_test(
+        r##"
+        def run(h, k, n = 300)
+          r = nil; i = 0
+          while i < n; r = h[k]; i += 1; end
+          r
+        end
+        res = []
+        hb = {}; (1..20).each { |i| hb[:"k#{i}"] = i }
+        res << run(hb, :k1) << run(hb, :k20) << run(hb, :k99)
+        hi = {a: 1, b: 2}
+        res << run(hi, :a) << run(hi, :b) << run(hi, :c)
+        hc = {a: 1, b: 2, c: 3, d: 4}.compare_by_identity
+        res << run(hc, :a) << run(hc, :x)
+        res
+        "##,
+    );
+}
+
+/// The key's class is this site's inline-cache assumption and is guarded;
+/// a key of another class at the same site must exit cleanly and still
+/// answer. And a map that grows across the linear / indexed boundary
+/// while the site is hot must keep answering on both sides of it.
+#[test]
+fn hash_probe_class_guard_and_growth() {
+    run_test(
+        r##"
+        def run(h, k, n = 300)
+          r = nil; i = 0
+          while i < n; r = h[k]; i += 1; end
+          r
+        end
+        res = []
+        hm = {a: 1, b: 2, c: 3, d: 4, 7 => :seven, "s" => :str}
+        res << run(hm, :a) << run(hm, 7) << run(hm, "s") << run(hm, :a)
+        hg = {}
+        (1..12).each { |i| hg[:"g#{i}"] = i; res << run(hg, :"g#{i}", 40) }
+        res << run(hg, :g1) << run(hg, :g12) << run(hg, :none)
+        res
+        "##,
+    );
+}
+
+/// A frozen Hash and a Hash mutated between lookups: the probe reads the
+/// live entries every time and caches nothing, so an insert, an overwrite
+/// and a delete between two lookups at the same site are all observed.
+#[test]
+fn hash_probe_reads_live_state() {
+    run_test(
+        r##"
+        def run(h, k, n = 300)
+          r = nil; i = 0
+          while i < n; r = h[k]; i += 1; end
+          r
+        end
+        h = {a: 1, b: 2, c: 3, d: 4}
+        res = [run(h, :a)]
+        h[:a] = 10;    res << run(h, :a)
+        h[:e] = 5;     res << run(h, :e)
+        h.delete(:b);  res << run(h, :b) << run(h, :c)
+        f = {a: 1, b: 2, c: 3, d: 4}.freeze
+        res << run(f, :a) << run(f, :zz)
+        res
+        "##,
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -133,6 +133,7 @@
 07b1d4b32547d6f6624dc2c846950ab0	[true, true]	t = Thread.new { :x }\n            t.join\n            [t.kill == t, 
 07d3d8701aafb106b630434fe110bc28	[8, 7]	inc = proc { |n| n + 1 }\n        d = Object.new\n        def d.call(n); 
 07db4a045facdc21787ed0ef44cb050c	["class or module required for rescue clause", "class or module required for rescue clause", "class or module required for rescue clause"]	res = []\n        rescuer = 42\n        3.times do\n          begin\n      
+07fc55c9c66fdcb526a444ef6361069c	[1, 5, nil, 1, :dflt, 1, "proc:q"]	def run(h, k, n = 300)\n          r = nil; i = 0\n          while i < n; 
 080f42d888ea5e1a7eb7a4c43d6b5064	"US-ASCII"	"Hello".encode("US-ASCII").swapcase.encoding.to_s
 080f929287fc4ac492b6fb2c6fb2aaac	[:interrupted]	def run_masked(timing, blocking = true)\n              klass = Class
 082c922854391d30efbd21f4e18518c3	true	File.writable?("/tmp")
@@ -614,6 +615,7 @@
 2c60a3b58b3cec1741ef306698cffc54	"missing: hello"	class C\n          def method_missing(name, *args)\n            "missing:
 2cbffbc78f3202b93258530c17eb3aec	[1200, "abcdefghij", true]	def app_piece2(s, piece, n)\n          i = 0\n          while i < n\n     
 2cf607598595d4b3f44991e7c7f960a0	[[:typeerr], [:typeerr], [:typeerr], [:ok]]	def t(x)\n              [x].map do |v|\n                begin\n       
+2d0977c7c034e1bbf8950d44e00c27b0	[1, 20, nil, 1, 2, nil, 1, nil]	def run(h, k, n = 300)\n          r = nil; i = 0\n          while i < n; 
 2d0f94c4757acfe87ab61946bc9adbbb	3	st = Process.detach(spawn("sh", "-c", "exit 3")).value; st.exitstatus
 2d2ff1c3ff5d4218de0d6a13eec1eeb7	"a"	"a".reverse
 2d4ecfc6a346da8617ce2f74c132236e	[["1", "9", "0", nil], ["global-variable", nil], nil, nil]	res = []\n        "1234567890" =~ /(1)(2)(3)(4)(5)(6)(7)(8)(9)(0)/\n     
@@ -805,6 +807,7 @@
 3d4f40c1f15e87af5d8f2875562332f0	true	"".dup.force_encoding("UTF-16BE") == "".dup.force_encoding("UTF-8")
 3d5aaee333bdf3c4bc36ded91dcd0aaf	[1, :nme]	class TrueClass; def only_true713; 1; end; end\n        res = []\n       
 3d5adde3fb0edf69c5646dd0efeadc07	["PSubC", :dup, :clone]	class PSubC < Proc\n                 def initialize_dup(o); super; @tag = :dup; e
+3d7615175fabd68b3fa63cd412a212f0	[:n, :t, :f, 1, nil]	def run(h, k, n = 300)\n          r = nil; i = 0\n          while i < n; 
 3d825ed681f4d3904854e2642bf813b4	A	class A; end\n            Class.new(A).superclass\n            
 3d87b9096253d3620333a296cee8e5f7	2.5	def call_block\n          yield\n        end\n        def p3\n          k =
 3d97f043dbc63d648bc8c08d3cd03cda	Array	class C < Array; end\n(C[1,2] | [3]).class
@@ -1225,6 +1228,7 @@
 5d03329e8ce3ae472df7fb2691c658f9	[3, :redefined]	a, b = 3, 9\n            r = []\n            50.times { r << [a, b].m
 5d04703a221875b0b4d2a0813111741a	nil	class CSrcLocMissing; end\n            CSrcLocMissing.const_source_l
 5d0c9438a810db95f43044dee3f665ba	[true, true]	class CSrcLocScopeOuter\n              class Inner\n                I
+5d133754b00e49c763d011ae4b0d6b42	[1, :seven, :str, 1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 12, nil]	def run(h, k, n = 300)\n          r = nil; i = 0\n          while i < n; 
 5d2068c7082fde255a8c47d3b3b3e849	nil	$stdout.write("a")\n            print "b"\n            $stdout.write(
 5d33630c505ca95acb062afbe222be3f	"Float"	before = Time.now\n            (Time.now - before).class.to_s
 5d37270fae8d3495ac4405dcd8502866	["fiber called across threads", "fiber called across threads", "fiber called across threads", "fiber called across threads", :r]	res = []\n            f1 = Fiber.new { :r }\n            f2 = Fiber.n
@@ -3026,6 +3030,7 @@ e40d3f8284923f9a5d0e3cb7bf4ebd90	:OVERRIDDEN	class String; def !=(o); :OVERRIDDE
 e4389faf07c04c6c6c14f39e455deef9	"Object"	Enumerator::Yielder.superclass.to_s
 e441908e5db44ae55d2d4454aa1055a2	["hello", "HI"]	class A\n              def greet; "hello"; end\n            end\n     
 e44c1ee57a646b552c6cf61a121a4a5f	["hellohellohello", "hellohello", "hello world", true, "x", "!‽", "abcd"]	a = +"hello"\n        a.concat a, a\n        b = +"hello"\n        b.conca
+e44cf67962ec6cc352d0ab49d20f4d1f	[nil, 4, 5, 1, nil, 2, 4, nil]	def run(h, k, n = 300)\n          r = nil; i = 0\n          while i < n; 
 e44fe0e6159ead6593e9820b1014b08b	[:two_ensure, :three_post, :three_ensure]	class BT\n          def one; two { yield }; end\n          def two\n      
 e45448fbfd8f7f0f3eff2312a6288466	nil	begin\n              raise "original"\n            rescue => e\n      
 e45816cf8d4aeb4f460e318b767a5882	1	(1..).min
@@ -3193,6 +3198,7 @@ f090d1117e83eac6fc71416bd205423e	[[195, 169], "Windows-31J", true]	s = "\\303\\2
 f090e128d692f747d1595559a1145a25	[499500, 4]	module Hot; end\n        class Integer\n          prepend Hot\n        end
 f098937c1782ad342405a495ac2f0063	true	class Foo\n              def bar; end\n            end\n            \n\n
 f09f3eb9548625635df9c1a64f0614c9	[2, :redefined, false]	def probe(a, b) = a == b\n                def probe_ne(a, b) = a
+f0c130f386e3895d3c36f721f172b025	[1, 10, 5, nil, 3, 1, nil]	def run(h, k, n = 300)\n          r = nil; i = 0\n          while i < n; 
 f0c50bd8de554c94bd61a098ac6b9b78	"#<data M amount=42, unit=\\"km\\">"	M = Data.define(:amount, :unit)\nM.new(42, "km").to_s
 f0e946f362739bd5f3dcdd127d2dbfe2	[:toa, :single]	class E1 < StandardError; end\n            class Custom; def to_a; [
 f12165564d922cbb529013b962e93e50	11	b = for a in 0..300 do\n                if a == 77 then break a/7 en

--- a/rubymap/src/lib.rs
+++ b/rubymap/src/lib.rs
@@ -249,6 +249,13 @@ pub struct EntriesLayout {
     pub key_offset: usize,
     /// Offset of the value within one entry.
     pub value_offset: usize,
+    /// Offset of the stored digest ([`HashValue`]) within one entry. A probe
+    /// compares this before it looks at the key.
+    pub hash_offset: usize,
+    /// Offset from `&RubyMap` to the `linear` flag: non-zero while the map
+    /// holds at most `AR_MAX` entries and has no indices table, in which case
+    /// the entries may be scanned directly.
+    pub linear_offset: usize,
 }
 
 ///
@@ -299,12 +306,15 @@ pub fn entries_layout<K, V, E, G, R, S>() -> Option<EntriesLayout> {
     }
     let entries = std::mem::offset_of!(RubyMap<K, V, E, G, R, S>, core)
         + crate::map::core::entries_offset::<K, V, E, G, R>();
+    let core = std::mem::offset_of!(RubyMap<K, V, E, G, R, S>, core);
     Some(EntriesLayout {
         ptr_offset: entries + vec_ptr,
         len_offset: entries + vec_len,
         bucket_size: std::mem::size_of::<Bucket<K, V>>(),
         key_offset: std::mem::offset_of!(Bucket<K, V>, key),
         value_offset: std::mem::offset_of!(Bucket<K, V>, value),
+        hash_offset: std::mem::offset_of!(Bucket<K, V>, hash),
+        linear_offset: core + crate::map::core::linear_offset::<K, V, E, G, R>(),
     })
 }
 
@@ -353,7 +363,24 @@ mod entries_layout_tests {
             let (k, v) = unsafe { raw_entry::<u64, u64>(p, &lay, i) };
             let (ek, ev) = map.get_index(i).unwrap();
             assert_eq!((k, v), (*ek, *ev), "entry {i}");
+            // The stored digest must be what the map itself would compute for
+            // the key: the JIT probe compares against it.
+            let h = unsafe {
+                p.add(lay.ptr_offset)
+                    .cast::<*const u8>()
+                    .read()
+                    .add(i * lay.bucket_size + lay.hash_offset)
+                    .cast::<usize>()
+                    .read()
+            };
+            assert_eq!(h, map.hash(&k, &mut (), &mut ()).unwrap().0, "hash of entry {i}");
         }
+        // 64 entries is past AR_MAX, so the map is indexed: `linear` is 0.
+        assert_eq!(unsafe { p.add(lay.linear_offset).read() }, 0);
+        let mut small: RubyMap<u64, u64> = RubyMap::new();
+        small.insert(1, 2, &mut (), &mut ()).unwrap();
+        let q = &small as *const _ as *const u8;
+        assert_ne!(unsafe { q.add(lay.linear_offset).read() }, 0);
     }
 
     /// A key type carrying a niche reorders `Bucket`'s fields, so the

--- a/rubymap/src/map/core.rs
+++ b/rubymap/src/map/core.rs
@@ -58,6 +58,14 @@ pub(crate) const fn entries_offset<K, V, E, G, R>() -> usize {
     std::mem::offset_of!(IndexMapCore<K, V, E, G, R>, entries)
 }
 
+/// Byte offset of the `linear` flag inside an `IndexMapCore`, for the same
+/// consumer as [`entries_offset`]: generated code reads it to decide whether
+/// the entries may be scanned directly (no indices table) or the probe must
+/// go through the table.
+pub(crate) const fn linear_offset<K, V, E, G, R>() -> usize {
+    std::mem::offset_of!(IndexMapCore<K, V, E, G, R>, linear)
+}
+
 /// Mutable references to the parts of an `IndexMapCore`.
 ///
 /// When using `HashTable::find_entry`, that takes hold of `&mut indices`, so we have to borrow our


### PR DESCRIPTION
Stage 1 of `doc/hash_optimization.md` §4.2.

## The problem this attacks

`Hash#[]`'s inline generator stopped at a direct call to `hashindex`: the method frame was skipped, but the digest, the probe and everything between them were Rust — `hashindex` → `Hashmap::index` → `HashRef::get` → `get_prehashed_with` → hashbrown. Those layers hold ~45 % of a String-key lookup's self time, and §4.4 (rejected earlier today) showed that neither thin LTO, outlining the cold arms, nor `#[inline]` collapses them: each layer carries the inlined probe and LLVM declines every hint.

So this removes the layers rather than thinning them.

## What it does

For a boxed map of at most `AR_MAX` (8) entries — the `linear` regime, where `entries` *is* the probe (no indices table; `Bucket` stores the digest, so it is a 64-bit compare per entry and a key compare only on a match) — and a key whose digest is its bits through the mixer (Symbol, nil, true, false), the JIT scans the entries in line and reads the value out of the entry on a hit. `AsmInst::HashProbePacked`, lowered on x86-64 and aarch64.

`emit-asm` on a Symbol-keyed site shows the shape: receiver and key class guards → representation / `linear` checks → one leaf call for the digest → a five-instruction scan loop → the value load. **The only call on the hit path is the digest leaf; `hashindex` is reached from the miss side alone.**

## Results (x86-64, release, pure lookup with the loop baseline subtracted, four alternating rounds)

| 6-entry Symbol-keyed Hash | master | this PR |
|---|---:|---:|
| hit, first entry | 16.3–18.1 ns | **6.3–9.7 ns** |
| hit, last entry | 15.3–19.3 ns | **8.2–11.0 ns** |
| miss | 16.5–20.4 ns | **7.4–10.6 ns** |
| 18 entries (indexed regime → builtin) | 18.7–26.0 ns | 15.5–21.2 ns (no regression) |

## Three decisions, each taken against something measured or observed

**The digest is a leaf call; the probe is machine code.** The mixer's fold is a 64×64→128 multiply, and monoasm's x86-64 side has no one-operand `mul` (`div`/`idiv` exist; `imul` is two-operand, low half only). aarch64 has `umulh`. `packed_digest_c` is a frameless leaf — no vm, no allocation — that becomes the emitted sequence once monoasm grows the instruction; nothing else changes.

**A shape the probe does not handle is a call, never a deopt.** The inline and identity-keyed representations and the indexed regime all route to `hashindex`. The first version deopted there — and that deopt does not recompile, so a Symbol-keyed Hash past eight entries would have exited on *every* lookup, strictly worse than today. Same trap as #1254's inline-cache gate; caught before measuring.

**A linear-regime miss answers nil in line.** After the scan is exhausted, one load of `Option<Box<HashDefault>>` (null = neither a default value nor a default proc) decides it. Handing every miss to the builtin redid the digest and the scan — the first measurement showed a miss at **30 ns against 16 ns on master**. Only a real default reaches the builtin now.

Also: `EntriesLayout` gains `hash_offset` and `linear_offset`, probed the way the existing offsets are. `Bucket { hash, key, value }` reorders under a niche-carrying key (`Option<Value>` lays out as value+0 / hash+8 / key+16), so nothing assumes an order; rubymap's layout test now reads the stored digest and the flag through the raw offsets.

## What stays on the call

- **Integer keys** — their digest reduces through SipHash first (`Value::ruby_hash_packed`, the §4.1 double hash). The leaf would compute it correctly but at most of a lookup's cost. Gated on the inline cache's key class, so they take the existing path.
- **The indexed regime** (stage 2: hashbrown's group probe) and **String keys** (stage 3: byte digest + `memcmp` + the `plain_string` check from #1258 — erubi's 18-entry String-keyed shape lives here). Both recorded in §4.2.

## Tests

`tests/hash_probe_jit.rs`, all against CRuby: hits / a miss / default value / default proc; nil, true and false keys; tombstones from `delete`; the shapes handed to the builtin answering correctly; the key-class guard exiting cleanly at a mixed-class site; a map growing across the linear/indexed boundary while the site is hot; live state after insert, overwrite and delete, and a frozen Hash.

Full `cargo test` with `stress-spill-pool`: 77 binaries pass. The aarch64 emitter type-checks under `aarch64-unknown-linux-gnu`; darwin CI exercises it.

One earlier suite run hung in `process_detach_type_errors` while two other cargo builds shared the machine. Its wait path — `Waiter#value` → `@reaper.join` → `IO.select([pidfd])` on a `fork { exit 5 }` child — contains no Hash lookup, and the test passes 20/20 on a quiet machine; a load-sensitive pidfd wakeup race outside this change, noted here so a future flake has a starting point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_