### PR TITLE
JIT: surrender only the outgoing block's home chain, not every frame

### DIFF
--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -760,9 +760,15 @@ impl<'a> JitContext<'a> {
                 }
                 // Not inlined: the block becomes a unit of its own, and
                 // whatever it stores it stores where we cannot see it. So
-                // hand the whole lexical chain over in its slots and keep
+                // hand the block's home chain over in its slots and keep
                 // no claim about any of it, exactly as a call that passes a
-                // block to a callee outside the unit does.
+                // block to a callee outside the unit does. When
+                // `resolve_given_block` pinned the block to an in-unit
+                // literal (`block_info.outer` frames up — a builtin-bodied
+                // block, or a dispatch arm), that home chain is in this
+                // state; otherwise the block came in through the root's own
+                // block argument, its home lies outside the unit, and no
+                // in-chain frame is reachable through it.
                 //
                 // Belt and braces with the `generic_yield` flag below: the
                 // flag settles what the *caller* may still believe when
@@ -772,7 +778,10 @@ impl<'a> JitContext<'a> {
                 // and the lexical chain stops at the enclosing method). One
                 // does not cover the other, and neither is worth resting on
                 // a per-case proof.
-                state.all_frames_unbox_to_S(self, ir);
+                let home = self.current_method_given_block().and_then(|bi| {
+                    state.innermost_level().checked_sub(bi.outer)
+                });
+                state.unbox_to_S_for_outgoing_block(self, ir, home);
                 self.set_generic_yield();
                 state.compile_yield(ir, &self.store, callid);
             }

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -451,7 +451,11 @@ impl<'a> JitContext<'a> {
             if inlined_block {
                 state.locals_unbox_to_S_keeping_claims(ir);
             } else {
-                state.all_frames_unbox_to_S(self, ir);
+                // The literal block handed out here is homed in the
+                // current frame: it can reach that frame and its lexical
+                // ancestors, and nothing else in the chain.
+                let home = state.innermost_level();
+                state.unbox_to_S_for_outgoing_block(self, ir, Some(home));
             }
         }
 

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -948,7 +948,7 @@ pub(crate) struct JitContext<'a> {
     ///
     /// Stage-C loop adoption: set when this context compiled anything
     /// that can rewrite an outer frame's slot *invisibly* — a call that
-    /// hands a block out of the unit (`all_frames_unbox_to_S`), a call
+    /// hands a block out of the unit (`unbox_to_S_for_outgoing_block`), a call
     /// site forwarding an explicit `&blk`, or a capture event. A loop
     /// analysed while this fires must not adopt an outer view: the
     /// compile-time widen hooks do not cover such stores, so the adopted
