### PR TITLE
Emit the Hash#[] probe as machine code for String keys and the indexed regime

### DIFF
--- a/doc/hash_optimization.md
+++ b/doc/hash_optimization.md
@@ -173,7 +173,7 @@ Integer キーだけ Symbol キーより 14 ns 遅い（39.5 vs 25.7）のがそ
 構造ハッシュ用（Ruby から見える `#hash` 値）とバケッティング用を分ければ、
 Integer キーの参照が Symbol キーと同じところまで来るはず。
 
-### 4.2 probe を JIT でインライン展開する（大・最大の残り。**段階 1 実装済み**、2026-09-04）
+### 4.2 probe を JIT でインライン展開する（大・最大の残り。**段階 1〜3 実装済み**、2026-09-04/05）
 
 いまは `Hash#[]` のインライン生成が `hashindex` への直接呼び出しまでしか
 やらない（メソッドフレームは省くが、そこから先は Rust）。受信側が
@@ -195,9 +195,9 @@ Integer キーの参照が Symbol キーと同じところまで来るはず。
 
 | 段階 | キー | 領域 | 状態 |
 |---|---|---|---|
-| 1 | packed のうちビットがそのままミキサーに入るもの（Symbol / nil / true / false） | 線形（≤ 8） | **実装済み** `AsmInst::HashProbePacked` |
-| 2 | 同上 | 索引（> 8）— hashbrown の group probe | 未 |
-| 3 | String — バイト列ダイジェスト + memcmp + `plain_string` 判定 | 両方 | 未（erubi の 18 エントリ・String キーはここ） |
+| 1 | packed のうちビットがそのままミキサーに入るもの（Symbol / nil / true / false） | 線形（≤ 8） | **実装済み** `AsmInst::HashProbe`（旧 `HashProbePacked`） |
+| 2 | 同上 | 索引（> 8）— hashbrown の group probe | **実装済み**（段階 3 と同時） |
+| 3 | String — バイト列ダイジェスト + memcmp + `plain_string` 判定 | 両方 | **実装済み**（erubi の 18 エントリ・String キーはここ） |
 
 Integer キーは 4.1 の二重ハッシュ（SipHash を内側で 1 回回す）が解けるまで
 対象外。葉ヘルパで正しく計算はできるが、ヘルパ自体が現状のルックアップの
@@ -237,6 +237,72 @@ miss 側にしか残らない（`emit-asm` で確認）。`tests/hash_probe_jit.
 hit / miss / default 値 / default proc / nil・true・false キー / tombstone /
 索引領域・inline 表現・identity マップへの委譲 / クラスガード / 線形↔索引の
 境界を跨ぐ成長 / 生きた状態の読み取りを CRuby と突き合わせる。
+
+#### 段階 2・3 の設計判断（2026-09-05）
+
+- **索引領域は hashbrown の `find_inner` を SIMD 無しで写す。** monoasm には
+  SIMD が無いので、16 バイトの control group を 64 ビット語 2 つとして読み、
+  hashbrown 自身の generic backend と同じ SWAR ゼロバイト判定
+  （`(x - 0x01..) & !x & 0x80..`、x = word ^ tag×0x01..）で候補ビットを出す。
+  真の一致より後ろのバイトに偽陽性が出うるが、候補は必ずエントリの格納
+  ダイジェスト（64 ビット全部）で検証するので無害。候補の添字は control
+  バイト列の**下**にあるバケット配列（bucket i は `ctrl - 8(i+1)`）から
+  読む。2 語とも見終わってから EMPTY（`0xFF` — bit 7 と 6 が立つので
+  `w & (w << 1) & 0x80..`）の有無で打ち切り、無ければ三角数列で次の group
+  へ。**EMPTY を見た瞬間に打ち切ってはいけない**：削除で EMPTY に戻った
+  スロットより後ろに、それ以前に挿入された要素が同じ group 内に居られる
+  （hashbrown は group 内の一致を全部見てから EMPTY を判定する）。
+  `rubymap` の `raw_probe` テストがこのアルゴリズムを生の offset だけで
+  なぞり、`find_inner` と同じ答えになることを固定している。
+- **レイアウトは `offset_of!` で取る。** `EntriesLayout` に
+  `indices_ctrl_offset` / `indices_mask_offset` / `group_width` を追加。
+  hashbrown（vendored）の `RawTable` / `HashTable` に `ctrl_offset()` /
+  `bucket_mask_offset()` / `GROUP_WIDTH` を生やした。group 幅が 16 で
+  ない構成では索引領域を builtin に渡す（静的分岐）。
+- **String キーは葉ヘルパ 2 つ + 機械語 probe。** `string_digest_c`（バイト
+  列の wyhash、挿入時と同じ）と `string_key_eq_c`（`string_key_eq` そのもの
+  ：identity → STRING×STRING バイト比較）。同一オブジェクト（frozen
+  リテラル）なら eq 呼び出しを省く。**格納ダイジェストが一致したのに eq が
+  偽**なら（64 ビット衝突か tombstone か異種キー）`miss` → builtin。こうする
+  と eq 呼び出しの前後で probe のループ状態を退避する必要が無く、rdx/rcx
+  と entry ポインタだけ push すれば済む。
+- **サブクラスは class guard が弾く。** `guard_class(STRING_CLASS)` はクラス
+  一致なので、`eql?` を dispatch すべき String サブクラス（#1258）は
+  probe に入らず deopt する。
+- **identity マップは probe しない。** `HashContent` の判別子（0 = Map,
+  1 = IdentMap）を見て IdentMap なら builtin へ。段階 1 は判別子を見て
+  いなかったが、Symbol は `IdentKey` のダイジェスト（`id()`）と packed
+  ダイジェストが一致するので偶然正しかった。String は内容ダイジェスト ≠
+  identity ダイジェストで、**自分自身すら見つからず nil を返していた**
+  （`compare_by_identity` + String キーで検出、テスト追加）。
+- **キークラスが混在するサイトは段階 1 と同じ性質。** `h[k]` の k の
+  クラスは抽象状態から取り、guard の失敗は plain deopt（再コンパイル無し）。
+  同じサイトに String と Symbol が交互に来ると、後から来たクラスは毎回
+  deopt して interpreter で実行される（計測では 12 → 24 ns）。段階 1 の
+  Symbol guard も同じ。receiver 側の `BecamePolymorphic` 再コンパイルは VM
+  が立てる POLY ビットで「次は generic に」と判断できるが、引数クラスには
+  その仕組みが無く、再コンパイルしても同じ guard が出るだけなので保留。
+
+#### 段階 2・3 の効果（純ルックアップ、交互 2 ラウンド、ns）
+
+| | 段階 1 | 段階 3 | CRuby+YJIT |
+|---|---:|---:|---:|
+| String 6 エントリ hit（先頭 / 末尾） | 12.4–13.7 / 14.6–16.2 | **10.7–11.1 / 14.4–14.6** | 33.1 / 34.6 |
+| String 6 エントリ miss | 13.5–15.6 | **10.9** | 27.9 |
+| String 18 エントリ（erubi 形）hit | 14.4–17.1 | **11.7–12.3** | 26.4–40.5 |
+| String 18 エントリ miss | 12.6–17.1 | **8.1–8.3** | 18.8 |
+| String 100 エントリ hit / miss | 14.7–17.1 / 12.7–14.6 | **11.6–12.1 / 8.0–10.7** | 25.3 / 19.0 |
+| Symbol 18 / 100 / 1000 エントリ hit | 10.9–13.3 | **7.5–8.6** | 10.6 |
+| Symbol 18 / 100 / 1000 エントリ miss | 11.1–15.0 | **8.8–11.2** | 11.2 |
+
+String の hit は digest 呼び出し（wyhash）と eq 呼び出し（memcmp）が残るので
+Symbol ほどは縮まないが、miss は in-line で nil を返せるので 8 ns 台。
+yjit-bench の erubi（`benchmark_mono.rb`、warmup 10 + 30 反復、交互 2 ラウンド）
+は 215–221 ms → **192–206 ms**（−7〜−10 %）。
+`tests/hash_probe_jit.rs` に String キー（線形 / 索引 / frozen 同一 /
+default 値・proc）、索引領域の Symbol（100・3000 エントリ、削除後）、
+索引領域の tombstone、サブクラスキー、identity マップ、線形↔索引の成長、
+String → Symbol のクラス変化を追加。
 
 ### 4.3 呼び出しサイトのキーセット・インラインキャッシュ（中・要検証）
 

--- a/hashbrown/src/raw/mod.rs
+++ b/hashbrown/src/raw/mod.rs
@@ -1161,6 +1161,19 @@ impl<T, E, G, R> RawTable<T, E, G, R> {
 
     /// Returns the number of buckets in the table.
     #[inline]
+    /// Byte offset of the control-byte pointer inside a `RawTable`, for a
+    /// consumer that reads the table from generated machine code (the
+    /// monoruby JIT's inline `Hash#[]` probe). Probed with `offset_of!` rather
+    /// than assumed from field order.
+    pub const fn ctrl_offset() -> usize {
+        core::mem::offset_of!(Self, table) + core::mem::offset_of!(RawTableInner, ctrl)
+    }
+
+    /// Byte offset of `bucket_mask` inside a `RawTable` — see [`Self::ctrl_offset`].
+    pub const fn bucket_mask_offset() -> usize {
+        core::mem::offset_of!(Self, table) + core::mem::offset_of!(RawTableInner, bucket_mask)
+    }
+
     pub fn buckets(&self) -> usize {
         self.table.bucket_mask + 1
     }

