### PR TITLE
Cover the io/console error paths that a pipe alone cannot reach

### DIFF
--- a/monoruby/tests/io_console.rs
+++ b/monoruby/tests/io_console.rs
@@ -134,6 +134,11 @@ fn io_console_without_a_tty() {
         res << (begin; w.cursor = 1; rescue TypeError => e; e.message; end)
         res << (begin; r.raw(intr: 1) {}; rescue ArgumentError => e; e.message; end)
         res << (begin; r.raw(foo: 1) {}; rescue ArgumentError => e; e.message; end)
+        null = File.open("/dev/null", "r+")
+        res << (begin; null.winsize; rescue SystemCallError => e; e.message; end)
+        res << (begin; null.raw!; rescue SystemCallError => e; e.message; end)
+        res << (begin; null.raw {}; rescue SystemCallError => e; e.message; end)
+        null.close
         c = IO.console
         res << (c.nil? || (c.is_a?(File) && c.sync && c.path == "/dev/tty" && c.equal?(IO.console)))
         res << IO.console(:close) << IO.console(:nil?).inspect.size
@@ -216,6 +221,9 @@ fn io_console_modes_on_a_pty() {
         cm2.echo = true
         res << (f.console_mode = cm2).equal?(cm2) << f.echo?
         res << (begin; f.console_mode = 1; rescue TypeError => e; e.message; end)
+        r, w = IO.pipe
+        res << (begin; r.console_mode = cm; rescue SystemCallError => e; e.class; end)
+        r.close; w.close
         res << (begin; f.raw {{ raise "boom" }}; rescue RuntimeError => e; e.message; end) << f.echo?
         f.cooked!
         f.close
@@ -253,6 +261,14 @@ fn io_console_winsize_on_a_pty() {
         "##,
         path = pty.path,
     ));
+}
+
+/// The termios blob is opaque to Ruby, but the primitives still refuse a
+/// String of the wrong length rather than reading past it.
+#[test]
+fn io_console_rejects_a_malformed_termios_blob() {
+    run_test_error(r#"require "io/console"; IO.__termios_echo?("x")"#);
+    run_test_error(r#"require "io/console"; IO.__termios_raw("", nil, nil, false)"#);
 }
 
 /// Reads fed by the fake terminal: getch, raw getc, getpass and the


### PR DESCRIPTION
Follow-up to #1265, tests only.

Codecov's patch check flagged `src/builtins/io_console.rs` at 90.9% (target 92.5%). A local `cargo llvm-cov --show-missing-lines` run put the 16 missing lines on four error paths, three of which the existing pipe-based tests could never reach:

- **The Errno form that appends the stream's path** — a pipe has no path, so only the bare form ran. `/dev/null` has a path and is not a tty, so it now exercises `winsize` / `raw!` (`Inappropriate ioctl for device - /dev/null`) and the bare form for `raw {}` in the same test, against CRuby.
- **`tcsetattr` failing after a successful `tcgetattr`** — the Ruby side always reads the attributes first, so a pipe never got that far. Applying an `IO::ConsoleMode` taken from the pty to a pipe reaches it (`Errno::ENOTTY` in CRuby too).
- **The termios blob length check** — reachable only through the hidden primitives, so it is a `run_test_error` case rather than a CRuby comparison.

The fourth, `ttyname_r`'s ERANGE retry and its error return, is left as it is; nothing in a test can make a 1 KiB buffer too small.

Six tests pass on x86-64 (the three new cases are 16 added lines in `tests/io_console.rs`; no source change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_