### PR TITLE
Implement io/console

### DIFF
--- a/monoruby/src/builtins.rs
+++ b/monoruby/src/builtins.rs
@@ -23,6 +23,7 @@ mod gc;
 mod hash;
 mod io;
 mod io_buffer;
+mod io_console;
 mod json;
 pub(crate) mod kernel;
 mod main_object;
@@ -125,6 +126,7 @@ pub(crate) fn init_builtins(globals: &mut Globals) {
     time::init(globals);
     io::init(globals);
     io_buffer::init(globals);
+    io_console::init(globals);
     struct_class::init(globals);
     data_class::init(globals);
     file::init(globals);

--- a/monoruby/src/builtins/io_console.rs
+++ b/monoruby/src/builtins/io_console.rs
@@ -1,0 +1,297 @@
+//! Hidden termios / ioctl primitives behind `io/console`.
+//!
+//! The public surface (`IO#raw`, `IO#getch`, `IO#winsize`, `IO.console`,
+//! `IO::ConsoleMode`, …) lives in Ruby, in `stdlib/io/console.rb`; this
+//! module only exposes what needs libc: reading and writing a terminal's
+//! attributes, transforming an attribute set the way CRuby's
+//! `set_rawmode` / `set_cookedmode` / `set_echo` do, the window size
+//! ioctls, `tcflush(3)` and `ttyname(3)`.
+//!
+//! A `struct termios` travels between Ruby and Rust as an opaque
+//! binary String of exactly `size_of::<libc::termios>()` bytes — that is
+//! what an `IO::ConsoleMode` wraps — so the flag layout, which differs
+//! between Linux and Darwin, never leaks into Ruby.
+
+use super::*;
+
+pub(super) fn init(globals: &mut Globals) {
+    globals.define_builtin_func(IO_CLASS, "__tcgetattr", io_tcgetattr, 1);
+    globals.define_builtin_func(IO_CLASS, "__tcsetattr", io_tcsetattr, 2);
+    globals.define_builtin_func(IO_CLASS, "__tcflush", io_tcflush, 1);
+    globals.define_builtin_func(IO_CLASS, "__winsize", io_winsize, 0);
+    globals.define_builtin_func(IO_CLASS, "__set_winsize", io_set_winsize, 4);
+    globals.define_builtin_func(IO_CLASS, "__ttyname", io_ttyname, 0);
+    globals.define_builtin_class_func(IO_CLASS, "__termios_raw", termios_raw, 4);
+    globals.define_builtin_class_func(IO_CLASS, "__termios_cooked", termios_cooked, 1);
+    globals.define_builtin_class_func(IO_CLASS, "__termios_echo", termios_echo, 2);
+    globals.define_builtin_class_func(IO_CLASS, "__termios_echo?", termios_echo_p, 1);
+}
+
+/// The `Errno::*` CRuby's console.c raises: `sys_fail(io)` appends the
+/// stream's path (`Inappropriate ioctl for device - <STDOUT>`), while the
+/// `ttymode` wrapper raises the bare description. Must be called right
+/// after the failing libc call, before anything else can touch `errno`.
+fn sys_fail(store: &Store, io: Value, with_path: bool) -> MonorubyErr {
+    let err = std::io::Error::last_os_error();
+    match (with_path, io.as_io_inner().path()) {
+        (true, Some(path)) => MonorubyErr::errno_with_msg(store, &err, path),
+        _ => MonorubyErr::errno_plain(store, &err),
+    }
+}
+
+fn termios_to_value(t: &libc::termios) -> Value {
+    // SAFETY: `t` was zero-initialised before the kernel filled it, so
+    // every byte of the struct (padding included) is initialised, and
+    // `termios` is plain old data.
+    let bytes = unsafe {
+        std::slice::from_raw_parts(
+            t as *const libc::termios as *const u8,
+            std::mem::size_of::<libc::termios>(),
+        )
+    };
+    Value::bytes(bytes.to_vec())
+}
+
+fn termios_from_value(store: &Store, v: Value) -> Result<libc::termios> {
+    let bytes = v.expect_bytes(store)?;
+    if bytes.len() != std::mem::size_of::<libc::termios>() {
+        return Err(MonorubyErr::typeerr(
+            "wrong argument type (expected IO::ConsoleMode)",
+        ));
+    }
+    // SAFETY: the length was checked against the struct size, and
+    // `read_unaligned` copies the plain-old-data struct out of the byte
+    // buffer without an alignment requirement.
+    Ok(unsafe { std::ptr::read_unaligned(bytes.as_ptr() as *const libc::termios) })
+}
+
+fn fetch_termios(store: &Store, io: Value, with_path: bool) -> Result<libc::termios> {
+    let fd = io.as_io_inner().fileno()?;
+    // SAFETY: an all-zero `termios` is a valid (if meaningless) value;
+    // tcgetattr(3) overwrites it on success.
+    let mut t: libc::termios = unsafe { std::mem::zeroed() };
+    // SAFETY: `t` is a live, writable `termios`.
+    if unsafe { libc::tcgetattr(fd, &mut t) } != 0 {
+        return Err(sys_fail(store, io, with_path));
+    }
+    Ok(t)
+}
+
+fn store_termios(store: &Store, io: Value, t: &libc::termios, with_path: bool) -> Result<()> {
+    let fd = io.as_io_inner().fileno()?;
+    loop {
+        // SAFETY: `t` is a live `termios`; TCSANOW applies it immediately,
+        // like console.c's `setattr`, retrying on EINTR.
+        if unsafe { libc::tcsetattr(fd, libc::TCSANOW, t) } == 0 {
+            return Ok(());
+        }
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() != Some(libc::EINTR) {
+            return Err(sys_fail(store, io, with_path));
+        }
+    }
+}
+
+/// `clamp_uchar` in console.c: VMIN / VTIME are `cc_t` (a byte).
+fn clamp_uchar(n: i64) -> libc::cc_t {
+    n.clamp(0, u8::MAX as i64) as libc::cc_t
+}
+
+fn opt_cc(store: &Store, v: Value) -> Result<Option<libc::cc_t>> {
+    if v.is_nil() {
+        Ok(None)
+    } else {
+        Ok(Some(clamp_uchar(v.expect_integer(store)?)))
+    }
+}
+
+///
+/// ### IO#__tcgetattr(with_path) -> String
+///
+/// The stream's current terminal attributes as an opaque `termios` blob.
+#[monoruby_builtin]
+fn io_tcgetattr(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let t = fetch_termios(&globals.store, lfp.self_val(), lfp.arg(0).as_bool())?;
+    Ok(termios_to_value(&t))
+}
+
+///
+/// ### IO#__tcsetattr(blob, with_path) -> nil
+#[monoruby_builtin]
+fn io_tcsetattr(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let t = termios_from_value(&globals.store, lfp.arg(0))?;
+    store_termios(&globals.store, lfp.self_val(), &t, lfp.arg(1).as_bool())?;
+    Ok(Value::nil())
+}
+
+///
+/// ### IO#__tcflush(queue) -> nil
+///
+/// `queue`: 0 = input (`iflush`), 1 = output (`oflush`), 2 = both.
+#[monoruby_builtin]
+fn io_tcflush(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let io = lfp.self_val();
+    let fd = io.as_io_inner().fileno()?;
+    let queue = match lfp.arg(0).expect_integer(&globals.store)? {
+        0 => libc::TCIFLUSH,
+        1 => libc::TCOFLUSH,
+        _ => libc::TCIOFLUSH,
+    };
+    // SAFETY: tcflush(3) takes only an fd and a queue selector.
+    if unsafe { libc::tcflush(fd, queue) } != 0 {
+        return Err(sys_fail(&globals.store, io, true));
+    }
+    Ok(Value::nil())
+}
+
+///
+/// ### IO#__winsize -> [rows, columns]
+#[monoruby_builtin]
+fn io_winsize(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let io = lfp.self_val();
+    let fd = io.as_io_inner().fileno()?;
+    // SAFETY: an all-zero `winsize` is a valid value; TIOCGWINSZ fills it.
+    let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
+    // SAFETY: TIOCGWINSZ writes a `struct winsize` through its pointer
+    // argument, which `ws` is.
+    if unsafe { libc::ioctl(fd, libc::TIOCGWINSZ as _, &mut ws as *mut libc::winsize) } != 0 {
+        return Err(sys_fail(&globals.store, io, true));
+    }
+    Ok(Value::array_from_vec(vec![
+        Value::integer(ws.ws_row as i64),
+        Value::integer(ws.ws_col as i64),
+    ]))
+}
+
+///
+/// ### IO#__set_winsize(rows, columns, xpixel, ypixel) -> nil
+///
+/// Each argument is an Integer already validated by the Ruby side (nil
+/// was mapped to 0 there); they are truncated to `unsigned short` like
+/// console.c's `SET` macro.
+#[monoruby_builtin]
+fn io_set_winsize(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let io = lfp.self_val();
+    let fd = io.as_io_inner().fileno()?;
+    let field = |i: usize| -> Result<u16> {
+        Ok(lfp.arg(i).expect_integer(&globals.store)? as u16)
+    };
+    let ws = libc::winsize {
+        ws_row: field(0)?,
+        ws_col: field(1)?,
+        ws_xpixel: field(2)?,
+        ws_ypixel: field(3)?,
+    };
+    // SAFETY: TIOCSWINSZ reads a `struct winsize` through its pointer
+    // argument, which `ws` is.
+    if unsafe { libc::ioctl(fd, libc::TIOCSWINSZ as _, &ws as *const libc::winsize) } != 0 {
+        return Err(sys_fail(&globals.store, io, true));
+    }
+    Ok(Value::nil())
+}
+
+///
+/// ### IO#__ttyname -> String | nil
+///
+/// `nil` when the descriptor is not a terminal (console.c checks
+/// `isatty` first), otherwise the device path from `ttyname_r(3)`.
+#[monoruby_builtin]
+fn io_ttyname(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let fd = lfp.self_val().as_io_inner().fileno()?;
+    // SAFETY: isatty(3) only inspects the descriptor.
+    if unsafe { libc::isatty(fd) } == 0 {
+        return Ok(Value::nil());
+    }
+    let mut buf = vec![0u8; 1024];
+    loop {
+        // SAFETY: `buf` is a writable buffer of the length passed.
+        let e = unsafe { libc::ttyname_r(fd, buf.as_mut_ptr() as *mut libc::c_char, buf.len()) };
+        if e == 0 {
+            let len = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+            buf.truncate(len);
+            return Ok(Value::string(String::from_utf8_lossy(&buf).into_owned()));
+        }
+        if e == libc::ERANGE {
+            buf.resize(buf.len() * 2, 0);
+            continue;
+        }
+        let err = std::io::Error::from_raw_os_error(e);
+        return Err(MonorubyErr::errno_with_msg(&globals.store, &err, "ttyname_r"));
+    }
+}
+
+///
+/// ### IO.__termios_raw(blob, min, time, intr) -> String
+///
+/// console.c's `set_rawmode` on a copy of `blob`: `cfmakeraw(3)`, then
+/// ECHOE / ECHOK off; `min` / `time` (nil = leave cfmakeraw's 1 / 0)
+/// set VMIN / VTIME; a true `intr` re-enables BRKINT, ISIG and OPOST.
+#[monoruby_builtin]
+fn termios_raw(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let mut t = termios_from_value(&globals.store, lfp.arg(0))?;
+    let min = opt_cc(&globals.store, lfp.arg(1))?;
+    let time = opt_cc(&globals.store, lfp.arg(2))?;
+    let intr = lfp.arg(3).as_bool();
+    // SAFETY: `t` is a live `termios`.
+    unsafe { libc::cfmakeraw(&mut t) };
+    t.c_lflag &= !(libc::ECHOE | libc::ECHOK);
+    if let Some(min) = min {
+        t.c_cc[libc::VMIN] = min;
+    }
+    if let Some(time) = time {
+        t.c_cc[libc::VTIME] = time;
+    }
+    if intr {
+        t.c_iflag |= libc::BRKINT;
+        t.c_lflag |= libc::ISIG;
+        t.c_oflag |= libc::OPOST;
+    }
+    Ok(termios_to_value(&t))
+}
+
+///
+/// ### IO.__termios_cooked(blob) -> String
+///
+/// console.c's `set_cookedmode`: BRKINT | ISTRIP | ICRNL | IXON on
+/// input, OPOST on output, echo + canonical + signals + extensions on.
+#[monoruby_builtin]
+fn termios_cooked(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let mut t = termios_from_value(&globals.store, lfp.arg(0))?;
+    t.c_iflag |= libc::BRKINT | libc::ISTRIP | libc::ICRNL | libc::IXON;
+    t.c_oflag |= libc::OPOST;
+    t.c_lflag |= libc::ECHO
+        | libc::ECHOE
+        | libc::ECHOK
+        | libc::ECHONL
+        | libc::ICANON
+        | libc::ISIG
+        | libc::IEXTEN;
+    Ok(termios_to_value(&t))
+}
+
+const ECHO_FLAGS: libc::tcflag_t = libc::ECHO | libc::ECHOE | libc::ECHOK | libc::ECHONL;
+
+///
+/// ### IO.__termios_echo(blob, flag) -> String
+///
+/// `set_echo` / `set_noecho`: ECHO | ECHOE | ECHOK | ECHONL on or off.
+#[monoruby_builtin]
+fn termios_echo(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let mut t = termios_from_value(&globals.store, lfp.arg(0))?;
+    if lfp.arg(1).as_bool() {
+        t.c_lflag |= ECHO_FLAGS;
+    } else {
+        t.c_lflag &= !ECHO_FLAGS;
+    }
+    Ok(termios_to_value(&t))
+}
+
+///
+/// ### IO.__termios_echo?(blob) -> bool
+///
+/// `echo_p`: true when ECHO or ECHONL is set.
+#[monoruby_builtin]
+fn termios_echo_p(_vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let t = termios_from_value(&globals.store, lfp.arg(0))?;
+    Ok(Value::bool((t.c_lflag & (libc::ECHO | libc::ECHONL)) != 0))
+}

--- a/monoruby/stdlib/io/console.rb
+++ b/monoruby/stdlib/io/console.rb
@@ -1,0 +1,409 @@
+# frozen_string_literal: true
+#
+# `io/console` for monoruby.
+#
+# CRuby ships this as a C extension (ext/io/console/console.c). Here the
+# public surface is Ruby, over a handful of hidden builtins that wrap
+# termios(3) and the winsize ioctls (`src/builtins/io_console.rs`):
+#
+#   IO#__tcgetattr(with_path)        -> opaque termios blob (String)
+#   IO#__tcsetattr(blob, with_path)
+#   IO.__termios_raw(blob, min, time, intr) / __termios_cooked(blob)
+#   IO.__termios_echo(blob, flag) / __termios_echo?(blob)
+#   IO#__tcflush(queue) / IO#__winsize / IO#__set_winsize(r, c, x, y)
+#   IO#__ttyname
+#
+# `with_path` picks the Errno message form: console.c's `sys_fail(io)`
+# appends the stream's path (`Inappropriate ioctl for device - <STDOUT>`)
+# for the direct setters (`raw!`, `echo=`, `winsize`, …), while the
+# `ttymode` wrapper used by the block forms (`raw`, `noecho`, `getch`, …)
+# raises the bare description.
+#
+# The escape-sequence methods (`goto`, `cursor`, `erase_line`, …) write
+# the same CSI sequences as the non-Windows branches of console.c.
+# `pressed?` and `check_winsize_changed` are Windows-only there and raise
+# NotImplementedError, as they do in CRuby on Unix.
+
+class IO
+  # An opaque terminal attribute set (`struct termios`), obtained from
+  # `IO#console_mode` and applied with `IO#console_mode=`.
+  class ConsoleMode
+    class << self
+      undef_method :new
+
+      def __new(termios) # :nodoc:
+        mode = allocate
+        mode.__send__(:__set_termios, termios)
+        mode
+      end
+    end
+
+    def initialize_copy(other)
+      __set_termios(other.instance_variable_get(:@__termios).dup)
+      self
+    end
+
+    # Enables or disables echo back.
+    def echo=(flag)
+      __set_termios(IO.__termios_echo(@__termios, flag))
+      flag
+    end
+
+    # Returns a copy in raw mode.
+    def raw(min: nil, time: nil, intr: nil)
+      dup.raw!(min: min, time: time, intr: intr)
+    end
+
+    # Switches this mode to raw mode.
+    def raw!(min: nil, time: nil, intr: nil)
+      __set_termios(IO.__termios_raw(@__termios, *IO.__rawmode_opt(min, time, intr)))
+      self
+    end
+
+    private
+
+    def __set_termios(termios)
+      @__termios = termios
+    end
+  end
+
+  class << self
+    # console.c's `rawmode_opt`: `min` / `time` (seconds, 1/10 s
+    # precision) become VMIN / VTIME bytes, `intr` must be true, false or
+    # nil. nil leaves cfmakeraw's defaults (1 / 0) in place.
+    def __rawmode_opt(min, time, intr) # :nodoc:
+      unless intr.nil? || intr == true || intr == false
+        raise ArgumentError, "true or false expected as intr: #{intr}"
+      end
+      min = __num2int(min) unless min.nil?
+      time = __num2int(time * 10) unless time.nil?
+      [min, time, intr == true]
+    end
+
+    def __num2int(v) # :nodoc:
+      case v
+      when Integer then v
+      when Float then v.to_i
+      else
+        raise TypeError, "no implicit conversion of #{v.nil? ? 'nil' : v.class} into Integer" unless v.respond_to?(:to_int)
+        v.to_int
+      end
+    end
+
+    # Returns an File instance opened console (`/dev/tty`), memoized;
+    # nil when it cannot be opened. With a Symbol, forwards the call to
+    # the console (`IO.console(:winsize)`); `IO.console(:close)` closes
+    # and forgets it.
+    def console(*args)
+      sym = args[0]
+      unless args.empty? || sym.is_a?(Symbol)
+        raise TypeError, "wrong argument type #{sym.class} (expected Symbol)"
+      end
+      con = File.instance_variable_get(:@__console)
+      if con && (!con.is_a?(File) || con.closed?)
+        File.instance_variable_set(:@__console, nil)
+        con = nil
+      end
+      if sym == :close && args.size == 1
+        if con
+          con.close
+          File.instance_variable_set(:@__console, nil)
+        end
+        return nil
+      end
+      unless con
+        begin
+          con = File.open("/dev/tty", "r+")
+        rescue SystemCallError
+          return nil
+        end
+        con.sync = true
+        File.instance_variable_set(:@__console, con)
+      end
+      sym ? con.__send__(*args) : con
+    end
+  end
+
+  # ---- terminal modes ----------------------------------------------
+
+  # console.c's `ttymode`: apply a transformed attribute set for the
+  # duration of the block and restore the original afterwards. A failed
+  # restore raises even when the block itself raised.
+  def __ttymode(transform) # :nodoc:
+    saved = __tcgetattr(false)
+    __tcsetattr(transform.call(saved), false)
+    begin
+      yield self
+    ensure
+      __tcsetattr(saved, false)
+    end
+  end
+  private :__ttymode
+
+  # Yields self within raw mode and returns the block's result.
+  def raw(min: nil, time: nil, intr: nil, &block)
+    opts = IO.__rawmode_opt(min, time, intr)
+    __ttymode(->(t) { IO.__termios_raw(t, *opts) }, &block)
+  end
+
+  # Enables raw mode; returns self.
+  def raw!(min: nil, time: nil, intr: nil)
+    opts = IO.__rawmode_opt(min, time, intr)
+    __tcsetattr(IO.__termios_raw(__tcgetattr(true), *opts), true)
+    self
+  end
+
+  # Yields self within cooked mode.
+  def cooked(&block)
+    __ttymode(->(t) { IO.__termios_cooked(t) }, &block)
+  end
+
+  # Enables cooked mode; returns self.
+  def cooked!
+    __tcsetattr(IO.__termios_cooked(__tcgetattr(true)), true)
+    self
+  end
+
+  # Reads and returns a character in raw mode.
+  def getch(min: nil, time: nil, intr: nil)
+    raw(min: min, time: time, intr: intr) { getc }
+  end
+
+  # Yields self with echo back disabled.
+  def noecho(&block)
+    __ttymode(->(t) { IO.__termios_echo(t, false) }, &block)
+  end
+
+  # Enables/disables echo back.
+  def echo=(flag)
+    __tcsetattr(IO.__termios_echo(__tcgetattr(true), flag), true)
+    flag
+  end
+
+  # Returns true if echo back is enabled.
+  def echo?
+    IO.__termios_echo?(__tcgetattr(true))
+  end
+
+  # Returns the current console mode as an IO::ConsoleMode.
+  def console_mode
+    IO::ConsoleMode.__new(__tcgetattr(true))
+  end
+
+  # Sets the console mode.
+  def console_mode=(mode)
+    unless mode.is_a?(IO::ConsoleMode)
+      raise TypeError, "wrong argument type #{mode.class} (expected console-mode)"
+    end
+    __tcsetattr(mode.instance_variable_get(:@__termios), true)
+    mode
+  end
+
+  # ---- window size, flushing, tty name ------------------------------
+
+  # Returns console size as `[rows, columns]`.
+  def winsize
+    __winsize
+  end
+
+  # Tries to set console size: `[rows, columns]` or
+  # `[rows, columns, xpixels, ypixels]`.
+  def winsize=(size)
+    size = Array(size)
+    unless size.size == 2 || size.size == 4
+      raise ArgumentError, "wrong number of arguments (given #{size.size}, expected 2 or 4)"
+    end
+    row, col, xpixel, ypixel = size
+    __set_winsize(*[row, col, xpixel, ypixel].map { |v| v.nil? ? 0 : IO.__num2int(v) })
+    size
+  end
+
+  # Flushes input buffer in kernel.
+  def iflush
+    __tcflush(0)
+    self
+  end
+
+  # Flushes output buffer in kernel.
+  def oflush
+    __tcflush(1)
+    self
+  end
+
+  # Flushes input and output buffers in kernel.
+  def ioflush
+    __tcflush(2)
+    self
+  end
+
+  # Returns name of associated terminal (tty) if self is a tty, or nil.
+  def ttyname
+    __ttyname
+  end
+
+  # ---- escape sequences ---------------------------------------------
+
+  CSI = "\e[" # :nodoc:
+
+  def __mode_in_range(val, high, modename) # :nodoc:
+    return 0 if val.nil?
+    unless val.is_a?(Integer) && val >= 0 && val <= high
+      raise ArgumentError, "wrong #{modename} mode: #{val}"
+    end
+    val
+  end
+  private :__mode_in_range
+
+  def __move(y, x) # :nodoc:
+    if x != 0 || y != 0
+      s = +""
+      s << CSI << y.abs.to_s << (y < 0 ? "A" : "B") if y != 0
+      s << CSI << x.abs.to_s << (x < 0 ? "D" : "C") if x != 0
+      write(s)
+      flush
+    end
+    self
+  end
+  private :__move
+
+  def __scroll(line) # :nodoc:
+    write("#{CSI}#{line.abs}#{line < 0 ? 'T' : 'S'}") if line != 0
+    self
+  end
+  private :__scroll
+
+  # Writes a query and parses the terminal's `ESC [ n ; m c` reply into
+  # `[n, m, "c"]` (console.c's `read_vt_response`); nil on a malformed
+  # reply.
+  def __read_vt_response(query) # :nodoc:
+    write(query)
+    flush
+    return nil unless getbyte == 0x1b
+    return nil unless getbyte == 0x5b
+    result = []
+    num = 0
+    while (b = getbyte)
+      if b == 0x3b
+        result << num
+        num = 0
+      elsif b >= 0x30 && b <= 0x39
+        num = num * 10 + b - 0x30
+      else
+        result << num
+        b = b.chr
+        break
+      end
+    end
+    result << b
+  end
+  private :__read_vt_response
+
+  # Beeps on the output console.
+  def beep
+    write("\a")
+    self
+  end
+
+  # Returns the current cursor position as `[row, column]` (zero-based).
+  def cursor
+    resp = raw { __read_vt_response("#{CSI}6n") }
+    return nil unless resp.is_a?(Array) && resp.size == 3
+    term = resp[2]
+    return nil unless term.is_a?(String) && term == "R"
+    [resp[0] - 1, resp[1] - 1]
+  end
+
+  # Moves the cursor to `[row, column]`.
+  def cursor=(pos)
+    ary = Array.try_convert(pos)
+    raise TypeError, "no implicit conversion of #{pos.class} into Array" unless ary
+    raise ArgumentError, "expected 2D coordinate" unless ary.size == 2
+    goto(ary[0], ary[1])
+  end
+
+  # Moves the cursor to the given row and column (zero-based).
+  def goto(y, x)
+    write("#{CSI}#{IO.__num2int(y) + 1};#{IO.__num2int(x) + 1}H")
+    self
+  end
+
+  # Moves the cursor to the given column (zero-based).
+  def goto_column(x)
+    write("#{CSI}#{IO.__num2int(x) + 1}G")
+    self
+  end
+
+  def cursor_up(n)
+    __move(-IO.__num2int(n), 0)
+  end
+
+  def cursor_down(n)
+    __move(IO.__num2int(n), 0)
+  end
+
+  def cursor_left(n)
+    __move(0, -IO.__num2int(n))
+  end
+
+  def cursor_right(n)
+    __move(0, IO.__num2int(n))
+  end
+
+  # Erases the line: 0 = after cursor, 1 = before and cursor, 2 = whole.
+  def erase_line(mode)
+    write("#{CSI}#{__mode_in_range(mode, 2, 'line erase')}K")
+    self
+  end
+
+  # Erases the screen: 0 = after cursor, 1 = before and cursor,
+  # 2 = whole screen, 3 = whole screen and scrollback.
+  def erase_screen(mode)
+    write("#{CSI}#{__mode_in_range(mode, 3, 'screen erase')}J")
+    self
+  end
+
+  def scroll_forward(n)
+    __scroll(IO.__num2int(n))
+  end
+
+  def scroll_backward(n)
+    __scroll(-IO.__num2int(n))
+  end
+
+  # Clears the entire screen and moves the cursor top-left.
+  def clear_screen
+    erase_screen(2)
+    goto(0, 0)
+  end
+
+  # ---- input ----------------------------------------------------------
+
+  # Reads and returns a line without echo back; the prompt (if any) and
+  # the trailing newline go to the stream itself, or to $stderr when
+  # reading $stdin.
+  def getpass(prompt = nil)
+    wio = equal?($stdin) ? $stderr : self
+    unless prompt.nil?
+      raise TypeError, "no implicit conversion of #{prompt.class} into String" unless prompt.is_a?(String)
+      raise ArgumentError, "string contains null byte" if prompt.include?("\0")
+      wio.write(prompt)
+    end
+    wio.flush
+    begin
+      str = noecho { gets }
+    ensure
+      wio.write("\n")
+    end
+    str&.chomp!
+    str
+  end
+
+  # Windows only in CRuby; unimplemented here as there.
+  def pressed?(_key)
+    raise NotImplementedError, "pressed?() function is unimplemented on this machine"
+  end
+
+  def check_winsize_changed
+    raise NotImplementedError, "check_winsize_changed() function is unimplemented on this machine"
+  end
+end

--- a/monoruby/stdlib/io/console/size.rb
+++ b/monoruby/stdlib/io/console/size.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: false
+#
+# `io/console/size` for monoruby — the same file CRuby 4.0 ships in
+# lib/ruby/4.0.0/io/console/size.rb.
+
+# fallback to console window size
+def IO.default_console_size
+  [
+    ENV["LINES"].to_i.nonzero? || 25,
+    ENV["COLUMNS"].to_i.nonzero? || 80,
+  ]
+end
+
+begin
+  require 'io/console'
+rescue LoadError
+  class << IO
+    alias console_size default_console_size
+  end
+else
+  # returns console window size
+  def IO.console_size
+    console.winsize
+  rescue NoMethodError
+    default_console_size
+  end
+end

--- a/monoruby/tests/io_console.rs
+++ b/monoruby/tests/io_console.rs
@@ -1,0 +1,289 @@
+//! `io/console` against CRuby.
+//!
+//! The terminal-mode methods need a real tty, so each test opens a
+//! pseudo terminal with `openpty(3)` and hands the slave's path to the
+//! Ruby code; both the in-process monoruby run and the CRuby process
+//! that verifies it open that same slave. A background thread plays the
+//! terminal on the master side: it swallows whatever the slave writes
+//! and answers a few in-band requests, so the blocking reads (`getch`,
+//! `getpass`, `cursor`) are fed the same bytes in both runs:
+//!
+//! | slave writes | terminal feeds back |
+//! |--------------|---------------------|
+//! | `0x01`       | `xy`                |
+//! | `0x02`       | `secret\n`          |
+//! | `ESC [ 6 n`  | `ESC [ 5 ; 7 R`     |
+//!
+//! Everything is `_live`: the slave path is per-run, so no snapshot
+//! could be replayed. Tests set the mode they rely on before reading it,
+//! since the two runs share one terminal and the second sees whatever
+//! the first left behind.
+
+use monoruby::tests::*;
+use std::ffi::CStr;
+use std::io::{Read, Write};
+use std::os::fd::FromRawFd;
+
+struct Pty {
+    path: String,
+    _master: std::fs::File,
+    _slave: std::fs::File,
+}
+
+fn open_pty() -> Pty {
+    let mut master = -1;
+    let mut slave = -1;
+    let mut name = [0u8; 256];
+    // SAFETY: openpty writes two descriptors and a NUL-terminated name
+    // into the buffers we pass; the termios / winsize pointers may be null.
+    let rc = unsafe {
+        libc::openpty(
+            &mut master,
+            &mut slave,
+            name.as_mut_ptr() as *mut libc::c_char,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, 0, "openpty failed: {}", std::io::Error::last_os_error());
+    let path = CStr::from_bytes_until_nul(&name).unwrap().to_str().unwrap().to_string();
+    // SAFETY: both descriptors were just returned by openpty and are owned here.
+    let master = unsafe { std::fs::File::from_raw_fd(master) };
+    let slave = unsafe { std::fs::File::from_raw_fd(slave) };
+
+    let mut reader = master.try_clone().unwrap();
+    let mut writer = master.try_clone().unwrap();
+    std::thread::spawn(move || {
+        let mut buf = [0u8; 256];
+        let mut tail: Vec<u8> = Vec::new();
+        loop {
+            let n = match reader.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => n,
+            };
+            for &b in &buf[..n] {
+                let feed: &[u8] = match b {
+                    0x01 => b"xy",
+                    0x02 => b"secret\n",
+                    _ => b"",
+                };
+                if !feed.is_empty() && writer.write_all(feed).is_err() {
+                    return;
+                }
+                tail.push(b);
+                if tail.len() > 4 {
+                    tail.remove(0);
+                }
+                if tail.ends_with(b"\x1b[6n") {
+                    if writer.write_all(b"\x1b[5;7R").is_err() {
+                        return;
+                    }
+                    tail.clear();
+                }
+            }
+        }
+    });
+
+    Pty {
+        path,
+        _master: master,
+        _slave: slave,
+    }
+}
+
+/// Everything that works without a terminal: the method table, the
+/// Errno / ArgumentError / TypeError forms on a pipe, and the constants.
+#[test]
+fn io_console_without_a_tty() {
+    run_test_once_live(
+        r##"
+        require "io/console"
+        r, w = IO.pipe
+        res = []
+        res << (IO.instance_methods & [:raw, :raw!, :cooked, :cooked!, :getch, :echo=, :echo?, :noecho,
+          :winsize, :winsize=, :iflush, :oflush, :ioflush, :beep, :goto, :cursor, :cursor=, :cursor_up,
+          :cursor_down, :cursor_left, :cursor_right, :goto_column, :erase_line, :erase_screen,
+          :scroll_forward, :scroll_backward, :clear_screen, :pressed?, :check_winsize_changed,
+          :getpass, :ttyname, :console_mode, :console_mode=]).size
+        res << IO.respond_to?(:console) << IO::ConsoleMode.instance_methods(false).sort
+        res << (begin; w.winsize; rescue SystemCallError => e; e.class; end)
+        res << (begin; r.raw {}; rescue SystemCallError => e; [e.class, e.message]; end)
+        res << (begin; r.noecho {}; rescue SystemCallError => e; e.class; end)
+        res << (begin; r.cooked {}; rescue SystemCallError => e; e.class; end)
+        res << (begin; r.getch; rescue SystemCallError => e; e.class; end)
+        res << (begin; r.raw!; rescue SystemCallError => e; e.class; end)
+        res << (begin; r.cooked!; rescue SystemCallError => e; e.class; end)
+        res << (begin; r.echo?; rescue SystemCallError => e; e.class; end)
+        res << (begin; r.echo = true; rescue SystemCallError => e; e.class; end)
+        res << (begin; r.console_mode; rescue SystemCallError => e; e.class; end)
+        res << (begin; w.winsize = [1, 2]; rescue SystemCallError => e; e.class; end)
+        res << (begin; w.winsize = [1, 2, 3]; rescue ArgumentError => e; e.message; end)
+        res << (begin; r.iflush; rescue SystemCallError => e; e.class; end)
+        res << (begin; r.getpass("x"); rescue IOError, SystemCallError => e; [e.class, e.message]; end)
+        res << (begin; w.getpass("x"); rescue IOError, SystemCallError => e; e.class; end)
+        res << (begin; w.cursor; rescue SystemCallError => e; e.class; end)
+        res << r.ttyname
+        res << (begin; r.pressed?(1); rescue NotImplementedError => e; e.message; end)
+        res << (begin; r.check_winsize_changed; rescue NotImplementedError => e; e.message; end)
+        res << (begin; IO::ConsoleMode.new; rescue NoMethodError; :no_new; end)
+        res << (begin; IO.console(3); rescue TypeError => e; e.message; end)
+        res << (begin; w.erase_line(3); rescue ArgumentError => e; e.message; end)
+        res << (begin; w.erase_screen(4); rescue ArgumentError => e; e.message; end)
+        res << (begin; w.erase_line(:a); rescue ArgumentError => e; e.message; end)
+        res << (begin; w.cursor = [1]; rescue ArgumentError => e; e.message; end)
+        res << (begin; w.cursor = 1; rescue TypeError => e; e.message; end)
+        res << (begin; r.raw(intr: 1) {}; rescue ArgumentError => e; e.message; end)
+        res << (begin; r.raw(foo: 1) {}; rescue ArgumentError => e; e.message; end)
+        c = IO.console
+        res << (c.nil? || (c.is_a?(File) && c.sync && c.path == "/dev/tty" && c.equal?(IO.console)))
+        res << IO.console(:close) << IO.console(:nil?).inspect.size
+        require "io/console/size"
+        res << IO.default_console_size.size
+        ENV["LINES"] = "7"; ENV["COLUMNS"] = "9"
+        res << IO.default_console_size
+        ENV["LINES"] = "-1"; ENV["COLUMNS"] = "x"
+        res << IO.default_console_size
+        res << IO.console_size.size
+        res
+        "##,
+    );
+}
+
+/// The escape sequences are plain writes, so a pipe captures them.
+#[test]
+fn io_console_escape_sequences() {
+    run_test_once_live(
+        r##"
+        require "io/console"
+        r, w = IO.pipe
+        res = []
+        res << w.beep.equal?(w) << w.goto(1, 2).equal?(w) << w.goto_column(4).equal?(w)
+        res << w.cursor_up(2).equal?(w) << w.cursor_down(3).equal?(w)
+        res << w.cursor_left(1).equal?(w) << w.cursor_right(5).equal?(w) << w.cursor_up(0).equal?(w)
+        res << w.erase_line(0).equal?(w) << w.erase_line(nil).equal?(w) << w.erase_line(2).equal?(w)
+        res << w.erase_screen(3).equal?(w) << w.erase_screen(nil).equal?(w)
+        res << w.scroll_forward(2).equal?(w) << w.scroll_backward(1).equal?(w)
+        res << w.scroll_forward(0).equal?(w) << w.clear_screen.equal?(w)
+        res << (w.cursor = [4, 5])
+        w.goto(1.9, 2.1)
+        w.close
+        res << r.read
+        res
+        "##,
+    );
+}
+
+/// Terminal modes on a pty: raw / cooked / echo, the block forms restore,
+/// the bang forms stick, and ConsoleMode round-trips.
+#[test]
+fn io_console_modes_on_a_pty() {
+    let pty = open_pty();
+    let stty = if cfg!(target_os = "linux") {
+        // stty(1) reports every termios flag, so the exact cfmakeraw /
+        // cooked flag sets are compared, not just echo.
+        format!(r#"`stty -a -F {}`.sub(/speed.*?;/, "")"#, pty.path)
+    } else {
+        "nil".to_string()
+    };
+    run_test_once_live(&format!(
+        r##"
+        require "io/console"
+        f = File.open("{path}", "r+")
+        f.sync = true
+        f.winsize = [24, 80]
+        res = []
+        f.cooked!
+        res << f.echo? << f.raw {{ f.echo? }} << f.echo? << f.noecho {{ f.echo? }} << f.cooked {{ f.echo? }}
+        res << f.raw {{ |io| io.equal?(f) }} << f.raw(min: 2, time: 0.5, intr: true) {{ f.echo? }}
+        res << f.raw!.equal?(f) << f.echo?
+        res << {stty}
+        res << f.cooked!.equal?(f) << f.echo?
+        res << {stty}
+        res << (f.echo = false) << f.echo? << (f.echo = true) << f.echo?
+        res << f.raw!(min: 3, time: 1).equal?(f)
+        res << {stty}
+        res << f.raw!(intr: true).equal?(f)
+        res << {stty}
+        f.cooked!
+        res << f.noecho {{ {stty} }}
+        res << f.iflush.equal?(f) << f.oflush.equal?(f) << f.ioflush.equal?(f)
+        res << f.ttyname
+        cm = f.console_mode
+        res << cm.class << cm.raw.class << cm.raw.equal?(cm) << cm.raw!.equal?(cm) << (cm.echo = false)
+        f.console_mode = cm
+        res << f.echo? << {stty}
+        cm2 = cm.dup
+        cm2.echo = true
+        res << (f.console_mode = cm2).equal?(cm2) << f.echo?
+        res << (begin; f.console_mode = 1; rescue TypeError => e; e.message; end)
+        res << (begin; f.raw {{ raise "boom" }}; rescue RuntimeError => e; e.message; end) << f.echo?
+        f.cooked!
+        f.close
+        res
+        "##,
+        path = pty.path,
+        stty = stty,
+    ));
+}
+
+/// Window size on a pty, including the four-element and nil forms.
+#[test]
+fn io_console_winsize_on_a_pty() {
+    let pty = open_pty();
+    run_test_once_live(&format!(
+        r##"
+        require "io/console"
+        f = File.open("{path}", "r+")
+        res = []
+        f.winsize = [10, 20]
+        res << f.winsize
+        f.winsize = [5, 6, 7, 8]
+        res << f.winsize
+        res << (f.winsize = [3, 4])
+        res << (begin; f.winsize = [1]; rescue ArgumentError => e; e.message; end)
+        res << (begin; f.winsize = [1, 2, 3, 4, 5]; rescue ArgumentError => e; e.message; end)
+        f.winsize = [nil, 9]
+        res << f.winsize
+        f.winsize = [11.7, 12]
+        res << f.winsize
+        require "io/console/size"
+        res << IO.console_size.size
+        f.close
+        res
+        "##,
+        path = pty.path,
+    ));
+}
+
+/// Reads fed by the fake terminal: getch, raw getc, getpass and the
+/// cursor-position query.
+#[test]
+fn io_console_reads_on_a_pty() {
+    let pty = open_pty();
+    run_test_once_live(&format!(
+        r##"
+        require "io/console"
+        f = File.open("{path}", "r+")
+        f.sync = true
+        res = []
+        f.cooked!
+        f.write("\x01")
+        res << f.getch << f.getch
+        f.write("\x01")
+        res << f.raw {{ f.getc }} << f.getch(min: 1)
+        f.write("\x01")
+        res << f.getch(min: 1, time: 1) << f.getch(intr: true)
+        res << f.echo?
+        f.write("\x02")
+        res << f.getpass("pw:")
+        f.write("\x02")
+        res << f.getpass
+        res << (begin; f.getpass(1); rescue TypeError => e; e.message; end)
+        res << f.cursor
+        res << f.echo?
+        f.close
+        res
+        "##,
+        path = pty.path,
+    ));
+}


### PR DESCRIPTION
`require "io/console"` raised LoadError. This adds the library, matching the io-console that ships with the reference CRuby 4.0.2.

## Shape

**The public surface is Ruby** (`stdlib/io/console.rb`): `IO#raw` / `raw!` / `cooked` / `cooked!` / `noecho` / `echo=` / `echo?` / `getch` / `getpass` / `console_mode` / `console_mode=` / `winsize` / `winsize=` / `iflush` / `oflush` / `ioflush` / `ttyname` / `beep` / `goto` / `goto_column` / `cursor` / `cursor=` / `cursor_up` / `cursor_down` / `cursor_left` / `cursor_right` / `erase_line` / `erase_screen` / `scroll_forward` / `scroll_backward` / `clear_screen`; `IO.console` (memoized `/dev/tty`, `:close`, Symbol forwarding); `IO::ConsoleMode` with `echo=` / `raw` / `raw!` and no `new`. `pressed?` and `check_winsize_changed` raise NotImplementedError as CRuby does on Unix. `io/console/size` is CRuby 4.0's file verbatim.

**Only what needs libc is Rust** (`src/builtins/io_console.rs`), as hidden builtins: `tcgetattr` / `tcsetattr`, the raw / cooked / echo transforms exactly as console.c's `set_rawmode` (`cfmakeraw` then ECHOE | ECHOK off, VMIN / VTIME / intr on top) / `set_cookedmode` / `set_echo` do them, TIOCGWINSZ / TIOCSWINSZ, `tcflush`, `ttyname_r`. A `struct termios` travels as an opaque binary String — that is what an `IO::ConsoleMode` wraps — so the flag layout, which differs between Linux and Darwin, never reaches Ruby.

## Fidelity

- The block forms (`raw {}`, `noecho {}`, `getch`, `getpass`, `cursor`) restore the saved attributes in `ensure` and raise the bare Errno like console.c's `ttymode`; the direct setters (`raw!`, `echo=`, `winsize`, …) append the stream's path like `sys_fail(io)` (`Inappropriate ioctl for device - <STDOUT>`).
- `raw(min:, time:, intr:)` clamps VMIN / VTIME to a byte, scales `time` by 10, and rejects a non-boolean `intr` with CRuby's message. Error texts for `erase_line` / `erase_screen` modes, `cursor=`, `winsize=` arity, `console_mode=` and `IO.console(non_symbol)` match.
- `getpass` writes the prompt and the trailing newline to the stream itself, or to `$stderr` when reading `$stdin`, and chomps.
- `cursor` sends `ESC [ 6 n` in raw mode and parses the `ESC [ r ; c R` reply with `read_vt_response`'s byte loop.

## Tests

`tests/io_console.rs`, five tests, all against a live CRuby. Each opens a pseudo terminal with `openpty(3)` and hands the slave's path to both the in-process monoruby run and the CRuby process; a thread on the master side plays the terminal, swallowing output and answering three in-band requests (`0x01` → `xy`, `0x02` → `secret\n`, `ESC [ 6 n` → `ESC [ 5 ; 7 R`), so `getch` / `getpass` / `cursor` are fed identically in both runs. On Linux the raw / cooked / noecho flag sets are compared through `stty -a`, not just `echo?`. The pipe-based tests cover the method table, every Errno / ArgumentError / TypeError form without a tty, the escape sequences byte for byte, and `io/console/size`. All pass on x86-64 and on aarch64 under qemu; the lib-side IO tests are unchanged.

## Noticed, not touched

Under a real tty, `STDOUT.cursor` reaches `IO#getbyte` on the write-only STDOUT, where monoruby raises ArgumentError "can't read from $stdin" while CRuby raises IOError "not opened for reading". That is the existing `IO#getbyte` behaviour, outside this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_