### PR TITLE
Stop NSS misses from stalling the differential tests for 45 s apiece

### DIFF
--- a/monoruby/src/builtins/dir.rs
+++ b/monoruby/src/builtins/dir.rs
@@ -1239,7 +1239,13 @@ mod tests {
         // Dir.home("root") is OS-dependent (/root on Linux, /var/root on
         // macOS): verify against a live CRuby, not the oracle.
         run_test_once_live(
-            r##"(a=Dir.home("root"); b=(begin; Dir.home("no_such_user_zzq"); rescue => e; e.class; end); c=Dir.foreach("/").is_a?(Enumerator); d=Dir.foreach("/").size; e2=(begin; Dir.fchdir(-1); rescue => x; [x.class, x.message]; end); f=(Dir.glob("**").sort==Dir.glob("*").sort); [a,b,c,d,e2,f])"##,
+            r##"(a=Dir.home("root"); c=Dir.foreach("/").is_a?(Enumerator); d=Dir.foreach("/").size; e2=(begin; Dir.fchdir(-1); rescue => x; [x.class, x.message]; end); f=(Dir.glob("**").sort==Dir.glob("*").sort); [a,c,d,e2,f])"##,
+        );
+        // The unknown-user ArgumentError is CRuby's own, OS-independent —
+        // oracle-backed, so a live ruby (whose miss lookup can hang for
+        // 45 s behind WSL2's nss-systemd) is spawned at most once.
+        run_test_once(
+            r##"(begin; Dir.home("no_such_user_zzq"); rescue => e; e.class; end)"##,
         );
     }
 

--- a/monoruby/src/builtins/file.rs
+++ b/monoruby/src/builtins/file.rs
@@ -3163,7 +3163,14 @@ mod tests {
         // ~user expands via getpwnam, mid-path ~ stays literal.
         // ~root is OS-dependent (/root vs /var/root) — live CRuby.
         run_test_once_live(
-            r##"[File.expand_path("////some/path"), File.expand_path("//some/path"), File.expand_path("/some////path"), File.expand_path("/a/./b/../c//d/"), File.expand_path("~root/x"), File.expand_path("/~root/a"), File.expand_path("a", "/"), File.expand_path("../../bin", "/tmp/x"), (begin; File.expand_path("~no_such_user_zzq"); rescue => e; [e.class, e.message]; end)]"##,
+            r##"[File.expand_path("////some/path"), File.expand_path("//some/path"), File.expand_path("/some////path"), File.expand_path("/a/./b/../c//d/"), File.expand_path("~root/x"), File.expand_path("/~root/a"), File.expand_path("a", "/"), File.expand_path("../../bin", "/tmp/x")]"##,
+        );
+        // The unknown-user error is CRuby's own, OS-independent — keep
+        // it oracle-backed so a live ruby (whose miss lookup can hang
+        // for 45 s behind WSL2's nss-systemd) is spawned at most once,
+        // at recording time.
+        run_test_once(
+            r##"(begin; File.expand_path("~no_such_user_zzq"); rescue => e; [e.class, e.message]; end)"##,
         );
     }
 

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -1037,8 +1037,43 @@ impl Globals {
     }
 
     pub fn new_test() -> Self {
+        Self::pin_test_nss_to_files();
         Globals::new(1, false, true)
     }
