### PR TITLE
Remove the phys-loop-aware feature and the loop_carried hint

### DIFF
--- a/doc/lir.md
+++ b/doc/lir.md
@@ -441,9 +441,10 @@ ordered sequence the allocator can walk and the drainer can replay faithfully.
 - **9d — The arch-dependent physical-allocation pass.** Walk the buffered LIR,
   assign physical GPs to `VReg`s (spilling to frame slots under pressure, exactly
   as `FPReg` does for FP), then drain → encode. This is the first point the
-  output may legitimately differ from today's bytes; like `phys-loop-aware`
-  (§42), it is a perf experiment gated behind a flag + the M1 A/B bench gate, and
-  the shadow digest becomes a delta meter, not an equality check.
+  output may legitimately differ from today's bytes; like the (since removed)
+  `phys-loop-aware` experiment (regalloc doc §42, §49), it is a perf experiment
+  gated behind a flag + the M1 A/B bench gate, and the shadow digest becomes a
+  delta meter, not an equality check.
 
 ### 9d allocatable GP pool (design decision)
 

--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -3259,3 +3259,16 @@ suite pass. The `*_state` analysis-half split of the two old functions
 (`write_back_slot_state`, `to_S_unguarded_state`) is folded in as well: the
 `Spill` record is still computed by the state transition and emitted through
 `ir.spill`, so analysis mode still emits nothing.
+
+## 49. `phys-loop-aware` removed
+
+The §42 loop-aware spill-victim policy (`loop_carried` on `SlotState`, filled
+at the loop-entry merge from the back-edge fixpoint; the phase-1 filter that
+kept a loop-carried `Sf` cache resident) is deleted along with its Cargo
+feature. It was default-off, not built by CI, and — as §42 itself records —
+inert under the shipping `POOL=14`: phase 1 runs only when no pool register is
+vacant, so the lever bit only under `stress-spill-pool` or a ≈14-live-float
+loop, and its M1 A/B (§27.3-2c) was never run. The `L`-collection timing
+finding (§42: the multi-iteration fixpoint makes the back-edge available at
+merge time) stays in the record for whoever revisits loop-aware allocation;
+the code it justified no longer earns its field in the per-path state.

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -53,7 +53,6 @@ run time with `--no-jit`. (The old `jit` / `jit_x86` build cfgs and the
 | `stress-spill-pool` | Shrink `PHYS_FPR_POOL` to 2 so almost every float-resident slot becomes a spilled virtual FP register, stressing the spill paths |
 | `shadow-placement` | Record every physical FP placement in emission order, producing a per-compile fingerprint of the lowering. The gate for the abstract-interpreter / register-allocation separation |
 | `phys-table` | Move the physical FP placement *policy* out of the resolver into an explicit table-backed function. Byte-identical to the formula it replaces |
-| `phys-loop-aware` | The loop-aware FP allocation policy: keep loop-carried floats resident so a fresh value spills instead of evicting one. Non-byte-identical by design |
 | `mimalloc` | Route the global allocator's delegation to mimalloc instead of glibc, changing exactly one variable for an A/B |
 
 The last three are gated on measurement and are off until their A/B clears;

--- a/monoruby/Cargo.toml
+++ b/monoruby/Cargo.toml
@@ -72,14 +72,6 @@ shadow-placement = []
 # formula it replaces (verified via `shadow-placement` digests); the seam where
 # P4's loop-aware allocator swaps in. Default-off until the M1 A/B gate clears.
 phys-table = []
-# §5 §27.3 Stage-2: the loop-aware FP allocation policy. ① (the back-edge
-# fixpoint) records the loop-carried float set `L`; the phase-1 spill-victim
-# policy then keeps `L`'s `Sf` caches resident (a fresh value spills instead of
-# evicting a loop-carried float), cutting in-loop reloads. NON-byte-identical by
-# design (§26): it changes placement / removes back-edge moves, so the
-# `shadow-placement` digest becomes a *delta* meter, not an equality check, and
-# the gate is M1 perf A/B (§27.3-2c). Default-off until that gate clears.
-phys-loop-aware = []
 emit-cfg = ["dump-bc", "dump-traceir"]
 dump-require = []
 

--- a/monoruby/src/codegen/jitgen/merge.rs
+++ b/monoruby/src/codegen/jitgen/merge.rs
@@ -238,21 +238,6 @@ impl<'a> JitContext<'a> {
                         target.keep_backedge_floats(adopt, adopt_sf, adopt_deferred, promotable);
                     }
                 }
-                // §27.3 Stage-2a: record the loop-carried float set `L` (slots
-                // `F`/`Sf` at the back-edge) on the loop-entry state, so the
-                // `phys-loop-aware` policy can keep them resident in the body.
-                // Available here only because the fixpoint already computed the
-                // back-edge — the timing §29's forward attempt lacked. It
-                // propagates into the body via clones / `&mut self` joins, and
-                // is an inert hint on the default path.
-                #[cfg(feature = "phys-loop-aware")]
-                if let Some(be) = &backedge_for_floats {
-                    let lc: std::collections::HashSet<SlotId> = be
-                        .all_regs()
-                        .filter(|&i| matches!(be.mode(i), LinkMode::F(_) | LinkMode::Sf(_, _)))
-                        .collect();
-                    target.set_loop_carried(lc);
-                }
             }
             #[cfg(feature = "jit-debug")]
             eprintln!("  target:  {:?}\n", target.slot_state());

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -117,23 +117,7 @@ mod alloc_policy {
         let victim = (0..state.fpr_alloc.len().min(PHYS_FPR_POOL))
             .map(FPReg)
             .filter(|&fpr| !state.fpr_alloc.is_pinned(fpr) && occ.occupied(fpr))
-            .filter(|&fpr| {
-                // §27.3 Stage-2b (`phys-loop-aware`): do not demote the `Sf`
-                // cache of a loop-carried float — keep `L` resident so the
-                // body re-reads it from `xmm` instead of decoding it each
-                // iteration; the fresh value goes to a phase-2 spill instead.
-                // Default path: this filter is absent (`loop_carried` empty),
-                // so victim selection is byte-identical.
-                #[cfg(feature = "phys-loop-aware")]
-                if occ.all_sf(fpr)
-                    && state
-                        .fpr_slots(fpr)
-                        .any(|s| state.loop_carried.contains(&s))
-                {
-                    return false;
-                }
-                occ.all_sf(fpr)
-            })
+            .filter(|&fpr| occ.all_sf(fpr))
             .min_by_key(|&fpr| ctx.victim_rank(fpr))?;
         // Demoting the slots is what frees the register: the file is
         // derived from the modes, so there is no reverse entry to clear.
@@ -254,15 +238,6 @@ pub(crate) struct SlotState {
     /// merge despite living in the cloned `SlotState`.
     pub(in crate::codegen::jitgen) gp_regfile: crate::codegen::jitgen::gp_alloc::GpRegFile,
     local_num: usize,
-    /// §27.3 Stage-2a: the loop-carried float set `L` for the enclosing loop —
-    /// slots that are `F`/`Sf` at the loop back-edge (so they round-trip the
-    /// loop). Populated at the loop-entry merge from the fixpoint's back-edge
-    /// (which is why §29's forward-allocation attempt found it empty), and
-    /// propagated through clones / `&mut self` joins. A correctness-neutral
-    /// *hint*: read only by the `phys-loop-aware` allocation policy to keep
-    /// loop-carried `Sf` resident; empty (no effect) on the default path.
-    #[cfg_attr(not(feature = "phys-loop-aware"), allow(dead_code))]
-    loop_carried: std::collections::HashSet<SlotId>,
     /// Float-consumed dynvar reads not yet reported to the `JitContext`
     /// (the frame itself cannot reach the outer frames' parked states).
     /// Drained at the next `compile_instruction` boundary into
@@ -346,7 +321,6 @@ impl SlotState {
             fpr_alloc: FprAllocator::new(),
             gp_regfile: crate::codegen::jitgen::gp_alloc::GpRegFile::new(),
             local_num,
-            loop_carried: std::collections::HashSet::new(),
             pending_outer_float_reads: vec![],
         };
         ctx.set_S_with_guard(SlotId::self_(), self_class);
@@ -519,15 +493,6 @@ impl SlotState {
     /// of the analysis-pass placement (`mode == F`). See doc §16.
     pub(in crate::codegen::jitgen) fn is_float_typed(&self, slot: SlotId) -> bool {
         matches!(self.guarded(slot), Guarded::Float)
-    }
-
-    /// §27.3 Stage-2a: record the loop-carried float set for this loop body.
-    #[cfg_attr(not(feature = "phys-loop-aware"), allow(dead_code))]
-    pub(in crate::codegen::jitgen) fn set_loop_carried(
-        &mut self,
-        set: std::collections::HashSet<SlotId>,
-    ) {
-        self.loop_carried = set;
     }
 
     pub(in crate::codegen::jitgen) fn class(&self, slot: SlotId) -> Option<ClassId> {


### PR DESCRIPTION
Follow-up to the `SlotState` slimming (#1273, #1275, #1277): the last dormant field goes.

## What changes

The §42 loop-aware spill-victim policy is deleted with its Cargo feature:

- `SlotState::loop_carried` (the loop-carried float set `L`) and `set_loop_carried`,
- the loop-entry merge code that filled it from the back-edge fixpoint (`merge.rs`),
- the `phys-loop-aware`-gated phase-1 filter in `try_alloc_fpr_ctx` that kept a loop-carried `Sf` cache resident,
- the `phys-loop-aware` feature in `monoruby/Cargo.toml` and its row in `docs/src/development.md`.

`SlotState` now has five fields: `slots`, `fpr_alloc` (issued-id count and pins), `gp_regfile`, `local_num`, `pending_outer_float_reads`.

## Why it is safe to drop

It was default-off, not built by CI, and — as doc §42 itself records — inert under the shipping `POOL=14`: phase 1 runs only when no pool register is vacant, so the lever bit only under `stress-spill-pool` or a ≈14-live-float loop, and its M1 A/B gate (§27.3-2c) was never run. The `L`-collection timing finding (the multi-iteration fixpoint makes the back-edge available at merge time) stays in the doc for whoever revisits loop-aware allocation; doc §49 records the removal.

## Verification

The default build is unchanged by construction: everything removed was behind the `cfg`, and the phase-1 filter closure reduces to the `occ.all_sf(fpr)` it already computed. JIT lib tests (113) and the float loop / block integration tests pass; no unused-code warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_