### PR TITLE
gosu: decode the window-flag bitmask, and clear each drawn frame

### DIFF
--- a/monoruby/gem/gosu.rb
+++ b/monoruby/gem/gosu.rb
@@ -404,6 +404,17 @@ module Gosu
                   :update_interval
     attr_reader :text_input
 
+    # Window flags, as swig_patches.rb's Window#initialize packs them before
+    # handing them down: it turns Gosu 1.x's options Hash
+    # (`Window.new(w, h, fullscreen: true, resizable: true)`) and the older
+    # positional boolean alike into this bitmask.
+    FLAG_FULLSCREEN = 1
+    FLAG_RESIZABLE  = 2
+    FLAG_BORDERLESS = 4
+
+    # `fullscreen_or_flags` is that bitmask, so it has to be read bit by bit.
+    # Read as one on/off fullscreen value it makes every other flag mean
+    # fullscreen: `resizable: true` on its own arrives as 2, and 2 != 0.
     def initialize(width, height, fullscreen_or_flags = 0,
                    update_interval = 16.666666)
       @width  = width
@@ -413,9 +424,14 @@ module Gosu
       @mouse_y = 0.0
       @update_interval = update_interval
       @text_input = nil
-      @fullscreen = fullscreen_or_flags != 0
-      @resizable = false
-      @borderless = false
+      flags = case fullscreen_or_flags
+              when true then FLAG_FULLSCREEN
+              when false, nil then 0
+              else fullscreen_or_flags.to_i
+              end
+      @fullscreen = flags & FLAG_FULLSCREEN != 0
+      @resizable  = flags & FLAG_RESIZABLE  != 0
+      @borderless = flags & FLAG_BORDERLESS != 0
       @_sdl_window = nil
       @_sdl_renderer = nil
       @_closing = false
@@ -434,6 +450,12 @@ module Gosu
           update
           last_tick = now
         end
+        # Gosu redraws the whole window each frame, so a frame starts from a
+        # cleared surface: whatever `draw` leaves unpainted must not show the
+        # back buffer's previous contents. The colour is set here every time
+        # because drawing (draw_rect, draw_line, ...) leaves its own behind.
+        SDL2.set_draw_color(@_sdl_renderer, 0, 0, 0, 255)
+        SDL2.render_clear(@_sdl_renderer)
         draw
         SDL2.render_present(@_sdl_renderer)
         SDL2.delay(1)
@@ -559,6 +581,9 @@ module Gosu
     #     .y                   int32  @ 24
     #   SDL_MouseButtonEvent:
     #     .button              uint8  @ 16
+    #   SDL_WindowEvent:
+    #     .event               uint8  @ 12
+    #     .data1 / .data2      int32  @ 16 / 20
     # All other fields are ignored for now.
     def _pump_events
       while SDL2.poll_event(@_event_buf) != 0
@@ -566,6 +591,14 @@ module Gosu
         case type
         when SDL2::EVENT_QUIT
           close
+        when SDL2::EVENT_WINDOW
+          # #width / #height are what a resizable or fullscreen window lays
+          # itself out against, and SDL, not the requested size, decides what
+          # they end up being.
+          if @_event_buf.get_uint8(12) == SDL2::WINDOWEVENT_SIZE_CHANGED
+            @width  = @_event_buf.get_int32(16)
+            @height = @_event_buf.get_int32(20)
+          end
         when SDL2::EVENT_KEYDOWN
           scancode = @_event_buf.get_int32(16)
           next if @text_input && _text_input_consume_keydown(scancode)

--- a/monoruby/gem/gosu.rb
+++ b/monoruby/gem/gosu.rb
@@ -450,14 +450,20 @@ module Gosu
           update
           last_tick = now
         end
-        # Gosu redraws the whole window each frame, so a frame starts from a
-        # cleared surface: whatever `draw` leaves unpainted must not show the
-        # back buffer's previous contents. The colour is set here every time
-        # because drawing (draw_rect, draw_line, ...) leaves its own behind.
-        SDL2.set_draw_color(@_sdl_renderer, 0, 0, 0, 255)
-        SDL2.render_clear(@_sdl_renderer)
-        draw
-        SDL2.render_present(@_sdl_renderer)
+        # Upstream Gosu gates clearing, drawing and presenting together on
+        # needs_redraw? (Window::tick -> Graphics::frame, which opens with
+        # glClearColor(0, 0, 0, 1) + glClear right before draw()), so a frame
+        # that is drawn always starts from a cleared surface and a frame that
+        # is skipped leaves the window exactly as it was. Without the clear,
+        # whatever `draw` does not paint shows the back buffer's previous
+        # contents instead of black. The colour is set every time because
+        # drawing (draw_rect, draw_line, ...) leaves its own behind.
+        if needs_redraw?
+          SDL2.set_draw_color(@_sdl_renderer, 0, 0, 0, 255)
+          SDL2.render_clear(@_sdl_renderer)
+          draw
+          SDL2.render_present(@_sdl_renderer)
+        end
         SDL2.delay(1)
       end
       close!