--- a/hashbrown/src/table.rs
+++ b/hashbrown/src/table.rs
@@ -1,5 +1,6 @@
 use core::{fmt, iter::FusedIterator, marker::PhantomData};
 
+use crate::control::Group;
 use crate::raw::{
     Bucket, InsertSlot, RawDrain, RawExtractIf, RawIntoIter, RawIter, RawIterHash, RawTable,
 };
@@ -45,6 +46,25 @@ pub struct HashTable<T, E = (), G = (), R = ()> {
 }
 
 impl<T, E, G, R> HashTable<T, E, G, R> {
+    /// Byte offset, from `&HashTable`, of the control-byte pointer — for a
+    /// consumer that walks the table from generated machine code. The data
+    /// buckets sit *below* that pointer: bucket `i` is at
+    /// `ctrl - (i + 1) * size_of::<T>()`; the control bytes run upward from it
+    /// for `bucket_mask + 1 + Group::WIDTH` bytes (the trailing `WIDTH` mirror
+    /// the first ones, so a group load at any position is in bounds).
+    pub const fn ctrl_offset() -> usize {
+        core::mem::offset_of!(Self, raw) + RawTable::<T, E, G, R>::ctrl_offset()
+    }
+
+    /// Byte offset, from `&HashTable`, of `bucket_mask` (buckets − 1).
+    pub const fn bucket_mask_offset() -> usize {
+        core::mem::offset_of!(Self, raw) + RawTable::<T, E, G, R>::bucket_mask_offset()
+    }
+
+    /// The width of one control group — the probe step, and the number of
+    /// mirrored trailing control bytes.
+    pub const GROUP_WIDTH: usize = Group::WIDTH;
+
     /// Creates an empty `HashTable`.
     ///
     /// The hash table is initially created with a capacity of 0, so it will not allocate until it

--- a/monoruby/src/builtins/hash.rs
+++ b/monoruby/src/builtins/hash.rs
@@ -1066,21 +1066,28 @@ fn hash_index(
     // The probe in line, when the key is one of the immediates whose digest
     // is its bits through the mixer (a fixnum's goes through SipHash first
     // — `Value::ruby_hash_packed` — and stays on the call until that is
-    // split). The key's class comes from this site's inline cache, so it is
-    // guarded; the receiver's shape is checked inside the probe, and a shape
-    // it does not handle is answered by the builtin call, not by an exit.
-    if let (Some(layout), Some(kc)) = (hash_entries_layout(), idx_class)
-        && matches!(kc, SYMBOL_CLASS | NIL_CLASS | TRUE_CLASS | FALSE_CLASS)
-    {
+    // split), or a String of class `String` itself (a subclass's `eql?` is
+    // dispatched — see `string_key_eq`). The key's class comes from this
+    // site's inline cache, so it is guarded; the receiver's shape is checked
+    // inside the probe, and a shape it does not handle is answered by the
+    // builtin call, not by an exit.
+    let probe = idx_class.and_then(|kc| match kc {
+        SYMBOL_CLASS | NIL_CLASS | TRUE_CLASS | FALSE_CLASS => {
+            Some((kc, packed_digest_c as *const () as u64, None))
+        }
+        STRING_CLASS => Some((
+            kc,
+            string_digest_c as *const () as u64,
+            Some(string_key_eq_c as *const () as u64),
+        )),
+        _ => None,
+    });
+    if let (Some(layout), Some((kc, digest, key_eq))) = (hash_entries_layout(), probe) {
         let deopt = ir.new_deopt(state);
         state.guard_class(ir, callsite.args, GP::Rcx, kc, deopt);
         let using_fpr = state.get_using_fpr(ir);
         ir.fpr_save(using_fpr);
-        ir.hash_probe_packed(
-            layout,
-            hashindex as *const () as u64,
-            packed_digest_c as *const () as u64,
-        );
+        ir.hash_probe(layout, hashindex as *const () as u64, digest, key_eq);
         ir.fpr_restore(using_fpr);
         let error = ir.new_error(state);
         ir.handle_error(error);

--- a/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
@@ -753,19 +753,26 @@ impl Codegen {
     }
 
     ///
-    /// `Hash#[]` with the probe in line — see `AsmInst::HashProbePacked`.
-    /// The x86-64 sequence, register for register: hash in x2 (Rdx), key in
+    /// `Hash#[]` with the probe in line — see `AsmInst::HashProbe`. The
+    /// x86-64 sequence, register for register: hash in x2 (Rdx), key in
     /// x1 (Rcx), result in x0 (Rax); x1 / x2 survive the probe for the miss
-    /// path's `emit_call_2args`. x3, x4, x9–x12 are scratch.
+    /// path's `emit_call_2args`. x10 holds the digest; x0, x3, x4, x9,
+    /// x11, x12 are scratch. The indexed regime is the same SWAR group walk
+    /// as the x86-64 emitter (see its doc): the control group is two
+    /// 64-bit words, each matched byte-wise against the digest's tag by the
+    /// zero-byte test, an EMPTY byte after both words ends the walk.
     ///
-    pub(crate) fn gen_hash_probe_packed(
+    pub(crate) fn gen_hash_probe(
         &mut self,
         layout: rubymap::EntriesLayout,
         hashindex: u64,
         digest: u64,
+        key_eq: Option<u64>,
     ) {
         let lp = self.jit.label();
         let next = self.jit.label();
+        let indexed = self.jit.label();
+        let group = self.jit.label();
         let exhausted = self.jit.label();
         let miss = self.jit.label();
         let done = self.jit.label();
@@ -778,25 +785,24 @@ impl Codegen {
         let ptr_off = layout.ptr_offset as u32;
         let bucket_size = layout.bucket_size as u64;
         let hash_off = layout.hash_offset as u32;
-        let key_off = layout.key_offset as u32;
-        let value_off = layout.value_offset as u32;
+        let ctrl_off = layout.indices_ctrl_offset as u32;
+        let mask_off = layout.indices_mask_offset as u32;
+        let content = HASH_CONTENT_OFFSET as u32;
         monoasm_arm64!(&mut self.jit,
             ldrb w3, [x2, #(ty_flags)];
             mov x9, (HASH_REP_MASK as u64);
             and x3, x3, x9;
             cmp x3, #(boxed_rep);
         );
+        // The boxed, value-keyed representation only; a shape this probe
+        // does not handle is a call, not an exit — see the x86-64 twin.
         self.jit.bcond_label(monoasm::Cond::Ne, &miss);
         monoasm_arm64!(&mut self.jit,
-            ldr x4, [x2, #(map_ptr)];
-            ldrb w3, [x4, #(linear_off)];
-            cmp x3, #(0);
+            ldr x3, [x2, #(content)];           // 0 = Map, 1 = IdentMap
         );
-        // A shape this probe does not handle is a call, not an exit — see
-        // the x86-64 twin.
-        self.jit.bcond_label(monoasm::Cond::Eq, &miss);
+        self.jit.cbnz_label(monoasm::GReg(3), &miss);
         monoasm_arm64!(&mut self.jit,
-            // digest = packed_digest_c(key); keep x1 / x2 for the miss path.
+            // digest = digest(key); keep x1 / x2 for the miss path.
             stp x1, x2, [sp, #(-16)]!;
             mov x0, x1;
             mov x9, (digest);
@@ -806,31 +812,82 @@ impl Codegen {
             ldp x1, x2, [sp], #(16);
             mov x10, x0;                        // x10 = digest
             ldr x4, [x2, #(map_ptr)];
-            ldr x11, [x4, #(ptr_off)];          // x11 = &entries[0]
+            ldrb w3, [x4, #(linear_off)];
+        );
+        self.jit.cbz_label(monoasm::GReg(3), &indexed);
+        monoasm_arm64!(&mut self.jit,
+            // Linear regime (no indices table): the entries are the whole
+            // probe.
+            ldr x12, [x4, #(ptr_off)];          // x12 = &entries[0]
             ldr x9, [x4, #(len_off)];
-            mov x12, (bucket_size);
-            mul x9, x9, x12;
-            add x9, x9, x11;                    // x9 = one past the last entry
+            mov x11, (bucket_size);
+            mul x9, x9, x11;
+            add x9, x9, x12;                    // x9 = one past the last entry
         lp:
-            cmp x11, x9;
+            cmp x12, x9;
         );
         self.jit.bcond_label(monoasm::Cond::Hs, &exhausted);
         monoasm_arm64!(&mut self.jit,
-            ldr x3, [x11, #(hash_off)];
+            ldr x3, [x12, #(hash_off)];
             cmp x3, x10;
         );
         self.jit.bcond_label(monoasm::Cond::Ne, &next);
+        // entry in x12; x3 / x4 / x11 are free here.
+        self.gen_hash_probe_key_check(&layout, key_eq, 12, 3, &next, &miss, &done);
         monoasm_arm64!(&mut self.jit,
-            ldr x3, [x11, #(key_off)];
-            cmp x3, x1;
-        );
-        self.jit.bcond_label(monoasm::Cond::Ne, &next);
-        monoasm_arm64!(&mut self.jit,
-            ldr x0, [x11, #(value_off)];
-            b done;
         next:
-            add x11, x11, x12;
+            add x12, x12, x11;
             b lp;
+        indexed:
+        );
+        if layout.group_width == 16 {
+            let lo = 0x0101_0101_0101_0101u64;
+            let hi = 0x8080_8080_8080_8080u64;
+            monoasm_arm64!(&mut self.jit,
+                ldr x3, [x4, #(mask_off)];
+                and x3, x10, x3;                // x3 = pos = h1 & bucket_mask
+                mov x4, #(0);                   // x4 = stride
+            group:
+            );
+            // The two words of the group at pos; x3 walks pos, pos + 8.
+            for word in 0..2 {
+                if word == 1 {
+                    monoasm_arm64!(&mut self.jit, add x3, x3, #(8););
+                }
+                self.gen_hash_probe_word(&layout, key_eq, lo, hi, &miss, &done);
+            }
+            monoasm_arm64!(&mut self.jit,
+                // Back to pos. An EMPTY byte in the group ends the walk.
+                sub x3, x3, #(8);
+                ldr x9, [x2, #(map_ptr)];
+                ldr x9, [x9, #(ctrl_off)];
+                ldr x0, [x9, x3];
+                lsl x11, x0, #(1);
+                and x0, x0, x11;
+                add x11, x3, #(8);
+                ldr x12, [x9, x11];
+                lsl x11, x12, #(1);
+                and x12, x12, x11;
+                orr x0, x0, x12;
+                mov x11, (hi);
+                tst x0, x11;
+            );
+            self.jit.bcond_label(monoasm::Cond::Ne, &exhausted);
+            monoasm_arm64!(&mut self.jit,
+                // pos = (pos + stride) & bucket_mask, stride += 16.
+                add x4, x4, #(16);
+                add x3, x3, x4;
+                ldr x11, [x2, #(map_ptr)];
+                ldr x11, [x11, #(mask_off)];
+                and x3, x3, x11;
+                b group;
+            );
+        } else {
+            // A control group this emitter does not know how to scan: the
+            // builtin walks the table.
+            self.jit.b_label(&miss);
+        }
+        monoasm_arm64!(&mut self.jit,
         exhausted:
             // Not present: nil in line unless a default value / proc exists
             // (null `Option<Box<HashDefault>>` means neither) — see the
@@ -846,6 +903,135 @@ impl Codegen {
         );
         self.emit_call_2args(hashindex);
         self.jit.bind_label(done);
+    }
+
+    /// One control word of the indexed probe (`gen_hash_probe`): x3 is the
+    /// word's position in the control bytes, x10 the digest; x0 / x9 / x11
+    /// / x12 are scratch. The x86-64 `gen_hash_probe_word`, register for
+    /// register (rax→x0, r9→x9, r10→x11, r11→x12).
+    fn gen_hash_probe_word(
+        &mut self,
+        layout: &rubymap::EntriesLayout,
+        key_eq: Option<u64>,
+        lo: u64,
+        hi: u64,
+        miss: &DestLabel,
+        done: &DestLabel,
+    ) {
+        let cand = self.jit.label();
+        let cand_next = self.jit.label();
+        let word_done = self.jit.label();
+        let map_ptr = HASH_CONTENT_MAP_OFFSET as u32;
+        let ptr_off = layout.ptr_offset as u32;
+        let bucket_size = layout.bucket_size as u64;
+        let hash_off = layout.hash_offset as u32;
+        let ctrl_off = layout.indices_ctrl_offset as u32;
+        let mask_off = layout.indices_mask_offset as u32;
+        monoasm_arm64!(&mut self.jit,
+            ldr x9, [x2, #(map_ptr)];
+            ldr x9, [x9, #(ctrl_off)];
+            ldr x0, [x9, x3];                   // the control word
+            lsr x9, x10, #(57);                 // the digest's 7-bit tag
+            mov x11, (lo);
+            mul x9, x9, x11;                    // ... in every byte
+            eor x0, x0, x9;                     // x: a zero byte per match
+            mvn x9, x0;
+            sub x0, x0, x11;
+            and x0, x0, x9;
+            mov x11, (hi);
+            and x0, x0, x11;                    // x0 = match mask (bit 7 of each byte)
+            mov x9, x3;                         // x9 = position of the byte at bit 0
+        cand:
+        );
+        self.jit.cbz_label(monoasm::GReg(0), &word_done);
+        self.jit.tbz_label(monoasm::GReg(0), 7, &cand_next);
+        monoasm_arm64!(&mut self.jit,
+            // Candidate: bucket (x9 & mask) holds an index into the entries.
+            ldr x11, [x2, #(map_ptr)];
+            ldr x12, [x11, #(mask_off)];
+            and x12, x9, x12;
+            mvn x12, x12;                       // -(index + 1)
+            ldr x11, [x11, #(ctrl_off)];
+            ldr x11, [x11, x12, lsl #(3)];      // the entry's index
+            mov x12, (bucket_size);
+            mul x11, x11, x12;
+            ldr x12, [x2, #(map_ptr)];
+            ldr x12, [x12, #(ptr_off)];
+            add x11, x11, x12;                  // x11 = the entry
+            ldr x12, [x11, #(hash_off)];
+            cmp x12, x10;
+        );
+        self.jit.bcond_label(monoasm::Cond::Ne, &cand_next);
+        // entry in x11; x12 is free (x0 / x9 are the loop state).
+        self.gen_hash_probe_key_check(layout, key_eq, 11, 12, &cand_next, miss, done);
+        monoasm_arm64!(&mut self.jit,
+        cand_next:
+            lsr x0, x0, #(8);
+            add x9, x9, #(1);
+            b cand;
+        word_done:
+        );
+    }
+
+    /// The key comparison of `gen_hash_probe` for the entry in `x(entry)`
+    /// whose stored digest matched — the x86-64 `gen_hash_probe_key_check`:
+    /// a hit loads the value into x0 and jumps to `done`; a stored key that
+    /// is not this key continues at `next`; a `key_eq` verdict of "not
+    /// equal" goes to `miss`. `x(tmp)` is scratch.
+    fn gen_hash_probe_key_check(
+        &mut self,
+        layout: &rubymap::EntriesLayout,
+        key_eq: Option<u64>,
+        entry: u32,
+        tmp: u32,
+        next: &DestLabel,
+        miss: &DestLabel,
+        done: &DestLabel,
+    ) {
+        let key_off = layout.key_offset as u32;
+        let value_off = layout.value_offset as u32;
+        match key_eq {
+            None => {
+                monoasm_arm64!(&mut self.jit,
+                    // `Option<Value>` in `Value`'s NonZero niche: `Some(k)` is
+                    // k's own bits, and a tombstone's `None` is the zero word,
+                    // which no packed key equals.
+                    ldr x(tmp), [x(entry), #(key_off)];
+                    cmp x(tmp), x1;
+                );
+                self.jit.bcond_label(monoasm::Cond::Ne, next);
+                monoasm_arm64!(&mut self.jit,
+                    ldr x0, [x(entry), #(value_off)];
+                );
+                self.jit.b_label(done);
+            }
+            Some(key_eq) => {
+                let hit = self.jit.label();
+                monoasm_arm64!(&mut self.jit,
+                    ldr x(tmp), [x(entry), #(key_off)];
+                );
+                self.jit.cbz_label(monoasm::GReg(tmp), next); // a tombstone
+                monoasm_arm64!(&mut self.jit,
+                    cmp x(tmp), x1;                 // the stored object itself
+                );
+                self.jit.bcond_label(monoasm::Cond::Eq, &hit);
+                monoasm_arm64!(&mut self.jit,
+                    stp x1, x2, [sp, #(-16)]!;
+                    stp x(entry), x30, [sp, #(-16)]!;
+                    mov x0, x(tmp);                 // (x1 = key already)
+                    mov x9, (key_eq);
+                    blr x9;
+                    ldp x(entry), x30, [sp], #(16);
+                    ldp x1, x2, [sp], #(16);
+                );
+                self.jit.cbz_label(monoasm::GReg(0), miss);
+                monoasm_arm64!(&mut self.jit,
+                hit:
+                    ldr x0, [x(entry), #(value_off)];
+                );
+                self.jit.b_label(done);
+            }
+        }
     }
 
     /// `Hash#__key_at` / `#__value_at`: hash in Rdx (x2), fixnum index in Rcx

--- a/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
@@ -728,11 +728,12 @@ impl Codegen {
     }
 
     ///
-    /// `Hash#[]` with the probe in line — see `AsmInst::HashProbePacked`.
+    /// `Hash#[]` with the probe in line — see `AsmInst::HashProbe`.
     ///
     /// ### in
     /// - rdx: the hash
-    /// - rcx: the key, a bits-hashed immediate (class-guarded by the caller)
+    /// - rcx: the key (class-guarded by the caller to what `digest` /
+    ///   `key_eq` expect)
     ///
     /// ### out
     /// - rax: the value on a hit; `hashindex`'s answer on a miss
@@ -742,14 +743,31 @@ impl Codegen {
     /// Total: a shape the probe does not handle is answered by the builtin,
     /// never by an exit.
     ///
-    pub(crate) fn gen_hash_probe_packed(
+    /// ### The indexed regime
+    ///
+    /// Past the linear size the map is probed through its hashbrown
+    /// indices table, mirroring `RawTableInner::find_inner` without SIMD:
+    /// a 16-byte control group is two 64-bit words, each matched against
+    /// the digest's 7-bit tag by the SWAR zero-byte test hashbrown's own
+    /// generic backend uses (`(x - 0x01..) & !x & 0x80..`; false positives
+    /// are possible past a true match and are harmless — every candidate is
+    /// verified by its full stored digest). Candidates are read from the
+    /// bucket array below the control bytes (bucket `i` at `ctrl - 8(i+1)`)
+    /// as indices into the entries. After both words, an EMPTY control byte
+    /// (`0xFF`: bits 7 and 6 set, so `w & (w << 1) & 0x80..`) anywhere in
+    /// the group ends the walk; otherwise the triangular sequence steps on.
+    ///
+    pub(crate) fn gen_hash_probe(
         &mut self,
         layout: rubymap::EntriesLayout,
         hashindex: u64,
         digest: u64,
+        key_eq: Option<u64>,
     ) {
         let lp = self.jit.label();
         let next = self.jit.label();
+        let indexed = self.jit.label();
+        let group = self.jit.label();
         let exhausted = self.jit.label();
         let miss = self.jit.label();
         let done = self.jit.label();
@@ -763,27 +781,23 @@ impl Codegen {
         let ptr_off = layout.ptr_offset;
         let bucket_size = layout.bucket_size;
         let hash_off = layout.hash_offset;
-        let key_off = layout.key_offset;
-        let value_off = layout.value_offset;
+        let ctrl_off = layout.indices_ctrl_offset;
+        let mask_off = layout.indices_mask_offset;
+        let content = HASH_CONTENT_OFFSET;
         monoasm! { &mut self.jit,
-            // The boxed representation only: inline pairs have no digests to
-            // compare, and the identity-keyed map is keyed differently.
+            // The boxed, value-keyed representation only: inline pairs have
+            // no digests to compare, and the identity-keyed map digests the
+            // key's identity, not its content (a String key's digest would
+            // not even find its own object).
             movzxb rsi, [rdx + (ty_flags)];
             andq rsi, (mask);
             cmpq rsi, (boxed_rep);
             jne  miss;
-            movq rdi, [rdx + (map_ptr)];
-            // Linear regime only (no indices table): the entries are the
-            // whole probe. Past that the table decides, which is stage 2.
-            // Either way the builtin answers correctly, so a shape this
-            // probe does not handle is a *call*, not an exit: a deopt here
-            // would not recompile, and a large Symbol-keyed Hash would then
-            // exit on every lookup — strictly worse than today.
-            movzxb rsi, [rdi + (linear_off)];
+            movq rsi, [rdx + (content)];        // 0 = Map, 1 = IdentMap
             testq rsi, rsi;
-            jz   miss;
-            // digest = packed_digest_c(key). A leaf, but a C call: rdx / rcx
-            // are caller-saved, and the miss path still needs them.
+            jne  miss;
+            // digest = digest(key). A leaf, but a C call: rdx / rcx are
+            // caller-saved, and the miss path still needs them.
             pushq rdx;
             pushq rcx;
             movq rdi, rcx;
@@ -793,6 +807,11 @@ impl Codegen {
             popq rdx;
             movq r8, rax;                       // r8 = digest
             movq rdi, [rdx + (map_ptr)];
+            movzxb rsi, [rdi + (linear_off)];
+            testq rsi, rsi;
+            jz   indexed;
+            // Linear regime (no indices table): the entries are the whole
+            // probe.
             movq r11, [rdi + (ptr_off)];        // r11 = &entries[0]
             movq r9, [rdi + (len_off)];
             movq rsi, (bucket_size);
@@ -803,19 +822,64 @@ impl Codegen {
             jae  exhausted;
             cmpq r8, [r11 + (hash_off)];
             jne  next;
-            // `Option<Value>` in `Value`'s NonZero niche: `Some(k)` is k's own
-            // bits, and a tombstone's `None` is the zero word, which no packed
-            // key equals.
-            cmpq rcx, [r11 + (key_off)];
-            jne  next;
-            movq rax, [r11 + (value_off)];
-            jmp  done;
+        }
+        // entry in r11; rsi / rdi / r10 are free here.
+        self.gen_hash_probe_key_check(&layout, key_eq, 11, 10, &next, &miss, &done);
+        monoasm! { &mut self.jit,
         next:
             addq r11, (bucket_size);
             jmp  lp;
+        indexed:
+        }
+        if layout.group_width == 16 {
+            let lo = 0x0101_0101_0101_0101u64;
+            let hi = 0x8080_8080_8080_8080u64;
+            monoasm! { &mut self.jit,
+                movq rsi, r8;
+                andq rsi, [rdi + (mask_off)];   // rsi = pos = h1 & bucket_mask
+                xorq rdi, rdi;                  // rdi = stride
+            group:
+            }
+            // The two words of the group at pos; rsi walks pos, pos + 8.
+            for word in 0..2 {
+                if word == 1 {
+                    monoasm! { &mut self.jit, addq rsi, 8; }
+                }
+                self.gen_hash_probe_word(&layout, key_eq, lo, hi, &miss, &done);
+            }
+            monoasm! { &mut self.jit,
+                // Back to pos. An EMPTY byte in the group ends the walk.
+                subq rsi, 8;
+                movq r9, [rdx + (map_ptr)];
+                movq r9, [r9 + (ctrl_off)];
+                movq rax, [r9 + rsi];
+                movq r10, rax;
+                shlq r10, 1;
+                andq rax, r10;
+                movq r11, [r9 + rsi + 8];
+                movq r10, r11;
+                shlq r10, 1;
+                andq r11, r10;
+                orq  rax, r11;
+                movq r10, (hi);
+                testq rax, r10;
+                jne  exhausted;
+                // pos = (pos + stride) & bucket_mask, stride += 16.
+                addq rdi, 16;
+                addq rsi, rdi;
+                movq r11, [rdx + (map_ptr)];
+                andq rsi, [r11 + (mask_off)];
+                jmp  group;
+            }
+        } else {
+            // A control group this emitter does not know how to scan: the
+            // builtin walks the table.
+            monoasm! { &mut self.jit, jmp miss; }
+        }
+        monoasm! { &mut self.jit,
         exhausted:
             // Not present. Without a default that *is* the answer, and the
-            // builtin would only redo the digest and the scan to say so;
+            // builtin would only redo the digest and the probe to say so;
             // `Option<Box<HashDefault>>` is null when there is neither a
             // default value nor a default proc.
             movq rsi, [rdx + (default_slot)];
@@ -829,6 +893,137 @@ impl Codegen {
         // handle: the builtin.
         self.emit_call_2args(hashindex);
         self.jit.bind_label(done);
+    }
+
+    /// One control word of the indexed probe (`gen_hash_probe`): rsi is
+    /// the word's position in the control bytes, r8 the digest; rax / r9 /
+    /// r10 / r11 are scratch. Every tag match is looked up through the
+    /// bucket array and verified against the entry's stored digest, then
+    /// its key. Falls through when the word is done.
+    fn gen_hash_probe_word(
+        &mut self,
+        layout: &rubymap::EntriesLayout,
+        key_eq: Option<u64>,
+        lo: u64,
+        hi: u64,
+        miss: &DestLabel,
+        done: &DestLabel,
+    ) {
+        let cand = self.jit.label();
+        let cand_next = self.jit.label();
+        let word_done = self.jit.label();
+        let map_ptr = HASH_CONTENT_MAP_OFFSET;
+        let ptr_off = layout.ptr_offset;
+        let bucket_size = layout.bucket_size;
+        let hash_off = layout.hash_offset;
+        let ctrl_off = layout.indices_ctrl_offset;
+        let mask_off = layout.indices_mask_offset;
+        monoasm! { &mut self.jit,
+            movq r9, [rdx + (map_ptr)];
+            movq r9, [r9 + (ctrl_off)];
+            movq rax, [r9 + rsi];               // the control word
+            movq r9, r8;
+            shrq r9, 57;                        // the digest's 7-bit tag
+            movq r10, (lo);
+            imul r9, r10;                       // ... in every byte
+            xorq rax, r9;                       // x: a zero byte per match
+            movq r9, rax;
+            notq r9;
+            subq rax, r10;
+            andq rax, r9;
+            movq r10, (hi);
+            andq rax, r10;                      // rax = match mask (bit 7 of each byte)
+            movq r9, rsi;                       // r9 = position of the byte at bit 0
+        cand:
+            testq rax, rax;
+            jz   word_done;
+            testq rax, (0x80);
+            jz   cand_next;
+            // Candidate: bucket (r9 & mask) holds an index into the entries.
+            movq r10, [rdx + (map_ptr)];
+            movq r11, r9;
+            andq r11, [r10 + (mask_off)];
+            notq r11;                           // -(index + 1)
+            movq r10, [r10 + (ctrl_off)];
+            movq r10, [r10 + r11 * 8];          // the entry's index
+            movq r11, (bucket_size);
+            imul r10, r11;
+            movq r11, [rdx + (map_ptr)];
+            addq r10, [r11 + (ptr_off)];        // r10 = the entry
+            cmpq r8, [r10 + (hash_off)];
+            jne  cand_next;
+        }
+        // entry in r10; r11 is free (rax / r9 are the loop state).
+        self.gen_hash_probe_key_check(layout, key_eq, 10, 11, &cand_next, miss, done);
+        monoasm! { &mut self.jit,
+        cand_next:
+            shrq rax, 8;
+            addq r9, 1;
+            jmp  cand;
+        word_done:
+        }
+    }
+
+    /// The key comparison of `gen_hash_probe` for the entry in `R(entry)`
+    /// whose stored digest matched: a hit loads the value into rax and jumps
+    /// to `done`; a stored key that is not this key continues at `next`.
+    /// With `key_eq`, identity decides first, then the leaf; a leaf verdict
+    /// of "not equal" against a full-digest match is (short of a 64-bit
+    /// collision) a tombstone or a foreign key, and goes to `miss` — the
+    /// builtin answers, and nothing of the probe's state need survive the
+    /// call. `R(tmp)` is scratch.
+    fn gen_hash_probe_key_check(
+        &mut self,
+        layout: &rubymap::EntriesLayout,
+        key_eq: Option<u64>,
+        entry: u64,
+        tmp: u64,
+        next: &DestLabel,
+        miss: &DestLabel,
+        done: &DestLabel,
+    ) {
+        let key_off = layout.key_offset;
+        let value_off = layout.value_offset;
+        match key_eq {
+            None => {
+                monoasm! { &mut self.jit,
+                    // `Option<Value>` in `Value`'s NonZero niche: `Some(k)` is
+                    // k's own bits, and a tombstone's `None` is the zero word,
+                    // which no packed key equals.
+                    cmpq rcx, [R(entry) + (key_off)];
+                    jne  next;
+                    movq rax, [R(entry) + (value_off)];
+                    jmp  done;
+                }
+            }
+            Some(key_eq) => {
+                let hit = self.jit.label();
+                monoasm! { &mut self.jit,
+                    movq R(tmp), [R(entry) + (key_off)];
+                    testq R(tmp), R(tmp);           // a tombstone
+                    jz   next;
+                    cmpq R(tmp), rcx;               // the stored object itself
+                    jeq  hit;
+                    pushq rdx;
+                    pushq rcx;
+                    pushq R(entry);
+                    subq rsp, 8;                    // keep the call 16-aligned
+                    movq rdi, R(tmp);
+                    movq rsi, rcx;
+                    movq rax, (key_eq);
+                    call rax;
+                    addq rsp, 8;
+                    popq R(entry);
+                    popq rcx;
+                    popq rdx;
+                    testq rax, rax;
+                    jz   miss;
+                hit:
+                    movq rax, [R(entry) + (value_off)];
+                    jmp  done;
+                }
+            }
+        }
     }
 
     /// `Hash#__live_at`: hash in rdx, fixnum index in rcx, Ruby bool in rax —

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -187,7 +187,7 @@ impl Codegen {
             | AsmInst::HashLenFixnum { .. }
             | AsmInst::HashEntryAt { .. }
             | AsmInst::HashLiveAt { .. }
-            | AsmInst::HashProbePacked { .. }
+            | AsmInst::HashProbe { .. }
             | AsmInst::HashCompareByIdentity { .. }
             | AsmInst::HashDefault { .. }
             | AsmInst::IsNilToBool { .. }

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -1225,17 +1225,19 @@ impl AsmIr {
         self.inst.push(AsmInst::HashEntryAt { want_key, layout });
     }
 
-    /// See [`AsmInst::HashProbePacked`].
-    pub(crate) fn hash_probe_packed(
+    /// See [`AsmInst::HashProbe`].
+    pub(crate) fn hash_probe(
         &mut self,
         layout: rubymap::EntriesLayout,
         hashindex: u64,
         digest: u64,
+        key_eq: Option<u64>,
     ) {
-        self.inst.push(AsmInst::HashProbePacked {
+        self.inst.push(AsmInst::HashProbe {
             layout,
             hashindex,
             digest,
+            key_eq,
         });
     }
 
@@ -2088,29 +2090,38 @@ pub(super) enum AsmInst {
     },
     ///
     /// `Rax <- Hash#[](Rcx)` for the hash in `Rdx`, with the probe emitted
-    /// as machine code: the boxed map's entries are scanned for the key's
-    /// digest and then its bits, and a hit reads the value straight out of
-    /// the entry. No Rust runs on a hit except the digest itself
-    /// (`digest`, a leaf). A miss answers `nil` in line when the Hash has
-    /// no default; a default value / default proc goes to `hashindex`,
-    /// which owns them — and so does a shape the probe does not handle (an
-    /// inline or identity-keyed representation, or a map past its linear
-    /// size, whose probe goes through the indices table). Total by
-    /// construction: nothing here exits, because a deopt would not
-    /// recompile and a large Symbol-keyed Hash would then exit on every
-    /// lookup.
+    /// as machine code. The boxed map is probed the way `IndexMapCore`
+    /// probes it: a map within its linear size scans the entries for the
+    /// key's digest; a larger one walks the hashbrown indices table
+    /// (control-byte groups matched a word at a time, triangular probe
+    /// sequence, an empty control byte ending the walk). A candidate whose
+    /// stored digest matches is then compared as the key kind demands, and
+    /// a hit reads the value straight out of the entry. No Rust runs on a
+    /// hit except the digest (`digest`, a leaf) and, for a String key that
+    /// is not the stored object itself, the byte comparison (`key_eq`, a
+    /// leaf). A miss answers `nil` in line when the Hash has no default; a
+    /// default value / default proc goes to `hashindex`, which owns them —
+    /// and so does a shape the probe does not handle (an inline or
+    /// identity-keyed representation). Total by construction: nothing here
+    /// exits, because a deopt would not recompile and the site would then
+    /// exit on every lookup.
     ///
-    /// The key must already be class-guarded to one of the bits-hashed
-    /// immediates (`Symbol`, `nil`, `true`, `false`): a fixnum's digest
-    /// reduces through SipHash first (`Value::ruby_hash_packed`), which the
-    /// leaf would do correctly but not cheaply.
+    /// The key must already be class-guarded to what `digest` / `key_eq`
+    /// expect: one of the bits-hashed immediates (`Symbol`, `nil`, `true`,
+    /// `false`; a fixnum's digest reduces through SipHash first) with
+    /// `key_eq: None` — the key is then compared by its bits — or `String`
+    /// itself (not a subclass, whose `eql?` is dispatched) with `key_eq`
+    /// naming the byte-equality leaf.
     ///
-    HashProbePacked {
+    HashProbe {
         layout: rubymap::EntriesLayout,
         /// `hashindex`'s address — the miss path.
         hashindex: u64,
-        /// `packed_digest_c`'s address.
+        /// The digest leaf's address: `fn(key_bits) -> digest`.
         digest: u64,
+        /// The equality leaf's address, `fn(stored_key_bits, key_bits) -> 0 | 1`,
+        /// for a key kind not decided by its bits; `None` compares bits.
+        key_eq: Option<u64>,
     },
     /// `dst <- (src == nil) ? true : false` as a Ruby bool `Value` (`Object#nil?`).
     /// Typed replacement for the `emit_kernel_nil` closure. Uses `GP::Rsi` as a

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -1507,17 +1507,18 @@ impl Codegen {
                     },
                 );
             }
-            AsmInst::HashProbePacked {
+            AsmInst::HashProbe {
                 layout,
                 hashindex,
                 digest,
+                key_eq,
             } => {
                 self.lower_via_inline(
                     store,
                     labels,
                     frame.base_stack_offset,
                     move |cg, _, _, _| {
-                        cg.gen_hash_probe_packed(layout, hashindex, digest);
+                        cg.gen_hash_probe(layout, hashindex, digest, key_eq);
                     },
                 );
             }

--- a/monoruby/src/value/rvalue/hash.rs
+++ b/monoruby/src/value/rvalue/hash.rs
@@ -178,6 +178,34 @@ pub(crate) extern "C" fn packed_digest_c(bits: u64) -> u64 {
     packed_digest(&rubymap::RubyRandomState::new(), k) as u64
 }
 
+///
+/// The bucketing digest of a String key, for the JIT's inline probe — the
+/// String counterpart of [`packed_digest_c`]: a leaf (no vm, no
+/// allocation, nothing it can raise) computing exactly what
+/// [`string_digest`] computes at insert time. The caller has already
+/// class-guarded the key to `String` itself (the same line
+/// [`Value::is_plain_rstring_inner`] draws), so the content is read
+/// unconditionally.
+///
+pub(crate) extern "C" fn string_digest_c(bits: u64) -> u64 {
+    let k = Value::from_u64(bits);
+    let s = k.as_rstring_inner();
+    string_digest(&rubymap::RubyRandomState::new(), s) as u64
+}
+
+///
+/// The `eql?` verdict of a stored boxed-map key against a plain String
+/// probe key, for the JIT's inline probe: [`string_key_eq`] as a leaf,
+/// answering 1 / 0. `stored` is the raw key slot of the entry — an
+/// `Option<Value>`, whose `None` is the zero word.
+///
+pub(crate) extern "C" fn string_key_eq_c(stored: u64, key: u64) -> u64 {
+    let stored = (stored != 0).then(|| Value::from_u64(stored));
+    let k = Value::from_u64(key);
+    let s = k.as_rstring_inner();
+    string_key_eq(&stored, k, s) as u64
+}
+
 /// The boxed map's digest of a String key, computed without the vm: the
 /// same builder and the same digest stream as `RubyMap::hash(&Some(k))`
 /// for an `ObjTy::STRING` payload — `Value::ruby_hash`'s STRING arm

--- a/monoruby/tests/hash_probe_jit.rs
+++ b/monoruby/tests/hash_probe_jit.rs
@@ -1,13 +1,16 @@
 extern crate monoruby;
 use monoruby::tests::*;
 
-// `Hash#[]` with the probe emitted as machine code (`AsmInst::HashProbePacked`):
-// for a boxed map of at most eight entries and a key whose digest is its
-// bits through the mixer (Symbol, nil, true, false), the JIT scans the
-// entries in line — digest first, then the key's bits — and reads the
-// value out of the entry on a hit. Everything else is the builtin call, as
-// before. These pin the answers against CRuby for every shape the probe
-// can meet, including the ones it must hand back.
+// `Hash#[]` with the probe emitted as machine code (`AsmInst::HashProbe`):
+// for a boxed map and a key that is either one of the bits-hashed
+// immediates (Symbol, nil, true, false) or a String of class String
+// itself, the JIT probes the map in line — the entries directly for a map
+// of at most eight entries, the hashbrown indices table (control groups,
+// triangular probe) past that — comparing digests first, then the key
+// (its bits, or identity-then-bytes for a String), and reads the value out
+// of the entry on a hit. Everything else is the builtin call, as before.
+// These pin the answers against CRuby for every shape the probe can meet,
+// including the ones it must hand back.
 
 /// The probe's home ground: a boxed (4+ pairs), linear (≤ 8) map with
 /// Symbol keys — hits, a miss, and the default value / default proc a miss
@@ -140,6 +143,148 @@ fn hash_probe_reads_live_state() {
         h.delete(:b);  res << run(h, :b) << run(h, :c)
         f = {a: 1, b: 2, c: 3, d: 4}.freeze
         res << run(f, :a) << run(f, :zz)
+        res
+        "##,
+    );
+}
+
+/// String keys, both regimes: a linear map and an 18-entry indexed one (the
+/// erubi shape). A hit through identity (the frozen literal is the stored
+/// object) and through bytes (a fresh String of the same content), a miss
+/// answered in line, and the default value / default proc a miss must still
+/// reach through the builtin.
+#[test]
+fn hash_probe_string_keys() {
+    run_test(
+        r##"
+        def run(h, k, n = 300)
+          r = nil; i = 0
+          while i < n; r = h[k]; i += 1; end
+          r
+        end
+        res = []
+        hs = {"a" => 1, "b" => 2, "c" => 3, "d" => 4, "e" => 5}
+        res << run(hs, "a") << run(hs, "e") << run(hs, "zz") << run(hs, "a".dup)
+        hb = {}
+        18.times { |i| hb["key#{i}"] = i }
+        res << run(hb, "key0") << run(hb, "key17") << run(hb, "key9") << run(hb, "nope")
+        fk = "key3".freeze
+        hb[fk] = :frozen
+        res << run(hb, fk) << run(hb, "key3") << run(hb, "key3".dup)
+        hd = Hash.new(:d); 12.times { |i| hd["d#{i}"] = i }
+        res << run(hd, "d3") << run(hd, "x")
+        hp = Hash.new { |h, k| "p:#{k}" }; 12.times { |i| hp["p#{i}"] = i }
+        res << run(hp, "p3") << run(hp, "x")
+        hl = Hash.new(:d); hl["a"] = 1; hl["b"] = 2; hl["c"] = 3; hl["d"] = 4
+        res << run(hl, "a") << run(hl, "x")
+        res
+        "##,
+    );
+}
+
+/// The indexed regime for the bits-compared keys, including a table big
+/// enough that the probe sequence must step past full control groups, and
+/// entries deleted after the table was built.
+#[test]
+fn hash_probe_indexed_symbol_keys() {
+    run_test(
+        r##"
+        def run(h, k, n = 300)
+          r = nil; i = 0
+          while i < n; r = h[k]; i += 1; end
+          r
+        end
+        res = []
+        hsym = {}; 100.times { |i| hsym[:"s#{i}"] = i }
+        res << run(hsym, :s0) << run(hsym, :s99) << run(hsym, :s50) << run(hsym, :none)
+        hsym.delete(:s50); hsym.delete(:s0)
+        res << run(hsym, :s50) << run(hsym, :s0) << run(hsym, :s51) << run(hsym, :s99)
+        hmix = {nil => :n, true => :t, false => :f}; 20.times { |i| hmix[:"m#{i}"] = i }
+        res << run(hmix, nil) << run(hmix, true) << run(hmix, false) << run(hmix, :m7)
+        big = {}; 3000.times { |i| big[:"b#{i}"] = i }
+        hit = 0; miss = 0
+        3000.times { |i| hit += 1 if run(big, :"b#{i}", 2) == i; miss += 1 if run(big, :"nb#{i}", 2).nil? }
+        res << hit << miss
+        res
+        "##,
+    );
+}
+
+/// String keys in the indexed regime with tombstones (the entries are not
+/// compacted on delete; the indices table no longer reaches the dead
+/// entry), and a table walked past full groups.
+#[test]
+fn hash_probe_indexed_string_keys_tombstones() {
+    run_test(
+        r##"
+        def run(h, k, n = 300)
+          r = nil; i = 0
+          while i < n; r = h[k]; i += 1; end
+          r
+        end
+        res = []
+        ht = {}; 20.times { |i| ht["t#{i}"] = i }
+        ht.delete("t5"); ht.delete("t19"); ht.delete("t0")
+        res << run(ht, "t5") << run(ht, "t19") << run(ht, "t0") << run(ht, "t6") << run(ht, "t18")
+        ht["t5"] = :back
+        res << run(ht, "t5")
+        big = {}; 3000.times { |i| big["b#{i}"] = i }
+        hit = 0; miss = 0
+        3000.times { |i| hit += 1 if run(big, "b#{i}", 2) == i; miss += 1 if run(big, "nb#{i}", 2).nil? }
+        res << hit << miss
+        res
+        "##,
+    );
+}
+
+/// What a String key must *not* be probed as: a String subclass key (its
+/// `eql?` decides, and the site's class guard keeps a subclass instance off
+/// the byte comparison), and an identity-keyed map, whose digests are of
+/// the key's identity — a content digest would not find the stored object
+/// itself. Both hand over to the builtin.
+#[test]
+fn hash_probe_string_keys_that_are_not_bytes_compared() {
+    run_test(
+        r##"
+        def run(h, k, n = 300)
+          r = nil; i = 0
+          while i < n; r = h[k]; i += 1; end
+          r
+        end
+        res = []
+        class Sub < String; def eql?(o) = false; def hash = "q".hash; end
+        hq = {}; hq[Sub.new("q")] = 1; hq["r"] = 2; hq["s"] = 3; hq["t"] = 4
+        res << run(hq, "q") << run(hq, Sub.new("q")) << run(hq, "r")
+        hc = {}.compare_by_identity
+        k = "x"; hc[k] = 1; hc["y"] = 2; hc["z"] = 3; hc["w"] = 4; hc["v"] = 5
+        res << run(hc, k) << run(hc, "x")
+        big = {}.compare_by_identity
+        keys = (0..20).map { |i| "b#{i}" }
+        keys.each_with_index { |kk, i| big[kk] = i }
+        res << run(big, keys[3]) << run(big, "b3")
+        res
+        "##,
+    );
+}
+
+/// A String-keyed map growing across the linear / indexed boundary while
+/// the site is hot, and a site that sees String keys first and Symbol keys
+/// after (the class guard must exit cleanly in that order too).
+#[test]
+fn hash_probe_string_growth_and_key_class_change() {
+    run_test(
+        r##"
+        def run(h, k, n = 300)
+          r = nil; i = 0
+          while i < n; r = h[k]; i += 1; end
+          r
+        end
+        res = []
+        hg = {}
+        (1..12).each { |i| hg["g#{i}"] = i; res << run(hg, "g#{i}", 40) }
+        res << run(hg, "g1") << run(hg, "g12") << run(hg, "none")
+        hm = {"s" => :str, :a => 1, 7 => :seven, "t" => :u, "v" => :w}
+        res << run(hm, "s") << run(hm, :a) << run(hm, 7) << run(hm, "t") << run(hm, :a)
         res
         "##,
     );

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -767,6 +767,7 @@
 39e6703b6b81cc1675c7d7f7730c417f	[[1, 2, 3, nil, nil, nil, nil], 31, [3, [[:a, 31], [1, 2], [nil, 3]], 31], [4, 4, 31, nil], [nil, nil, 0], [7, 1, 1], ["gen", 1]]	def drive(n)\n              r = nil\n              n.times { r = yiel
 39eb22a6c09538f53ff55e200b562be8	59	f = ->(x){x + 42}\n            \n\n            f.call(17)\n            
 3a01dc8fffbde1143e30f29445a348d4	[42, "z", 99]	out = nil\n        50.times do\n          a = []\n          a << (class C7
+3a19a4b42a902a2326b2eab0711379ad	[1, nil, 2, 1, nil, 3, nil]	def run(h, k, n = 300)\n          r = nil; i = 0\n          while i < n; 
 3a319d3cfdb21a4802f64f67da78477f	"US-ASCII"	s = "Hello".encode("US-ASCII")\n              s.swapcase!\n        
 3a3ea224e66a902c9412e5a9bc4f8e3d	[[:A, [7], {}], [:A, [1, 2], {x: 9}], [:A, [], {}], [:A, [3, 4], {}], [:t, [1, 2], {z: 3}], [:t, [], {}]]	class A\n              def m(*a, **k); [:A, a, k]; end\n            e
 3a4a3fd8d76c29f29774b570dd11adcd	[true, :ok, 42, 42, :called]	res = []\n        class DMNest\n          define_method(:dm) { def dm_nes
@@ -1068,6 +1069,7 @@
 4e78c9407fe210294bad93265e6fe237	"Class"	"mutable-str".dup.singleton_class.class.to_s
 4e8da0b5e2010b485853959988c37a10	[5.0]	class RS2\n          def initialize = (@objs = [1.5, 2.5, 3.5])\n        
 4e91589759e06abf5967280f353d07c5	[9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError"]	def g(a, b, c) = yield(a + b + c)\n        def f(...) = g(1, ...)\n      
+4e9433807c6ac2166e6457fd13ba0a0f	[nil, nil, nil, 6, 18, :back, 3000, 3000]	def run(h, k, n = 300)\n          r = nil; i = 0\n          while i < n; 
 4e9bfbcee73c693e57ccc4d38d0dfa34	["x", "y"]	base = "/tmp/monoruby_dir_eachchild_#{Process.pid}_#{rand(100000)}"
 4ebe3f743c44083475b01a20ac7c38bc	false	binding.local_variable_defined?(:_10)
 4edbac695b5ed45b538971de1ca0ed2c	[true, true, true, false]	f = File.open("Cargo.toml")\n            begin\n              [f.binm
@@ -1878,6 +1880,7 @@
 8dd55defdf95efbdd977e6c2174cf434	[3, false]	s = "abc"\n            s.instance_eval { alias my_len length }\n     
 8df6d4abdff110c4dbaffcd3404ca581	{amount: 42, unit: "km"}	M = Data.define(:amount, :unit)\nM[42, "km"].to_h
 8e1574a4b3216e60ac128b6d348f4518	"bar is true"	foo = false\n        bar = true\n        quu = false\n        \n        x =
+8e430b6b2eaf098fe9c551a79ce5e682	[1, 5, nil, 1, 0, 17, 9, nil, :frozen, :frozen, :frozen, 3, :d, 3, "p:x", 1, :d]	def run(h, k, n = 300)\n          r = nil; i = 0\n          while i < n; 
 8e4e8019a5cb826e7c04db9f7be00c08	[[10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4], [10, 2, 3, 4]]	def g(a, b, c, d) = [a, b, c, d]\n        def f(...) = g(10, ...)\n      
 8e5bf6a49a3af8219a95bf2205693b54	"from ensure"	def m\n              raise "orig"\n            rescue\n              r
 8e826807820a874b952371a0550c1442	true	m = Module.new\n            m.const_set(:X, 1)\n            m.depreca
@@ -1931,6 +1934,7 @@
 929ec88122ad3533893000031753c174	[999, 999]	def m_dyn(a, b)\n          yield\n          a + b\n        end\n        def
 92ae34eef31e84efce3356329a17c934	"US-ASCII"	"\\x01".unpack("b")[0].encoding.to_s
 92c320086797b71e965185f0332f276e	[true, "nil"]	begin\n              raise "x"\n            rescue => e\n             
+92c7fd1254ddfbf42a32cc10aff9632c	[0, 99, 50, nil, nil, nil, 51, 99, :n, :t, :f, 7, 3000, 3000]	def run(h, k, n = 300)\n          r = nil; i = 0\n          while i < n; 
 92c81d1822b4b41aa65c4eff4e01c590	[[100, 200, 300], [[:a, 250], [:c, 400]], [100, 200, 300], [[:a, 250], [:c, 400]]]	class S\n            def f(*x, **y)\n                $res << x\n         
 92d03f760ad8afc09f2a68a94487b012	["Fri Dec", "Fri Dec", " Dec", " Dec", " Dec", " Dec", nil, 2, [" Dec"], "Fri Dec", 7, "", " 12 1975 14:39", "IndexError", " 12", "Fri Dec ", " 1975 14:39", "12", 7, " 12", "Fri Dec ", " 1975 14:39", 10, " ", " ", " ", 1, 5, "19", "75", ["19", "75"], "1975 ", 3, 0, 3, 3, "tes", nil, ["t", "e", nil, "s"], ["tes", "s", "s", nil], 0]	require "strscan"\n        r = []\n        s = StringScanner.new("Fri Dec
 92d55f7191fed22f0d1af9face39145d	[:a, :b, :block, :x, :z]	a = 1\n        b = 2\n        def f(x, &block)\n          z = nil\n        
@@ -2500,6 +2504,7 @@ bc4a7a2f49371fc147939e3a5a54bd45	[nil, true]	r, w = IO.pipe\n            pid = f
 bc5ee3d6a54ec78cbbccd9f386e31604	[true, true, "test"]	class MyMod < Module\n              def initialize(name)\n           
 bc7468de3c49bfa7febfbc6e20e4709c	[4, 1170]	a = 0\n        for i in [0,1,2,3,4]\n            1.times do\n             
 bca890206e651d8b1e7121a1d6d0052d	[1, 2, 3, 4, [5, 6, 7]]	def f(x,y,a=42,b=55,*z)\n            [x,y,a,b,z]\n        end\n        \n\n 
+bcc6b943a1ec50a193fa5cfc44c60d80	[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 12, nil, :str, 1, :seven, :u, 1]	def run(h, k, n = 300)\n          r = nil; i = 0\n          while i < n; 
 bcd4d79874131b33a41f66ab63d74f9a	[["historical binary regexp match"], ["historical binary regexp match"], true, true, true]	def cap\n              saved = $stderr\n              buf = +""\n     
 bd014186227c44d7add99e1236397a73	[[[:a, 1], ["b", 2], [3, :c]], ["k99", 99], [], [["k", 1], ["k", 2]]]	def entries(h)\n              if h.respond_to?(:__key_at)\n          
 bd22533535800c77fe48058df3d9f037	"1"	def foo\n          eval("a = 1", $b)\n        end\n        \n\n        eval(

--- a/rubymap/src/lib.rs
+++ b/rubymap/src/lib.rs
@@ -256,6 +256,14 @@ pub struct EntriesLayout {
     /// holds at most `AR_MAX` entries and has no indices table, in which case
     /// the entries may be scanned directly.
     pub linear_offset: usize,
+    /// Offset from `&RubyMap` to the indices table's control-byte pointer
+    /// (valid when `linear` is zero). Bucket `i` — an index into the entries —
+    /// sits at `ctrl - (i + 1) * 8`; the control bytes run upward from `ctrl`.
+    pub indices_ctrl_offset: usize,
+    /// Offset from `&RubyMap` to the indices table's `bucket_mask`.
+    pub indices_mask_offset: usize,
+    /// The control-group width the probe steps by (16 with SSE2 / NEON).
+    pub group_width: usize,
 }
 
 ///
@@ -315,6 +323,13 @@ pub fn entries_layout<K, V, E, G, R, S>() -> Option<EntriesLayout> {
         value_offset: std::mem::offset_of!(Bucket<K, V>, value),
         hash_offset: std::mem::offset_of!(Bucket<K, V>, hash),
         linear_offset: core + crate::map::core::linear_offset::<K, V, E, G, R>(),
+        indices_ctrl_offset: core
+            + crate::map::core::indices_offset::<K, V, E, G, R>()
+            + crate::map::core::indices_ctrl_offset::<E, G, R>(),
+        indices_mask_offset: core
+            + crate::map::core::indices_offset::<K, V, E, G, R>()
+            + crate::map::core::indices_mask_offset::<E, G, R>(),
+        group_width: crate::map::core::INDICES_GROUP_WIDTH,
     })
 }
 
@@ -337,6 +352,50 @@ mod entries_layout_tests {
                 entry.add(lay.key_offset).cast::<K>().read(),
                 entry.add(lay.value_offset).cast::<V>().read(),
             )
+        }
+    }
+
+    /// Reference for the machine-code probe: `hash` is the full 64-bit
+    /// digest, `eq` decides a candidate key. Mirrors `RawTableInner::find_inner`
+    /// with the group scanned a byte at a time.
+    #[allow(unsafe_code)]
+    unsafe fn raw_probe<K: Copy, V: Copy>(
+        map: *const u8,
+        lay: &EntriesLayout,
+        hash: u64,
+        eq: impl Fn(&K) -> bool,
+    ) -> Option<V> {
+        unsafe {
+            let ctrl = map.add(lay.indices_ctrl_offset).cast::<*const u8>().read();
+            let mask = map.add(lay.indices_mask_offset).cast::<usize>().read();
+            let entries = map.add(lay.ptr_offset).cast::<*const u8>().read();
+            let tag = ((hash >> 57) & 0x7f) as u8;
+            let mut pos = (hash as usize) & mask;
+            let mut stride = 0usize;
+            loop {
+                let mut empty = false;
+                for i in 0..lay.group_width {
+                    let b = ctrl.add(pos + i).read();
+                    if b == tag {
+                        let idx = (pos + i) & mask;
+                        let ent = ctrl.cast::<usize>().sub(idx + 1).read();
+                        let e = entries.add(ent * lay.bucket_size);
+                        if e.add(lay.hash_offset).cast::<usize>().read() as u64 == hash
+                            && eq(&e.add(lay.key_offset).cast::<K>().read())
+                        {
+                            return Some(e.add(lay.value_offset).cast::<V>().read());
+                        }
+                    }
+                    if b == 0xff {
+                        empty = true;
+                    }
+                }
+                if empty {
+                    return None;
+                }
+                stride += lay.group_width;
+                pos = (pos + stride) & mask;
+            }
         }
     }
 
@@ -377,6 +436,17 @@ mod entries_layout_tests {
         }
         // 64 entries is past AR_MAX, so the map is indexed: `linear` is 0.
         assert_eq!(unsafe { p.add(lay.linear_offset).read() }, 0);
+        // The indexed probe, exactly as the JIT emits it — byte-wise over one
+        // control group at a time, empty byte ends the probe, triangular step
+        // — must find every key through the raw offsets alone.
+        for i in 0..map.len() {
+            let (k, v) = unsafe { raw_entry::<u64, u64>(p, &lay, i) };
+            let hash = map.hash(&k, &mut (), &mut ()).unwrap().0 as u64;
+            let found = unsafe { raw_probe::<u64, u64>(p, &lay, hash, |ek| *ek == k) };
+            assert_eq!(found, Some(v), "probe for entry {i}");
+        }
+        let hash = map.hash(&999u64, &mut (), &mut ()).unwrap().0 as u64;
+        assert_eq!(unsafe { raw_probe::<u64, u64>(p, &lay, hash, |ek| *ek == 999) }, None);
         let mut small: RubyMap<u64, u64> = RubyMap::new();
         small.insert(1, 2, &mut (), &mut ()).unwrap();
         let q = &small as *const _ as *const u8;

--- a/rubymap/src/map/core.rs
+++ b/rubymap/src/map/core.rs
@@ -66,6 +66,22 @@ pub(crate) const fn linear_offset<K, V, E, G, R>() -> usize {
     std::mem::offset_of!(IndexMapCore<K, V, E, G, R>, linear)
 }
 
+/// Byte offset of the `indices` table inside an `IndexMapCore` — see
+/// [`entries_offset`]. Combined with the table's own `ctrl_offset` /
+/// `bucket_mask_offset`, this lets generated code run the indexed probe.
+pub(crate) const fn indices_offset<K, V, E, G, R>() -> usize {
+    std::mem::offset_of!(IndexMapCore<K, V, E, G, R>, indices)
+}
+
+/// The indices table's own layout, for [`crate::entries_layout`].
+pub(crate) const fn indices_ctrl_offset<E, G, R>() -> usize {
+    Indices::<E, G, R>::ctrl_offset()
+}
+pub(crate) const fn indices_mask_offset<E, G, R>() -> usize {
+    Indices::<E, G, R>::bucket_mask_offset()
+}
+pub(crate) const INDICES_GROUP_WIDTH: usize = Indices::<(), (), ()>::GROUP_WIDTH;
+
 /// Mutable references to the parts of an `IndexMapCore`.
 ///
 /// When using `HashTable::find_entry`, that takes hold of `&mut indices`, so we have to borrow our


### PR DESCRIPTION
Stages 2 and 3 of `doc/hash_optimization.md` §4.2, on top of #1261 (merged; this branch is rebased onto it, so the diff is the one stage-2/3 commit).

## What it does

#1261 probed a boxed map in line only for a Symbol / nil / true / false key in the `linear` regime (≤ 8 entries). This PR generalizes `AsmInst::HashProbePacked` into `AsmInst::HashProbe`, carrying the digest leaf and an optional key-equality leaf, and the emitters on both arches now probe a map of any size and String keys — erubi's 18-entry String-keyed shape is exactly this.

**The indexed regime is hashbrown's `find_inner` without SIMD.** monoasm has none, so each 16-byte control group is read as two 64-bit words and matched against the digest's 7-bit tag by the same SWAR zero-byte test hashbrown's generic backend uses (`(x - 0x01…) & !x & 0x80…`, `x = word ^ tag×0x01…`). That test admits false positives after a true match; every candidate is verified against its full stored 64-bit digest, so they are harmless. Candidate indices are read from the bucket array below the control bytes (bucket `i` is at `ctrl - 8(i+1)`). An EMPTY byte (`0xFF`, bits 7 and 6 set: `w & (w << 1) & 0x80…`) ends the walk only **after both words are scanned** — a delete can return a slot to EMPTY with an earlier-inserted element sitting past it in the same group, and hashbrown checks every match in the group before EMPTY — otherwise the triangular sequence steps on.

**String keys go through two leaves.** `string_digest_c` (the insert-time wyhash over the bytes) and `string_key_eq_c` (`string_key_eq` itself: identity, then STRING × STRING byte compare). The stored object itself — a frozen literal — hits without the eq call. A digest match whose key compares unequal (64-bit collision, tombstone, foreign key class) goes to the builtin, so no probe state has to survive the call: only rdx/rcx and the entry pointer are pushed around it. The site's `guard_class(STRING_CLASS)` is an exact class match, so a String subclass (whose `eql?` must be dispatched, #1258) never enters the probe.

**The layout comes from `offset_of!`.** The vendored hashbrown `RawTable` / `HashTable` gain `ctrl_offset()` / `bucket_mask_offset()` / `GROUP_WIDTH`; rubymap's `EntriesLayout` gains `indices_ctrl_offset` / `indices_mask_offset` / `group_width`. A configuration whose group width is not 16 hands the indexed regime to the builtin (static branch). A `raw_probe` reference test in rubymap walks the emitted algorithm over the raw offsets and pins it to `find_inner`'s answer.

## A latent bug in stage 1, fixed here

The stage-1 probe did not look at the `HashContent` discriminant (Map vs IdentMap). It was right by coincidence: a Symbol's `IdentKey` digest (`id()`) equals its packed digest. A String's content digest is not its identity digest, so on a `compare_by_identity` map the probe could not find even the stored object itself and answered nil. The probe now checks the discriminant and hands an identity-keyed map to the builtin; the case is under test.

## Results (x86-64, release, pure lookup, two alternating rounds, ns)

| | #1261 | this PR | CRuby+YJIT |
|---|---:|---:|---:|
| String, 6 entries, hit first / last | 12.4–13.7 / 14.6–16.2 | **10.7–11.1 / 14.4–14.6** | 33.1 / 34.6 |
| String, 6 entries, miss | 13.5–15.6 | **10.9** | 27.9 |
| String, 18 entries (erubi shape), hit | 14.4–17.1 | **11.7–12.3** | 26.4–40.5 |
| String, 18 entries, miss | 12.6–17.1 | **8.1–8.3** | 18.8 |
| String, 100 entries, hit / miss | 14.7–17.1 / 12.7–14.6 | **11.6–12.1 / 8.0–10.7** | 25.3 / 19.0 |
| Symbol, 18 / 100 / 1000 entries, hit | 10.9–13.3 | **7.5–8.6** | 10.6 |
| Symbol, 18 / 100 / 1000 entries, miss | 11.1–15.0 | **8.8–11.2** | 11.2 |

A String hit keeps the digest (wyhash) and eq (memcmp) calls, so it does not shrink as far as Symbol; a miss answers nil in line. yjit-bench erubi (`benchmark_mono.rb`, 10 warmup + 30 iterations, two alternating rounds): 215–221 ms → **192–206 ms**.

## What stays as it was

A site that alternates String and Symbol keys deopts on the class guard for whichever class came second, on every lookup (measured 12 → 24 ns). This is the same property #1261's Symbol guard has: the receiver side has the VM's POLY bit to trigger a `BecamePolymorphic` recompile into generic code, the argument class has no such signal, and a recompile would emit the same guard. Recorded in §4.2 rather than papered over.

## Tests

`tests/hash_probe_jit.rs` grows from 6 to 11: String keys in both regimes, frozen-literal identity, default value / proc; the indexed regime for Symbol keys at 100 and 3000 entries with deletes; indexed-regime tombstones; String subclass keys; identity-keyed maps; growth across the linear/indexed boundary while hot; a site whose key class changes String → Symbol. All 11 pass on x86-64 and on aarch64 under qemu. The rubymap and hashbrown crate tests, the `hash_*` integration tests, the lib-side hash tests and the neighbouring JIT test files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM