### PR TITLE
JIT: profile heap Integers as a Bignum class tag, so representation misses heal

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/mod.rs
@@ -1811,12 +1811,16 @@ impl Codegen {
                     // `BecamePolymorphic` is checked, not assumed: recompile
                     // only once the VM has actually stamped the site's POLY
                     // byte (`opcode_sub`, set by the interpreter on an
-                    // operand/receiver *class* change). A representation-only
-                    // miss — a BigInt failing an `Integer` guard's fixnum tag
-                    // test — never moves the byte, so the gate keeps such a
-                    // site on the plain deopt instead of recompiling against
-                    // an unchanged profile every N misses. Mirrors the x86
-                    // gate in `side_exit_with_label`.
+                    // operand/receiver *class* change). A miss the profile
+                    // cannot describe as a class change never moves the
+                    // byte, so the gate keeps such a site on the plain deopt
+                    // instead of recompiling against an unchanged profile
+                    // every N misses. (Binop/cmp ICs record a heap Integer
+                    // under the `BIGNUM_CLASS` tag, so a Bignum miss *is* a
+                    // class change there and heals into the dispatch; the
+                    // gate still protects the send-side exits, whose ICs
+                    // class every Integer alike.) Mirrors the x86 gate in
+                    // `side_exit_with_label`.
                     if reason == RecompileReason::BecamePolymorphic {
                         let poly_byte = pc.as_ptr() as u64 + 7;
                         monoasm_arm64!(&mut self.jit,

--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -1389,10 +1389,25 @@ impl Codegen {
         let get_class = self.get_class.clone();
         let skip = self.jit.label();
         let record = self.jit.label();
+        let keep = self.jit.label();
         monoasm_arm64!(&mut self.jit,
             ldr w10, [x(PC.0), #(8)]; // old classid1 (0 = cache empty)
+            // Stash the operand: `get_class` clobbers x2 for immediate
+            // receivers, and the representation refinement below needs its
+            // fixnum bit. x11 is in this helper's clobber set and is not
+            // read again until the poly-stamp below.
+            mov x11, x2;
             mov x0, x2;
             bl get_class;             // x0 = class(operand)
+            // Representation refinement (see `BIGNUM_CLASS`): record a heap
+            // Integer under the Bignum tag — mirrors `a64_save_binary_class`.
+            cmp w0, #(INTEGER_CLASS.u32());
+        );
+        self.jit.bcond_label(Cond::Ne, &keep);
+        monoasm_arm64!(&mut self.jit,
+            tbnz x11, #(0), keep;
+            mov x0, (BIGNUM_CLASS.u32() as u64);
+        keep:
             str w0, [x(PC.0), #(8)];  // classid1
             cbz w10, record;          // first population: record, no flag
             cmp w10, w0;
@@ -1422,6 +1437,8 @@ impl Codegen {
         let set_poly = self.jit.label();
         let skip = self.jit.label();
         let record = self.jit.label();
+        let keep_l = self.jit.label();
+        let keep_r = self.jit.label();
         monoasm_arm64!(&mut self.jit,
             // Read the previously-cached operand classes before overwriting
             // them (x10 = old classid1, x12 = old classid2; 0 = cache empty),
@@ -1431,9 +1448,29 @@ impl Codegen {
             ldr w12, [x(PC.0), #(12)];  // old classid2
             mov x0, x13;
             bl get_class;             // x0 = class(lhs)
+            // Representation refinement (see `BIGNUM_CLASS`): a heap
+            // Integer is recorded under the Bignum tag, so a
+            // fixnum-profiled site stays monomorphic and the first Bignum
+            // operand reads as a class change (POLY stamp + PMC entry)
+            // instead of vanishing into `Integer`. x13/x14 survive
+            // `get_class`, so the operand's fixnum bit is still testable.
+            cmp w0, #(INTEGER_CLASS.u32());
+        );
+        self.jit.bcond_label(Cond::Ne, &keep_l);
+        monoasm_arm64!(&mut self.jit,
+            tbnz x13, #(0), keep_l;
+            mov x0, (BIGNUM_CLASS.u32() as u64);
+        keep_l:
             str w0, [x(PC.0), #(8)];  // classid1
             mov x0, x14;
             bl get_class;             // x0 = class(rhs)
+            cmp w0, #(INTEGER_CLASS.u32());
+        );
+        self.jit.bcond_label(Cond::Ne, &keep_r);
+        monoasm_arm64!(&mut self.jit,
+            tbnz x14, #(0), keep_r;
+            mov x0, (BIGNUM_CLASS.u32() as u64);
+        keep_r:
             str w0, [x(PC.0), #(12)]; // classid2
             // Polymorphic detection (mirrors x86 `vm_save_binary_class`): once
             // the cache is populated (old classid1 != 0), if either operand's

--- a/monoruby/src/codegen/arch/x86_64/vmgen.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen.rs
@@ -614,8 +614,20 @@ impl Codegen {
         let get_class = self.get_class.clone();
         let skip = self.jit.label();
         let record = self.jit.label();
+        let keep = self.jit.label();
         monoasm! { &mut self.jit,
             call  get_class;
+            // Representation refinement (see `BIGNUM_CLASS`): a heap Integer
+            // is recorded under the Bignum tag, so a fixnum-profiled site
+            // stays monomorphic and the first Bignum operand reads as a
+            // class change (POLY stamp + PMC entry) instead of vanishing
+            // into `Integer`. `get_class` preserves rdi (the operand).
+            cmpl  rax, (INTEGER_CLASS.u32());
+            jne   keep;
+            testq rdi, 0x1;
+            jne   keep;
+            movl  rax, (BIGNUM_CLASS.u32());
+        keep:
             // r8 <- cached class (0 if the inline cache is empty)
             movl  r8, [r13 - 8];
             movl  [r13 - 8], rax;
@@ -659,14 +671,33 @@ impl Codegen {
         let skip = self.jit.label();
         let set_poly = self.jit.label();
         let record = self.jit.label();
+        let keep_l = self.jit.label();
+        let keep_r = self.jit.label();
         monoasm! { &mut self.jit,
             call  get_class;
+            // Representation refinement (see `BIGNUM_CLASS`): a heap Integer
+            // is recorded under the Bignum tag, so a fixnum-profiled site
+            // stays monomorphic and the first Bignum operand reads as a
+            // class change (POLY stamp + PMC entry) instead of vanishing
+            // into `Integer`. `get_class` preserves rdi (the operand).
+            cmpl  rax, (INTEGER_CLASS.u32());
+            jne   keep_l;
+            testq rdi, 0x1;
+            jne   keep_l;
+            movl  rax, (BIGNUM_CLASS.u32());
+        keep_l:
             // r8 <- cached lhs class (0 if the inline cache is empty)
             movl  r8, [r13 - 8];
             movl  [r13 - 8], rax;
             xchgq rdi, rsi;
             //movq  rdi, rsi;
             call  get_class;
+            cmpl  rax, (INTEGER_CLASS.u32());
+            jne   keep_r;
+            testq rdi, 0x1;
+            jne   keep_r;
+            movl  rax, (BIGNUM_CLASS.u32());
+        keep_r:
             // r9 <- cached rhs class
             movl  r9, [r13 - 4];
             movl  [r13 - 4], rax;

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -1705,13 +1705,16 @@ impl Codegen {
             // `BecamePolymorphic` is checked, not assumed: recompile only
             // once the VM has actually stamped the site's POLY byte
             // (`opcode_sub`, op1 bits 63:56 — the interpreter sets it on an
-            // operand/receiver *class* change). A miss that splits one class
-            // by representation — a BigInt failing an `Integer` guard's
-            // fixnum tag test — re-executes in the VM without moving the
-            // byte, and a recompile against an unchanged profile would
-            // reproduce the same guard: the activerecord `out_of_range?`
-            // shape recompiled 8,756 times that way. With the gate such a
-            // site just deopts plainly, byte-for-byte the pre-heal behavior.
+            // operand/receiver *class* change). A miss the profile cannot
+            // describe as a class change re-executes in the VM without
+            // moving the byte, and a recompile against an unchanged profile
+            // would reproduce the same guard: the activerecord
+            // `out_of_range?` shape recompiled 8,756 times that way. With
+            // the gate such a site just deopts plainly, byte-for-byte the
+            // pre-heal behavior. (Binop/cmp ICs record a heap Integer under
+            // the `BIGNUM_CLASS` tag, so a Bignum miss *is* a class change
+            // there and heals into the dispatch; the gate still protects
+            // the send-side exits, whose ICs class every Integer alike.)
             if reason == RecompileReason::BecamePolymorphic {
                 let poly_byte = pc.as_ptr() as usize + 7;
                 monoasm!( &mut self.jit,

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -228,6 +228,14 @@ impl<'a> JitContext<'a> {
         // the state already knows the class and no guard is emitted at all.
         heal: Option<RecompileTarget>,
     ) -> Option<BinaryInlineOutcome> {
+        // The Bignum tag resolves to Integer's methods, whose inline
+        // generators compute raw fixnum arithmetic — firing one behind a
+        // Bignum-profiled receiver would operate on a heap pointer. A
+        // Bignum receiver has no inline form; the caller's residual
+        // (generic helper / dispatch slow arm) is its fast path.
+        if lhs_class == BIGNUM_CLASS {
+            return None;
+        }
         let (fid, _visibility) = self.jit_check_method(lhs_class, op)?;
         let inline = self.store.inline_info.get_inline(fid)?;
         if !matches!(
@@ -349,15 +357,21 @@ impl<'a> JitContext<'a> {
             pmc.entries().iter().map(|e| (e.recv, e.count)).collect();
         classes.sort_unstable_by_key(|(_, count)| std::cmp::Reverse(*count));
         classes.into_iter().map(|(class, _)| class).find(|&class| {
-            matches!(
-                self.jit_check_method(class, op)
-                    .and_then(|(fid, _)| self.store.inline_info.get_inline(fid)),
-                Some(InlineFuncInfo::InlineGenBinary(_))
-            )
-            // Same licence the guarded direct-fire path needs: the arm runs
-            // without a class-version guard, so a redefinition has to reach
-            // it through the recorded bop dependency.
-            && self.basic_op_assumable(class, op)
+            // The Bignum tag resolves to Integer's methods and would look
+            // inlinable, but the arm guard proves the *fixnum*
+            // representation — a Bignum can never enter it. Its share is
+            // served by the residual arm (where `BrClassNe(INTEGER)`'s tag
+            // test already routes every heap Integer).
+            class != BIGNUM_CLASS
+                && matches!(
+                    self.jit_check_method(class, op)
+                        .and_then(|(fid, _)| self.store.inline_info.get_inline(fid)),
+                    Some(InlineFuncInfo::InlineGenBinary(_))
+                )
+                // Same licence the guarded direct-fire path needs: the arm
+                // runs without a class-version guard, so a redefinition has
+                // to reach it through the recorded bop dependency.
+                && self.basic_op_assumable(class, op)
         })
     }
 
@@ -599,6 +613,9 @@ impl<'a> JitContext<'a> {
         };
         if recv_class == INTEGER_CLASS
             || recv_class == FLOAT_CLASS
+            // The Bignum tag is numeric too (and `BrClassNe` cannot test a
+            // representation): its sites belong to the generic helper.
+            || recv_class == BIGNUM_CLASS
             || !recvs.all(|c| c == recv_class)
         {
             return Ok(false);
@@ -835,13 +852,17 @@ impl<'a> JitContext<'a> {
             // residual treatment above. The exit only actually recompiles
             // once the VM has stamped the site's POLY byte (see the
             // `BecamePolymorphic` gate in the side-exit lowering), so a
-            // representation-only miss — a BigInt failing the fixnum tag
-            // test, class `Integer` all the same, which never sets POLY —
-            // can never recompile-livelock (the activerecord
-            // `out_of_range?` storm shape). At a site already compiled
-            // polymorphic, reaching here means the polymorphic treatments
-            // were tried at *this* compile and declined; a recompile would
-            // reproduce this very body, so the guard deopts plainly.
+            // miss the profile cannot describe as a class change can never
+            // recompile-livelock (the activerecord `out_of_range?` storm
+            // shape). A Bignum miss *is* a class change here — the binop
+            // ICs record heap Integers under `BIGNUM_CLASS` — so a
+            // fixnum-compiled site that starts seeing Bignums heals into
+            // the dispatch, whose `Integer` arm is the fixnum tag test and
+            // whose residual arm is exactly where the Bignum share wants
+            // to run. At a site already compiled polymorphic, reaching
+            // here means the polymorphic treatments were tried at *this*
+            // compile and declined; a recompile would reproduce this very
+            // body, so the guard deopts plainly.
             let heal = (!polymorphic)
                 .then(|| self.recv_miss_recompile_target())
                 .flatten();
@@ -914,6 +935,22 @@ impl<'a> JitContext<'a> {
                 .jit_check_method(lhs_class, IdentId::from(binop))
                 .is_none()
         {
+            state.flush_gp(ir);
+            let is_func_call = self
+                .store
+                .get_callsite_id(self.iseq_id(), bc_pos)
+                .is_some_and(|c| self.store[c].is_func_call());
+            self.emit_generic_binary(state, ir, binop, lhs, rhs, case_semantics, is_func_call);
+            return Ok(BinaryLowering::Generic);
+        }
+        // A Bignum-profiled receiver has no inline form and nothing worth
+        // guarding: a direct call would need a compound representation
+        // guard, and the generic helper already dispatches a heap Integer
+        // correctly. Same treatment as the unresolvable BOOL case above —
+        // and a site that later turns fixnum flips polymorphic (the tag
+        // change stamps POLY) and takes the dispatch, whose Integer arm
+        // serves the fixnum share inline.
+        if lhs_class == BIGNUM_CLASS {
             state.flush_gp(ir);
             let is_func_call = self
                 .store
@@ -1465,13 +1502,17 @@ mod tests {
         );
     }
 
-    /// A representation-only miss must NOT heal: the guard is the fixnum tag
-    /// test, a Bignum carries `Integer` all the same, and the VM never marks
-    /// the site polymorphic — so the `BecamePolymorphic` exit's POLY-byte
-    /// gate keeps it on the plain deopt (no recompile-per-N-misses storm; the
-    /// activerecord `out_of_range?` shape). Pins the semantics either way.
+    /// A fixnum-compiled site that starts seeing Bignums: the binop ICs
+    /// record a heap Integer under the `BIGNUM_CLASS` tag, so the first
+    /// Bignum operand is a class change — it stamps the POLY byte, feeds
+    /// the PMC, and the guard's `BecamePolymorphic` exit heals the site
+    /// into the polymorphic treatment (fused: the generic residual;
+    /// value-mode: the two-arm dispatch, whose `Integer` arm is the fixnum
+    /// tag test and whose residual arm serves the Bignum share) instead of
+    /// side-exiting on every heap operand forever. Pins the semantics
+    /// through the transition.
     #[test]
-    fn mono_cmp_bigint_misses_stay_plain() {
+    fn mono_cmp_heals_on_bignum_misses() {
         run_test(
             r#"
             def probe(a, b)
@@ -1486,6 +1527,27 @@ mod tests {
             big = 1 << 62
             300.times { |n| res << probe(big + n, 100) }
             res.tally.sort_by { |k, _| k.to_s }
+            "#,
+        );
+    }
+
+    /// A site that has only ever seen Bignum receivers compiles to the
+    /// generic helper — no inline form exists for a heap Integer, and a
+    /// class guard for the representation tag would deopt on every
+    /// execution. Both the pure-Bignum and the value-mode mixed shape must
+    /// answer exactly as the interpreter.
+    #[test]
+    fn bignum_mono_cmp_takes_generic() {
+        run_test(
+            r#"
+            big = 1 << 62
+            def probe(a, b) = a < b ? 1 : 0
+            def eq(a, b) = (a == b)
+            r = 0
+            300.times { |n| r += probe(big + n, big) }
+            ok = []
+            300.times { |n| ok << eq(big + (n % 2), big) }
+            [r, ok.tally.sort_by { |k, _| k.to_s }]
             "#,
         );
     }

--- a/monoruby/src/codegen/jitgen/compile/unary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/unary_op.rs
@@ -72,6 +72,15 @@ impl<'a> JitContext<'a> {
         let Some(recv_class) = state.class(src).or(ic) else {
             return Ok(CompileResult::Recompile(RecompileReason::NotCached));
         };
+        // The unary paths are not (yet) representation-aware: normalize the
+        // profile's Bignum tag back to `Integer` so a Bignum-profiled site
+        // compiles exactly as it did before the binop ICs learned to
+        // distinguish the representations.
+        let recv_class = if recv_class == BIGNUM_CLASS {
+            INTEGER_CLASS
+        } else {
+            recv_class
+        };
         if self.fire_unary_inline(state, ir, kind.into(), src, recv_class, bc_pos) {
             // ④-b: the Integer/Float inline unaries are pure arithmetic
             // (guards exit the trace) — the unfrozen-slot proofs survive.

--- a/monoruby/src/globals/store.rs
+++ b/monoruby/src/globals/store.rs
@@ -1460,6 +1460,13 @@ impl Store {
         if class_id == BOOL_CLASS {
             return self.check_bool_method_with_version(name, class_version);
         }
+        // The Bignum tag is a representation, not a method namespace: every
+        // heap Integer resolves methods exactly as a fixnum does.
+        let class_id = if class_id == BIGNUM_CLASS {
+            INTEGER_CLASS
+        } else {
+            class_id
+        };
         let mut cache = self.method_cache.borrow_mut();
         if let Some(entry) = cache.get(class_id, name, class_version) {
             return entry.cloned();

--- a/monoruby/src/globals/store/class.rs
+++ b/monoruby/src/globals/store/class.rs
@@ -89,6 +89,26 @@ pub const YIELDER_CLASS: ClassId = ClassId::new(60);
 /// on (for `Module.used_modules` and for `#to_s`).
 pub const REFINEMENT_CLASS: ClassId = ClassId::new(61);
 
+/// Internal "Bignum" tag — like [`BOOL_CLASS`], not a Ruby-visible class:
+/// every Integer keeps its `Integer` identity at the user level. The
+/// binop/cmp inline caches (and the PMC they feed) record a heap Integer
+/// under this tag instead of `INTEGER_CLASS`, so the profile machinery
+/// sees the two *representations* as two classes: a site that has only
+/// ever seen fixnums stays monomorphic, and the first Bignum operand is a
+/// class change — it stamps the site's POLY byte and lands in the PMC,
+/// exactly like `nil` arriving at an Integer compare. The existing
+/// polymorphic treatments then apply unchanged: the two-arm dispatch's
+/// `Integer` arm is the fixnum tag test, so the Bignum share falls to the
+/// guard-free generic arm instead of deopting forever, and the
+/// `BecamePolymorphic` heal's POLY-byte gate passes for genuinely
+/// Bignum-visited sites (it exists to block exactly the sites the old
+/// vocabulary could not describe). Method resolution for the tag
+/// delegates to `INTEGER_CLASS` (see
+/// `check_method_for_class_with_version`); the JIT never emits an inline
+/// arm or a class guard for it — a Bignum-profiled receiver takes the
+/// generic call, which is where a heap Integer wants to be anyway.
+pub const BIGNUM_CLASS: ClassId = ClassId::new(62);
+
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct ClassId(NonZeroU32);
@@ -155,6 +175,7 @@ impl std::fmt::Debug for ClassId {
             55 => write!(f, "ARITHMETIC_SEQUENCE"),
             56 => write!(f, "SIGNAL_EXCEPTION"),
             57 => write!(f, "INTERRUPT"),
+            62 => write!(f, "BIGNUM"),
             n => write!(f, "ClassId({n})"),
         }
     }

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -1809,6 +1809,7 @@
 8ac618ade447bc8197083d4232e91f3a	[42, 42, 294, 23, 2]	def __f(x)\n          \n        a = x + 3\n        b = a\n        c = 7 * b
 8ac98985ac612f0703d37bf0737bc3e8	["ABいう", true]	s = "あいう"\n            s.bytesplice(0, 3, "AB".force_encoding("ASCII
 8ad0bb005e97f639e1a5c706a270ed11	[true, false, true, true, true, true]	class W\n            include Comparable\n            attr_accessor :x\n 
+8ad8e77fe5dfee952b57c56f285f1173	[0, [[false, 150], [true, 150]]]	big = 1 << 62\n            def probe(a, b) = a < b ? 1 : 0\n         
 8aff130d4cf4e00d7d7b4435b5691762	[true, "hi"]	require 'tmpdir'\n            path = File.join(Dir.tmpdir, "mrb_fifo
 8b1c707195f0233d91b133db6b2549a0	3	S = Struct.new(:a, :b, :c)\n        s = S.new(10, 20, 30)\n        \ns.len
 8b55158395e31dd88ba473b1a6f3e551	true	GC.auto_compact = true; GC.auto_compact


### PR DESCRIPTION
Implements the Bignum-vocabulary design (①②③) on top of #1274's dispatch/heal machinery.

## Problem

The type lattice's `Integer` has always meant "fixnum": `GuardClass(INTEGER)` is the fixnum tag test, doubling as the representation proof the inline generators build on. The *profile* shared that conflation — a heap Integer recorded plain `Integer` in the binop/cmp inline caches — so a fixnum-compiled site fed Bignums missed its guard on every execution while looking monomorphic to every healing mechanism: the IC pair never changed, POLY never stamped, the PMC never grew, and #1274's `BecamePolymorphic` gate (correctly) refused to recompile against an unchanged profile. dewasm DOOM's `Doom::Rt#m64` comparison paid 3,714 such deopts per 60-tick smoke, forever — each one at the leaf of a deeply specialized unit, abandoning compiled execution for the rest of that mega-invocation.

## Fix: give the profile the missing word, not the compiler two Integers

* **① `BIGNUM_CLASS`** — a compiler-internal class tag like `BOOL_CLASS` (ClassId 62, a reserved pre-allocated slot), never user-visible; method resolution delegates to `INTEGER_CLASS`. The binop/cmp/unary IC savers (both arches' vmgen) record a heap Integer under it: after `get_class`, an `Integer` whose value fails the fixnum tag test is stored as `BIGNUM`.
* **② Fixnum-only = monomorphic.** In the profile's own terms, the first Bignum operand is now an ordinary class change: it stamps the site's POLY byte and lands in the PMC via the existing displaced-pair recording. No new guards and no lattice change — `Guarded::Fixnum` and every inline path are untouched.
* **③ Type-dispatch on recompile.** The existing machinery does the rest: the counter-gated heal recompiles the site once, and `binary_dispatch`'s `Integer` arm — already the fixnum tag test — keeps the fixnum share inline while the Bignum share falls to the guard-free generic arm (fused sites take the step-3c residual the same way).

Consumers that are not representation-aware keep exact pre-change behavior: the basic-op licence has no `(BIGNUM, op)` rows, so the tag declines every inline path on its own (explicit declines added where the licence is not consulted — `fire_binary_inline`, `dispatch_inline_class`, `binary_recv_dispatch`); a Bignum-*mono* site compiles straight to the generic helper (no guard, no deopt); the unary path normalizes the tag back to `Integer` on entry.

## Measurements

- Fixnum-then-Bignum repro (fused `a < b` and value-mode `a >= b`): 30k misses -> **11 deopts + 1 recompile**, then silence; profile shows the site as `[BIGNUM][Integer]`.
- DOOM 60-tick smoke: `Doom::Rt#m64` / `s64` deopts **3,714 / 179 -> 11 each** (counter drain only).
- The remaining DOOM storms (`Renderer#render` 296k, `_f869` 2k) are a different, pre-existing shape (deopt-cause sampling: every one is `class Integer but guard expected NilClass` — a site mono-compiled during the first frame's nil-filled `@prev`, whose misses re-execute through the VM's fixnum fast path, which re-stamps the IC silently without POLY/PMC). Follow-up material.

## Tests

- `mono_cmp_heals_on_bignum_misses` (rewritten from the old "stays plain" premise — under the new vocabulary the site is *supposed* to heal) and `bignum_mono_cmp_takes_generic` (new); the operand-matrix suites now exercise the tag end-to-end.
- Full suite: default 3580/3580, `stress-spill-pool` 3580/3580 (both re-run after rebasing onto #1275).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