--- a/monoruby/gem/gosu/sdl2.rb
+++ b/monoruby/gem/gosu/sdl2.rb
@@ -64,6 +64,9 @@ module Gosu
     EVENT_CONTROLLERDEVICEREMOVED = 0x654
     EVENT_TEXTINPUT               = 0x303
 
+    # --- SDL_WindowEvent.event kinds (EVENT_WINDOW) ---------------------
+    WINDOWEVENT_SIZE_CHANGED = 6
+
     # --- Core -----------------------------------------------------------
     attach_function :init,             :SDL_Init,             [:uint32], :int
     attach_function :init_sub_system,  :SDL_InitSubSystem,    [:uint32], :int


### PR DESCRIPTION
A gosu app asking for a plain resizable window opened **fullscreen**, and part of the screen showed garbage. Both come from one misread in the gosu shim.

## The bitmask

`gosu/swig_patches.rb`'s `Window#initialize` packs Gosu 1.x's options Hash (`Window.new(w, h, fullscreen: true, resizable: true)`) and the older positional boolean alike into a bitmask, then hands it down:

```ruby
flags = 0
flags |= 1 if args.first[:fullscreen]
flags |= 2 if args.first[:resizable]
flags |= 4 if args.first[:borderless]
initialize_with_bitmask(width, height, flags, ...)
```

The shim's `Window#initialize` read that bitmask as a single on/off fullscreen value:

```ruby
@fullscreen = fullscreen_or_flags != 0
@resizable  = false
@borderless = false
```

So every flag other than fullscreen *meant* fullscreen: `resizable: true` on its own arrives as `2`, and `2 != 0`. `:resizable` and `:borderless` were dropped besides, both hardcoded. Now read bit by bit, with the bits named.

## Why the screen also garbled

With `WINDOW_FULLSCREEN_DESKTOP` the window is the size of the display, while `#width` / `#height` keep reporting the size that was asked for. An app laying its frame out against them paints only a corner of the surface, and the rest kept whatever the back buffer held: `show` cleared once, in `_create_window`, never per frame. With double buffering the unpainted region alternated between two old frames.

Upstream keeps clearing, drawing and presenting together, gated on `needs_redraw?` — `Window::tick` wraps the lot in `if (needs_redraw())`, and `Graphics::frame` opens with `glClearColor(0, 0, 0, 1)` + `glClear` immediately before `draw()`, with the buffer swap after it in the same branch (`Window.cpp:372`, `Graphics.cpp:168`). `show` now does the same, so a frame that is drawn always starts from a cleared surface and a frame that is skipped leaves the window untouched. The shim never consulted `needs_redraw?` at all, though it defines it, so a subclass overriding it to `false` (Gosu's documented way to hold a static screen) was drawn and presented anyway. The clear colour is set every time because drawing (`draw_rect`, `draw_line`, ...) leaves its own behind.

A `SIZE_CHANGED` window event now also updates `#width` / `#height`, which honouring `:resizable` newly makes reachable. That needs no new FFI binding, only the existing event buffer.

## Verification

Against `examples/doom/ruby-gosu` from sisshiki1969/dewasm, the app that surfaced this, under `SDL_VIDEODRIVER=dummy`.

Its `super(960, 600, fullscreen: false, resizable: true)`:

| | before | after |
| --- | --- | --- |
| `@fullscreen` | `true` | `false` |
| `@resizable` | `false` | `true` |

All eight constructor forms were checked (no third argument, positional `true` / `false`, and the Hash with each flag and `:update_interval`); the positional forms are unchanged.

Frame gating, over five frames:

| `needs_redraw?` | `draw` | `render_clear` | `render_present` |
| --- | --- | --- | --- |
| `true` (the default) | 5 | 5 per frame, + 1 from `_create_window` | 5 |
| `false` | 0 | 0, leaving only `_create_window`'s | 0 |

## Note

No test is added: `require "gosu"` attaches the SDL2, SDL2_image, SDL2_ttf and SDL2_mixer libraries at load time, so a test would put all four on CI. Happy to add one if you would like that tradeoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CreYezJ9tefe5BjESSzd7Q