### PR TITLE
JIT: eliminate the DOOM deopt storms (bool ^, bignum constants, block-root heal)

### DIFF
--- a/monoruby/builtins/boolean.rb
+++ b/monoruby/builtins/boolean.rb
@@ -100,10 +100,17 @@ end
 class FalseClass
   # core/false/inspect_spec.rb: inspect is an alias of to_s (to_s on FalseClass).
   alias inspect to_s
-  # core/false/xor_spec.rb: ^ is an alias of |. Both `|` and `^` are rooted
-  # directly on FalseClass (registered by bool_class.rs on FALSE_CLASS, not an
-  # inherited parent), so just re-point `^` at the existing `|`. For false,
-  # `false ^ x` and `false | x` are both `!!x`, so behaviour is unchanged.
-  # (`true` keeps distinct `^`/`|` on the shared Boolean, where they differ.)
-  alias ^ |
+  # core/false/xor_spec.rb: ^ and | are the same method entry on FalseClass
+  # (for false, `false ^ x` and `false | x` are both `!!x`). The alias
+  # direction matters for the JIT: bool_class.rs registers `^` with ONE
+  # FuncId on both TrueClass and FalseClass so a polymorphic-on-true/false
+  # `^` site can use the unified BOOL_CLASS inline cache — dewasm-generated
+  # wasm code leans on `(a < 0) ^ (b < 0)` sign tests, and `alias ^ |` here
+  # used to re-point false's `^` at `|`'s FuncId, breaking that unification
+  # and turning every such JIT site into a deopt/recompile storm. Re-point
+  # `|` at `^` instead: the spec's identity check still holds, `^` stays
+  # unified, and only `|` diverges (true keeps its own genuinely different
+  # `|`; a divergent bool operator now falls back to the generic dispatch
+  # in the JIT rather than deopting).
+  alias | ^
 end

