### PR TITLE
JIT: share abstract-state frames by identity (Rc chain, ptr_eq fast paths)

### DIFF
--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -16,12 +16,12 @@ use crate::{
 pub(crate) use crate::basic_block::{BasicBlockId, BasicBlockInfoEntry};
 pub(crate) use self::context::JitContext;
 pub(crate) use self::state::{AbstractFrame, AbstractState};
-use state::{DeoptPoint, LinkMode, ReturnState};
+use state::{FrameRef, DeoptPoint, LinkMode, ReturnState};
 
 use super::*;
 use asmir::*;
 use context::{JitArgumentInfo, JitType};
-use state::{Liveness, SlotState};
+use state::Liveness;
 use trace_ir::*;
 
 pub mod asmir;

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -20,7 +20,7 @@ impl<'a> JitContext<'a> {
     pub(super) fn traceir_to_asmir(
         &mut self,
         frame: JitStackFrame,
-        entry_chain: Option<Vec<AbstractFrame>>,
+        entry_chain: Option<Vec<FrameRef>>,
     ) -> JitResult<JitStackFrame> {
         self.push_frame(frame);
 

--- a/monoruby/src/codegen/jitgen/compile/dispatch.rs
+++ b/monoruby/src/codegen/jitgen/compile/dispatch.rs
@@ -121,7 +121,7 @@ impl<'a> JitContext<'a> {
         // merge state inherited an empty file from `declare_merge`, so every
         // arm has to pay its own residents back to their stack homes first.
         arm.flush_gp(ir);
-        arm.gen_bridge_all(ir, &m.target.slot_states(), m.pc, &self.chain_surrender_table());
+        arm.gen_bridge_all(ir, &m.target.frames_cloned(), m.pc, &self.chain_surrender_table());
         if jump {
             ir.push(AsmInst::Br(m.merge));
         }

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -474,7 +474,7 @@ pub(super) struct JitStackFrame {
     ///
     return_edges: Vec<(
         JitLabel,
-        Vec<AbstractFrame>,
+        Vec<FrameRef>,
         AbstractFrame,
         SlotId,
         BasicBlockId,
@@ -524,7 +524,7 @@ pub(super) struct JitStackFrame {
     /// Outer frames are carried because a block handed out of the unit can
     /// write their locals, so their modes have to be merged (and written
     /// back) at the loop head like the innermost frame's.
-    backedge_map: HashMap<BasicBlockId, Vec<SlotState>>,
+    backedge_map: HashMap<BasicBlockId, Vec<FrameRef>>,
     ///
     /// Contexts for returning from this frame.
     ///
@@ -1355,7 +1355,7 @@ impl<'a> JitContext<'a> {
             // resuming level" only at its own caller's resume, where this
             // same rule applies.
             let joined_caller = chain.last().unwrap().clone();
-            *chain.last_mut().unwrap() = innermost;
+            *chain.last_mut().unwrap() = FrameRef::new(innermost);
             state.set_frames(chain);
             state.overlay_kept_constants_innermost(joined_caller.slot_state());
         } else {
@@ -1368,7 +1368,7 @@ impl<'a> JitContext<'a> {
             // arrives here — and every later merge's claims are
             // established by its *reachable* entries' bridges.
             let mut chain = fallback_chain;
-            *chain.last_mut().unwrap() = innermost;
+            *chain.last_mut().unwrap() = FrameRef::new(innermost);
             state.set_frames(chain);
             for (pos, slot) in self.widened_outer_log[widen_mark..].to_vec() {
                 state.invalidate_at(pos, slot);
@@ -1766,13 +1766,13 @@ impl<'a> JitContext<'a> {
     /// frame) covers both. Lexical (dynvar) addressing walks the per-frame
     /// links, exactly as [`Self::outer_pos`] walks `stack_frame`.
     ///
-    pub(super) fn trace_contexts(&self) -> Vec<AbstractFrame> {
+    pub(super) fn trace_contexts(&self) -> Vec<FrameRef> {
         let end = self.stack_frame.len() - 1;
         (0..end)
             .map(|pos| {
                 let mut f = self.stack_frame[pos].abstract_state.clone().unwrap();
                 f.set_lexical_outer(self.stack_frame[pos].outer);
-                f
+                FrameRef::new(f)
             })
             .collect()
     }
@@ -2630,7 +2630,7 @@ impl<'a> JitContext<'a> {
         self.current_frame_mut().branch_map.remove(&bb)
     }
 
-    pub(super) fn remove_backedge(&mut self, bb: BasicBlockId) -> Option<Vec<SlotState>> {
+    pub(super) fn remove_backedge(&mut self, bb: BasicBlockId) -> Option<Vec<FrameRef>> {
         self.current_frame_mut().backedge_map.remove(&bb)
     }
 
@@ -2717,7 +2717,7 @@ impl<'a> JitContext<'a> {
     ///
     /// Add new backward branch from *src_idx* to *dest* with `state`.
     ///
-    pub(super) fn new_backedge(&mut self, target: Vec<SlotState>, bb_pos: BasicBlockId) {
+    pub(super) fn new_backedge(&mut self, target: Vec<FrameRef>, bb_pos: BasicBlockId) {
         #[cfg(feature = "jit-debug")]
         eprintln!("   new_backedge:{bb_pos:?} {target:?}");
         self.current_frame_mut().backedge_map.insert(bb_pos, target);
@@ -2791,16 +2791,21 @@ impl<'a> JitContext<'a> {
         crate::codegen::jitgen::state::ChainSurrender { per_level }
     }
 
-    fn build_return_segments(&mut self, frame: &mut JitStackFrame) -> Option<Vec<AbstractFrame>> {
+    fn build_return_segments(&mut self, frame: &mut JitStackFrame) -> Option<Vec<FrameRef>> {
         let edges = std::mem::take(&mut frame.return_edges);
         if edges.is_empty() {
             return None;
         }
-        let mut target: Vec<AbstractFrame> = edges[0].1.clone();
+        let mut target: Vec<FrameRef> = edges[0].1.clone();
         for (_, chain, ..) in edges.iter().skip(1) {
             debug_assert_eq!(target.len(), chain.len());
             for (t, e) in target.iter_mut().zip(chain.iter()) {
-                t.join_no_alloc(e);
+                // Identity fast path: the frame no path has touched joins
+                // with itself — a pointer compare instead of a slot walk.
+                if FrameRef::ptr_eq(t, e) {
+                    continue;
+                }
+                FrameRef::make_mut(t).join_no_alloc(e);
             }
         }
         for (seg, chain, mut inner, ret_slot, bbid) in edges {

--- a/monoruby/src/codegen/jitgen/merge.rs
+++ b/monoruby/src/codegen/jitgen/merge.rs
@@ -279,7 +279,7 @@ impl<'a> JitContext<'a> {
             // the deopt resume past the fused BinCmp into the bare
             // CondBr, which then reads a stale `%dst` — see #480.
             self.gen_bridges_for_branches(&target, entries, bbid, pc, &outer_inits);
-            self.new_backedge(target.slot_states(), bbid);
+            self.new_backedge(target.frames_cloned(), bbid);
 
             Some(target)
         } else {
@@ -308,7 +308,7 @@ impl<'a> JitContext<'a> {
         pc: BytecodePtr,
         outer_inits: &[(Vec<SpecializedId>, usize, SlotId, OuterFprHome)],
     ) {
-        let target = target.slot_states();
+        let target = target.frames_cloned();
         #[cfg(feature = "jit-debug")]
         eprintln!("  bridge to:{bbid:?} target:{target:?}");
         for BranchEntry {

--- a/monoruby/src/codegen/jitgen/state.rs
+++ b/monoruby/src/codegen/jitgen/state.rs
@@ -14,21 +14,33 @@ pub(in crate::codegen::jitgen) use slot::SfGuarded;
 pub(in crate::codegen::jitgen) use slot::DynVarAliasLoad;
 pub(super) use slot::{Guarded, LinkMode, SlotState};
 
+/// A frame of the abstract-state chain, shared by reference.
+///
+/// The `Rc` pointer is the frame's *identity*: a chain clone bumps
+/// refcounts instead of deep-copying `SlotState`s, a mutation goes
+/// through `Rc::make_mut` (copy-on-write — untouched sharers keep the
+/// old version), and `Rc::ptr_eq` is the O(1) same-frame check the
+/// merge machinery uses to skip frames no path has touched. In a deep
+/// specialization tower the outer frames — the *largest* ones, with the
+/// root at the far end — are exactly the ones nothing touches, so every
+/// per-slot walk over them collapses to a pointer compare.
+pub(in crate::codegen::jitgen) type FrameRef = std::rc::Rc<AbstractFrame>;
+
 #[derive(Debug, Clone)]
 pub(crate) struct AbstractState {
-    frames: Vec<AbstractFrame>,
+    frames: Vec<FrameRef>,
 }
 
 impl std::ops::Deref for AbstractState {
     type Target = AbstractFrame;
     fn deref(&self) -> &Self::Target {
-        &self.frames.last().unwrap()
+        self.frames.last().unwrap()
     }
 }
 
 impl std::ops::DerefMut for AbstractState {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.frames.last_mut().unwrap()
+        FrameRef::make_mut(self.frames.last_mut().unwrap())
     }
 }
 
@@ -41,21 +53,21 @@ impl std::ops::Index<usize> for AbstractState {
 
 impl std::ops::IndexMut<usize> for AbstractState {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.frames[index]
+        FrameRef::make_mut(&mut self.frames[index])
     }
 }
 
 impl AbstractState {
     /// Nested compile entry from the caller's live chain (B3a, gated).
-    pub(super) fn with_chain(jitctx: &JitContext, chain: Vec<AbstractFrame>) -> Self {
+    pub(super) fn with_chain(jitctx: &JitContext, chain: Vec<FrameRef>) -> Self {
         let mut frames = chain;
         let mut current = AbstractFrame::new(jitctx);
         current.set_lexical_outer(jitctx.current_frame_lexical_outer());
-        frames.push(current);
+        frames.push(FrameRef::new(current));
         AbstractState { frames }
     }
 
-    pub(super) fn frames_cloned(&self) -> Vec<AbstractFrame> {
+    pub(super) fn frames_cloned(&self) -> Vec<FrameRef> {
         self.frames.clone()
     }
 
@@ -68,7 +80,7 @@ impl AbstractState {
         let mut frames = jitctx.trace_contexts();
         let mut current = AbstractFrame::new(jitctx);
         current.set_lexical_outer(jitctx.current_frame_lexical_outer());
-        frames.push(current);
+        frames.push(FrameRef::new(current));
         AbstractState { frames }
     }
 
@@ -91,10 +103,7 @@ impl AbstractState {
     /// (the resume overlay — see `specialized_compile`).
     ///
     pub(super) fn overlay_kept_constants_innermost(&mut self, joined: &SlotState) {
-        self.frames
-            .last_mut()
-            .unwrap()
-            .overlay_kept_constants(joined);
+        FrameRef::make_mut(self.frames.last_mut().unwrap()).overlay_kept_constants(joined);
     }
 
     ///
@@ -102,7 +111,7 @@ impl AbstractState {
     /// loop-entry adoption whose owner is found by trace position.
     ///
     pub(super) fn set_outer_sf_at(&mut self, pos: usize, slot: SlotId, fpr: FPReg) {
-        let frame = &mut self.frames[pos];
+        let frame = FrameRef::make_mut(&mut self.frames[pos]);
         frame.grow_fpr_to(fpr.0 + 1);
         frame.set_Sf(slot, fpr, SfGuarded::Float);
     }
@@ -119,7 +128,10 @@ impl AbstractState {
     /// dropped at a join is never re-issued to a transient.
     ///
     pub(super) fn grow_frame_fpr_to(&mut self, pos: usize, len: usize) {
-        self.frames[pos].grow_fpr_to(len);
+        // Growing to the current length must not break sharing.
+        if self.frames[pos].fpr_len() < len {
+            FrameRef::make_mut(&mut self.frames[pos]).grow_fpr_to(len);
+        }
     }
 
     ///
@@ -130,20 +142,20 @@ impl AbstractState {
     ///
     pub(super) fn invalidate_at(&mut self, pos: usize, slot: SlotId) {
         if let Some(frame) = self.frames.get_mut(pos) {
-            frame.invalidate_slot(slot);
+            FrameRef::make_mut(frame).invalidate_slot(slot);
         }
     }
 
     pub(super) fn innermost_clone(&self) -> AbstractFrame {
-        self.frames.last().unwrap().clone()
+        (**self.frames.last().unwrap()).clone()
     }
 
-    pub(super) fn chain_prefix(&self, pos: usize) -> Vec<AbstractFrame> {
+    pub(super) fn chain_prefix(&self, pos: usize) -> Vec<FrameRef> {
         debug_assert!(pos < self.frames.len());
         self.frames[..=pos].to_vec()
     }
 
-    pub(super) fn set_frames(&mut self, frames: Vec<AbstractFrame>) {
+    pub(super) fn set_frames(&mut self, frames: Vec<FrameRef>) {
         debug_assert_eq!(frames.len(), self.frames.len());
         self.frames = frames;
     }
@@ -165,7 +177,7 @@ impl AbstractState {
             return;
         }
         if let Some(level) = self.outer_level(outer) {
-            let frame = &mut self.frames[level];
+            let frame = FrameRef::make_mut(&mut self.frames[level]);
             frame.grow_fpr_to(fpr.0 + 1);
             frame.set_Sf(slot, fpr, SfGuarded::Float);
         }
@@ -175,7 +187,7 @@ impl AbstractState {
     /// boxed slot store made the slot current, so `S` is sound).
     #[coverage(off)] // only called from the dormant drain — see `drain_kept_outer_views`
     pub(super) fn invalidate_innermost(&mut self, slot: SlotId) {
-        self.frames.last_mut().unwrap().invalidate_slot(slot);
+        FrameRef::make_mut(self.frames.last_mut().unwrap()).invalidate_slot(slot);
     }
 
     ///
@@ -186,7 +198,10 @@ impl AbstractState {
     ///
     pub(super) fn mark_outer_float_read(&mut self, outer: usize, slot: SlotId) {
         if let Some(level) = self.outer_level(outer) {
-            self.frames[level].mark_subtree_float_read(slot);
+            // A monotone hint: skip the copy-on-write when already set.
+            if !self.frames[level].subtree_float_read(slot) {
+                FrameRef::make_mut(&mut self.frames[level]).mark_subtree_float_read(slot);
+            }
         }
     }
 
@@ -195,15 +210,11 @@ impl AbstractState {
             return;
         }
         if let Some(level) = self.outer_level(outer) {
-            self.frames[level].invalidate_slot(slot);
+            FrameRef::make_mut(&mut self.frames[level]).invalidate_slot(slot);
         }
     }
 
-    /// Every frame's `SlotState`, innermost last — the loop-entry shape
-    /// each back edge is bridged to.
-    pub(super) fn slot_states(&self) -> Vec<SlotState> {
-        self.frames.iter().map(|f| f.slot_state().clone()).collect()
-    }
+
 
     ///
     /// Bridge every frame of this compilation to *target*, not just the
@@ -224,7 +235,7 @@ impl AbstractState {
     pub(super) fn gen_bridge_all(
         mut self,
         ir: &mut AsmIr,
-        target: &[SlotState],
+        target: &[FrameRef],
         pc: BytecodePtr,
         sur: &ChainSurrender,
     ) {
@@ -233,11 +244,18 @@ impl AbstractState {
         let depth = self.frames.len();
         debug_assert_eq!(depth, target.len());
         for (level, tgt) in target.iter().enumerate().rev() {
+            // Identity fast path: bridging a frame to itself moves
+            // nothing — a pointer compare instead of a slot walk over
+            // every suspended frame at every merge edge.
+            if FrameRef::ptr_eq(&self.frames[level], tgt) {
+                continue;
+            }
+            let tgt: &SlotState = tgt;
             // `level` counts from the outermost frame; `outer` is the
             // distance from the innermost, which is what the frame-chain
             // addressing takes.
             let outer = depth - 1 - level;
-            let frame = &mut self.frames[level];
+            let frame = FrameRef::make_mut(&mut self.frames[level]);
             // The target may have allocated more spill slots than us (a
             // sibling branch reached the merge with a wider spill region).
             // Grow to match so a `LinkMode::F(VirtFPReg(N))` in `tgt` with
@@ -324,7 +342,7 @@ impl AbstractState {
         for level in levels {
             let outer = depth - 1 - level;
             for i in self.frames[level].locals() {
-                match self.frames[level].unbox_to_S_at(ir, i, outer) {
+                match FrameRef::make_mut(&mut self.frames[level]).unbox_to_S_at(ir, i, outer) {
                     crate::codegen::jitgen::state::slot::OuterBarrier::Kept => {}
                     crate::codegen::jitgen::state::slot::OuterBarrier::Widened => {
                         widened.push((level, i));
@@ -366,7 +384,7 @@ impl AbstractState {
         self.frames
             .iter()
             .zip(other.frames.iter())
-            .all(|(lhs, rhs)| lhs.equiv(rhs))
+            .all(|(lhs, rhs)| FrameRef::ptr_eq(lhs, rhs) || lhs.equiv(rhs))
     }
 
     pub(super) fn unset_no_capture_guard(&mut self, jitctx: &mut JitContext) {
@@ -400,7 +418,11 @@ impl AbstractState {
     pub(super) fn set_lexical_no_capture_guard(&mut self) {
         let mut level = self.frames.len() - 1;
         loop {
-            self.frames[level].set_no_capture_guard();
+            // Monotone bit: skip the copy-on-write when already set, so a
+            // re-proof does not fork a shared frame for a no-op.
+            if !self.frames[level].no_capture_guard() {
+                FrameRef::make_mut(&mut self.frames[level]).set_no_capture_guard();
+            }
             match self.frames[level].lexical_outer() {
                 Some(o) if level >= o => level -= o,
                 _ => break,
@@ -411,7 +433,9 @@ impl AbstractState {
     pub(super) fn unset_lexical_no_capture_guard(&mut self) {
         let mut level = self.frames.len() - 1;
         loop {
-            self.frames[level].unset_no_capture_guard();
+            if self.frames[level].no_capture_guard() {
+                FrameRef::make_mut(&mut self.frames[level]).unset_no_capture_guard();
+            }
             match self.frames[level].lexical_outer() {
                 Some(o) if level >= o => level -= o,
                 _ => break,
@@ -460,7 +484,7 @@ impl AbstractState {
     pub(super) fn defer_outer_boxing_to(&mut self, outer: usize, slot: SlotId, hfpr: FPReg) {
         debug_assert!(hfpr.0 >= crate::codegen::PHYS_FPR_POOL);
         if let Some(level) = self.outer_level(outer) {
-            let frame = &mut self.frames[level];
+            let frame = FrameRef::make_mut(&mut self.frames[level]);
             match frame.mode(slot) {
                 // Already deferred to this home by an earlier store.
                 LinkMode::F(fpr) if fpr == hfpr => {}

--- a/monoruby/src/codegen/jitgen/state/join.rs
+++ b/monoruby/src/codegen/jitgen/state/join.rs
@@ -7,13 +7,20 @@ impl AbstractState {
     pub(in crate::codegen::jitgen) fn join(&mut self, other: &AbstractState) {
         let innermost = self.frames.len() - 1;
         for (level, (lhs, rhs)) in self.frames.iter_mut().zip(other.frames.iter()).enumerate() {
+            // Identity fast path: a frame neither path has touched since
+            // they forked is the *same* `Rc` on both sides — the meet is
+            // itself, no slot walk needed. In a deep specialization tower
+            // this is every suspended outer frame of every merge.
+            if FrameRef::ptr_eq(lhs, rhs) {
+                continue;
+            }
             // Only the innermost frame owns fp registers today: a call that
             // hands out a block spills every live one, so an outer frame
             // holds nothing unboxed and the merge must not hand it one
             // either — the two frames' fpr allocators are separate, and an
             // outer bridge has no way to load a slot into an fpr. Lifting
             // this is what carrying `F`/`Sf` across the boundary will need.
-            lhs.join_with(rhs, level == innermost);
+            FrameRef::make_mut(lhs).join_with(rhs, level == innermost);
         }
     }
 }


### PR DESCRIPTION
Stage 2 of the compile-cost work on the abstract-state tower (follows #1271). The DOOM profile put the JIT front-end plus its allocation churn at ~65-70% of steady-state CPU: every state clone deep-copied every suspended frame's `SlotState`, and every merge re-walked every frame's slots — with the *largest* frame (the root, hundreds of slots in dewasm-generated code) sitting at the outer end of every nested unit's chain, so a mega-unit's 250 nested specializations each paid for the whole tower.

## What

`AbstractFrame` now travels as **`FrameRef` (an `Rc`)**: the pointer is the frame's *identity*.

- **Clone** of a chain bumps refcounts instead of deep-copying `SlotState`s.
- **Mutation** goes through `Rc::make_mut` (copy-on-write), routed via the existing `Deref`/`Index` accessors — the borrow checker found every mutation site, so the original live-chain semantics are preserved exactly: dynvar stores, yield-block loop fixpoints and invariant walks all flow through the same joins as before. (An earlier prototype that *parked* untouched frames out of the chain broke precisely those flows — three distinct failure classes in the suite; this design subsumes it with no gating and no semantic seams. The prototype is archived on `park-v1-archive`.)
- **`Rc::ptr_eq`** is the O(1) "no path touched this frame" check, and the fast paths ride on it:
  - state join: a ptr-equal frame's meet is itself — skipped;
  - `gen_bridge_all`: bridge targets (the loop-entry shapes, `backedge_map` included) are `FrameRef`s, and bridging a frame to itself emits nothing — skipped;
  - return-chain join (`build_return_segments`) and the loop-fixpoint `equiv`: pointer compare first, content compare only when identities differ (so convergence is untouched);
  - monotone bits (no-capture, subtree-float-read marks) skip the copy-on-write when already at their target value, so re-proofs don't fork shared frames.

In a deep specialization tower the suspended outer frames are exactly the ones nothing touches, so every per-slot walk over them collapses to a pointer compare — for wasm-generated code (plain method calls all the way down) that is the entire chain above the current frame.

## Results

DOOM 60-tick smoke (`jit-log` build, idle machine, same-build comparison):

| | before | after |
|---|---|---|
| total JIT compile time | 8.95s | **4.17s (−53%)** |
| `Doom#_f130` (largest unit, 250 nested specializations) | 1.69s | **0.61s** |
| tick rate | 8.8/s | **16.9/s (+92%)** |

The test suite itself — compile-heavy under test-mode thresholds — drops from ~95s to **~38s**.

## Testing

- Full suite **3575/3575**, with and without `--features stress-spill-pool`, re-verified after rebasing onto current master
- The shapes that expose outer-frame mutation flows (a `times`-block storing through `each` into its home; `Enumerable#one?`'s transitively forwarded yield; `float_across_block_call`'s block writing an unboxed outer float) all produce byte-identical results to CRuby
- Arch-neutral front-end change; aarch64 inherits it

🤖 Generated with [Claude Code](https://claude.com/claude-code)