### PR TITLE
SlotState: mark outer float reads at the consumption; drop the pending queue

### DIFF
--- a/doc/regalloc_separation.md
+++ b/doc/regalloc_separation.md
@@ -3272,3 +3272,38 @@ loop, and its M1 A/B (§27.3-2c) was never run. The `L`-collection timing
 finding (§42: the multi-iteration fixpoint makes the back-edge available at
 merge time) stays in the record for whoever revisits loop-aware allocation;
 the code it justified no longer earns its field in the per-path state.
+
+## 50. `pending_outer_float_reads` removed: the mark lands at the consumption
+
+§46 kept the stage-A report queue on the grounds that the raw-f64
+consumption sites (`load_fpr_state` and the float binop helpers) were
+`AbstractFrame` methods that only see their own frame, so the owner frame of a
+dynvar-loaded value could not be marked there and the pair had to wait for the
+next `compile_instruction` boundary, where the `JitContext` holds the chain.
+
+The cheaper move is to put those consumption sites on the chain. `binop.rs`'s
+single `impl AbstractFrame` block is now `impl AbstractState`, and `load_fpr` /
+`load_fpr_state` moved with it; every field and frame-level method they use
+still resolves through `AbstractState`'s `Deref`/`DerefMut` to the innermost
+frame, so the bodies are unchanged. `AbstractState::use_as_float` then does
+what the drain did — look up the slot's `dynvar_src`, resolve `outer` against
+the chain, `mark_outer_float_read` — right at the consumption, and the frame
+keeps only the liveness half (`use_as_float_liveness`). The queue, its drain,
+its join concatenation and `take_pending_outer_float_reads` are gone, and
+`SlotState` is down to `slots`, `fpr_alloc`, `gp_regfile`, `local_num`.
+
+Why the timing change is safe: `outer` is resolved against the chain as it
+stands at the consumption, which is the chain the `LoadDynVar` recorded the
+provenance under (a nested compile pushes and pops its frames inside the same
+instruction, and a `LoadDynVar`'s consumer is a later instruction of the same
+frame). The mark is a monotone hint whose readers run at merges and
+boundaries, after the instruction that would have drained it, so seeing it one
+instruction earlier changes nothing they compute; and a read consumed by an
+instruction that ends a block is no longer parked on a queue that a merge
+concatenates — the owner frame simply carries the bit into the join, which
+ORs it exactly as the concatenated queue's drain would have.
+
+Verified byte-identical: `emit-asm` dumps of eight benchmarks match master;
+`app_aobench` differs only at the site master itself emits differently from run
+to run (§46). The JIT lib tests, the float / block / loop integration tests and
+the full `cargo test` suite pass.

--- a/monoruby/src/builtins/numeric/float.rs
+++ b/monoruby/src/builtins/numeric/float.rs
@@ -4,10 +4,8 @@ use super::*;
 use crate::ast::CmpKind;
 use crate::bytecodegen::{BinOpK, UnOpK};
 use crate::executor::Visibility;
-#[cfg(target_arch = "aarch64")]
-use jitgen::AbstractState;
 use jitgen::trace_ir::{FBinOpInfo, FOpClass};
-use jitgen::{AbstractFrame, BinaryInlineMode, BinaryInlineOutcome, JitContext};
+use jitgen::{AbstractState, BinaryInlineMode, BinaryInlineOutcome, JitContext};
 use crate::codegen::jitgen::deopt_log::DeoptCause;
 
 //
