### PR TITLE
JIT: raw-bit nil arms for polymorphic compares; keep the fixnum fast path from erasing class transitions

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/vmgen.rs
+++ b/monoruby/src/codegen/arch/aarch64/vmgen.rs
@@ -1298,7 +1298,7 @@ impl Codegen {
             tbz x14, #(0), generic;
         );
         self.a64_bop_guard(bop, &generic);
-        self.a64_save_binary_integer();
+        self.a64_save_binary_integer(&generic);
         monoasm_arm64!(&mut self.jit,
             cmp x13, x14;
         );
@@ -1516,14 +1516,42 @@ impl Codegen {
     /// `Integer`/`Integer` into the BinOp inline cache (`[PC+8]` classid1,
     /// `[PC+12]` classid2) so the JIT can type integer arithmetic/compare
     /// sites. Without this the cache stays empty (`<INVALID>`) and the JIT
-    /// deopts every integer binop. Mirrors x86 `vm_save_binary_integer`.
-    /// Clobbers X10; leaves the NZCV flags untouched (mov-immediate + stores).
-    pub(in crate::codegen) fn a64_save_binary_integer(&mut self) {
+    /// deopts every integer binop.
+    ///
+    /// Not an unconditional store: displacing a cached non-Integer pair is a
+    /// class change the profile must not lose (the old silent overwrite kept
+    /// `NilClass`-mono-compiled sites deopting forever while never reading
+    /// as polymorphic, and their PMC never learned the site takes Integer
+    /// receivers at all) — so that one execution is routed through *generic*
+    /// instead, whose class saver stamps POLY, records both pairs in the
+    /// PMC, and computes the same result the fast path would have. This
+    /// preserves the invariant the compile-time gates rest on: a POLY
+    /// site's PMC always holds every observed class. Steady state is two
+    /// compares and no stores. Mirrors x86 `vm_save_binary_integer`.
+    /// Clobbers X10 and the NZCV flags (both call sites set their own flags
+    /// afterwards).
+    pub(in crate::codegen) fn a64_save_binary_integer(&mut self, generic: &DestLabel) {
         let int_class: u32 = INTEGER_CLASS.into();
+        let stamp = self.jit.label();
+        let done = self.jit.label();
         monoasm_arm64!(&mut self.jit,
+            ldr w10, [x(PC.0), #(8)];   // cached classid1 (0 = empty)
+            cbz w10, stamp;             // first population: record, no flag
+            cmp w10, #(int_class);
+        );
+        self.jit.bcond_label(Cond::Ne, generic);
+        monoasm_arm64!(&mut self.jit,
+            ldr w10, [x(PC.0), #(12)];  // cached classid2
+            cmp w10, #(int_class);
+        );
+        self.jit.bcond_label(Cond::Ne, generic);
+        monoasm_arm64!(&mut self.jit,
+            b done;                     // steady state: already Integer/Integer
+            stamp:
             mov x10, (int_class);
             str w10, [x(PC.0), #(8)];   // classid1
             str w10, [x(PC.0), #(12)];  // classid2
+            done:
         );
     }
 
@@ -1585,7 +1613,7 @@ impl Codegen {
             tbz x14, #(0), generic;
         );
         self.a64_bop_guard(bop, &generic);
-        self.a64_save_binary_integer();
+        self.a64_save_binary_integer(&generic);
         if is_sub {
             monoasm_arm64!(&mut self.jit,
                 subs x9, x13, x14;

--- a/monoruby/src/codegen/arch/x86_64/vmgen.rs
+++ b/monoruby/src/codegen/arch/x86_64/vmgen.rs
@@ -25,7 +25,7 @@ macro_rules! vm_cmp_opt {
               self.vm_get_slot_value(GP::Rsi);
               self.guard_rdi_rsi_fixnum(&generic);
               self.vm_bop_guard(VmBop::$bop, &generic);
-              self.vm_save_binary_integer();
+              self.vm_save_binary_integer(&generic);
 
               self.[<icmp_ $op>]();
               self.vm_store_r15(GP::Rax);
@@ -56,7 +56,7 @@ impl Codegen {
         self.fetch3();
         self.vm_get_slot_value(GP::Rdi);
         self.vm_get_slot_value(GP::Rsi);
-        self.vm_save_binary_integer();
+        self.vm_save_binary_integer(&generic);
         self.vm_generic_binop(&generic, cmp_teq_rescue_values as _);
         self.fetch_and_dispatch();
         label
@@ -73,7 +73,7 @@ impl Codegen {
         self.vm_get_slot_value(GP::Rsi);
         self.guard_rdi_rsi_fixnum(&generic);
         self.vm_bop_guard(VmBop::TEq, &generic);
-        self.vm_save_binary_integer();
+        self.vm_save_binary_integer(&generic);
 
         self.icmp_eq();
         self.vm_store_r15(GP::Rax);
@@ -753,11 +753,37 @@ impl Codegen {
         };
     }
 
-    fn vm_save_binary_integer(&mut self) {
+    /// Fixnum-fast-path IC stamp. Not an unconditional store: a cached
+    /// non-Integer pair being displaced by a fixnum/fixnum execution is a
+    /// class change the profile must not lose — the old silent overwrite is
+    /// how a site mono-compiled for a `NilClass` operand (dewasm DOOM's
+    /// first-frame `@prev` fill) kept failing its guard 296k times while
+    /// never reading as polymorphic: every deopt re-executed right here,
+    /// which re-stamped `Integer`/`Integer` without touching POLY, so the
+    /// `BecamePolymorphic` heal's gate never opened and the PMC never
+    /// learned the site takes Integer receivers at all. On displacement,
+    /// route this one execution through *generic* — the slow path stamps
+    /// POLY, records both pairs in the PMC (displaced pair included), and
+    /// computes the same result the fast path would have — preserving the
+    /// invariant the compile-time gates rest on: a POLY site's PMC always
+    /// holds every observed class. Steady state is two compares and no
+    /// stores. Clobbers only the flags.
+    fn vm_save_binary_integer(&mut self, generic: &DestLabel) {
         let int_class: u32 = INTEGER_CLASS.into();
+        let stamp = self.jit.label();
+        let done = self.jit.label();
         monoasm! { &mut self.jit,
+            cmpl  [r13 - 8], 0;
+            jeq   stamp;           // first population: record without the flag
+            cmpl  [r13 - 8], (int_class);
+            jne   generic;         // displacing a non-Integer pair: full save
+            cmpl  [r13 - 4], (int_class);
+            jne   generic;
+            jmp   done;            // steady state: already Integer/Integer
+        stamp:
             movl  [r13 - 8], (int_class);
             movl  [r13 - 4], (int_class);
+        done:
         };
     }
 
@@ -1533,7 +1559,7 @@ impl Codegen {
         self.guard_rdi_rsi_fixnum(&generic);
         self.vm_bop_guard(bop, &generic);
         self.jit.bind_label(common.clone());
-        self.vm_save_binary_integer();
+        self.vm_save_binary_integer(&generic);
         opt_func(self, generic.clone());
         self.vm_store_r15(GP::Rax);
         self.jit.bind_label(exit.clone());

--- a/monoruby/src/codegen/jitgen/compile/binary_op.rs
+++ b/monoruby/src/codegen/jitgen/compile/binary_op.rs
@@ -348,8 +348,23 @@ impl<'a> JitContext<'a> {
     /// `None` when no observed class can carry the arm, in which case the
     /// caller keeps the ordinary (guarded, deopting) path.
     ///
-    fn dispatch_inline_class(&mut self, callid: CallSiteId, op: IdentId) -> Option<ClassId> {
-        if !self.pmc_really_alternates(callid) {
+    /// *nil_arm_eligible*: the caller will give a nil share its own raw-bit
+    /// arm. That changes the economics of the share gate: a nil runner-up
+    /// below 1/8 still deopts on every appearance under the monomorphic
+    /// guard (dewasm DOOM's `_f262` paid 16k exits at a ~1/20 nil share),
+    /// while the nil arm costs the hot class one untaken compare — so a
+    /// site with any observed nil dispatches regardless of the runner-up's
+    /// share. Non-nil stragglers keep the 1/8 rule: their arm is the
+    /// generic *call*, which really does want a fair share of the traffic.
+    fn dispatch_inline_class(
+        &mut self,
+        callid: CallSiteId,
+        op: IdentId,
+        nil_arm_eligible: bool,
+    ) -> Option<ClassId> {
+        if !self.pmc_really_alternates(callid)
+            && !(nil_arm_eligible && self.store[callid].pmc.entries().len() >= 2)
+        {
             return None;
         }
         let pmc = &self.store[callid].pmc;
@@ -388,6 +403,15 @@ impl<'a> JitContext<'a> {
     /// 1/8 the class-set guard demands of its members. (etanni measured
     /// ~2% slower before this test existed on the two-arm dispatch.)
     ///
+    /// Did the VM ever observe *class* as this site's receiver?
+    fn pmc_recv_contains(&self, callid: CallSiteId, class: ClassId) -> bool {
+        self.store[callid]
+            .pmc
+            .entries()
+            .iter()
+            .any(|e| e.recv == class)
+    }
+
     fn pmc_really_alternates(&self, callid: CallSiteId) -> bool {
         let pmc = &self.store[callid].pmc;
         if pmc.entries().len() < 2 {
@@ -487,7 +511,12 @@ impl<'a> JitContext<'a> {
             return Ok(false);
         };
         let op: IdentId = binop.into();
-        let Some(inline_class) = self.dispatch_inline_class(callid, op) else {
+        // See the `nil_arm` comment below; computed up front because it also
+        // loosens the dispatch gate (`dispatch_inline_class`).
+        let nil_arm_eligible = matches!(binop, BinaryOp::Cmp(CmpKind::Eq | CmpKind::TEq))
+            && self.pmc_recv_contains(callid, NIL_CLASS)
+            && self.basic_op_assumable(NIL_CLASS, op);
+        let Some(inline_class) = self.dispatch_inline_class(callid, op, nil_arm_eligible) else {
             return Ok(false);
         };
         // The dispatch guards the *receiver*. An arithmetic arm still guards
@@ -527,10 +556,23 @@ impl<'a> JitContext<'a> {
         let (entry, merge) = self.declare_merge(state, ir, &[lhs, rhs], dst);
         let slow = self.label();
 
+        // A `nil` receiver needs no method call at all for `==` / `===`:
+        // `NilClass#==` is identity, and nil's encoding is unique, so the
+        // answer is one raw bit-compare of the *argument* against
+        // `NIL_VALUE`. Give it its own arm (behind the hot class's) instead
+        // of sending the nil share through the generic helper — the
+        // rubykon/DOOM alternating shapes spend half their traffic there.
+        // Licence: the arm bakes in the builtin, so it is gated on and
+        // recorded against the (NIL_CLASS, op) basic-op pair — `!=` has no
+        // such pair and is excluded by the gate itself.
+        let nil_arm = nil_arm_eligible && inline_class != NIL_CLASS;
+        let nil_chk = self.label();
+        let arm1_miss = if nil_arm { nil_chk.clone() } else { slow.clone() };
+
         // ---- arm 1: the class that can be compared inline.
         let mut fast = entry.clone();
         fast.load(ir, lhs, GP::Rdi);
-        ir.push(AsmInst::BrClassNe(GP::Rdi, inline_class, slow));
+        ir.push(AsmInst::BrClassNe(GP::Rdi, inline_class, arm1_miss));
         // Reaching the arm *is* the proof, so `fire_binary_inline`'s own
         // receiver guard sees a state that already knows the class and emits
         // nothing.
@@ -558,7 +600,31 @@ impl<'a> JitContext<'a> {
         }
         self.end_arm(fast, ir, &merge, true);
 
-        // ---- arm 2: every other operand pair, through the generic helper.
+        // ---- nil arm: `nil == x` ⇔ `x` is nil, decided by the raw bits.
+        if nil_arm {
+            ir.push(AsmInst::Label(nil_chk));
+            // Rdi still holds the receiver: the only way here is arm 1's
+            // class branch, which sits after the load.
+            let mut narm = entry.clone();
+            ir.push(AsmInst::BrClassNe(GP::Rdi, NIL_CLASS, slow));
+            narm.load(ir, rhs, GP::Rsi);
+            // `IntegerCmpImm` is a raw `cmp` + flag-to-bool; `NIL_VALUE` is
+            // not a tagged fixnum, but for `Eq` bit-equality is exactly the
+            // question (no other value shares nil's encoding). `===` on nil
+            // is the same identity test.
+            ir.push(AsmInst::IntegerCmpImm {
+                kind: CmpKind::Eq,
+                dst: None,
+                lhs: GP::Rsi,
+                imm: crate::value::NIL_VALUE as i32,
+            });
+            narm.def_rax2acc(ir, dst);
+            self.end_arm(narm, ir, &merge, true);
+            self.record_bop_dep(NIL_CLASS, op);
+        }
+
+        // ---- residual arm: every other operand pair, through the generic
+        // helper.
         ir.push(AsmInst::Label(slow));
         let mut rest = entry.clone();
         self.emit_generic_binary(&mut rest, ir, binop, lhs, rhs, case_semantics, is_func_call);
@@ -800,26 +866,114 @@ impl<'a> JitContext<'a> {
         }
 
         // ---- 3c. A *fused* comparison (`BinCmpBr`) at a site the VM marked
-        // polymorphic and whose receiver genuinely alternates: take the
-        // polymorphic residual (step 5) instead of the mono inline below.
-        // The two-arm dispatch (step 2) cannot serve the fused form — the
-        // arms would have to materialize the very flag the fusion exists to
+        // polymorphic and whose receiver genuinely alternates. The two-arm
+        // *value* dispatch (step 2) cannot serve the fused form — its arms
+        // would have to materialize the very flag the fusion exists to
         // avoid — so these sites used to fall through to the single-class
         // guard and side-exit on every off-class operand, forever (dewasm
         // DOOM: thousands of `Integer == nil` exits per tick, the "~24
-        // fused side exits" note on step 2 notwithstanding). The residual
-        // is guard-free, and for `==`/`!=` it is `opt_eq_cmp`'s inline
-        // bit-equality fast path, which answers an immediate-vs-immediate
-        // compare — the `nil` operand included — without the C call. The
-        // 1/8-share gate keeps the hot-class fast path for one-hot-class
-        // sites, exactly as it does for the two-arm dispatch.
-        let fused_poly_residual = polymorphic
-            && case_semantics
-            && state.class(lhs).is_none()
-            && self
-                .store
-                .get_callsite_id(self.iseq_id(), bc_pos)
-                .is_some_and(|callid| self.pmc_really_alternates(callid));
+        // fused side exits" note on step 2 notwithstanding). The 1/8-share
+        // gate keeps the hot-class fast path for one-hot-class sites,
+        // exactly as it does for the value dispatch.
+        let fused_poly_callid = (polymorphic && case_semantics && state.class(lhs).is_none())
+            .then(|| self.store.get_callsite_id(self.iseq_id(), bc_pos))
+            .flatten();
+
+        // The nil/Integer alternation gets real arms, not the C helper: the
+        // arms of a *fused* dispatch need no value merge, because each one
+        // branches for itself — the nil arm is one raw compare of the
+        // argument against `NIL_VALUE` fused straight into the branch, and
+        // the Integer arm is the ordinary fused inline (whose receiver
+        // guard now only ever sees the leftover classes). Both arms jump to
+        // the same branch label with every slot at home (`declare_merge`
+        // flushed the operands, the inline's own flush covers its spills),
+        // so the caller's single side-branch bookkeeping — registered
+        // against the conservative merge state — covers them both.
+        // Licence as everywhere: the nil arm bakes in `NilClass#==`/`===`,
+        // so it is gated on and recorded against the basic-op pair.
+        if let Some(callid) = fused_poly_callid
+            && let BinaryInlineMode::CmpBr { brkind, dest } = mode
+            && matches!(binop, BinaryOp::Cmp(CmpKind::Eq | CmpKind::TEq))
+            && self.pmc_recv_contains(callid, NIL_CLASS)
+            && self.pmc_recv_contains(callid, INTEGER_CLASS)
+            // The peel has no generic arm: a receiver outside {nil,
+            // Integer} lands on the Integer arm's guard, a plain deopt. So
+            // it only serves sites whose whole observed profile is the
+            // nil/Integer pair — anything richer keeps the guard-free
+            // residual routing below. No share gate: the nil arm costs the
+            // hot class one untaken compare, while an under-1/8 nil share
+            // still deopts on every appearance under a monomorphic guard.
+            && self.store[callid]
+                .pmc
+                .entries()
+                .iter()
+                .all(|e| e.recv == NIL_CLASS || e.recv == INTEGER_CLASS)
+            && self.basic_op_assumable(NIL_CLASS, binop.into())
+        {
+            let state_save = state.clone();
+            let ir_save = ir.save();
+            let (entry, merge) = self.declare_merge(state, ir, &[lhs, rhs], None);
+            let not_nil = self.label();
+
+            // nil arm: `nil == x` ⇔ `x` is nil — raw bit compare, fused.
+            let mut narm = entry.clone();
+            narm.load(ir, lhs, GP::Rdi);
+            ir.push(AsmInst::BrClassNe(GP::Rdi, NIL_CLASS, not_nil));
+            narm.load(ir, rhs, GP::Rsi);
+            // Raw `cmp` + fused branch; `NIL_VALUE` is not a tagged fixnum,
+            // but for `Eq` bit-equality is exactly the question (no other
+            // value shares nil's encoding; `===` on nil is the same test).
+            ir.push(AsmInst::IntegerCmpBrImm {
+                kind: CmpKind::Eq,
+                brkind,
+                branch_dest: dest,
+                lhs: GP::Rsi,
+                imm: crate::value::NIL_VALUE as i32,
+            });
+            self.end_arm(narm, ir, &merge, true);
+
+            // Integer arm: the fused inline the mono path would have
+            // emitted, now behind the nil peel — its fixnum guard still
+            // deopts for a class the site never showed (the profile-subset
+            // gate above keeps this to genuinely unobserved classes).
+            ir.push(AsmInst::Label(not_nil));
+            let mut iarm = entry.clone();
+            match self.fire_binary_inline(
+                &mut iarm,
+                ir,
+                binop.into(),
+                lhs,
+                rhs,
+                INTEGER_CLASS,
+                rhs_class,
+                bc_pos,
+                mode,
+                None,
+            ) {
+                Some(BinaryInlineOutcome::Done) => {
+                    self.record_bop_dep(NIL_CLASS, binop.into());
+                    self.end_arm(iarm, ir, &merge, false);
+                    self.bind_merge(state, ir, merge);
+                    return Ok(BinaryLowering::Emitted);
+                }
+                // The generator declined (or, impossibly for an unknown
+                // receiver, folded): back the peel out and take the
+                // residual routing below.
+                _ => {
+                    ir.restore(ir_save);
+                    *state = state_save;
+                }
+            }
+        }
+
+        // Residual routing for the remaining fused polymorphic shapes: the
+        // generic helper, which for `==`/`!=` is `opt_eq_cmp`'s inline
+        // bit-equality fast path — guard-free either way. Unlike the peel
+        // (whose nil arm costs the hot class one compare, so any observed
+        // nil justifies it), sending *everything* to the helper taxes the
+        // hot class on each execution, so the 1/8-share gate stands here.
+        let fused_poly_residual =
+            fused_poly_callid.is_some_and(|callid| self.pmc_really_alternates(callid));
 
         // ---- 4. One path for every operator: guard the receiver, run the
         // generator registered on `lhs_class#op`, and fall back for whatever
@@ -1527,6 +1681,55 @@ mod tests {
             big = 1 << 62
             300.times { |n| res << probe(big + n, 100) }
             res.tally.sort_by { |k, _| k.to_s }
+            "#,
+        );
+    }
+
+    /// The fused nil-peel: an alternating nil/Integer receiver at a fused
+    /// compare gets a raw-bit nil arm plus the ordinary fused Integer
+    /// inline, under both branch polarities (`if` and `unless`), with the
+    /// nil == nil, `===`, and Float-argument corners pinned against the
+    /// interpreter.
+    #[test]
+    fn fused_nil_peel_operand_matrix() {
+        run_test(
+            r#"
+            def hit(prev, key)
+              if prev == key then :hit else :miss end
+            end
+            def inv(prev, key)
+              unless prev == key then :ne else :eq end
+            end
+            def teq(prev, key)
+              if prev === key then :hit else :miss end
+            end
+            res = []
+            300.times do |n|
+              v = n % 3 == 0 ? nil : n
+              res << hit(v, 7) << inv(v, 7) << teq(v, 7)
+            end
+            [res.tally.sort_by { |k, _| k.to_s },
+             hit(nil, nil), inv(nil, nil), teq(nil, nil),
+             hit(nil, 7.0), hit(7, 7.0), hit(1 << 70, 7)]
+            "#,
+        );
+    }
+
+    /// The value-mode nil arm: the two-arm dispatch grows a raw-bit nil arm
+    /// when the PMC shows a nil share, so `res = (a == b)` at an
+    /// alternating site answers nil receivers without the generic helper.
+    /// Semantics pinned across the operand mixes.
+    #[test]
+    fn value_cmp_nil_arm_operand_matrix() {
+        run_test(
+            r#"
+            def probe(a, b) = (a == b)
+            res = []
+            300.times do |n|
+              v = n % 3 == 0 ? nil : n
+              res << probe(v, 7) << probe(v, nil)
+            end
+            [res.tally.sort_by { |k, _| k.to_s }, probe(nil, nil), probe(7, 7.0)]
             "#,
         );
     }

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -2709,6 +2709,7 @@ ccd878c1f1810dfef13a53d1e1a05fb8	:te	begin; :sym.instance_eval { alias :foo :to_
 ccdd40701f9797edf931ec9bb16c3abf	[:alpha, 1.5, :beta, 2.5]	class PmF\n          def tag = :alpha\n          def rate = 1.5\n        e
 ccebcacf1f0e521c283f27ea3d09e042	[[[:hit, 1], [:miss, 299]], :hit, :miss, :hit, :hit, :miss]	def probe(prev, key)\n              if prev == key\n                :
 ccee79e211a63a6f8408eaaa13a6aee9	[{a: 1}, [1, {a: 1}], {}, "no implicit conversion of Object into Hash", "can't convert Object to Hash (Object#to_hash gives Integer)"]	def f(**o) = o\n            def g(a, **o) = [a, o]\n            m = O
+cd2701bc81848b76a6ea4326a7d33198	[[[:eq, 1], [:hit, 2], [:miss, 598], [:ne, 299]], :hit, :eq, :hit, :miss, :hit, :miss]	def hit(prev, key)\n              if prev == key then :hit else :mis
 cd29ece16f52c170d36a353d72be8fb8	[1, 2, [3, 4, 5, 6, 7]]	def f(x,y,*z)\n            [x,y,z]\n        end\n        \n\n        f(1,2,3
 cd2df73dc4bb642c9c1db8166dee2691	true	t = File.birthtime("Cargo.toml") rescue :unsupported\n            t 
 cd4f0795009d40364b489188418b4b29	42	$a = 42\n            alias $b $a\n            $b\n            
@@ -3222,6 +3223,7 @@ f4cc159c69dc86f34d5c5c1a1739908b	nil	$!\n
 f4dbd65859826724c9fb5648c3f84c3a	[:re]	def m\n              re = /(?<matched>foo)/\n              re =~ "foo
 f4e35e264294b3bd8913c077f24dea7a	[{"a" => 10, "b" => 20}, {1 => :a, 2 => :b}, {}]	h = { a: 1, b: 2 }\n            [h.to_h { |k, v| [k.to_s, v * 10] },
 f4ef37c05309c4811b6d78d2a1b7c9ce	[true, true]	S = Struct.new(:a, :b)\n            \n\n            a = S.new(1, "x")\n
+f4f168f8c67128f9b1bc02c608e68a9c	[[[false, 499], [true, 101]], true, true]	def probe(a, b) = (a == b)\n            res = []\n            300.tim
 f4f318253ef6eda2bd57d54a445dae64	[1, 2, [3, 4], 5, [6], 7, 8, [9, 10]]	f = ->((a, b, *c, d), (*e, f, g), (*h)) { [a, b, c, d, e, f, g, h] }\n  
 f54339b0ac95ca56fd90790bbbaab021	[[1], [2], :missing, [:hi], :gone]	class R; def v = 1; end\n        first = [R.new].map(&:v)\n        class 
 f54dcd2ea5a345f130209fcaaafe0294	"US-ASCII"	"abc".encode("US-ASCII").center(5).encoding.to_s


### PR DESCRIPTION
Follow-up to #1274/#1276, closing the last dewasm DOOM deopt storms — all of which turned out to be one shape (deopt-cause sampling: every exit is `class Integer but guard expected NilClass`): a compare mono-compiled during a nil warm-up era (`Renderer#render`'s first frame runs against a nil-filled `@prev` — 296k exits per 60-tick smoke) that then sees Integers forever. Nothing could heal it, because the VM's fixnum fast path re-stamped the inline cache silently on every re-execution: POLY never set, and the PMC never learned the site takes Integer receivers at all.

## The three pieces

**1. The fixnum fast path stops erasing class transitions.** `vm_save_binary_integer` (both arches) no longer overwrites the IC blindly: displacing a cached non-Integer pair is a class change the profile must not lose, so that one execution is routed through the generic slow path — which stamps POLY, records both pairs in the PMC (displaced pair included), and computes the same result the fast path would have. This restores the invariant the compile-time gates rest on (**a POLY site's PMC holds every observed class**), which also makes the poly-compile ratchet sound again. Steady state becomes two compares and *no stores*, replacing two unconditional stores.

**2. A raw-bit nil arm for polymorphic compares** (the direction proposed in review: inline the trivially-inlinable `NilClass#==` rather than dropping to generic). `nil == x` ⇔ `x` is nil, decided by one compare against `NIL_VALUE`:

- the two-arm **value dispatch** grows a nil arm (`br_class_ne` → `cmp arg, NIL_VALUE` + flag-to-bool) behind the hot class's arm;
- **fused** compares get a *nil peel*: the same compare fused straight into the branch, ahead of the ordinary fused Integer inline. A fused dispatch needs no value merge — each arm branches for itself — and both arms reach the branch label with every slot at home, so the caller's single side-branch registration (made against the conservative `declare_merge` state) covers them both. The peel requires the whole observed profile to be the nil/Integer pair, since it has no generic arm.

Both are gated on and recorded against the `(NIL_CLASS, op)` basic-op pair (`==`/`===`; `!=` has no pair and is excluded by the gate itself), so a `NilClass#==` redefinition evicts them.

**3. The 1/8-share gate learns about nil.** The gate assumed the runner-up's arm is the generic *call*; a nil runner-up below 1/8 still deopted on every appearance under the monomorphic guard (`_f262`: 16k exits at a ~1/20 nil share), while the nil arm costs the hot class one untaken compare. A site with any observed nil now dispatches regardless of share; non-nil stragglers keep the 1/8 rule.

## Measurements

DOOM 60-tick smoke (profile build), deopts per site:

| site | before | after |
|---|---|---|
| `Renderer#render [:00056]` | 296,000 | **61** |
| `Doom#_f262 [:00548]` | 16,830 | **11** |
| `Doom#_f869 [:00045]` | 2,054 | **gone** |

Every remaining binop/cmp site is at the heal-counter drain (≤ 61). Micro-repros: the render shape (nil-filled array warm-up) goes from an unbounded storm to 11 deopts + 1 `BecamePolymorphic` recompile; the alternating nil/Integer shapes deopt zero times.

## Tests

- `fused_nil_peel_operand_matrix` (both branch polarities, `===`, nil==nil, Float-argument and Bignum corners) and `value_cmp_nil_arm_operand_matrix`; the existing redefinition test now exercises the nil arm's bop dependency.
- Suites: default and `stress-spill-pool` 3582/3582.
- The one flake seen during development (`string_subclass_key_dispatches_eql`, ~1/70 per process) reproduced on a pristine master binary — a pre-existing, hash-seed-dependent bug where a broadly-true `eql?` can match a colliding entry — and is left for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