--- a/monoruby/src/builtins/io_buffer.rs
+++ b/monoruby/src/builtins/io_buffer.rs
@@ -161,11 +161,23 @@ fn parse_value_type(name: &str) -> Option<(usize, ValKind, bool)> {
 }
 
 fn value_type_arg(v: Value) -> Result<(usize, ValKind, bool)> {
-    let name = match v.try_symbol_or_string() {
-        Some(id) => id.get_name(),
-        None => return Err(MonorubyErr::argumenterr("Invalid type name!")),
-    };
-    parse_value_type(&name).ok_or_else(|| MonorubyErr::argumenterr("Invalid type name!"))
+    // get/set_value sit on every wasm-style memory access, so resolve the
+    // type symbol by interned id — `IdentId::get_name` allocates a String
+    // per call, and that alone showed up at several percent of a DOOM run.
+    static TABLE: std::sync::OnceLock<std::collections::HashMap<IdentId, (usize, ValKind, bool)>> =
+        std::sync::OnceLock::new();
+    let table = TABLE.get_or_init(|| {
+        [
+            "U8", "S8", "u16", "U16", "s16", "S16", "u32", "U32", "s32", "S32", "u64", "U64",
+            "s64", "S64", "f32", "F32", "f64", "F64",
+        ]
+        .into_iter()
+        .map(|name| (IdentId::get_id(name), parse_value_type(name).unwrap()))
+        .collect()
+    });
+    v.try_symbol_or_string()
+        .and_then(|id| table.get(&id).copied())
+        .ok_or_else(|| MonorubyErr::argumenterr("Invalid type name!"))
 }
 
 fn decode_value(bytes: &[u8], kind: ValKind, big: bool) -> Value {

--- a/monoruby/src/builtins/io_buffer.rs
+++ b/monoruby/src/builtins/io_buffer.rs
@@ -164,19 +164,23 @@ fn value_type_arg(v: Value) -> Result<(usize, ValKind, bool)> {
     // get/set_value sit on every wasm-style memory access, so resolve the
     // type symbol by interned id — `IdentId::get_name` allocates a String
     // per call, and that alone showed up at several percent of a DOOM run.
-    static TABLE: std::sync::OnceLock<std::collections::HashMap<IdentId, (usize, ValKind, bool)>> =
+    // An 18-entry linear scan of u32 ids: SipHashing the IdentId for a
+    // HashMap cost ~2% of the same run.
+    static TABLE: std::sync::OnceLock<[(IdentId, (usize, ValKind, bool)); 18]> =
         std::sync::OnceLock::new();
     let table = TABLE.get_or_init(|| {
         [
-            "U8", "S8", "u16", "U16", "s16", "S16", "u32", "U32", "s32", "S32", "u64", "U64",
+            "u32", "u64", "U8", "S8", "u16", "U16", "s16", "S16", "U32", "s32", "S32", "U64",
             "s64", "S64", "f32", "F32", "f64", "F64",
         ]
-        .into_iter()
         .map(|name| (IdentId::get_id(name), parse_value_type(name).unwrap()))
-        .collect()
     });
     v.try_symbol_or_string()
-        .and_then(|id| table.get(&id).copied())
+        .and_then(|id| {
+            table
+                .iter()
+                .find_map(|(tid, spec)| (*tid == id).then_some(*spec))
+        })
         .ok_or_else(|| MonorubyErr::argumenterr("Invalid type name!"))
 }
 

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -1184,6 +1184,15 @@ fn integer_binop_gen(kind: BinOpK) -> Box<InlineGenBinary> {
             } = *callsite;
             match rhs_class {
                 Some(INTEGER_CLASS) => {
+                    // A bignum-constant operand (`x & 0xffff_ffff_ffff_ffff`,
+                    // the dewasm mask idiom) has no fixnum lowering: the
+                    // fixnum guard would land on the constant and fail on
+                    // every execution. Decline to the direct-call residual.
+                    if state.is_bigint_literal_sign(recv).is_some()
+                        || state.is_bigint_literal_sign(args).is_some()
+                    {
+                        return BinaryInlineOutcome::Declined;
+                    }
                     state.binop_integer(ir, kind, dst, recv, args);
                     BinaryInlineOutcome::Done
                 }
@@ -1250,6 +1259,9 @@ fn integer_cmp_gen(kind: CmpKind) -> Box<InlineGenBinary> {
                                 return BinaryInlineOutcome::Folded(AbstractFrame::fold_cmp(
                                     kind, l, r,
                                 ));
+                            }
+                            if let Some(b) = state.fold_bigint_const_cmpbr(ir, kind, recv, args) {
+                                return BinaryInlineOutcome::Folded(b);
                             }
                             state.gen_cmpbr_integer(ir, kind, recv, args, brkind, dest);
                         }

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -402,6 +402,16 @@ impl<'a> JitContext<'a> {
             TraceIr::FrozenLiteral(dst, val) => {
                 if let Some(imm) = val.is_immediate() {
                     state.def_C(dst, imm);
+                } else if matches!(val.unpack(), RV::BigInt(_)) {
+                    // A bignum literal (`x >= 0x8000_0000_0000_0000`, the
+                    // dewasm sign-test idiom) folds as `LinkMode::C` like a
+                    // bignum from the constant cache (`load_constant`), so
+                    // the comparison/binop lowerings see its compile-time
+                    // sign instead of emitting a fixnum guard the heap
+                    // Integer fails on every execution. GC safety is the
+                    // const fold's: `wb_literal` writes the value back to
+                    // the stack slot before every safepoint.
+                    state.def_C(dst, val);
                 } else {
                     // Load the literal straight into a GP-pool register resident
                     // rather than through rax to the stack home (see `def_lit2gp`).
@@ -1325,7 +1335,8 @@ impl<'a> JitContext<'a> {
         bc_pos: BcIndex,
         recv_miss: RecvMissMode,
     ) -> JitResult<CompileResult> {
-        if let Some((fid, visibility)) = self.jit_check_method(lhs_class, name.into()) {
+        let name = name.into();
+        if let Some((fid, visibility)) = self.jit_check_method(lhs_class, name) {
             let callid = self.store.get_callsite_id(self.iseq_id(), bc_pos).unwrap();
             assert_eq!(self.store[callid].recv, lhs);
             assert_eq!(self.store[callid].args, rhs);

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -732,6 +732,45 @@ impl<'a> JitContext<'a> {
             )));
         };
 
+        // ---- 3b. A comparison with exactly one bignum-constant operand
+        // folds to its sign-decided answer here, BEFORE the inline
+        // dispatch: the receiver guard the dispatch would emit is a
+        // fixnum-representation test, which a bignum constant receiver
+        // (`M64 >= x`) can never pass, so the fold has to intercept — the
+        // constant side needs no runtime check at all, only the variable
+        // side keeps its fixnum guard. Same discipline as
+        // `fire_binary_inline`: the answer bakes in the builtin
+        // comparison, so it is gated on bop assumability and records the
+        // dependency.
+        if let BinaryOp::Cmp(kind) = binop
+            && lhs_class == INTEGER_CLASS
+            && !polymorphic
+        {
+            let rhs_big = state.is_bigint_literal_sign(rhs).is_some();
+            let lhs_big = state.is_bigint_literal_sign(lhs).is_some();
+            // Exactly one constant side, and the variable side profiled
+            // Integer (that's where the fold's fixnum guard lands).
+            if rhs_big != lhs_big
+                && (rhs_big || rhs_class == Some(INTEGER_CLASS))
+                && self.basic_op_assumable(INTEGER_CLASS, binop.into())
+            {
+                match mode {
+                    BinaryInlineMode::Value => {
+                        if state.fold_bigint_const_cmp(ir, kind, dst, lhs, rhs) {
+                            self.record_bop_dep(INTEGER_CLASS, binop.into());
+                            return Ok(BinaryLowering::Emitted);
+                        }
+                    }
+                    BinaryInlineMode::CmpBr { .. } => {
+                        if let Some(b) = state.fold_bigint_const_cmpbr(ir, kind, lhs, rhs) {
+                            self.record_bop_dep(INTEGER_CLASS, binop.into());
+                            return Ok(BinaryLowering::Folded(b));
+                        }
+                    }
+                }
+            }
+        }
+
         // ---- 4. One path for every operator: guard the receiver, run the
         // generator registered on `lhs_class#op`, and fall back for whatever
         // it declines. The generator picks its emission from the argument
@@ -799,6 +838,25 @@ impl<'a> JitContext<'a> {
             }
             // Any C-ABI call flushes at its `get_using_fpr` chokepoint; the
             // GP pool has to be spilled here because the helper clobbers it.
+            state.flush_gp(ir);
+            let is_func_call = self
+                .store
+                .get_callsite_id(self.iseq_id(), bc_pos)
+                .is_some_and(|c| self.store[c].is_func_call());
+            self.emit_generic_binary(state, ir, binop, lhs, rhs, case_semantics, is_func_call);
+            return Ok(BinaryLowering::Generic);
+        }
+        // A BOOL_CLASS receiver whose operator has no unified resolution
+        // (TrueClass and FalseClass diverge on it — `|` after boolean.rb's
+        // alias, or a user redefinition on one class) has nothing to guard:
+        // the profile tags every boolean BOOL_CLASS, so a recompile re-asks
+        // the same unanswerable question and the site deopts forever.
+        // Dispatch through the generic helper instead.
+        if lhs_class == BOOL_CLASS
+            && self
+                .jit_check_method(lhs_class, IdentId::from(binop))
+                .is_none()
+        {
             state.flush_gp(ir);
             let is_func_call = self
                 .store

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -227,26 +227,25 @@ impl<'a> JitContext<'a> {
     ///
     ///
     /// The recompile target a receiver-class-guard `Learn` exit uses for
-    /// this compilation unit, or `None` when no sound one exists.
+    /// this compilation unit.
     ///
-    /// A block ROOT cannot take a whole-recompile: the side exit recompiles
-    /// whatever `lfp.func_id()` names as if it were a method, which rebuilds
-    /// a block body under the wrong argument convention (see
-    /// `guard_const_version`, which learned this the hard way). Loop JITs
-    /// (position = Some) and specialized block bodies (idx route) recompile
-    /// fine.
+    /// Block ROOTs take the whole-recompile route like any other whole
+    /// unit. They used to be excluded — an early recompile path rebuilt a
+    /// block body under the method argument convention (#1127 records
+    /// `Kernel#caller_locations`' block losing its argument) — but the
+    /// compile pipeline has been iseq-driven and identical for the initial
+    /// compile and the recompile since the abstract-state unification, and
+    /// the exclusion had become the last permanent-deopt hole: a block
+    /// compiled while a receiver was still `nil` (dewasm DOOM's terminal
+    /// renderer compares `prev_row[cx] == key` — nil on the first frame,
+    /// Integer forever after) failed its class guard on every later cell
+    /// of every later frame, ~296k plain deopts per minute, with the VM
+    /// interpreting the rest of each block invocation.
     ///
     pub(super) fn recv_miss_recompile_target(&self) -> Option<RecompileTarget> {
         match self.jit_type() {
             JitType::Specialized { idx, .. } => Some(RecompileTarget::Specialized(*idx)),
-            _ => {
-                let position = self.position();
-                if position.is_none() && self.store[self.func_id()].is_block_style() {
-                    None
-                } else {
-                    Some(RecompileTarget::Whole(position))
-                }
-            }
+            _ => Some(RecompileTarget::Whole(self.position())),
         }
     }
 
@@ -471,6 +470,22 @@ impl<'a> JitContext<'a> {
         // best and — since only one of the arm's classes is `recv_class` —
         // would deopt the rest at worst.
         let mut same_target_set_guarded = self.in_set_guarded_arm();
+        // A compile-time heap-constant receiver of the right class needs no
+        // runtime guard — its class is a static fact (`M64 - x` reaching the
+        // direct-call residual: the Integer guard is a fixnum-tag test a
+        // bignum can never pass). But it gets no representation refinement
+        // either (a bignum constant is Integer without being a fixnum), so
+        // for everything downstream it must look like the set-guarded case:
+        // class known, nothing proven untagged, generators decline or
+        // handle `None`, the ordinary builtin call carries boxed Values.
+        let mut recv_const_unrefined = false;
+        if !same_target_set_guarded
+            && state.class(recv) != Some(recv_class)
+            && state.is_const_of_class(recv, recv_class)
+        {
+            same_target_set_guarded = true;
+            recv_const_unrefined = true;
+        }
         if !same_target_set_guarded && state.class(recv) != Some(recv_class) {
             if recv_miss != RecvMissMode::PartB
                 && let Some(classes) = self.pmc_same_target_classes(callid, recv_class, func_id)
@@ -566,10 +581,20 @@ impl<'a> JitContext<'a> {
                 // `object_id` keep firing there while a generator that needs
                 // the class declines to the ordinary call.
                 InlineFuncInfo::InlineGen(f) => {
-                    let proven = (!same_target_set_guarded).then_some(recv_class);
-                    if self.inline_asm(state, ir, f, callid, proven, arg_class) {
-                        state.unset_side_effect_guard();
-                        return Ok(CompileResult::Continue);
+                    // Not behind a const-receiver guard skip: the Integer
+                    // generators load the receiver raw on the strength of
+                    // the caller's guard (a set guard's INTEGER member is
+                    // the same fixnum-tag test, so `None` there is safe) —
+                    // a skipped guard for a heap constant proves no
+                    // representation, so they must not fire (`999…9[0]`
+                    // would shift the bignum's pointer bits); fall through
+                    // to the ordinary builtin call instead.
+                    if !recv_const_unrefined {
+                        let proven = (!same_target_set_guarded).then_some(recv_class);
+                        if self.inline_asm(state, ir, f, callid, proven, arg_class) {
+                            state.unset_side_effect_guard();
+                            return Ok(CompileResult::Continue);
+                        }
                     }
                 }
                 // The operator generators still take a definite receiver

--- a/monoruby/src/codegen/jitgen/state/binop.rs
+++ b/monoruby/src/codegen/jitgen/state/binop.rs
@@ -491,7 +491,91 @@ impl AbstractFrame {
             self.fold_constant_cmp(kind, lhs, rhs, dst);
             return;
         };
+        // One operand a bignum constant (`x <= 0xffff_ffff_ffff_ffff`, the
+        // dewasm mask idiom): guard the other operand fixnum and the result
+        // is decided by the constant's sign alone. Without this the fixnum
+        // guard lands on the constant itself and fails on every execution.
+        if self.fold_bigint_const_cmp(ir, kind, dst, lhs, rhs) {
+            return;
+        }
         self.gen_cmp_integer_gp(ir, kind, dst, lhs, rhs);
+    }
+
+    /// The (variable side, folded answer) of a comparison with a bignum
+    /// constant on the other side: `fixnum <op> B` orders by B's sign
+    /// alone (equality never holds), flipped when B is the lhs. `None`
+    /// when neither side is a bignum constant.
+    fn bigint_cmp_fold_plan(&self, kind: CmpKind, lhs: SlotId, rhs: SlotId) -> Option<(SlotId, bool)> {
+        let (var, const_above, const_on_lhs) = if let Some(pos) = self.is_bigint_literal_sign(rhs) {
+            (lhs, pos, false)
+        } else if let Some(pos) = self.is_bigint_literal_sign(lhs) {
+            (rhs, pos, true)
+        } else {
+            return None;
+        };
+        let var_is_less = const_above != const_on_lhs;
+        let b = match kind {
+            CmpKind::Lt | CmpKind::Le => var_is_less,
+            CmpKind::Gt | CmpKind::Ge => !var_is_less,
+            CmpKind::Eq | CmpKind::TEq => false,
+            CmpKind::Ne => true,
+        };
+        Some((var, b))
+    }
+
+    /// The fixnum guard a bignum-constant fold's answer depends on: a
+    /// bignum in the variable operand must still deopt. Skipped when the
+    /// slot is already fixnum-proven or itself a fixnum constant.
+    fn guard_fixnum_for_fold(&mut self, ir: &mut AsmIr, var: SlotId) {
+        if self.is_fixnum_literal(var).is_none() {
+            let (var_gp, var_guard) = self.gp_ensure(ir, var, &[]);
+            if var_guard {
+                let deopt = ir.new_deopt(self);
+                ir.push(AsmInst::GuardClass(var_gp, INTEGER_CLASS, deopt));
+                self.refine_S_fixnum(var);
+            }
+        }
+    }
+
+    /// The `gen_cmp_integer` bignum-constant fold: when one operand is a
+    /// compile-time bignum constant, emit only the fixnum guard for the
+    /// other operand and link `dst` to the constant boolean answer.
+    /// Returns false (emitting nothing) when neither side qualifies.
+    pub(crate) fn fold_bigint_const_cmp(
+        &mut self,
+        ir: &mut AsmIr,
+        kind: CmpKind,
+        dst: Option<SlotId>,
+        lhs: SlotId,
+        rhs: SlotId,
+    ) -> bool {
+        let Some((var, b)) = self.bigint_cmp_fold_plan(kind, lhs, rhs) else {
+            return false;
+        };
+        self.guard_fixnum_for_fold(ir, var);
+        if let Some(dst) = dst {
+            self.gp_regfile.invalidate(dst);
+        }
+        let next_sp = self.next_sp();
+        self.gp_regfile.free_above_sp(next_sp);
+        self.def_C(dst, Value::bool(b));
+        true
+    }
+
+    /// The fused compare-and-branch form of the bignum-constant fold
+    /// (`x >= 0x8000_0000_0000_0000 ? … : …`, the dewasm sign-test
+    /// idiom): emit only the fixnum guard and hand the static answer to
+    /// the caller, which resolves the branch like a constant `CondBr`.
+    pub(crate) fn fold_bigint_const_cmpbr(
+        &mut self,
+        ir: &mut AsmIr,
+        kind: CmpKind,
+        lhs: SlotId,
+        rhs: SlotId,
+    ) -> Option<bool> {
+        let (var, b) = self.bigint_cmp_fold_plan(kind, lhs, rhs)?;
+        self.guard_fixnum_for_fold(ir, var);
+        Some(b)
     }
 
     /// the register-allocated fixnum comparison. Operands are
@@ -818,6 +902,12 @@ impl AbstractFrame {
         if self.class(slot) == Some(class) {
             return;
         }
+        // NOTE: a compile-time heap constant of the right class (a bignum
+        // receiver, say) must NOT skip this guard: for INTEGER it doubles
+        // as the fixnum-representation proof the inline generators build
+        // on (a skipped guard let `BIGNUM_CONST >> 4` shift the raw heap
+        // pointer). Bignum-constant sites are instead intercepted before
+        // the dispatch (`compile_binary`'s fold / the generators' decline).
         match class {
             INTEGER_CLASS => {
                 let (gp, needs_guard) = self.gp_ensure(ir, slot, &[]);

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -1535,6 +1535,39 @@ impl SlotState {
         }
     }
 
+    /// Whether `slot` is a compile-time constant of class `class` — a
+    /// static fact that needs no runtime class guard. Matters for heap
+    /// constants (a bignum's Guarded state is deliberately `Value`, so a
+    /// class-based check would emit the fixnum-tag guard it can never
+    /// pass).
+    pub(in crate::codegen::jitgen) fn is_const_of_class(&self, slot: SlotId, class: ClassId) -> bool {
+        matches!(self.mode(slot), LinkMode::C(v) if v.class() == class)
+    }
+
+    /// A compile-time heap-`Integer` (bignum) constant slot, reduced to its
+    /// sign: `Some(true)` = above the fixnum window, `Some(false)` = below
+    /// it. Every fixnum compares the same way against such a constant, so a
+    /// fixnum-guarded operand's comparison folds to that one answer —
+    /// dewasm-generated wasm code hits this on every 64-bit op via masks
+    /// like `x <= 0xffff_ffff_ffff_ffff`. A denormalized bignum that would
+    /// fit the fixnum window is not folded (`None`).
+    pub fn is_bigint_literal_sign(&self, slot: SlotId) -> Option<bool> {
+        use num::ToPrimitive;
+        if let LinkMode::C(v) = self.mode(slot)
+            && v.is_immediate().is_none()
+            && let RV::BigInt(b) = v.unpack()
+        {
+            if let Some(i) = b.to_i64()
+                && (-(1i64 << 62)..(1i64 << 62)).contains(&i)
+            {
+                return None;
+            }
+            Some(b.sign() == num::bigint::Sign::Plus)
+        } else {
+            None
+        }
+    }
+
     /// The tagged `Value` of a fixnum compile-time-constant slot, if any — the
     /// immediate to load straight into a register (the local GP allocator), skipping
     /// the stack-home materialization and the fixnum guard.

--- a/monoruby/tests/bigint_const_ops.rs
+++ b/monoruby/tests/bigint_const_ops.rs
@@ -1,0 +1,116 @@
+//! Comparisons and arithmetic against bignum *constants* in JIT-compiled
+//! code.
+//!
+//! dewasm-generated wasm runtimes lean on `x <= 0xffff_ffff_ffff_ffff`
+//! masks and `x >= 0x8000_0000_0000_0000` sign tests. The bignum sits in
+//! a constant (or literal) slot, so the integer lowering's fixnum guard
+//! used to land on the constant itself and fail on every execution — a
+//! deopt per call, forever (and for `&`-style arithmetic, a recompile
+//! storm). Now:
+//!
+//! - a comparison with a bignum-constant operand folds to its
+//!   sign-decided answer under a fixnum guard on the *other* operand
+//!   (value and fused compare-branch forms both);
+//! - integer arithmetic with a bignum-constant operand declines to the
+//!   direct builtin call;
+//! - a compile-time constant receiver skips the runtime class guard
+//!   (its class is a static fact), in both the binop dispatcher and the
+//!   method-call path.
+//!
+//! These tests pin the *semantics* across the JIT tier — every shape
+//! runs hot enough to compile, with bignum-valued arguments mixed in so
+//! the fold's fixnum guard deopts (and must stay correct) too.
+extern crate monoruby;
+use monoruby::tests::*;
+
+#[test]
+fn cmp_against_bignum_const_folds() {
+    run_test(
+        r##"
+        BIGP = 0xffff_ffff_ffff_ffff
+        BIGN = -(2**63)
+        def t(x)
+          [x < BIGP, x <= BIGP, x > BIGP, x >= BIGP, x == BIGP, x != BIGP,
+           BIGP < x, BIGP <= x, BIGP > x, BIGP >= x, BIGP == x, BIGP != x,
+           x < BIGN, x >= BIGN, x == BIGN, BIGN >= x]
+        end
+        r = []
+        60.times { |i| r = t(i - 30) }
+        # Bignum arguments take the fold's fixnum-guard deopt and must
+        # still answer correctly; the fixnum-window boundaries must not
+        # be confused with bignums.
+        [r, t(2**64), t(-2**64), t(2**62), t(-2**62), t(2**62 - 1)]
+        "##,
+    );
+}
+
+#[test]
+fn fused_cmpbr_against_bignum_literal_folds() {
+    // The `x >= 0x8000_...` ? : shape compiles to the fused
+    // compare-and-branch; the bignum is a *literal* (LinkMode::C via
+    // FrozenLiteral), not a constant-cache entry.
+    run_test(
+        r##"
+        def s64(x) = x >= 0x8000_0000_0000_0000 ? x - 0x1_0000_0000_0000_0000 : x
+        def m64(x) = (x >= 0 && x <= 0xffff_ffff_ffff_ffff) ? x : (x & 0xffff_ffff_ffff_ffff)
+        r = 0
+        60.times { |i| r ^= s64(i) ^ m64(i * 3) }
+        [r, s64(2**64 - 1), s64(2**63), s64(2**63 - 1), s64(5),
+         m64(-1), m64(2**64 - 1), m64(2**70), m64(-2**70)]
+        "##,
+    );
+}
+
+#[test]
+fn arith_with_bignum_const_takes_direct_call() {
+    run_test(
+        r##"
+        BIGP = 0xffff_ffff_ffff_ffff
+        BIGN = -(2**63)
+        def t(x)
+          [x & BIGP, x | 0x1_0000_0000_0000_0000, x ^ BIGP,
+           x + BIGP, BIGP - x, x * BIGN, BIGP >> 4, x - BIGN]
+        end
+        r = []
+        60.times { |i| r = t(i - 30) }
+        [r, t(2**64), t(-2**63)]
+        "##,
+    );
+}
+
+#[test]
+fn bignum_const_receiver_declines_raw_inlines() {
+    // Integer#[] / #>> / #succ load the receiver raw on the strength of
+    // the caller's fixnum guard; a bignum-constant receiver skips that
+    // guard (its class is static) and must therefore take the ordinary
+    // builtin call, not the raw-bits inline (`999…9[0]` once shifted the
+    // bignum's heap pointer).
+    run_test(
+        r##"
+        B = 999999999999999999999999999999999
+        def t = [B[0], B[47], B[48], B[86], B[-1], B >> 4, B << 1, B.succ, B % 7]
+        r = nil
+        30.times { r = t }
+        r
+        "##,
+    );
+}
+
+#[test]
+fn bignum_const_cmp_respects_redefinition() {
+    // The fold rides the basic-op machinery: redefining Integer#<=
+    // must evict the folded body and dispatch the new method.
+    run_test_once(
+        r##"
+        M = 0xffff_ffff_ffff_ffff
+        def t(x) = x <= M
+        r = []
+        30.times { r << t(1) }
+        class Integer
+          def <=(other) = :redefined
+        end
+        30.times { r << t(1) }
+        r.uniq
+        "##,
+    );
+}

--- a/monoruby/tests/block_root_recv_miss_heal.rs
+++ b/monoruby/tests/block_root_recv_miss_heal.rs
@@ -1,0 +1,77 @@
+//! A whole-compiled block body whose receiver-class guard goes polymorphic
+//! after the compile.
+//!
+//! `recv_miss_recompile_target` used to return `None` for block ROOTs
+//! (#1127-era: an early recompile path rebuilt a block under the method
+//! argument convention), leaving a receiver-class-guard miss on a plain
+//! deopt with no healing — a block compiled while a receiver was still
+//! `nil` then deopted on every later execution, forever. dewasm DOOM's
+//! terminal renderer (`prev_row[cx] == key`: nil on the first frame,
+//! Integer after) paid ~296k such deopts a minute. Block ROOTs now take
+//! the whole-recompile route; these tests pin the semantics of exactly
+//! that shape — the block's own argument must survive the recompile (the
+//! historical breakage), and the values must stay correct across the
+//! heal.
+extern crate monoruby;
+use monoruby::tests::*;
+
+#[test]
+fn block_root_heals_after_nil_warmup() {
+    run_test(
+        r##"
+        class R
+          def initialize(n)
+            @n = n
+            @prev = Array.new(n)
+          end
+          def render(key)
+            s = 0
+            @n.times do |i|
+              # nil == key during warmup, Integer == key forever after:
+              # the block is whole-compiled with a NilClass guard that
+              # must heal via recompile, and `i` (the block argument) is
+              # live across the deopt site.
+              next if @prev[i] == key
+              @prev[i] = key
+              s += i + 1
+            end
+            s
+          end
+        end
+        r = R.new(40)
+        t = 0
+        120.times { |f| t += r.render(f / 13) }
+        t
+        "##,
+    );
+}
+
+#[test]
+fn block_argument_survives_recompile() {
+    // The #1127 breakage shape: a block forwarding its arguments to a
+    // constructor, with a receiver-class flip inside forcing the block
+    // ROOT's whole recompile mid-run.
+    run_test(
+        r##"
+        class Loc
+          attr_reader :a, :b
+          def initialize(a, b) = (@a = a; @b = b)
+        end
+        def probe(xs, key)
+          out = []
+          xs.each_with_index do |x, i|
+            flag = x == key
+            out << Loc.new(i, flag)
+          end
+          out
+        end
+        acc = 0
+        src = Array.new(30)
+        120.times do |f|
+          src = Array.new(30, f) if f == 40
+          probe(src, f).each { |l| acc += l.a + (l.b ? 1 : 0) }
+        end
+        acc
+        "##,
+    );
+}

--- a/monoruby/tests/bool_op_jit.rs
+++ b/monoruby/tests/bool_op_jit.rs
@@ -1,0 +1,50 @@
+//! `TrueClass`/`FalseClass` operators on polymorphic-on-true/false JIT
+//! sites.
+//!
+//! The JIT profile tags every boolean receiver `BOOL_CLASS`, whose method
+//! lookup answers only while TrueClass and FalseClass resolve the name to
+//! one FuncId (bool_class.rs registers `&`/`|`/`^` that way). boolean.rb's
+//! ruby/spec identity alias used to re-point false's `^` at `|`, breaking
+//! that unification — every `(a < 0) ^ (b < 0)` site then looped through
+//! `MethodNotFound` recompiles and deopted on every execution (dewasm's
+//! `i32_div_s`/`i64_div_s` sign tests, ~700 recompiles in a minute of
+//! DOOM). The alias now points `|` at `^` instead (`false ^ x` and
+//! `false | x` are both `!!x`, and the spec's identity check still
+//! holds), keeping `^` unified; a divergent bool operator (`|`, or a
+//! user redefinition on one class) falls back to the generic dispatch in
+//! the JIT instead of a non-converging recompile.
+extern crate monoruby;
+use monoruby::tests::*;
+
+#[test]
+fn bool_xor_stays_unified() {
+    run_test(
+        r##"
+        def g(a, b) = (a < 0) ^ (b < 0)
+        r = []
+        60.times { |i| r = [g(i - 30, 7), g(i - 30, -7)] }
+        r << (true ^ true) << (true ^ false) << (false ^ true) << (false ^ false)
+        r << (true ^ nil) << (false ^ nil) << (true ^ "x") << (false ^ 0)
+        r
+        "##,
+    );
+}
+
+#[test]
+fn divergent_bool_or_takes_generic_dispatch() {
+    // `|` is the divergent pair now (true keeps its own; false's aliases
+    // to `^`): a hot polymorphic-on-true/false site must neither storm
+    // nor change semantics.
+    run_test(
+        r##"
+        def h(a, b) = (a < 0) | (b < 0)
+        def k(a, b) = (a < 0) & (b < 0)
+        r = []
+        60.times { |i| r = [h(i - 30, 7), k(i - 30, -7)] }
+        r << (true | false) << (false | nil) << (false | 3) << (true | nil)
+        r << (true & 1) << (false & 1) << (true & nil) << (false & nil)
+        r << (false.method(:^) == false.method(:|)) << (true.method(:^) == true.method(:|))
+        r
+        "##,
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -271,6 +271,7 @@
 12ac69d0e3d7829ff39cbbddc61b3277	["elefant", 4]	S = Struct.new(:name, :legs, keyword_init: true)\n            \n\n    
 12b1a598797e50c460f3d7646ca37481	[:y]	class B\n              def x; end\n            end\n            class 
 12cd2297f4d6ac25a476739a253c9292	["RUBZ", "RUBZ", 7, 8, false, true, 7]	class C\n              def succ(s); s.succ; end\n              def po
+12dced64afc93b420fbe2976ff18cf1d	[1, 0, 1, 1, 0, 62499999999999999999999999999999, 1999999999999999999999999999999998, 1000000000000000000000000000000000, 5]	B = 999999999999999999999999999999999\n        def t = [B[0], B[47], B[4
 12f9391c89c11935d8348e594acea735	[[10, 2, 3]]	class C\n          def f(a, b, c)\n            $res << [a, b, c]\n        
 130d9d1858257d1d752139ea21b67095	3240	def outer(n) = ->{ ->{ n } }\n            (1..80).map { |i| outer(i)
 131328b07507899394604b346dd7ea4c	{"A" => 65, "B" => 66}	hash = { "a" => 97, "b" => 98 }\n        hash.to_h {|key, value| [key.up
@@ -1144,6 +1145,7 @@
 573a889f327b5f24c438d7517aacf15a	nil	"hello".byteindex("ll", 3)
 573fe669ac971343defbd1cde20dc915	["MONORUBY_ENV_TEST_KEY", nil]	ENV["MONORUBY_ENV_TEST_KEY"] = "uniq_value_5678"\n            r = EN
 576157356419a5741dbdbde29df95789	true	GC.stat.values.all? { |v| v.is_a?(Integer) }
+577054b1d14b6315e02a2fd981488055	[false, true, false, true, true, false, true, false, false, true]	def g(a, b) = (a < 0) ^ (b < 0)\n        r = []\n        60.times { |i| r
 578de94984c2ccfde4e12e4b109f9b81	[1, 0]	class Hash\n          def []=(k, v)\n            "redef #{k}"\n          e
 57bd29081de5740463b29a1c3ee0ef00	"US-ASCII"	s = "hello".dup.force_encoding("US-ASCII")\n              s[/(ll)/
 57c833a5c1b734fc7100669600389b9b	[nil, nil, nil, 2.5, 3.5, :sym]	def __f(x)\n          \n        a = x.odd? ? nil : "str"\n        b = a\n  
@@ -1275,6 +1277,7 @@
 61999c6ea193c221146e7ca8536ca661	[1, 0, 7, 8, false, true, false, "File", true, true, "A", "B"]	require 'tmpdir'\n            f1 = File.join(Dir.tmpdir, "argf_t1_#{
 61c0d3358404d8b3ec51225d2fe11ce4	ArgumentError	class Integer; def <=>(o); :OVERRIDDEN; end; end\n            begin\n
 61d6a9b0085afd6c0cbfefe4fc3fe618	[true, true, true, Hash]	klass = Class.new(Hash)\n            [\n              klass[].instanc
+61fd9e5f4b3828247ba8a86b2a04db06	[[true, true, false, false, false, true, false, false, true, true, false, true, false, true, false, false], [false, false, true, true, false, true, true, true, false, false, false, true, false, true, false, false], [true, true, false, false, false, true, false, false, true, true, false, true, true, false, false, true], [true, true, false, false, false, true, false, false, true, true, false, true, false, true, false, false], [true, true, false, false, false, true, false, false, true, true, false, true, false, true, false, false], [true, true, false, false, false, true, false, false, true, true, false, true, false, true, false, false]]	BIGP = 0xffff_ffff_ffff_ffff\n        BIGN = -(2**63)\n        def t(x)\n 
 61fdd1242a66df09095c5df145f21012	12	def m(n); eval("BEGIN {return n*3}"); end; m(4)
 6201f6ca2228419027d2e3763e300a6c	:OVERRIDDEN	class Float; def !=(o); :OVERRIDDEN; end; end; 3.0 != 4.0
 62299cb34bf9144c91ccc814afcbeb05	"ab"	$/ = "c"; r = "abc".chomp; $/ = "\\n"; r
@@ -1478,6 +1481,7 @@
 71b94208b971bf119d6f24e1a29ca23a	[1, 2, 3]	class Foo\n              def to_proc\n                Proc.new {|v| $
 71c24f8639e7747006e674bc0fbf4547	256	def f(x)\n          x * 2\n        end\n        def g(x)\n          x + 2\n 
 71d85b9646b325d57ec9e46b0c5bd105	"hello"	class Foo; def to_str; "hello"; end; end\n            String.new(Foo
+71e5d3e78e179f2f4f8f383bbcd87148	[[29, 18446744073709551645, 18446744073709551586, 18446744073709551644, 18446744073709551586, -267477789068788498432, 1152921504606846975, 9223372036854775837], [0, 18446744073709551616, 36893488147419103231, 36893488147419103231, -1, -170141183460469231731687303715884105728, 1152921504606846975, 27670116110564327424], [9223372036854775808, -9223372036854775808, -9223372036854775809, 9223372036854775807, 27670116110564327423, 85070591730234615865843651857942052864, 1152921504606846975, 0]]	BIGP = 0xffff_ffff_ffff_ffff\n        BIGN = -(2**63)\n        def t(x)\n 
 71f4d67c2c270e965eaade7505c22804	[20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 0]	def count(n)\n              i = 0\n              c = 0\n              
 7223f396f3e66e954bb3f1b4f21a88a0	[[:a, :one, [0]], [:a, :two, [0]], [:a, :real, [0]], [:b, :one, [0]], [:b, :two, [0]], [:b_real, 0], [:a, :one, [1]], [:a, :two, [1]], [:a, :real, [1]], [:b, :one, [1]], [:b, :two, [1]], [:b_real, 1]]	class A\n          def method_missing(name, *args) = [:a, name, args]\n  
 7235ebfc85831c502397c3cbb35ce813	Foo	class Foo\n              def bar; end\n            end\n            \n\n
@@ -1583,6 +1587,7 @@
 79df004215796258833bafeb383ba684	5	def f; return 5; end; f()
 79f4d501500e80397f0486c89f664adf	[[-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0], [-7, 7, -8, -1.5, 1.5], [3, -3, 2, 0.25, -0.25], [4611686018427387904, -4611686018427387904, 4611686018427387903, -0.0, 0.0]]	def u(a, b)\n              [-a, +a, ~a, -b, +b]\n            end\n    
 79f521b7a2931ecaf21b4ae269dca011	"AB"	[65, 66].pack("C # first byte\\nC")
+79f83cffe41fecbab6352c9428ed0aa5	[false, false, true, false, true, true, true, false, false, false, true, false]	def h(a, b) = (a < 0) | (b < 0)\n        def k(a, b) = (a < 0) & (b < 0)
 7a214163208727ff855a9c86b078e3e2	[:foo, :bar]	$res = []\n            class C\n              def self.method_added(n
 7a22fbab65c686870df2b5b99250f03d	["bc", "Windows-31J"]	m = /b./s.match("abc".dup.force_encoding(Encoding::Windows_31J))\n               
 7a4714b990c4d0b20606ba3b944a11b0	[Module, 42]	$res = []\n        m = Module.new do |mod|\n          $res << mod.class\n 
@@ -1805,6 +1810,7 @@
 8b1c707195f0233d91b133db6b2549a0	3	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \ns.len
 8b55158395e31dd88ba473b1a6f3e551	true	GC.auto_compact = true; GC.auto_compact
 8b98d44ec4272b482412f750678a9964	1	obj = Object.new\n            def obj.infinite?; -1; end\n           
+8bb7ba05994d18d3475fe6de3651363c	[196, -1, -9223372036854775808, 9223372036854775807, 5, 18446744073709551615, 18446744073709551615, 0, 0]	def s64(x) = x >= 0x8000_0000_0000_0000 ? x - 0x1_0000_0000_0000_0000 :
 8bc4cf0cc800784b3cf613c74c5a0702	[[:init, :body], true, :uninitialized, "must be called with a block", :already, true, 2, 1]	r = []\n            arr = []\n            sub = Class.new(Thread) do\n
 8bc5ef741a233aec240c5b062658f9b1	[4, 2, 4, 2, []]	splat = BasicObject.new\n        def splat.to_a; [2, 3, 4]; end\n        
 8bc9d3da4bf1a6f87b5745a463b34756	0	base = "/tmp/monoruby_dir_openblk_#{Process.pid}_#{rand(100000)}"\n 
@@ -2485,6 +2491,7 @@ be1808a6727b8d3bac7af6a899237547	1	class C; define_method(:m) { |a,| a }; end\n 
 be32db402f76154708fa32e248c791d9	[[:a, :c, nil, true, false], [1, 3, 4, 5, 6, nil], [:int, :float], [:x, :dflt], [:hit, "miss2"], [:one, nil, :int], [30, 110, [1, 2, 3]], [30, nil, 5], [:nan, nil]]	r = []\n            h = { 1 => :a, 5 => :b, 9 => :c }\n            r 
 be4f9b746714ae0e4ffd2af6d6fbee22	[0, 1, 2, 3, 4, 5, 6, 7, 8]	def f(*x)\n          x\n        end\n        \n\n        f(0,1,2,3,4,5,6,7,8
 be742cca1782a87afe5f5416052525fb	["CHUNKED BODY", "chunked body"]	require "socket"\n            s = TCPServer.new("127.0.0.1", 0)\n    
+be788727e64dc4ef73b6181bdb6cd3e8	8200	class R\n          def initialize(n)\n            @n = n\n            @pre
 be89db2e4e8d046b8a6387300e1417a7	[["Other 1\\n", true], [false, "Line 1\\n"], "Other 1\\n", true, true, "Errno::ENOENT", true, true, ["original data", "new data"]]	require 'fcntl'\n            base = "/tmp/monoruby_test_reopenp_#{Pr
 be99d9b9ef932ccac7c6d76c7e115282	[3, 9, 9, 1]	a, b = 3, 9\n            x = [b, a]\n            r = nil\n            
 bea8826dff62c61422cfd5dbadf7f523	[ArgumentError, "invalid byte sequence in UTF-8"]	x = [150].pack("C").force_encoding("utf-8");\n               (/(.).(.)/.match("ab
@@ -2731,6 +2738,7 @@ cffe2bea88b632377cf81196a0f5adbc	:OVERRIDDEN	class Integer; def %(o); :OVERRIDDE
 d005def98ec838cc7d6f37a7bdf0aaa0	[1, 2, 42, 12]	def f(x,y,z=42,w=12)\n            [x,y,z,w]\n        end\n        \n\n      
 d00a59254916621fa57745491676e04c	[true, false]	m = Module.new\n            m.freeze\n            ok = false\n        
 d01f7af924363a6dde43e88de3de59d1	nil	"hello".byteindex("x")
+d02239e9ea6a9ec41f97d63367a30a78	52230	class Loc\n          attr_reader :a, :b\n          def initialize(a, b) =
 d03f3da52be16a5382075d9aea65e40c	[0, true]	class Symbol; def ==(o) = true; end\n        [[:a, :b].index(:z), [:a, :
 d044b1d1eedcdda6f15b67ec84350344	4	"hello".byteindex("o")
 d05976bbfb14033f00937939ab90a32c	36000000	class Lib; def twice(n); n + n; end; end\n        $lib = Lib.new\n       
@@ -3112,6 +3120,7 @@ ed9d8e2f202ed982f57795adbdcbe43f	3	File.write("/tmp/foo", "woo")
 ed9eb5bf08edb4fb19ef55071777ac61	["a", "b"]	def foo(&block)\n        ["a","b"].each { |e| block.call(e) }\n\t    end\n    
 eda7a759e9b973f854bd82f3e9fc91f6	"nil"	begin; raise "a"; rescue; end\n            begin; raise "b"; rescue 
 edb5dbcaeaf97748d60848f2d876bf85	87520950	a = 0\n        for x in 0..20\n          for y in 0..20\n            for z
+edb915162043d994549434f1c1361e14	[true, :redefined]	M = 0xffff_ffff_ffff_ffff\n        def t(x) = x <= M\n        r = []\n    
 edd7521592e8b800133323de5557ca5d	[[1, 0], [2, 1]]	r = []; [1, 2].each.with_index { |v, i| r << [v, i] }; r
 edfa5f14dfb3ce9aa5f33fbf8b2f4c1f	[3, 3]	class C\n              def each_twice(n); r = []; 2.times { r << (yi
 ee0ddcc65de084a835c47f1e8ef4b537	true	Process.clock_gettime(Process::CLOCK_REALTIME, nil).is_a?(Float)


### PR DESCRIPTION
Profiling dewasm's DOOM port (wasm-generated Ruby; the dewasm side is off-limits) surfaced four independent monoruby-side deopt/recompile storms. A 60-tick `--smoke` run paid **~310k deopts + ~700 whole recompiles**; with this PR it pays ~14k (all genuinely dynamic values) and a handful of recompiles.

## 1. IO::Buffer type-symbol resolution cache

`get_value`/`set_value` resolved the type symbol via `IdentId::get_name` — a String allocation + string match per call, sitting under every wasm memory access (~6% of the run in perf: `get_name` 4.3% + `value_type_arg` 1.7% + malloc traffic). Now a lazily built `IdentId → (width, kind, endian)` table.

## 2. Bool `^` re-unified + generic fallback for divergent bool operators

`bool_class.rs` deliberately registers `&`/`|`/`^` with **one FuncId on both TrueClass and FalseClass** so a polymorphic-on-true/false site can use the unified `BOOL_CLASS` inline cache. boolean.rb's ruby/spec identity alias (`class FalseClass; alias ^ |`) silently broke that for `^` — and a BOOL-profiled `^` site then looped through `MethodNotFound` recompiles forever (`jit_check_method(BOOL_CLASS, :^)` can never answer). dewasm's `(a < 0) ^ (b < 0)` sign tests in `i32_div_s`/`i64_div_s`: 466+227 recompiles + ~9k deopts per run; a standalone hot loop showed **99,962 deopts / 100k calls**.

- The alias now points `|` at `^` (for `false` both are `!!other`, and `false.method(:^) == false.method(:|)` still holds), keeping `^` unified — the site compiles to a plain direct call, zero deopts.
- A bool operator with **no** unified resolution (now `|`, or a user redefinition on one class) falls back to the generic dispatch instead of the non-converging recompile — closing the storm hole for the whole class of divergent bool methods.

## 3. Bignum-constant comparisons fold; bignum-constant arithmetic declines

`Rt#m64` / `Rt#s64` sit under every 64-bit wasm op and compare against `0xffff_ffff_ffff_ffff` / `0x8000_0000_0000_0000` — always heap Integers, on which the integer lowering's **fixnum-tag guard** landed and failed on every execution (~42k deopts/run; the same disease ActiveModel's `1 << 63` comparison is on record for).

- A comparison with exactly one bignum-constant operand now folds to its **sign-decided answer** (any fixnum < a positive bignum, etc.) under a fixnum guard on the variable side only — value form and fused compare-branch form both, gated on bop assumability with the dependency recorded (redefining `Integer#<=` evicts it; pinned in a test).
- Bignum **literals** (`x >= 0x8000_…`) fold to `LinkMode::C` like constant-cache bignums, so the fold sees them.
- Integer **arithmetic** with a bignum-constant operand (`x & M64`) declines to the direct builtin call instead of the doomed fixnum path.
- A compile-time constant **receiver** (`M64 - x`) skips the method-call class guard — its class is a static fact — but counts as set-guarded, so no raw-load inline generator (`Integer#[]`, `#>>`, `#succ`…) fires on an unrefined heap value. (Two earlier drafts of this change were caught emitting raw pointer shifts by the new tests; the final shape keeps `GuardClass(INTEGER)`'s dual role — class check *and* fixnum-representation proof — intact everywhere a generator relies on it.)

Semantics verified byte-identical to CRuby 4.0 over a 54-case boundary matrix (both orientations, fixnum-window edges, bignum arguments deopting through the fold's guard, floats, redefinition).

## 4. Block-root receiver-guard heal (the 296k renderer storm)

The largest single source: DOOM's terminal renderer compares `prev_row[cx] == key` inside a nested block — `nil` on the first frame, Integer forever after. The block body whole-compiles during frame 1 with a NilClass guard, and `recv_miss_recompile_target` returned **`None` for block ROOTs**, so the `Learn`-mode heal (#1156) never fired: one plain deopt per cell per frame, **296,000/minute**, with the VM interpreting the rest of each block invocation. This was #1156's documented known residual (the activerecord `deserialize` block), guarding against a #1127-era recompile path that rebuilt blocks under the method argument convention.

The compile pipeline has been iseq-driven and identical for initial compile and recompile since the abstract-state unification (#1171/#1194), so the exclusion is stale: lifted, the storm heals with one counter-gated recompile (~10 deopts total in the repro), the full suite passes, and the #1127 breakage shape (a block forwarding its argument to a constructor across the recompile) is pinned in a new test.

## Testing

- Full suite **3572/3572** (three new test files: `bigint_const_ops`, `bool_op_jit`, `block_root_recv_miss_heal`)
- 54-case bignum matrix + bool-op semantics diffed against live CRuby 4.0
- DOOM: deopt total ~310k → ~14k, recompiles ~700 → ~10; interleaved A/B on the 60-tick smoke ~+8% for items 1–3 (the smoke is warmup/compile-dominated, so steady-state gains are larger); fib/optcarrot-family unchanged
- All changes are arch-neutral front-end (state/jitgen), so aarch64 inherits them

🤖 Generated with [Claude Code](https://claude.com/claude-code)