### PR TITLE
JIT: serve fused polymorphic compares, and heal mono-compiled cmp guards

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -1808,6 +1808,23 @@ impl Codegen {
                     let deopt_body = self.jit.label();
                     let error_body = self.jit.label();
                     self.jit.bind_label(entry);
+                    // `BecamePolymorphic` is checked, not assumed: recompile
+                    // only once the VM has actually stamped the site's POLY
+                    // byte (`opcode_sub`, set by the interpreter on an
+                    // operand/receiver *class* change). A representation-only
+                    // miss — a BigInt failing an `Integer` guard's fixnum tag
+                    // test — never moves the byte, so the gate keeps such a
+                    // site on the plain deopt instead of recompiling against
+                    // an unchanged profile every N misses. Mirrors the x86
+                    // gate in `side_exit_with_label`.
+                    if reason == RecompileReason::BecamePolymorphic {
+                        let poly_byte = pc.as_ptr() as u64 + 7;
+                        monoasm_arm64!(&mut self.jit,
+                            mov x9, (poly_byte);
+                            ldrb w9, [x9];
+                            cbz w9, deopt_body;
+                        );
+                    }
                     self.emit_recompile_deopt(target, &deopt_body, Some(&error_body), reason);
                     self.a64_gen_deopt(pc, &wb, deopt_body, loop_jit_spill_bytes, base, chain);
                     self.a64_gen_handle_error(pc, &wb, error_body, loop_jit_spill_bytes, base, chain);

--- a/monoruby/src/codegen/arch/x86_64/guard.rs
+++ b/monoruby/src/codegen/arch/x86_64/guard.rs
@@ -228,14 +228,26 @@ impl Codegen {
             movq [rsp], rax;
         );
         self.save_registers();
+        // The guard jumps here straight out of the body, so the stack
+        // parity is whatever the unit happened to run at — a Loop-JIT
+        // frame with an odd spill-slot count sits 8 bytes off the parity a
+        // method frame has, and a fixed `subq` would call the recorder
+        // misaligned there (Rust code then faults on the first `movdqa`
+        // spill — seen as a SIGSEGV inside a `HashMap::insert`). Align
+        // explicitly instead of assuming, exactly as a signal handler
+        // must: stash rsp below the red-zone hop, round down to 16, and
+        // restore from the stash.
         monoasm!( &mut self.jit,
             movq rdx, rdi;      // the value that failed the guard
             movq rdi, rbx;      // &mut Executor
             movq rsi, r12;      // &mut Globals
+            movq rax, rsp;
+            subq rsp, 4112;
+            andq rsp, (-16);
+            movq [rsp], rax;
             movq rax, (guard_fail);
-            subq rsp, 4088;
             call rax;
-            addq rsp, 4088;
+            movq rsp, [rsp];
         );
         self.restore_registers();
         monoasm!( &mut self.jit,

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -1697,6 +1697,24 @@ impl Codegen {
                 RecompileTarget::Whole(_) => COUNT_DEOPT_RECOMPILE,
                 RecompileTarget::Specialized(_) => COUNT_DEOPT_RECOMPILE_SPECIALIZED,
             });
+            // `BecamePolymorphic` is checked, not assumed: recompile only
+            // once the VM has actually stamped the site's POLY byte
+            // (`opcode_sub`, op1 bits 63:56 — the interpreter sets it on an
+            // operand/receiver *class* change). A miss that splits one class
+            // by representation — a BigInt failing an `Integer` guard's
+            // fixnum tag test — re-executes in the VM without moving the
+            // byte, and a recompile against an unchanged profile would
+            // reproduce the same guard: the activerecord `out_of_range?`
+            // shape recompiled 8,756 times that way. With the gate such a
+            // site just deopts plainly, byte-for-byte the pre-heal behavior.
+            if reason == RecompileReason::BecamePolymorphic {
+                let poly_byte = pc.as_ptr() as usize + 7;
+                monoasm!( &mut self.jit,
+                    movq rax, (poly_byte);
+                    cmpb [rax], 0;
+                    jeq  skip;
+                );
+            }
             monoasm!( &mut self.jit,
                 cmpl [rip + counter], 0;
                 jle  skip;

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -222,6 +222,11 @@ impl<'a> JitContext<'a> {
         rhs_class: Option<ClassId>,
         bc_pos: BcIndex,
         mode: BinaryInlineMode,
+        // `Some`: the receiver guard exits through a counter-gated,
+        // POLY-byte-checked recompile of *target* instead of a plain deopt
+        // (see `compile_binary` step 4). `None` inside a dispatch arm, where
+        // the state already knows the class and no guard is emitted at all.
+        heal: Option<RecompileTarget>,
     ) -> Option<BinaryInlineOutcome> {
         let (fid, _visibility) = self.jit_check_method(lhs_class, op)?;
         let inline = self.store.inline_info.get_inline(fid)?;
@@ -246,7 +251,7 @@ impl<'a> JitContext<'a> {
         // that declines after the guard was emitted must leave no trace.
         let state_save = state.clone();
         let ir_save = ir.save();
-        state.guard_recv_class(ir, lhs, lhs_class);
+        state.guard_recv_class(ir, lhs, lhs_class, heal);
         let outcome = match self.store.inline_info.get_inline(fid).unwrap() {
             InlineFuncInfo::InlineGenBinary(f) => {
                 self.inline_asm_binary(state, ir, f, callid, lhs_class, rhs_class, mode)
@@ -336,32 +341,13 @@ impl<'a> JitContext<'a> {
     /// caller keeps the ordinary (guarded, deopting) path.
     ///
     fn dispatch_inline_class(&mut self, callid: CallSiteId, op: IdentId) -> Option<ClassId> {
-        let pmc = &self.store[callid].pmc;
-        // Two-arm dispatch only pays off where the site really alternates;
-        // one observed class is the monomorphic guard's case.
-        if pmc.entries().len() < 2 {
+        if !self.pmc_really_alternates(callid) {
             return None;
         }
-        let observations = pmc.observations();
+        let pmc = &self.store[callid].pmc;
         let mut classes: Vec<(ClassId, u32)> =
             pmc.entries().iter().map(|e| (e.recv, e.count)).collect();
         classes.sort_unstable_by_key(|(_, count)| std::cmp::Reverse(*count));
-        // The POLY bit only says the site was *ever* seen with a second
-        // class; it never clears. A site that is one hot class plus a
-        // handful of stragglers is monomorphic in every way that matters,
-        // and dispatching it is a pure loss — the hot class pays an extra
-        // branch on every execution and, worse, gives up its result's type
-        // at the merge, where a register-resident flag becomes a boxed
-        // stack slot. So require the runner-up to be a real share of the
-        // traffic, the same 1/8 the class-set guard demands of its members.
-        // (etanni measured ~2% slower before this test existed.)
-        if classes[1]
-            .1
-            .saturating_mul(PMC_SET_SHARE_DIVISOR)
-            < observations
-        {
-            return None;
-        }
         classes.into_iter().map(|(class, _)| class).find(|&class| {
             matches!(
                 self.jit_check_method(class, op)
@@ -373,6 +359,30 @@ impl<'a> JitContext<'a> {
             // it through the recorded bop dependency.
             && self.basic_op_assumable(class, op)
         })
+    }
+
+    ///
+    /// Does the PMC show this site's *receiver* genuinely alternating
+    /// between classes?
+    ///
+    /// The POLY bit only says the site was *ever* seen with a second
+    /// class; it never clears. A site that is one hot class plus a
+    /// handful of stragglers is monomorphic in every way that matters,
+    /// and treating it polymorphically is a pure loss — the hot class
+    /// pays an extra branch (or the generic call) on every execution. So
+    /// require the runner-up to be a real share of the traffic, the same
+    /// 1/8 the class-set guard demands of its members. (etanni measured
+    /// ~2% slower before this test existed on the two-arm dispatch.)
+    ///
+    fn pmc_really_alternates(&self, callid: CallSiteId) -> bool {
+        let pmc = &self.store[callid].pmc;
+        if pmc.entries().len() < 2 {
+            return false;
+        }
+        let observations = pmc.observations();
+        let mut counts: Vec<u32> = pmc.entries().iter().map(|e| e.count).collect();
+        counts.sort_unstable_by_key(|count| std::cmp::Reverse(*count));
+        counts[1].saturating_mul(PMC_SET_SHARE_DIVISOR) >= observations
     }
 
     ///
@@ -522,6 +532,7 @@ impl<'a> JitContext<'a> {
                 rhs_class,
                 bc_pos,
                 BinaryInlineMode::Value,
+                None,
             ),
             Some(BinaryInlineOutcome::Done)
         ) {
@@ -771,6 +782,28 @@ impl<'a> JitContext<'a> {
             }
         }
 
+        // ---- 3c. A *fused* comparison (`BinCmpBr`) at a site the VM marked
+        // polymorphic and whose receiver genuinely alternates: take the
+        // polymorphic residual (step 5) instead of the mono inline below.
+        // The two-arm dispatch (step 2) cannot serve the fused form — the
+        // arms would have to materialize the very flag the fusion exists to
+        // avoid — so these sites used to fall through to the single-class
+        // guard and side-exit on every off-class operand, forever (dewasm
+        // DOOM: thousands of `Integer == nil` exits per tick, the "~24
+        // fused side exits" note on step 2 notwithstanding). The residual
+        // is guard-free, and for `==`/`!=` it is `opt_eq_cmp`'s inline
+        // bit-equality fast path, which answers an immediate-vs-immediate
+        // compare — the `nil` operand included — without the C call. The
+        // 1/8-share gate keeps the hot-class fast path for one-hot-class
+        // sites, exactly as it does for the two-arm dispatch.
+        let fused_poly_residual = polymorphic
+            && case_semantics
+            && state.class(lhs).is_none()
+            && self
+                .store
+                .get_callsite_id(self.iseq_id(), bc_pos)
+                .is_some_and(|callid| self.pmc_really_alternates(callid));
+
         // ---- 4. One path for every operator: guard the receiver, run the
         // generator registered on `lhs_class#op`, and fall back for whatever
         // it declines. The generator picks its emission from the argument
@@ -790,33 +823,57 @@ impl<'a> JitContext<'a> {
         // return via the eviction walk's return-address patching (see
         // `emit_call`). A `def` executed *inside* JIT code is caught by the
         // `check_bop` after `MethodDef`/`SingletonMethodDef`.
-        match self.fire_binary_inline(
-            state,
-            ir,
-            binop.into(),
-            lhs,
-            rhs,
-            lhs_class,
-            rhs_class,
-            bc_pos,
-            mode,
-        ) {
-            Some(BinaryInlineOutcome::Done) => {
-                // ④-b: the Integer/Float inline lowerings are pure
-                // arithmetic — overflow promotes via a Rust helper, guards
-                // and errors exit the trace, nothing dispatches Ruby code —
-                // so the unfrozen-slot proofs survive them. Other classes'
-                // inline generators are not audited for that; drop the
-                // proofs there.
-                if (lhs_class == INTEGER_CLASS || lhs_class == FLOAT_CLASS)
-                    && (rhs_class == Some(INTEGER_CLASS) || rhs_class == Some(FLOAT_CLASS))
-                {
-                    self.restore_unfrozen(dst);
+        if !fused_poly_residual {
+            // A site still monomorphic in the VM's eyes gets the plain
+            // single-class guard — but that guard must not deopt forever
+            // once the program *does* start feeding it a second class
+            // (compile-before-variance is pure timing: the DOOM shape is a
+            // fused `prev == key` whose `prev` starts feeding `nil` only
+            // after the site compiled). Hand the guard a counter-gated
+            // recompiling exit instead: after a few misses the site
+            // recompiles and, now marked polymorphic, takes the dispatch /
+            // residual treatment above. The exit only actually recompiles
+            // once the VM has stamped the site's POLY byte (see the
+            // `BecamePolymorphic` gate in the side-exit lowering), so a
+            // representation-only miss — a BigInt failing the fixnum tag
+            // test, class `Integer` all the same, which never sets POLY —
+            // can never recompile-livelock (the activerecord
+            // `out_of_range?` storm shape). At a site already compiled
+            // polymorphic, reaching here means the polymorphic treatments
+            // were tried at *this* compile and declined; a recompile would
+            // reproduce this very body, so the guard deopts plainly.
+            let heal = (!polymorphic)
+                .then(|| self.recv_miss_recompile_target())
+                .flatten();
+            match self.fire_binary_inline(
+                state,
+                ir,
+                binop.into(),
+                lhs,
+                rhs,
+                lhs_class,
+                rhs_class,
+                bc_pos,
+                mode,
+                heal,
+            ) {
+                Some(BinaryInlineOutcome::Done) => {
+                    // ④-b: the Integer/Float inline lowerings are pure
+                    // arithmetic — overflow promotes via a Rust helper, guards
+                    // and errors exit the trace, nothing dispatches Ruby code —
+                    // so the unfrozen-slot proofs survive them. Other classes'
+                    // inline generators are not audited for that; drop the
+                    // proofs there.
+                    if (lhs_class == INTEGER_CLASS || lhs_class == FLOAT_CLASS)
+                        && (rhs_class == Some(INTEGER_CLASS) || rhs_class == Some(FLOAT_CLASS))
+                    {
+                        self.restore_unfrozen(dst);
+                    }
+                    return Ok(BinaryLowering::Emitted);
                 }
-                return Ok(BinaryLowering::Emitted);
+                Some(BinaryInlineOutcome::Folded(b)) => return Ok(BinaryLowering::Folded(b)),
+                Some(BinaryInlineOutcome::Declined) | None => {}
             }
-            Some(BinaryInlineOutcome::Folded(b)) => return Ok(BinaryLowering::Folded(b)),
-            Some(BinaryInlineOutcome::Declined) | None => {}
         }
 
         // ---- 5. The residual.
@@ -1353,6 +1410,111 @@ mod tests {
             res = []
             600.times { |n| res << probe(t, n % 5, (n + 1) % 5) }
             [res.tally.sort_by { |k, _| k.to_s }, probe(t, 4, 0), probe(t, 1, 4)]
+            "#,
+        );
+    }
+
+    /// A *fused* comparison (`if a == b`) at a genuinely alternating
+    /// nil/Integer site. The two-arm dispatch cannot serve the fused form,
+    /// so `compile_binary` step 3c routes it to the guard-free generic
+    /// residual (`opt_eq_cmp`'s bit-equality fast path) instead of the
+    /// single-class guard that used to side-exit on every nil (the dewasm
+    /// DOOM `prev == key` shape). Every operand mix must answer exactly as
+    /// the interpreter does.
+    #[test]
+    fn fused_cmp_poly_residual() {
+        run_test(
+            r#"
+            def probe(prev, key)
+              if prev == key
+                :hit
+              else
+                :miss
+              end
+            end
+            res = []
+            300.times { |n| res << probe(n % 3 == 0 ? nil : n, 7) }
+            [res.tally.sort_by { |k, _| k.to_s },
+             probe(nil, nil), probe(nil, 7), probe(7, 7), probe(7.0, 7), probe(1 << 70, 7)]
+            "#,
+        );
+    }
+
+    /// The compile-before-variance half of the same story: the site compiles
+    /// while still monomorphic (plain fused Integer compare, class guard),
+    /// and only *then* starts seeing nil. The guard's `BecamePolymorphic`
+    /// recompiling exit must flip the body to the polymorphic residual after
+    /// a few misses — and, healed or not, every answer must match the
+    /// interpreter through the transition.
+    #[test]
+    fn fused_cmp_mono_heals_to_poly() {
+        run_test(
+            r#"
+            def probe(prev, key)
+              if prev == key
+                :hit
+              else
+                :miss
+              end
+            end
+            res = []
+            300.times { |n| res << probe(n, 7) }
+            300.times { |n| res << probe(n % 3 == 0 ? nil : n, 7) }
+            res.tally.sort_by { |k, _| k.to_s }
+            "#,
+        );
+    }
+
+    /// A representation-only miss must NOT heal: the guard is the fixnum tag
+    /// test, a Bignum carries `Integer` all the same, and the VM never marks
+    /// the site polymorphic — so the `BecamePolymorphic` exit's POLY-byte
+    /// gate keeps it on the plain deopt (no recompile-per-N-misses storm; the
+    /// activerecord `out_of_range?` shape). Pins the semantics either way.
+    #[test]
+    fn mono_cmp_bigint_misses_stay_plain() {
+        run_test(
+            r#"
+            def probe(a, b)
+              if a < b
+                :lt
+              else
+                :ge
+              end
+            end
+            res = []
+            300.times { |n| res << probe(n, 100) }
+            big = 1 << 62
+            300.times { |n| res << probe(big + n, 100) }
+            res.tally.sort_by { |k, _| k.to_s }
+            "#,
+        );
+    }
+
+    /// The polymorphic residual's `==` fast path answers bit equality for
+    /// `nil` under the basic-op licence, so a `NilClass#==` redefinition must
+    /// evict it and the site must dispatch the redefined method from then on
+    /// — same contract the guard-free inline generators honor.
+    #[test]
+    fn poly_cmp_respects_nil_eq_redefinition() {
+        // `run_test_once`: the 25× rerun harness would carry the NilClass
+        // redefinition into the warmup of every later iteration. Test-mode
+        // JIT thresholds make the in-script loops warm enough on their own.
+        run_test_once(
+            r#"
+            def probe(prev, key)
+              if prev == key
+                :hit
+              else
+                :miss
+              end
+            end
+            res = []
+            300.times { |n| res << probe(n % 3 == 0 ? nil : n, 7) }
+            class NilClass
+              def ==(other) = true
+            end
+            60.times { |n| res << probe(n % 3 == 0 ? nil : n, 7) }
+            res.tally.sort_by { |k, _| k.to_s }
             "#,
         );
     }

--- a/monoruby/src/codegen/jitgen/state/binop.rs
+++ b/monoruby/src/codegen/jitgen/state/binop.rs
@@ -898,7 +898,17 @@ impl AbstractFrame {
     ///   and emits nothing.
     /// * anything else — materialize into `Rdi` and compare the class id.
     ///
-    pub(crate) fn guard_recv_class(&mut self, ir: &mut AsmIr, slot: SlotId, class: ClassId) {
+    pub(crate) fn guard_recv_class(
+        &mut self,
+        ir: &mut AsmIr,
+        slot: SlotId,
+        class: ClassId,
+        // `Some`: a guard miss exits through a counter-gated recompile of
+        // *target* (reason `BecamePolymorphic`) instead of a plain deopt,
+        // so a site compiled before the VM saw class variance flips to the
+        // polymorphic treatment instead of side-exiting forever.
+        heal: Option<RecompileTarget>,
+    ) {
         if self.class(slot) == Some(class) {
             return;
         }
@@ -908,23 +918,33 @@ impl AbstractFrame {
         // on (a skipped guard let `BIGNUM_CONST >> 4` shift the raw heap
         // pointer). Bignum-constant sites are instead intercepted before
         // the dispatch (`compile_binary`'s fold / the generators' decline).
+        let new_deopt = |state: &Self, ir: &mut AsmIr| match heal {
+            Some(target) => {
+                ir.new_recompile_deopt(state, RecompileReason::BecamePolymorphic, target)
+            }
+            None => ir.new_deopt(state),
+        };
         match class {
             INTEGER_CLASS => {
                 let (gp, needs_guard) = self.gp_ensure(ir, slot, &[]);
                 if needs_guard {
-                    let deopt = ir.new_deopt(self);
+                    let deopt = new_deopt(self, ir);
                     ir.push(AsmInst::GuardClass(gp, INTEGER_CLASS, deopt));
                     self.refine_S_fixnum(slot);
                 }
             }
             FLOAT_CLASS => {
+                // The unboxing guard admits both float representations
+                // (flonum and heap Float), so its misses are genuine class
+                // misses — but the deopt is welded into `load_fpr`; healing
+                // it is a separate plumbing job. Left plain for now.
                 self.load_fpr(ir, slot);
             }
             _ => {
                 // Snapshot before the guard: the side exit re-reads the
                 // operands from their stack homes, so the write-back must be
                 // the pre-guard placement.
-                let deopt = ir.new_deopt(self);
+                let deopt = new_deopt(self, ir);
                 self.load(ir, slot, GP::Rdi);
                 self.guard_class(ir, slot, GP::Rdi, class, deopt);
             }

--- a/monoruby/src/tests.rs
+++ b/monoruby/src/tests.rs
@@ -12,6 +12,14 @@ static RUBY: LazyLock<String> = LazyLock::new(|| {
     find_ruby()
 });
 
+/// The reference CRuby the harness resolved (PATH, then rbenv/rvm shims —
+/// see [`find_ruby`]). Integration tests that spawn `ruby` themselves must
+/// use this rather than `Command::new("ruby")`, which breaks in shells
+/// where only a version manager provides Ruby.
+pub fn ruby_path() -> &'static str {
+    &RUBY
+}
+
 pub fn run_test(code: &str) {
     let wrapped = format!(
         r##"

--- a/monoruby/tests/begin_end.rs
+++ b/monoruby/tests/begin_end.rs
@@ -13,7 +13,7 @@ fn run_both(script: &str) {
         .args(["--disable=gems", "-e", script])
         .output()
         .unwrap();
-    let ruby = Command::new("ruby")
+    let ruby = Command::new(monoruby::tests::ruby_path())
         // Match the main harness: skip rubygems boot and ambient RUBYOPT.
         .args(["--disable=gems,rubyopt", "-e", script])
         .output()

--- a/monoruby/tests/method_call.rs
+++ b/monoruby/tests/method_call.rs
@@ -3235,7 +3235,7 @@ fn toplevel_return_argument_warns() {
     let mut f = std::fs::File::create(&script).unwrap();
     writeln!(f, "return 10 if false\nreturn 10\nputs :unreachable").unwrap();
     drop(f);
-    for bin in ["ruby", env!("CARGO_BIN_EXE_monoruby")] {
+    for bin in [ruby_path(), env!("CARGO_BIN_EXE_monoruby")] {
         let out = std::process::Command::new(bin)
             // The script needs no gem, and both interpreters take the
             // flag — skipping the rubygems boot is most of a spawn's

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -522,6 +522,7 @@
 2725417552fe9cf3994cb6d9305ea32c	7	class C; def to_int; nil; end; def to_i; 7; end; end; o = C.new\nInteger(o)
 272fe9061909044beaae1c691819f22b	"/dev/null"	File.path("/dev/null")
 273609161e526f0caca0d803b1f5ac8c	3	$x = 0\n            begin\n              $x += 1\n              raise 
+273898934e7df5dea5c4e43f205ec103	[[:hit, 2], [:miss, 598]]	def probe(prev, key)\n              if prev == key\n                :
 27452ff2af75468b18d93adad2bb0edd	["nil", "nil", "nil", "nil"]	[STDOUT.external_encoding, STDERR.external_encoding,\n         STDOUT.in
 27679c36ace334b798b8ac5753b80532	42	# Test 2: include + prepend where M appears twice in the chain\n#\n# B2 includes 
 2771493de6880db912552ec36e380f75	[true, true, nil, true, true, true, true, IPSocket, TCPSocket, IO, StandardError]	require "socket"\n            sock = Socket.new(:INET, :STREAM)\n    
@@ -1826,6 +1827,7 @@
 8c70e2dbc965b5a240d04429bfa944de	["UTF-8", "UTF-8", "abc", "nil", "plain"]	path = "/tmp/monoruby_io_bom_#{Process.pid}_#{rand(100000)}"\n      
 8c83bb3ecc9ac2c1e06a16d061103347	Array	class C < Array; end\n(C[1,2,2] & [2,3]).class
 8c8d2f17496ea5fcffabf17deeb83042	["a", "b"]	base = "/tmp/monoruby_dir_eachinst_#{Process.pid}_#{rand(100000)}"\n
+8c9756554430bb7072dc29c2c12abded	[[:ge, 500], [:lt, 100]]	def probe(a, b)\n              if a < b\n                :lt\n        
 8cccb4747cfdbfa71bed00dbdaf949ab	[["RuntimeError", "TypeError"], ["RuntimeError", nil], "TypeError", ["RuntimeError", nil], "ArgumentError"]	def t; yield; rescue Exception => e; [e.class.to_s, (e.cause && e.c
 8cf4538ff9dc5775c6aa04d3c95d1924	[[:pa, 1000], [:pb, 1000], [:pc, 1000]]	class Vbase; def val = @v; end\n            class Va < Vbase; def in
 8cf61f75f99a0e9c53f3bf071168dad0	[:foo]	class P\n              def foo; end\n              def bar; end\n     
@@ -2672,6 +2674,7 @@ ca23ef27e73796162ee1e53425e88043	[2, 1]	class C\n                CONST = 1\n    
 ca52734c6644d5ea8d449f149120fcc2	[3, -1, :nme]	res = []\n            res << (1 + 2)\n            class Integer\n     
 ca6aea137215ef3580ab386ef7dcb37d	[[1, 2], [1, 2]]	def f(a,b,*)\n              [a,b]\n            end\n        \n\n        
 ca79e057f33cc52f3f630ba69bc2c841	42	x = 42\n            binding.local_variable_get("x")\n            
+ca8d43e6bd29bc3dae725a7ca1983f22	[[:hit, 22], [:miss, 338]]	def probe(prev, key)\n              if prev == key\n                :
 ca8e2478f764162473914c7004640057	[10, 20, 30, 40, 50, 60, 70, 80, 1, 2, 3, 4, 5, 6, 7, 8]	class S\n                def initialize\n                    @a = 10\n
 ca928535f52567b7ee925c29e111ffe1	89.75113055617776	def call_block\n          yield\n        end\n        def w8(s, flag)\n    
 ca9a7fe5197626d693b7a2d84780366f	[["a", "cc", "bbb", "dddd"], ["a", "bbb", "cc", "dddd"], ["a", "cc", "bbb", "dddd"], [3, 2, 1], ArgumentError, ["a", "cc", "bbb", "dddd"], [0.5, 1.5], []]	words = ["bbb", "a", "cc", "dddd"]\n        by_int = words.sort_by { |s|
@@ -2702,6 +2705,7 @@ cc8aebeeff87148f768f16c8f957f04b	[File, Errno::EEXIST, "hello\\nmore\\n", nil, "
 cca80bdce242e79abc49108091469b12	3	module MShip\n              class Widget\n                attr_reader
 ccd878c1f1810dfef13a53d1e1a05fb8	:te	begin; :sym.instance_eval { alias :foo :to_s }; :no; rescue TypeError; :te; end
 ccdd40701f9797edf931ec9bb16c3abf	[:alpha, 1.5, :beta, 2.5]	class PmF\n          def tag = :alpha\n          def rate = 1.5\n        e
+ccebcacf1f0e521c283f27ea3d09e042	[[[:hit, 1], [:miss, 299]], :hit, :miss, :hit, :hit, :miss]	def probe(prev, key)\n              if prev == key\n                :
 ccee79e211a63a6f8408eaaa13a6aee9	[{a: 1}, [1, {a: 1}], {}, "no implicit conversion of Object into Hash", "can't convert Object to Hash (Object#to_hash gives Integer)"]	def f(**o) = o\n            def g(a, **o) = [a, o]\n            m = O
 cd29ece16f52c170d36a353d72be8fb8	[1, 2, [3, 4, 5, 6, 7]]	def f(x,y,*z)\n            [x,y,z]\n        end\n        \n\n        f(1,2,3
 cd2df73dc4bb642c9c1db8166dee2691	true	t = File.birthtime("Cargo.toml") rescue :unsupported\n            t 


### PR DESCRIPTION
## Problem

`prev == key` inside `if` compiles to the fused `BinCmpBr`, which the two-arm polymorphic dispatch deliberately never serves (the arms would have to materialize the very flag the fusion exists to avoid — and fused side exits measured as a rounding error at the time). A polymorphic fused site therefore fell through to the mono Integer inline, whose fixnum guard side-exited on **every** nil operand, forever: the plain deopt has no recompile counter. On dewasm DOOM this is thousands of `Integer == nil` exits per tick; a 100k-iteration repro deopts 33,321 times with zero recompiles.

## Fix

**Step 3c (fused polymorphic residual).** A fused site the VM marked polymorphic whose receiver genuinely alternates (PMC runner-up ≥ 1/8 — the same share gate the two-arm dispatch uses, factored into `pmc_really_alternates`) skips the mono inline and takes the guard-free generic residual. For `==`/`!=` that residual is `opt_eq_cmp`'s inline bit-equality fast path, so nil-vs-Integer resolves inline with no C call. The repro's deopts drop to zero.

**BecamePolymorphic heal with a POLY-byte gate.** A site compiled *before* the VM saw variance now gets its receiver guard as a counter-gated recompiling exit (`guard_recv_class` + `new_recompile_deopt`). The side-exit stub checks the site's POLY byte (`opcode_sub`, which the VM stamps only on an operand **class** change) before counting:

- genuine class miss → the byte is stamped by the VM re-executions behind the deopts → exactly **one** recompile into the polymorphic treatment (verified: 11 deopts total, 1 recompile, then silence);
- representation-only miss (BigInt failing the fixnum tag test — class `Integer` all the same, POLY never set) → the gate never lets the counter drain → **zero** recompiles (verified with 30k BigInt misses), so the activerecord `out_of_range?` recompile-storm shape is structurally impossible.

The gate is emitted on both arches and also covers the existing send-side `BecamePolymorphic` exits, whose sites the VM stamps identically (for a PIC site the byte is already 1, so it is a no-op there).

## Also fixed en route

- **`profile`-build crash (pre-existing on master):** `class_guard_fail_recorder` (x86) called the stats hook at whatever stack parity the unit ran at; a unit 8 bytes off faulted on the first `movdqa` spill inside `HashMap::insert` (on WSL2 this looked like a hang — the core pipe blocks). The recorder now aligns rsp itself, as an async-context call must.
- **Test-env robustness:** `tests/begin_end.rs` and `toplevel_return_argument_warns` spawned a bare `"ruby"`, failing in rbenv-only shells; they now use the harness resolver, exported as `tests::ruby_path()`.

## Measurements

- Repro (`f(i % 3 == 0 ? nil : i, 7)` × 100k): 33,321 deopts / 0 recompiles → **0–1 deopts**.
- Mono-compiled-then-nil repro: 11 deopts, **1** `BecamePolymorphic` recompile, correct results.
- BigInt-trap repro: 30k guard misses, **0** recompiles.
- DOOM 60-tick smoke (profile build): nil/Integer POLY cmp deopts **~8,000 → ~225** (the survivors are heal counters draining); JIT compile time +0.23s (five heal recompiles); wall time within WSL2 noise (±15%). The payoff is steady-state: without the fix the deopts accrue for the life of the process.
- Largest remaining DOOM deopt is now `Renderer#render`'s `== [Integer][Integer]` at 296k/60 ticks (a representation-miss site the gate correctly refuses to churn on) — follow-up material.

## Tests

- 4 new regression tests: fused poly residual semantics, mono→poly heal transition, BigInt-miss plainness, and `NilClass#==` redefinition honoring at a healed site.
- Full suite: default features 3579/3579, `stress-spill-pool` 3579/3579.

🤖 Generated with [Claude Code](https://claude.com/claude-code)