### PR TITLE
SlotState: derive the fpr file from the slot modes; freeze the specialized call-site save set

### DIFF
--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -3183,3 +3183,48 @@ What was *not* folded, and why:
   (`wb_fpr`) emits stores in that order — a derived map would emit them in slot
   order, so the change is semantics-preserving but not byte-identical. Left for
   its own change with its own gate.
+
+## 47. The fpr file is derived from the slot modes (and the stale entry it was hiding)
+
+`FprAllocator` kept a reverse map `vfpr: Vec<Vec<SlotId>>` — for each fpr, the
+slots bound to it — maintained by `fpr_add` / `fpr_remove` / `clear` / `swap`
+alongside every `F` / `Sf` mode transition. The map is a function of the modes,
+so it is now computed from them: `SlotState::fpr_slots(fpr)` and a one-pass
+`pool_occupancy()` (per pool register: occupied?, all-`Sf`?) serve the
+allocator's two phases, `is_fpr_vacant`, the call-site save set and the deopt
+write-back. `FprAllocator` keeps only what is *not* derivable: the number of ids
+issued (spill ids are never re-issued once vacant — §46's `pick_vacant` note)
+and the pin set. `set_F` / `set_Sf` / `clear` no longer touch a file, and the
+bookkeeping that the `alloc_fpr` aliasing regression lived in is gone.
+
+**What the reverse map was hiding.** The suite caught the derivation:
+`outer_float_write_through`'s type-flip tests returned wrong values. The
+emitted code differed from master at exactly one place — the `each` call site
+in the owner loop saved `xmm2` on master and not on the branch — and the block
+compiled inside that call then read the owner's `a` where it meant to read `i`
+(the `_%2 = %2 == %3 [Float][Integer]` deopt storm: the block's static
+frame-chain offsets were off by the missing 16-byte save).
+
+The mechanism: `specialized_compile` freezes the caller's FP save set *before*
+the nested compile (`stack_offset = using_fpr_offset().offset()` lays out the
+callee's `extra` chain offsets over it), while the call emission after the
+compile took `get_using_fpr` *again*. In between, the callee's compile can
+widen a caller slot (`StoreDynVar` through the chain → `widen_outer_slot` →
+`invalidate_slot`, which set `S` **without** `fpr_remove`). With the map, the
+stale entry kept `xmm2` "occupied", so both sets agreed by accident (and the
+register was leaked for the rest of the compile). Derived from the modes, the
+second set was smaller than the first, and the callee's offsets no longer
+matched the frame the call actually built.
+
+Fixed at the root, not by re-adding the map: the frozen set rides back on the
+compiled frame (`JitStackFrame::call_site_using_fpr`, surfaced as
+`SpecializedCompileResult::using_fpr`), and both specialized call sites emit
+*that* set — `get_using_fpr` still runs for its GP flush and alias kill, and a
+debug assertion checks the live set is a subset of the frozen one (it can only
+shrink: a suspended frame never gains a pool register). Saving a register the
+caller no longer needs is harmless; saving fewer than the callee was laid out
+over was the bug.
+
+Verified: `emit-asm` dumps of the nine benchmarks are identical to master
+(`app_aobench` included this time), the JIT lib tests and the float / block /
+loop integration tests pass, and the full `cargo test` suite passes.

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -378,6 +378,11 @@ impl UsingFpr {
         let len = self.count_ones();
         (len + len % 2) * 8
     }
+
+    /// Every register in *other* is in `self`.
+    pub(crate) fn is_superset_of(&self, other: &Self) -> bool {
+        (0..PHYS_FPR_POOL).all(|i| !other.inner[i] || self.inner[i])
+    }
 }
 
 ///

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -1159,6 +1159,7 @@ impl<'a> JitContext<'a> {
             had_deopt: _,
             generic_yield: _,
             spec_id,
+            using_fpr: frozen_using_fpr,
         } = self.compile_specialized_func(
             state,
             iseq,
@@ -1175,7 +1176,13 @@ impl<'a> JitContext<'a> {
         // Pre-flush GP-pool snapshot for direct argument stores — see
         // `send`.
         let arg_hints = state.peek_gp_residents();
-        let using_fpr = state.get_using_fpr(ir);
+        // The save set was frozen when the callee's compile began (its
+        // frame-chain offsets are laid out over it); the live set can only
+        // have shrunk since, so saving the frozen set is sound and keeps
+        // the offsets right. `get_using_fpr` still runs for its flushes.
+        let live = state.get_using_fpr(ir);
+        let using_fpr = frozen_using_fpr;
+        debug_assert!(using_fpr.is_superset_of(&live), "{using_fpr:?} < {live:?}");
         // Stage 1': the resolve pass places write-through refreshes into
         // this site's save area by this record.
         self.record_call_site_fpr_save(spec_id, using_fpr);
@@ -1971,6 +1978,7 @@ impl<'a> JitContext<'a> {
             had_deopt,
             generic_yield,
             spec_id,
+            using_fpr: frozen_using_fpr,
         } = compiled;
         // The call site passes a block literal: if the callee heapifies
         // its *own* frame during the call (`Proc.new` / `lambda` /
@@ -2013,9 +2021,11 @@ impl<'a> JitContext<'a> {
         // Pre-flush GP-pool snapshot for direct argument stores — see
         // `send`. Captured before `get_using_fpr`'s flush.
         let arg_hints = state.peek_gp_residents();
-        // Snapshot the save set here (it is what `fpr_save_cont` below
-        // will emit) and record it for the resolve pass — stage 1'.
-        let using_fpr = state.get_using_fpr(ir);
+        // The save set was frozen when the callee's compile began — see
+        // the yield site above and `specialized_compile`.
+        let live = state.get_using_fpr(ir);
+        let using_fpr = frozen_using_fpr;
+        debug_assert!(using_fpr.is_superset_of(&live), "{using_fpr:?} < {live:?}");
         self.record_call_site_fpr_save(spec_id, using_fpr);
         state.send_specialized(
             ir,
@@ -2056,6 +2066,10 @@ pub(super) struct SpecializedCompileResult {
     /// The compiled callee instance, keying its call site's recorded FP
     /// save layout (stage 1' write-through).
     pub spec_id: context::SpecializedId,
+    /// The FP save set the call site must emit: the caller's set frozen
+    /// when the callee's compile began, over which the callee's
+    /// frame-chain offsets were laid out (`specialized_compile`).
+    pub using_fpr: UsingFpr,
     /// A `yield` in the compiled subtree was not inlined — see
     /// [`JitStackFrame::generic_yield`].
     pub generic_yield: bool,
@@ -2129,6 +2143,7 @@ impl<'a> JitContext<'a> {
         self.merge_return_context(return_context);
         // Capture before `frame.asm_info` is moved below.
         let spec_id = frame.asm_info.specialized_id;
+        let frame_using_fpr = frame.call_site_using_fpr;
         let frame_had_deopt = frame.had_deopt;
         let frame_deferred_rest = frame.deferred_rest;
         let frame_needs_rest_array = frame.needs_rest_array;
@@ -2226,6 +2241,7 @@ impl<'a> JitContext<'a> {
             had_deopt: frame_had_deopt,
             generic_yield: frame_generic_yield,
             spec_id,
+            using_fpr: frame_using_fpr,
         })
     }
 

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -580,6 +580,13 @@ pub(super) struct JitStackFrame {
     /// store it makes into an outer frame is invisible here.
     ///
     pub(super) generic_yield: bool,
+    ///
+    /// The caller's FP save set frozen when this frame's specialized
+    /// compile began (`specialized_compile`): the callee's static
+    /// frame-chain offsets are laid out over it, so the call emission
+    /// must save exactly this set. Filled by `specialized_compile`.
+    ///
+    pub(super) call_site_using_fpr: UsingFpr,
     /// D1: set when the trampoline forwarding consumer routed `g(...)`
     /// straight from the caller source (elided `f`'s rest Array).
     /// Aggregated from `AsmIr::deferred_rest()` like `had_deopt`,
@@ -730,6 +737,7 @@ impl JitStackFrame {
             specialized_id: SpecializedId(usize::MAX),
             had_deopt: false,
             generic_yield: false,
+            call_site_using_fpr: UsingFpr::default(),
             deferred_rest: false,
             needs_rest_array: false,
             speculated_floats: vec![],
@@ -767,6 +775,7 @@ impl JitStackFrame {
             specialized_id: self.specialized_id,
             had_deopt: self.had_deopt,
             generic_yield: self.generic_yield,
+            call_site_using_fpr: self.call_site_using_fpr,
             deferred_rest: self.deferred_rest,
             needs_rest_array: self.needs_rest_array,
             speculated_floats: self.speculated_floats.clone(),
@@ -1314,7 +1323,17 @@ impl<'a> JitContext<'a> {
         // Stage-B home-aliased reads: the callee can store through the
         // frame chain, so no alias survives a specialized call either.
         state.clear_dynvar_aliases();
-        let stack_offset = state.using_fpr_offset().offset();
+        // The call site's FP save set, frozen *here*: the callee's static
+        // frame-chain offsets (`extra`) are laid out over `stack_offset`,
+        // so the call emission after this compile must save exactly this
+        // set — not the set the caller's state holds *then*. The callee
+        // can widen the caller's slots while it compiles (a `StoreDynVar`
+        // through the chain drops an `Sf`/`F` view to `S`), which would
+        // shrink a freshly derived set and shift every offset the callee
+        // already baked in. It rides back to the call site on the compiled
+        // frame (`call_site_using_fpr`).
+        let using_fpr = state.using_fpr_offset();
+        let stack_offset = using_fpr.offset();
         // The live chain's invariants are maintained lexically (see
         // `unset_lexical_no_capture_guard`), so the entry chain is simply
         // this path's live frames.
@@ -1330,6 +1349,7 @@ impl<'a> JitContext<'a> {
         assert!(std::mem::replace(&mut caller.abstract_state, Some(scope)).is_none());
 
         let mut frame = self.traceir_to_asmir(frame, Some(entry_chain))?;
+        frame.call_site_using_fpr = using_fpr;
 
         // Every plain `Ret` in the callee branched to a return segment;
         // build them (and the join of the return-path chains) now, while

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -53,7 +53,7 @@ mod alloc_policy {
         /// it to keep loop-carried values resident. Zero extra cost on the default
         /// path (it is the original Phase-0 scan).
         ///
-        fn pick_vacant(&self, state: &SlotState) -> Option<FPReg> {
+        fn pick_vacant(&self, state: &SlotState, occ: &PoolOccupancy) -> Option<FPReg> {
             // Pool registers only, per this phase's contract ("vacant
             // phys"). A vacant *spill* id must not be re-issued: it may
             // be a persistent raw-f64 home whose binding this path does
@@ -64,7 +64,7 @@ mod alloc_policy {
             // ids are also skipped; that only costs frame bytes.
             (0..state.fpr_alloc.len().min(PHYS_FPR_POOL))
                 .map(FPReg)
-                .find(|&fpr| !state.fpr_alloc.is_pinned(fpr) && state.fpr_alloc.is_vacant(fpr))
+                .find(|&fpr| !state.fpr_alloc.is_pinned(fpr) && !occ.occupied(fpr))
         }
 
         ///
@@ -95,9 +95,13 @@ mod alloc_policy {
     /// pluggable.
     ///
     pub(super) fn try_alloc_fpr_ctx(state: &mut SlotState, ctx: &AllocCtx) -> Option<FPReg> {
+        // One pass over the slots gives every per-register fact both
+        // phases need (the register file is derived from the slot modes,
+        // not tracked beside them).
+        let occ = state.pool_occupancy();
         // Phase 0: a vacant fpr chosen by the policy (default: lowest index, as
         // before — the real placement lever, doc §27).
-        if let Some(fpr) = ctx.pick_vacant(state) {
+        if let Some(fpr) = ctx.pick_vacant(state, &occ) {
             return Some(fpr);
         }
         // Phase 1: among the fprs whose linked slots are *all* `Sf` (stack already
@@ -112,7 +116,7 @@ mod alloc_policy {
         // that callee code still writes at runtime.
         let victim = (0..state.fpr_alloc.len().min(PHYS_FPR_POOL))
             .map(FPReg)
-            .filter(|&fpr| !state.fpr_alloc.is_pinned(fpr) && !state.fpr_alloc.is_vacant(fpr))
+            .filter(|&fpr| !state.fpr_alloc.is_pinned(fpr) && occ.occupied(fpr))
             .filter(|&fpr| {
                 // §27.3 Stage-2b (`phys-loop-aware`): do not demote the `Sf`
                 // cache of a loop-carried float — keep `L` resident so the
@@ -121,36 +125,25 @@ mod alloc_policy {
                 // Default path: this filter is absent (`loop_carried` empty),
                 // so victim selection is byte-identical.
                 #[cfg(feature = "phys-loop-aware")]
-                if state
-                    .fpr_alloc
-                    .slots(fpr)
-                    .iter()
-                    .any(|&s| state.loop_carried.contains(&s))
+                if occ.all_sf(fpr)
                     && state
-                        .fpr_alloc
-                        .slots(fpr)
-                        .iter()
-                        .all(|&s| matches!(state.mode(s), LinkMode::Sf(_, _)))
+                        .fpr_slots(fpr)
+                        .any(|s| state.loop_carried.contains(&s))
                 {
                     return false;
                 }
-                state
-                    .fpr_alloc
-                    .slots(fpr)
-                    .iter()
-                    .all(|&s| matches!(state.mode(s), LinkMode::Sf(_, _)))
+                occ.all_sf(fpr)
             })
             .min_by_key(|&fpr| ctx.victim_rank(fpr))?;
+        // Demoting the slots is what frees the register: the file is
+        // derived from the modes, so there is no reverse entry to clear.
         let to_demote: Vec<(SlotId, SfGuarded)> = state
-            .fpr_alloc
-            .slots(victim)
-            .iter()
-            .map(|&s| match state.mode(s) {
+            .fpr_slots(victim)
+            .map(|s| match state.mode(s) {
                 LinkMode::Sf(_, g) => (s, g),
                 _ => unreachable!(),
             })
             .collect();
-        state.fpr_alloc.clear(victim);
         for (s, g) in to_demote {
             state.set_mode(s, LinkMode::S(g.into()));
         }
@@ -171,17 +164,19 @@ mod alloc_policy {
 }
 
 ///
-/// The fpr-register allocation state (item ②, step 1): the reverse map from
-/// physical/spill FP registers to the slots bound to them, plus the pin set.
-/// `SlotState` owns one of these and drives it through its `fpr_*` methods; the
-/// allocation *policy* (`alloc_policy::try_alloc_fpr` / `alloc_fpr`) takes `&mut
-/// SlotState` because it also reads/mutates slot placements. Indices
-/// `0..PHYS_FPR_POOL` map to physical `xmm2..xmm15`; `>= PHYS_FPR_POOL` are stack
-/// spills.
+/// The fpr-register file's *bookkeeping*: how many register ids have been
+/// issued and which are pinned. Which slots occupy a register is **not**
+/// tracked here — it is derived from the slot modes
+/// ([`SlotState::fpr_slots`] / [`SlotState::pool_occupancy`]), so the file
+/// can never disagree with the placements. Indices `0..PHYS_FPR_POOL` map to
+/// physical `xmm2..xmm15`; `>= PHYS_FPR_POOL` are stack spills.
 ///
 #[derive(Clone, Default)]
 pub(super) struct FprAllocator {
-    vfpr: Vec<Vec<SlotId>>,
+    /// Ids issued so far: the pool prefix plus every spill id this file
+    /// has ever issued or been grown to. A spill id is never re-issued
+    /// once vacant (see `pick_vacant`), so this only grows.
+    len: usize,
     /// fpr registers that must not be reused by `alloc_fpr` until unpinned.
     pinned: Vec<FPReg>,
 }
@@ -189,49 +184,27 @@ pub(super) struct FprAllocator {
 impl FprAllocator {
     fn new() -> Self {
         Self {
-            vfpr: (0..PHYS_FPR_POOL).map(|_| vec![]).collect(),
+            len: PHYS_FPR_POOL,
             pinned: Vec::new(),
         }
     }
 
     fn len(&self) -> usize {
-        self.vfpr.len()
-    }
-
-    fn slots(&self, fpr: FPReg) -> &[SlotId] {
-        &self.vfpr[fpr.0 as usize]
-    }
-
-    fn is_vacant(&self, fpr: FPReg) -> bool {
-        self.vfpr[fpr.0 as usize].is_empty()
+        self.len
     }
 
     fn is_pinned(&self, fpr: FPReg) -> bool {
         self.pinned.contains(&fpr)
     }
 
-    fn add(&mut self, slot: SlotId, fpr: FPReg) {
-        self.vfpr[fpr.0 as usize].push(slot);
-    }
-
-    fn remove(&mut self, slot: SlotId, fpr: FPReg) {
-        self.vfpr[fpr.0 as usize].retain(|e| *e != slot);
-    }
-
-    fn clear(&mut self, fpr: FPReg) {
-        self.vfpr[fpr.0 as usize].clear();
-    }
-
     fn grow_to(&mut self, new_len: usize) {
-        while self.vfpr.len() < new_len {
-            self.vfpr.push(vec![]);
-        }
+        self.len = self.len.max(new_len);
     }
 
-    /// Append a fresh spill slot beyond the physical pool and return its id.
+    /// Issue a fresh spill id beyond everything issued so far.
     fn push_spill(&mut self) -> FPReg {
-        let new_id = self.vfpr.len();
-        self.vfpr.push(vec![]);
+        let new_id = self.len;
+        self.len += 1;
         FPReg(new_id)
     }
 
@@ -246,9 +219,25 @@ impl FprAllocator {
             self.pinned.swap_remove(pos);
         }
     }
+}
 
-    fn swap(&mut self, l: FPReg, r: FPReg) {
-        self.vfpr.swap(l.0 as usize, r.0 as usize);
+///
+/// Per-pool-register facts collected in one pass over the slots: whether
+/// the register holds any slot, and whether every slot it holds is an `Sf`
+/// view (the stack is canonical, so the register can be dropped for free).
+///
+struct PoolOccupancy {
+    occupied: [bool; PHYS_FPR_POOL],
+    all_sf: [bool; PHYS_FPR_POOL],
+}
+
+impl PoolOccupancy {
+    fn occupied(&self, fpr: FPReg) -> bool {
+        self.occupied[fpr.0]
+    }
+
+    fn all_sf(&self, fpr: FPReg) -> bool {
+        self.occupied[fpr.0] && self.all_sf[fpr.0]
     }
 }
 
@@ -574,8 +563,32 @@ impl SlotState {
         &mut self.slots[slot.0 as usize].used
     }
 
-    fn fpr(&self, fpr: FPReg) -> &[SlotId] {
-        self.fpr_alloc.slots(fpr)
+    /// The slots bound to *fpr* (as `F` or `Sf`), in slot order — the
+    /// register file, read off the slot modes.
+    fn fpr_slots(&self, fpr: FPReg) -> impl Iterator<Item = SlotId> + '_ {
+        self.all_regs().filter(move |&s| {
+            matches!(self.mode(s), LinkMode::F(x) | LinkMode::Sf(x, _) if x == fpr)
+        })
+    }
+
+    fn pool_occupancy(&self) -> PoolOccupancy {
+        let mut occ = PoolOccupancy {
+            occupied: [false; PHYS_FPR_POOL],
+            all_sf: [true; PHYS_FPR_POOL],
+        };
+        for s in self.all_regs() {
+            match self.mode(s) {
+                LinkMode::F(x) if x.0 < PHYS_FPR_POOL => {
+                    occ.occupied[x.0] = true;
+                    occ.all_sf[x.0] = false;
+                }
+                LinkMode::Sf(x, _) if x.0 < PHYS_FPR_POOL => {
+                    occ.occupied[x.0] = true;
+                }
+                _ => {}
+            }
+        }
+        occ
     }
 
     ///
@@ -597,14 +610,7 @@ impl SlotState {
     ///
     pub(super) fn grow_fpr_to(&mut self, new_len: usize) {
         self.fpr_alloc.grow_to(new_len);
-    }
 
-    fn fpr_add(&mut self, slot: SlotId, fpr: FPReg) {
-        self.fpr_alloc.add(slot, fpr);
-    }
-
-    fn fpr_remove(&mut self, slot: SlotId, fpr: FPReg) {
-        self.fpr_alloc.remove(slot, fpr);
     }
 
     /// Mark *fpr* off-limits for subsequent `alloc_fpr` /
@@ -654,15 +660,8 @@ impl SlotState {
         // Any transition away from the aliased-`F` binding ends the alias;
         // the consult site takes it *before* transitioning.
         self.slots[slot.0 as usize].dynvar_alias = None;
-        match self.mode(slot) {
-            LinkMode::Sf(fpr, _) | LinkMode::F(fpr) => {
-                assert!(self.fpr(fpr).contains(&slot));
-                self.fpr_remove(slot, fpr);
-            }
-            LinkMode::C(_) => {}
-            LinkMode::S(_) => {}
-            LinkMode::MaybeNone | LinkMode::None => {}
-            LinkMode::V => return,
+        if self.mode(slot) == LinkMode::V {
+            return;
         }
         self.set_mode(slot, LinkMode::V);
     }
@@ -809,7 +808,6 @@ impl SlotState {
     pub(super) fn set_F(&mut self, slot: SlotId, fpr: FPReg) {
         self.clear(slot);
         self.set_mode(slot, LinkMode::F(fpr));
-        self.fpr_add(slot, fpr);
     }
 
     ///
@@ -819,7 +817,6 @@ impl SlotState {
     pub(super) fn set_Sf(&mut self, slot: SlotId, fpr: FPReg, guarded: SfGuarded) {
         self.clear(slot);
         self.set_mode(slot, LinkMode::Sf(fpr, guarded));
-        self.fpr_add(slot, fpr);
     }
 
     ///
@@ -1401,8 +1398,6 @@ impl SlotState {
                 // place, and the boxed value is materialized only where a
                 // path actually gives the claim up.
                 let h = self.fpr_alloc.push_spill();
-                self.fpr_remove(slot, fpr);
-                self.fpr_add(slot, h);
                 self.set_mode(slot, LinkMode::F(h));
                 ir.fpr_move(fpr, h);
             }
@@ -1688,7 +1683,7 @@ impl SlotState {
     }
 
     fn is_fpr_vacant(&self, fpr: FPReg) -> bool {
-        self.fpr(fpr).is_empty()
+        self.fpr_slots(fpr).next().is_none()
     }
 }
 
@@ -1893,9 +1888,11 @@ impl AbstractFrame {
         let mut b = UsingFpr::new();
         // Only physical pool slots need save/restore at call
         // boundaries; spill slots already live on the stack.
-        for i in 0..PHYS_FPR_POOL {
-            if !self.fpr_alloc.is_vacant(FPReg(i)) {
-                b.set(i, true);
+        for s in self.all_regs() {
+            if let LinkMode::F(x) | LinkMode::Sf(x, _) = self.mode(s)
+                && x.0 < PHYS_FPR_POOL
+            {
+                b.set(x.0, true);
             }
         }
         b
@@ -1961,7 +1958,6 @@ impl AbstractFrame {
     }
 
     fn fpr_swap(&mut self, l: FPReg, r: FPReg) {
-        self.fpr_alloc.swap(l, r);
         // A physical fpr swap (`FprSwap`) only changes *which register* holds
         // each live value; every slot keeps its own representation and
         // refinement. The two registers need not share a refinement — e.g. the
@@ -1990,20 +1986,23 @@ impl AbstractFrame {
         }
     }
 
+    /// Every register holding an `F` slot, with those slots — the raw
+    /// f64s a side exit has to box into their stack homes. Registers in
+    /// id order, slots in slot order.
     fn wb_fpr(&self, f: impl Fn(SlotId) -> bool) -> Vec<(FPReg, Vec<SlotId>)> {
-        (0..self.fpr_alloc.len())
-            .filter_map(|i| {
-                let reg = FPReg::new(i);
-                let v: Vec<_> = self
-                    .fpr_alloc
-                    .slots(reg)
-                    .iter()
-                    .filter(|s| f(**s) && matches!(self.mode(**s), LinkMode::F(_)))
-                    .cloned()
-                    .collect();
-                if v.is_empty() { None } else { Some((reg, v)) }
-            })
-            .collect()
+        let mut by_reg: Vec<(FPReg, Vec<SlotId>)> = Vec::new();
+        for s in self.all_regs() {
+            if let LinkMode::F(x) = self.mode(s)
+                && f(s)
+            {
+                match by_reg.iter_mut().find(|(r, _)| *r == x) {
+                    Some((_, v)) => v.push(s),
+                    None => by_reg.push((x, vec![s])),
+                }
+            }
+        }
+        by_reg.sort_by_key(|(r, _)| r.0);
+        by_reg
     }
 
     fn wb_literal(&self, f: impl Fn(SlotId) -> bool) -> Vec<(Value, SlotId)> {

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -2774,6 +2774,28 @@ mod tests {
         ));
     }
 
+    /// A local still held only in an fpr (`F`) when a block is handed to a
+    /// callee outside the unit (`String#each_char` is a Rust builtin, so
+    /// the block is not specialized) is boxed into its slot first — the
+    /// `F` arm of `unbox_to_S` without `keep_claims`: the block reads and
+    /// writes `x` through the frame, so the register copy alone would be
+    /// stale on both sides.
+    #[test]
+    fn test_unboxed_local_homed_before_an_outgoing_block() {
+        run_test(
+            r###"
+        def f(a)
+          x = a * 2.0
+          "abc".each_char { |c| x += c.size }
+          y = x * 0.5
+          loop { y += 1.0; break }
+          [x, y]
+        end
+        f(1.5)
+        "###,
+        );
+    }
+
     /// §15.5: a loop-carried float enters a loop JIT from the VM as a boxed
     /// `S(Value)`, but the back-edge fixpoint proves it is a `Float`. The
     /// loop-entry specialization re-adopts `F` (the `S -> F` bridge unboxes the

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -542,6 +542,7 @@
 285185fceec5d66e9a0b0017921fcdb3	:ok	old_stderr = $stderr\n            captured = String.new\n            
 2856d276c472b3b28a51d514662d76c0	"Cargo.toml"	File.open("Cargo.toml") { |f| f.to_path }
 2857ee8562740e3a303e0b419aa33d73	["EUC-JP", true]	(f="/tmp/mono_tpe_#{Process.pid}"; File.write(f, ""); io=File.new(f.encode(Encod
+285956e4dfd6239b0f5020e2c849f546	[6.0, 4.0]	def f(a)\n          x = a * 2.0\n          "abc".each_char { |c| x += c.s
 286b90c6e98dbe079e4a2b613b749cdb	"nil"	Set[1, 2, 3].freeze.flatten!.inspect
 289051905abb74616bfde774be4d9349	32.5	def call_block\n      yield\n    end\n    def call_block_twice\n      yield\n   
 2890bbfd125193c6fcb4cb125c9bd264	[999, 999]	$flag = false\n        def maybe_redefine\n          if $flag\n           


### PR DESCRIPTION
Second slice of the `SlotState` slimming (after #1273). The fpr register file's reverse map is gone, and the suite caught a latent bug the map had been masking, which is fixed at its root here.

## The derivation

`FprAllocator` kept `vfpr: Vec<Vec<SlotId>>` — for each fpr, the slots bound to it — maintained by `fpr_add` / `fpr_remove` / `clear` / `swap` beside every `F` / `Sf` transition. It is a function of the slot modes, so it is now computed from them: `SlotState::fpr_slots(fpr)` and a one-pass `pool_occupancy()` (per pool register: occupied?, all-`Sf`?) serve the allocator's two phases, `is_fpr_vacant`, the call-site save set and the deopt write-back. `FprAllocator` keeps only what is *not* derivable: the number of ids issued (spill ids are never re-issued once vacant) and the pin set. `set_F` / `set_Sf` / `clear` no longer touch a file; `fpr_swap` only relabels; the bookkeeping the `alloc_fpr` aliasing regression lived in is gone.

## What the map was hiding

`outer_float_write_through`'s two type-flip tests returned wrong values with the derived file. The emitted code differed from master at exactly one place: the `each` call site in the owner loop saved `xmm2` on master and not on the branch, and the block compiled inside that call then read the owner's `a` where it meant `i` — a `_%2 = %2 == %3 [Float][Integer]` deopt storm, because the block's static frame-chain offsets were off by the missing 16-byte save.

The mechanism: `specialized_compile` freezes the caller's FP save set *before* the nested compile (`stack_offset = using_fpr_offset().offset()` lays out the callee's `extra` chain offsets over it), while the call emission after the compile took `get_using_fpr` *again*. In between, the callee's compile can widen a caller slot (`StoreDynVar` through the chain → `widen_outer_slot` → `invalidate_slot`, which set `S` **without** `fpr_remove`). With the map, the stale entry kept `xmm2` "occupied", so both sets agreed by accident (and the register was leaked for the rest of the compile). Derived from the modes, the second set was smaller than the first, and the callee's offsets no longer matched the frame the call actually built.

## The fix

The frozen set rides back on the compiled frame (`JitStackFrame::call_site_using_fpr`, surfaced as `SpecializedCompileResult::using_fpr`), and both specialized call sites (`compile_yield_specialized`, `specialized_iseq`) emit *that* set and record it for the resolve pass. `get_using_fpr` still runs for its GP flush and alias kill; a debug assertion checks the live set is a subset of the frozen one (it can only shrink — a suspended frame never gains a pool register). Saving a register the caller no longer needs is harmless; saving fewer than the callee was laid out over was the bug. Written up in doc/regalloc_separation.md §47.

## Verification

- `emit-asm` dumps of nine benchmarks (`app_fib`, `so_mandelbrot`, `so_nbody`, `app_aobench`, `binarytrees`, `quick_sort`, `bf`, `tarai`, `loop_whileloop`), this branch vs master, addresses and compile-time lines normalised: **all identical**.
- JIT lib tests (107), the float / block / loop integration tests (15 files, `outer_float_write_through` included), and the **full `cargo test` suite** pass.
- aarch64 cross build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_