@@ -1514,7 +1514,7 @@ impl<'a> JitContext<'a> {
     /// believing a mode this store just invalidated.
     ///
     /// A frame's locals cross a call boundary with their `Guarded` intact
-    /// (`all_frames_unbox_to_S`), which is only sound if a callee that
+    /// (`unbox_to_S_for_outgoing_block`), which is only sound if a callee that
     /// writes one of them says so: an `S(Guarded::Float)` a callee stores
     /// a String into would otherwise still be read as a Float once the
     /// call returns.

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -219,7 +219,7 @@ impl AbstractState {
     /// Nothing is reported to the context here. A bridge relocates or
     /// materialises a value; it never *changes* one, so it has nothing to
     /// tell the frame that owns the slot. Only a store the compiler cannot
-    /// see behind does — `store_dynvar` and `all_frames_unbox_to_S`.
+    /// see behind does — `store_dynvar` and `unbox_to_S_for_outgoing_block`.
     ///
     pub(super) fn gen_bridge_all(
         mut self,
@@ -272,24 +272,56 @@ impl AbstractState {
     }
 
     ///
-    /// The same over *every* frame of this compilation, keeping no
-    /// constant.
+    /// The same over the frames an outgoing block can actually reach:
+    /// its home frame (chain position `home_level`) and the home's
+    /// *lexical* ancestors, keeping no constant there.
     ///
     /// What a call that hands a block to a callee outside this unit needs.
     /// The block is compiled on its own, so its stores never reach
-    /// `store_dynvar`'s hook — and it can reach not only this frame but,
-    /// through its own outer chain, every frame further out.
+    /// `store_dynvar`'s hook — but the frames those stores (and reads)
+    /// can land in are exactly the block's own outer chain, which is the
+    /// home's lexical chain, not the whole state chain. A suspended
+    /// *method* caller outside that chain keeps its views and claims —
+    /// the same reachability argument `unbox_to_S_at` already makes for
+    /// the pool-`F` binding, and the blanket walk's demotion of those
+    /// frames was pure pessimization (the same lesson
+    /// `unset_lexical_no_capture_guard` records for the invariants).
+    ///
+    /// `home_level == None` means the block's home lies outside this
+    /// unit (the root's own block argument reaching a generic `yield`):
+    /// no in-chain frame is reachable, so only the adoption barrier is
+    /// raised — mirroring what an explicit `&blk` hand-off has always
+    /// done (`compile_method_call`'s entry).
     ///
     #[allow(non_snake_case)]
-    pub(super) fn all_frames_unbox_to_S(&mut self, jitctx: &mut JitContext, ir: &mut AsmIr) {
+    pub(super) fn unbox_to_S_for_outgoing_block(
+        &mut self,
+        jitctx: &mut JitContext,
+        ir: &mut AsmIr,
+        home_level: Option<usize>,
+    ) {
         // Stage-C loop adoption: a block leaves the unit here — its
         // runtime stores bypass every compile-time widen hook, and its
         // lexical chain can reach frames this state chain does not
         // (a forwarded block's home). No outer view adopts across this.
         jitctx.set_outer_claim_barrier();
+        let Some(home_level) = home_level else {
+            return;
+        };
         let depth = self.frames.len();
+        // The home chain: `home_level` and its lexical ancestors — the
+        // same walk as `unset_lexical_no_capture_guard`.
+        let mut levels = vec![];
+        let mut level = home_level;
+        loop {
+            levels.push(level);
+            match self.frames[level].lexical_outer() {
+                Some(o) if level >= o && o > 0 => level -= o,
+                _ => break,
+            }
+        }
         let mut widened = vec![];
-        for level in (0..depth).rev() {
+        for level in levels {
             let outer = depth - 1 - level;
             for i in self.frames[level].locals() {
                 match self.frames[level].unbox_to_S_at(ir, i, outer) {
@@ -323,6 +355,11 @@ impl AbstractState {
         for (pos, slot) in widened {
             jitctx.widen_outer_at_pos(pos, slot);
         }
+    }
+
+    /// Chain position of the innermost (current) frame.
+    pub(super) fn innermost_level(&self) -> usize {
+        self.frames.len() - 1
     }
 
     pub(super) fn equiv(&self, other: &Self) -> bool {

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -2601,7 +2601,7 @@ impl AbstractFrame {
     /// give the claim up, for the reason above. Most claims go with
     /// nothing emitted; a stage-1'' deferred `F(spill home)` — whose slot
     /// is genuinely stale — reports [`OuterBarrier::BoxHome`] so the
-    /// caller ([`AbstractState::all_frames_unbox_to_S`]) can emit the
+    /// caller ([`AbstractState::unbox_to_S_for_outgoing_block`]) can emit the
     /// box-from-home surrender write through the chain.
     ///
     #[allow(non_snake_case)]

--- a/monoruby/tests/block_surrender_narrowing.rs
+++ b/monoruby/tests/block_surrender_narrowing.rs
@@ -1,0 +1,77 @@
+//! Handing a block out of a JIT unit surrenders only the block's home
+//! chain, not every frame of the state chain.
+//!
+//! `unbox_to_S_for_outgoing_block` (né `all_frames_unbox_to_S`) used to
+//! demote every frame's float views and constants when any block left
+//! the unit; a block can only reach its home frame and that frame's
+//! lexical ancestors, so a suspended *method* caller elsewhere in the
+//! specialization chain keeps its views now. These shapes pin the
+//! semantics of exactly the narrowed paths, with float state alive in
+//! the frames that are (and are not) reachable — the stress-spill-pool
+//! feature exercises the same shapes with a shrunken FPR pool.
+extern crate monoruby;
+use monoruby::tests::*;
+
+#[test]
+fn suspended_caller_floats_survive_block_handout() {
+    // outer_m's float local is live across a specialized call to inner,
+    // which hands a block literal to a builtin (non-inlinable block →
+    // the surrender path). The block's home is inner's frame; outer_m's
+    // frame must keep computing correctly without being surrendered.
+    run_test(
+        r##"
+        def inner(k)
+          arr = [k + 2, k, k + 1]
+          arr.sort! { |a, b| b <=> a }
+          arr[0] + 0.25
+        end
+        def outer_m(x)
+          f = x * 1.5
+          g = inner(3)
+          f + g
+        end
+        r = 0.0
+        60.times { |i| r += outer_m(i) }
+        r
+        "##,
+    );
+}
+
+#[test]
+fn generic_yield_with_outside_home() {
+    // yield in a root unit: the block's home is the root's caller,
+    // outside the unit — no in-chain frame is reachable, and the root's
+    // own float locals stay live across the yield.
+    run_test(
+        r##"
+        def leaf(i)
+          q = 1.25 * i
+          t = yield 3
+          q + t
+        end
+        r = 0.0
+        60.times { |i| r += leaf(i) { |v| v + i } }
+        r
+        "##,
+    );
+}
+
+#[test]
+fn block_writes_into_its_home_chain() {
+    // The handed block writes its home's local: the home chain must
+    // still be surrendered (stale views dropped) so the write is
+    // observed after the call.
+    run_test(
+        r##"
+        def collect(n)
+          acc = 0.0
+          sink = [3, 1, 2]
+          sink.sort! { |a, b| acc += 0.5; a <=> b }
+          acc + sink[0]
+        end
+        r = 0.0
+        60.times { r += collect(3) }
+        r
+        "##,
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -216,6 +216,7 @@
 0e54a426c81dbbf91db0373ac6572904	["qy", "sx", 2]	def sapp(s, a)\n          s.<<(*a)\n        end\n        def papp(o)\n     
 0e56d42fa329cec66eaa8a31dadafef0	[true, true]	def m; proc{|x| x}; end; p = m; [p.dup.eql?(p), p.dup.hash == p.hash]
 0e58e78424730044c7b8bdc310bb26e6	["Fri Dec 12 ", "Fri Dec 12 ", "Fri", "Dec", "12", 4, ["Fri", "Dec", "12"], ["Fri Dec 12 ", "Dec"], "Fri Dec 12 ", true, 11, "", "1975 14:39", 11, 0, "Fri"]	require "strscan"\n        s = StringScanner.new("Fri Dec 12 1975 14:39"
+0e7e3c1fe18a8cbea4e15f4300b4c145	150.0	def collect(n)\n          acc = 0.0\n          sink = [3, 1, 2]\n         
 0eb451479b9e3deffa5ff499cb00893c	[:private_answer]	class P\n          def method_missing(name, *args) = :missed\n          p
 0ed19825320ad4f01be8637520de3fe5	[[0, 0, 0], [0, 1, 0], [1, 0, 0], [1, 1, 0], [2, 0, 0], [2, 1, 0]]	res = []\n        3.times do |i|\n          2.times do |j|\n            1.
 0ed9e8d09d16c423c6e622570359536f	[["MONORUBY_ENV_TEST_ASSOC", "yes"], nil]	ENV["MONORUBY_ENV_TEST_ASSOC"] = "yes"\n            r = ENV.assoc("M
@@ -2185,6 +2186,7 @@ a7e6e135e95d618e3ae7fc235b8624b8	17158183388.626425	def calc(i)\n              f
 a7ea202d40851dfadabc161faaaaffb7	true	GC.config({}) == GC.config
 a800cb1d66d4f7c50d700a30535cce0f	["UTF-16LE", [97, 0, 98, 0, 99, 0]]	File.write("/tmp/mr_rd2.txt", "abc")\n            r = []\n           
 a8018262ffba8fba491e3b1e7bcd20b9	42	module M\n              @x = 42\n              remove_instance_variab
+a81d22f2a88cfcc16513b0ca5f20189b	2970.0	def inner(k)\n          arr = [k + 2, k, k + 1]\n          arr.sort! { |a
 a86010e766462d5eea966a5e9133b6f0	[nil, true, nil, true]	a = Signal.trap(:EXIT, proc { })\n            b = Signal.trap(:EXIT,
 a87019ce1fb4a58da98eb0fcd22f397c	[1.0, "caught", 2.0, "caught", 3.0, "done"]	x = 0.0\n            $res = []\n            begin\n              x += 
 a88bdad4ba8d9e033a1c6a53c309f4ea	["42", 100]	class C\n          def [](idx)\n            idx.to_s\n          end\n      
@@ -2435,6 +2437,7 @@ ba4ff971390140cc452d6a37019cd25e	["hello", "hellohellohellohellohellohellohelloh
 ba657172c9c846fc29d3c12c19422d81	3	m = Mutex.new\n            cv = ConditionVariable.new\n            wo
 ba6f639d6a80fdb3a0102d2205ebee91	[["one x\\n", "two x\\n", "\\n", "\\n", "\\n", "three\\n", "four\\n"], ["one x\\ntwo x\\n\\n", "three\\nfour\\n"], ["one ", "x\\n", "two ", "x\\n", "\\n", "\\n", "\\n", "thre", "e\\n", "four", "\\n"], ["one ", "\\ntwo ", "\\n\\n\\n\\nthree\\nfour\\n"], "invalid limit: 0 for each_line", ["one x", "two x", "", "", "", "three", "four"], [], ["one x\\ntw", "o x\\n\\n"], 7, ["one x", "two x", ""], ["one", " x", "\\ntw", "o x", "\\n\\n\\n", "\\nth", "ree", "\\nfo", "ur\\n"], 1, :t1, :t2, [["one x\\n", 1], ["two x\\n", 2], ["\\n", 3], ["\\n", 4], ["\\n", 5], ["three\\n", 6], ["four\\n", 7]], "nil", ["one x\\n", "two x\\n", "\\n", "\\n", "\\n", "three\\n", "four\\n"], ["one x\\ntwo x", "three\\nfour\\n"], "nil", 7, 7, :notread, ""]	require "tempfile"\n            t = Tempfile.new("mrb_lines")\n      
 ba7058a9f888bace3485573d10433a9e	true	M = Data.define(:amount, :unit)\nm = M.new(42, "km"); m.with.equal?(m)
+ba70657eca5ff02438e4ed7fd9465199	4162.5	def leaf(i)\n          q = 1.25 * i\n          t = yield 3\n          q + 
 ba73e17b465fecb689735f04e9f7047e	[1, 2, "l1\\nl2\\n"]	path = "/tmp/mr_gvar_lines.txt"\n            File.write(path, "l1\\nl
 ba8132b4a761c3cc445f79982ea307f1	[:frozen, :frozen, 1]	klass = Class.new; klass.freeze\n            r1 = begin; klass.class
 ba8abe11f8c7c450d64cf7c0c8aaeef7	:finished	ec = Encoding::Converter.new("UTF-8", "ISO-8859-1")\n             


### PR DESCRIPTION
Stage 1 of the compile-cost work on the abstract-state tower (the DOOM profile shows the JIT front-end + its allocation churn at ~65-70% of steady-state CPU, dominated by mega-units whose nested specializations clone/join the whole frame chain).

## What

Handing a block out of a unit — a non-inlinable literal at a call site, or a generic `yield` — ran `all_frames_unbox_to_S` over **every** frame of the state chain. But a block can only reach its home frame and that frame's *lexical* ancestors: the same reachability argument `unbox_to_S_at` already makes for the pool-`F` binding, and the same lesson `unset_lexical_no_capture_guard` records for the invariants ("the old blanket poisoned suspended method callers a capture cannot touch"). Demoting a suspended method caller's `Sf`/`C` views elsewhere in the specialization chain was pure pessimization.

`unbox_to_S_for_outgoing_block(home_level)` now walks only the home's lexical chain:

- **literal handed at the call site** → home is the current frame; its lexical chain is surrendered as before
- **generic `yield`** → `current_method_given_block()` pins the owning frame (`JitBlockInfo::outer` up the positionally-aligned chain); that home chain is surrendered
- **unresolvable** → the block came in through the root's own block argument, its home lies outside the unit, and no in-chain frame is reachable: only the Stage-C adoption barrier is raised — exactly what an explicit `&blk` hand-off has always done (`compile_method_call`'s entry)

## Why now

Besides keeping float views alive across block-handing calls, this is the enabler for parking non-lexical suspended callers outside `AbstractState` (the next stage): after the narrowing, no surrender writes into those frames from an inner compile, so the remaining positional writers are down to the loop-entry adoption and the specialization-boundary machinery itself.

## Testing

- Full suite **3572/3572**, both default and `--features stress-spill-pool` (the shrunken-FPR-pool stress that exercises exactly these spill/surrender paths)
- New shapes pinned in `tests/block_surrender_narrowing.rs`: a suspended caller's float local across a block hand-out in a specialized callee; a root-unit `yield` whose block's home is outside the unit; a handed block writing into its home chain
- DOOM smoke unchanged (8.9 ticks/sec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)