+
+    /// On glibc hosts, pin the test process's passwd/group NSS lookups
+    /// to the `files` service. The differential tests probe nonexistent
+    /// users and groups (`Etc.getpwnam` errors, `~no_such_user`
+    /// expansion, `Process.groups=` by unknown name), and any NSS
+    /// service listed after `files` turns each such miss into that
+    /// service's timeout — WSL2's nss-systemd waits out systemd's
+    /// 45-second varlink timeout per miss, which alone put five tests
+    /// at 90-136 s. Existing entries resolve from `files` identically;
+    /// only the miss path changes, only inside this process (the
+    /// host's nsswitch.conf is untouched), and only for test Globals.
+    /// Must run before the process's first passwd/group lookup — glibc
+    /// parses nsswitch.conf once per database on first use.
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    fn pin_test_nss_to_files() {
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        ONCE.call_once(|| {
+            unsafe extern "C" {
+                fn __nss_configure_lookup(
+                    dbname: *const std::ffi::c_char,
+                    string: *const std::ffi::c_char,
+                ) -> std::ffi::c_int;
+            }
+            // SAFETY: both arguments are valid NUL-terminated C strings;
+            // the glibc extension only records the override.
+            unsafe {
+                __nss_configure_lookup(c"passwd".as_ptr(), c"files".as_ptr());
+                __nss_configure_lookup(c"group".as_ptr(), c"files".as_ptr());
+            }
+        });
+    }
+
+    #[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+    fn pin_test_nss_to_files() {}
 
     pub fn locals_len(&self, func_id: FuncId) -> usize {
         match self.store[func_id].kind {

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -697,6 +697,7 @@
 350fc45901c7ff4041bdf8a1abf3a79c	["via_send", "BSend", "BSend", [], [:a], 1]	class BSend\n              def direct; binding; end\n              de
 351c5e2d7c1113c1b45bd6b66e8aa52a	[2.0, 3.0, -3.0, -2.0, 0.0, 2.0, 0.5]	def fa; 17 % 5.0; end\n            def fb; -17 % 5.0; end\n          
 3535eecf4c57db26badbf664b0539819	["DEFAULT", true, "IGNORE"]	Signal.trap("USR2", "DEFAULT")\n            a = Signal.trap("USR2") 
+354035ac9f6036c3a6b9b24e07a634bf	ArgumentError	(begin; Dir.home("no_such_user_zzq"); rescue => e; e.class; end)
 355f64ccc41342dde6bb12c04da77410	true	[Process.getpgrp, Process.getpgid(0), Process.getsid].all? { |v| v.is_a?(Integer
 3565c58dca7325f9f598f2c1ae3626b3	true	GC.config.is_a?(Hash)
 356bbf9786b1d2f6d8025e7e3cda3118	[4, [0, 104, 0, 105], [104, 233], "Encoding::UndefinedConversionError"]	path = "/tmp/monoruby_test_iowt_#{Process.pid}_#{rand(100000)}"\n   
@@ -1678,6 +1679,7 @@
 81521b66a2141f9037bbfa1330b6895b	"abcdefghijabcdefghijabcdefghijabcdefghijabcdefghij"	"abcdefghij" * 5
 815fb5dfd31836a4be23fedfa5db3a46	"ok"	r, w = IO.pipe\n            t = Thread.new { r.read(2) }\n           
 81674508001763ecbda6a61bcd269308	[1, :assigned]	module M1; end\n        x = 0\n        (x += 1; M1)::C ||= :assigned\n    
+817da22aee03e98f9c09abf7ff088595	[ArgumentError, "user no_such_user_zzq doesn't exist"]	(begin; File.expand_path("~no_such_user_zzq"); rescue => e; [e.class, e.message]
 8193766d4ea2f53b2e9b0d421c63493f	["no keywords accepted", :ok, :ok, :ok, "no keywords accepted", 3, "no keywords accepted", :mok, "no keywords accepted", "no keywords accepted", :mok]	def rescue_msg\n              yield; :no_error\n            rescue Ar
 819786c3c521ff97cda2204ae5eaf866	[true]	def check(o); o.is_a?(Integer); end\n            r = []\n            
 81a4893d8dc3fd03a6cb2cc3f973f7b0	[4, 8, 111, 58, 14, 69, 120, 99, 101, 112, 116, 105, 111, 110, 8, 58, 9, 109, 101, 115, 103, 73, 34, 6, 120, 6, 58, 6, 69, 84, 58, 7, 98, 116, 48, 58, 10, 64, 105, 118, 97, 114, 105, 12]	e = Exception.new("x")\n            e.instance_variable_set(:@ivar, 


### PR DESCRIPTION
## Problem

Five tests took 90–136 s each on a WSL2 host: `etc_passwd_group_database`, `dir_methods_coverage`, `file_expand_path_slashes_and_tilde`, `process_groups_set_by_name_error`, `process_id_setter_type_errors`.

They all probe **nonexistent** users/groups (`Etc.getpwnam` errors, `~no_such_user` expansion, `Process.groups=` by unknown name). With `passwd: files systemd` in `nsswitch.conf`, every such *miss* falls through to nss-systemd, which waits out systemd's **45-second varlink timeout** when systemd-userdbd doesn't answer — `getent passwd no-such-user` alone takes 45.0 s on that host. Hits resolve from `files` instantly, so only the error-path tests stalled (and monoruby and CRuby are affected equally — this is libc, not interpreter code).

## Fix (host's nsswitch.conf untouched)

1. **`Globals::new_test`** pins the test process's passwd/group NSS lookups to the `files` service via glibc's `__nss_configure_lookup` (gated to linux-gnu, applied once, before the first lookup). Existing entries resolve identically; only the miss path stops timing out, and only for test Globals in this process.
2. The spawned reference CRuby cannot inherit that override, so the two live-compared tests keep their OS-dependent parts (`~root`, `Dir.home("root")`) live and move the unknown-user error cases — CRuby's own OS-independent `ArgumentError` — to the snapshot oracle, where the recording spawn happens at most once (entries included).

## Results

| test | before | after |
|---|---:|---:|
| etc_passwd_group_database | 136 s | 0.47 s |
| dir_methods_coverage | 91 s | 0.70 s |
| file_expand_path_slashes_and_tilde | 91 s | 0.70 s |
| process_groups_set_by_name_error | 91 s | 0.38 s |
| process_id_setter_type_errors | (same class) | 0.45 s |

Full suite: 3338 tests pass; wall time ~154 s → ~119 s on the affected host. Unaffected hosts (fast NSS, macOS) see no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)