@@ -214,7 +212,7 @@ fn float_cmp_gen(kind: CmpKind) -> Box<InlineGenBinary> {
                 }
                 BinaryInlineMode::CmpBr { brkind, dest } => {
                     if let Some((l, r)) = state.check_binary_C_f64(recv, args) {
-                        return BinaryInlineOutcome::Folded(AbstractFrame::fold_cmp(kind, l, r));
+                        return BinaryInlineOutcome::Folded(AbstractState::fold_cmp(kind, l, r));
                     }
                     state.gen_cmpbr_float(ir, info, kind, brkind, dest);
                     BinaryInlineOutcome::Done

--- a/monoruby/src/builtins/numeric/integer.rs
+++ b/monoruby/src/builtins/numeric/integer.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::ast::CmpKind;
 use crate::bytecodegen::BinOpK;
 use jitgen::trace_ir::{FBinOpInfo, FOpClass};
-use jitgen::{AbstractFrame, AbstractState, BinaryInlineMode, BinaryInlineOutcome, JitContext};
+use jitgen::{AbstractState, BinaryInlineMode, BinaryInlineOutcome, JitContext};
 use num::{BigInt, ToPrimitive, Zero};
 use std::ops::{BitAnd, BitOr, BitXor};
 use crate::codegen::jitgen::deopt_log::DeoptCause;
@@ -1256,7 +1256,7 @@ fn integer_cmp_gen(kind: CmpKind) -> Box<InlineGenBinary> {
                     match float_info {
                         None => {
                             if let Some((l, r)) = state.check_concrete_i64(recv, args) {
-                                return BinaryInlineOutcome::Folded(AbstractFrame::fold_cmp(
+                                return BinaryInlineOutcome::Folded(AbstractState::fold_cmp(
                                     kind, l, r,
                                 ));
                             }
@@ -1267,7 +1267,7 @@ fn integer_cmp_gen(kind: CmpKind) -> Box<InlineGenBinary> {
                         }
                         Some(info) => {
                             if let Some((l, r)) = state.check_binary_C_f64(recv, args) {
-                                return BinaryInlineOutcome::Folded(AbstractFrame::fold_cmp(
+                                return BinaryInlineOutcome::Folded(AbstractState::fold_cmp(
                                     kind, l, r,
                                 ));
                             }

--- a/monoruby/src/codegen/jitgen/compile.rs
+++ b/monoruby/src/codegen/jitgen/compile.rs
@@ -300,13 +300,6 @@ impl<'a> JitContext<'a> {
         bc_pos: BcIndex,
     ) -> JitResult<CompileResult> {
         assert!(state.no_capture_guard());
-        // Stage-A use propagation: land the float-consumed dynvar reads the
-        // previous instruction queued on the owner frames' parked states,
-        // while this frame's `outer` distances are still the ones the reads
-        // were recorded under.
-        for (outer, slot) in state.take_pending_outer_float_reads() {
-            state.mark_outer_float_read(outer as usize, slot);
-        }
         // A fusing arm (e.g. `try_fuse_array_minmax`) already emitted this
         // instruction's work together with its predecessor's.
         if self.fused_skip == Some(bc_pos) {
@@ -629,8 +622,8 @@ impl<'a> JitContext<'a> {
                 state.def_rax2acc(ir, dst);
                 // Stage-A use propagation: remember where the value came
                 // from — a later raw-f64 consumption of *dst* is float-use
-                // evidence about the owner's slot (`use_as_float` queues
-                // it, the `compile_instruction` boundary lands it).
+                // evidence about the owner's slot, which
+                // `AbstractState::use_as_float` lands on the chain.
                 state.set_dynvar_src(dst, src_outer, src_reg);
                 // LFP-chain walk + loads: transparent.
                 self.restore_unfrozen(Some(dst));

--- a/monoruby/src/codegen/jitgen/state/binop.rs
+++ b/monoruby/src/codegen/jitgen/state/binop.rs
@@ -43,7 +43,7 @@ where
     }
 }
 
-impl AbstractFrame {
+impl AbstractState {
     fn fold_constant_cmp<T>(&mut self, kind: CmpKind, lhs: T, rhs: T, dst: Option<SlotId>)
     where
         T: PartialEq + PartialOrd,

--- a/monoruby/src/codegen/jitgen/state/read_slot.rs
+++ b/monoruby/src/codegen/jitgen/state/read_slot.rs
@@ -405,6 +405,52 @@ impl AbstractFrame {
     /// - rdi, rax
     ///
     ///
+    ///
+    /// Capture the deopt **program point** at the current placement state (item
+    /// ②, step 2 — deopt program-point-ification, doc §9): the bytecode `pc`
+    /// plus the write-back snapshot `get_write_back()` — *which* values are
+    /// unboxed/in-acc and must be restored to the stack if a guard fails. This is
+    /// pure analysis state; the codegen half turns it into an `AsmDeopt`
+    /// side-exit via [`AsmIr::deopt_from_point`]. Mirrors `AsmIr::new_deopt`'s
+    /// snapshot, minus the `side_exit` push.
+    ///
+    pub(in crate::codegen::jitgen) fn deopt_point(&self) -> DeoptPoint {
+        DeoptPoint::new(self.pc(), self.get_write_back())
+    }
+
+    #[allow(non_snake_case)]
+    fn load_fpr_from_C_state(&mut self, slot: SlotId, v: Value) -> (FPReg, FprLoad) {
+        // `LinkMode::C` may hold any Value; fpr loads only ever come from
+        // numeric literals (fixnum / float / heap Float), so anything else
+        // is a bug at the call site.
+        match v.unpack() {
+            RV::Float(f) => {
+                // -> F
+                let x = self.set_new_F(slot);
+                (x, FprLoad::FromF64(f, x))
+            }
+            RV::Fixnum(i) => {
+                // -> Sf
+                let x = self.set_new_Sf(slot, SfGuarded::Fixnum);
+                (x, FprLoad::FromFixnum(i, x))
+            }
+            _ => {
+                unreachable!("load_fpr_from_C() {:?}", v);
+            }
+        }
+    }
+}
+
+impl AbstractState {
+    ///
+    /// load *slot* as f64 into an fpr register. On the chain rather than
+    /// the frame: consuming a value as a raw f64 is float-use evidence
+    /// about the slot it was loaded from, which for a dynvar-loaded value
+    /// is an *outer* frame's slot ([`Self::use_as_float`]).
+    ///
+    /// ### destroy
+    /// - rdi, rax
+    ///
     pub(crate) fn load_fpr(&mut self, ir: &mut AsmIr, slot: SlotId) -> FPReg {
         // The deopt point is recorded *before* the state transition, so its
         // write-back snapshot (`get_write_back`) is the pre-load placement — see
@@ -417,18 +463,19 @@ impl AbstractFrame {
         x
     }
 
-
     ///
-    /// Capture the deopt **program point** at the current placement state (item
-    /// ②, step 2 — deopt program-point-ification, doc §9): the bytecode `pc`
-    /// plus the write-back snapshot `get_write_back()` — *which* values are
-    /// unboxed/in-acc and must be restored to the stack if a guard fails. This is
-    /// pure analysis state; the codegen half turns it into an `AsmDeopt`
-    /// side-exit via [`AsmIr::deopt_from_point`]. Mirrors `AsmIr::new_deopt`'s
-    /// snapshot, minus the `side_exit` push.
+    /// Stage-A use propagation: a raw-f64 consumption of *slot*. Besides
+    /// the frame's own liveness, a value that arrived through `LoadDynVar`
+    /// is float-use evidence *about the owner's slot*, so the mark lands
+    /// on the owner frame on this chain right away (`outer` is resolved
+    /// against the chain as it stands at the consumption, which is the
+    /// chain the read was recorded under).
     ///
-    pub(in crate::codegen::jitgen) fn deopt_point(&self) -> DeoptPoint {
-        DeoptPoint::new(self.pc(), self.get_write_back())
+    pub(super) fn use_as_float(&mut self, slot: SlotId) {
+        if let Some((outer, src)) = self.dynvar_src(slot) {
+            self.mark_outer_float_read(outer as usize, src);
+        }
+        self.use_as_float_liveness(slot);
     }
 
     ///
@@ -455,27 +502,6 @@ impl AbstractFrame {
         }
     }
 
-    #[allow(non_snake_case)]
-    fn load_fpr_from_C_state(&mut self, slot: SlotId, v: Value) -> (FPReg, FprLoad) {
-        // `LinkMode::C` may hold any Value; fpr loads only ever come from
-        // numeric literals (fixnum / float / heap Float), so anything else
-        // is a bug at the call site.
-        match v.unpack() {
-            RV::Float(f) => {
-                // -> F
-                let x = self.set_new_F(slot);
-                (x, FprLoad::FromF64(f, x))
-            }
-            RV::Fixnum(i) => {
-                // -> Sf
-                let x = self.set_new_Sf(slot, SfGuarded::Fixnum);
-                (x, FprLoad::FromFixnum(i, x))
-            }
-            _ => {
-                unreachable!("load_fpr_from_C() {:?}", v);
-            }
-        }
-    }
 }
 
 impl AbstractFrame {

--- a/monoruby/src/codegen/jitgen/state/slot.rs
+++ b/monoruby/src/codegen/jitgen/state/slot.rs
@@ -238,11 +238,6 @@ pub(crate) struct SlotState {
     /// merge despite living in the cloned `SlotState`.
     pub(in crate::codegen::jitgen) gp_regfile: crate::codegen::jitgen::gp_alloc::GpRegFile,
     local_num: usize,
-    /// Float-consumed dynvar reads not yet reported to the `JitContext`
-    /// (the frame itself cannot reach the outer frames' parked states).
-    /// Drained at the next `compile_instruction` boundary into
-    /// `JitContext::mark_outer_float_read`.
-    pending_outer_float_reads: Vec<(u16, SlotId)>,
 }
 
 ///
@@ -261,9 +256,9 @@ struct Slot {
     /// redefinition ([`SlotState::discard`]); a mode transition that
     /// keeps the value (write-back, unguarded demotion) keeps it.
     /// Consulted when the slot is consumed as a raw f64
-    /// ([`SlotState::use_as_float`]), which queues the pair on
-    /// `pending_outer_float_reads`. A correctness-neutral hint: it only
-    /// feeds the loop-entry float-adoption policy.
+    /// ([`AbstractState::use_as_float`]), which marks the owner frame's
+    /// slot on the chain. A correctness-neutral hint: it only feeds the
+    /// loop-entry float-adoption policy.
     dynvar_src: Option<(u16, SlotId)>,
     /// Stage-A use propagation, the owner-side landing spot: an inlined
     /// callee read this slot through the frame chain and consumed it as a
@@ -321,7 +316,6 @@ impl SlotState {
             fpr_alloc: FprAllocator::new(),
             gp_regfile: crate::codegen::jitgen::gp_alloc::GpRegFile::new(),
             local_num,
-            pending_outer_float_reads: vec![],
         };
         ctx.set_S_with_guard(SlotId::self_(), self_class);
         ctx
@@ -934,17 +928,18 @@ impl SlotState {
 
     // APIs for 'use'
 
-    /// used as f64 with no conversion
-    pub(super) fn use_as_float(&mut self, slot: SlotId) {
-        // Stage-A use propagation: a raw-f64 consumption of a value that
-        // arrived through `LoadDynVar` is float-use evidence *about the
-        // owner's slot* — queue it for the next `compile_instruction`
-        // boundary, where the `JitContext` can reach the owner's parked
-        // frame ([`JitContext::mark_outer_float_read`]).
-        if let Some(src) = self.slots[slot.0 as usize].dynvar_src {
-            self.pending_outer_float_reads.push(src);
-        }
+    /// Liveness: used as f64 with no conversion. The chain-level
+    /// [`AbstractState::use_as_float`] is the entry point — it also lands
+    /// the stage-A float-read mark on the owner frame of a dynvar-loaded
+    /// value, which this frame cannot reach on its own.
+    pub(super) fn use_as_float_liveness(&mut self, slot: SlotId) {
         self.is_used_mut(slot).use_as_float();
+    }
+
+    /// Stage-A use propagation: where *slot*'s value came from, if it was
+    /// loaded through the frame chain (`outer` levels out, slot `src`).
+    pub(super) fn dynvar_src(&self, slot: SlotId) -> Option<(u16, SlotId)> {
+        self.slots[slot.0 as usize].dynvar_src
     }
 
     pub(super) fn use_as_value(&mut self, slot: SlotId) {
@@ -964,16 +959,6 @@ impl SlotState {
         if let Ok(outer) = u16::try_from(outer) {
             self.slots[slot.0 as usize].dynvar_src = Some((outer, src));
         }
-    }
-
-    ///
-    /// Stage-A use propagation: hand over the float-consumed dynvar reads
-    /// queued since the last drain.
-    ///
-    pub(in crate::codegen::jitgen) fn take_pending_outer_float_reads(
-        &mut self,
-    ) -> Vec<(u16, SlotId)> {
-        std::mem::take(&mut self.pending_outer_float_reads)
     }
 
     ///
@@ -1038,8 +1023,8 @@ impl SlotState {
 
     ///
     /// Stage-A use propagation: merge the hint fields at a path join —
-    /// provenance is kept only where both paths agree, pending reports and
-    /// landed subtree-read marks from either path remain evidence.
+    /// provenance is kept only where both paths agree, landed subtree-read
+    /// marks from either path remain evidence.
     ///
     pub(super) fn join_subtree_read_meta(&mut self, other: &SlotState) {
         for (l, r) in self.slots.iter_mut().zip(other.slots.iter()) {
@@ -1054,8 +1039,6 @@ impl SlotState {
                 l.dynvar_alias = None;
             }
         }
-        self.pending_outer_float_reads
-            .extend(other.pending_outer_float_reads.iter().copied());
     }
 
     ///


### PR DESCRIPTION
The last of the `SlotState` fields that #1273 (doc §46) had left in place. Byte-identical.

## What changes

The stage-A report queue (`pending_outer_float_reads`) existed because the raw-f64 consumption sites — `load_fpr_state` and the float binop helpers — were `AbstractFrame` methods that only see their own frame, so the owner frame of a dynvar-loaded value could not be marked there and the `(outer, src)` pair waited for the next `compile_instruction` boundary, where the `JitContext` holds the chain.

The consumption sites are on the chain now:

- `binop.rs`'s single `impl AbstractFrame` block is `impl AbstractState`, and `load_fpr` / `load_fpr_state` moved with it. Their bodies are unchanged — every field and frame-level method they use resolves through `AbstractState`'s `Deref`/`DerefMut` to the innermost frame. (Three `AbstractFrame::fold_cmp` references in the numeric builtins follow.)
- `AbstractState::use_as_float` does what the drain did — look up the slot's `dynvar_src`, resolve `outer` against the chain, `mark_outer_float_read` — right at the consumption. The frame keeps only the liveness half (`use_as_float_liveness`).
- The queue, its drain at the top of `compile_instruction`, its join concatenation and `take_pending_outer_float_reads` are gone.

`SlotState` is down to `slots`, `fpr_alloc`, `gp_regfile`, `local_num`.

## Why the timing change is safe

`outer` is resolved against the chain as it stands at the consumption, which is the chain the `LoadDynVar` recorded the provenance under (a nested compile pushes and pops its frames inside the same instruction; a `LoadDynVar`'s consumer is a later instruction of the same frame). The mark is a monotone hint whose readers run at merges and boundaries, after the instruction that would have drained it, so seeing it one instruction earlier changes nothing they compute. A read consumed by a block-ending instruction now rides into the join on the owner frame (ORed) instead of on a queue the merge concatenated and the successor drained — the same bit either way. Written up in doc §50.

## Verification

- `emit-asm` dumps of nine benchmarks vs master, addresses and compile-time lines normalised: eight **identical**; `app_aobench` differs only at the `%13 + %14 [<INVALID>]`/`[Float]` site that master alone emits differently across runs (the nondeterminism noted in #1273).
- JIT lib tests (113), the float / block / loop integration tests (15 files), and the full `cargo test` suite pass; aarch64 cross build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_