### PR TITLE
bytesplice_with: a broken result keeps its negotiated encoding

### DIFF
--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -1513,10 +1513,14 @@ fn index_assign(
     // only has to survive the trip through a `&str`, which ASCII-only
     // bytes do whatever their encoding, and which broken UTF-8 does not:
     // encoding alone cannot say, since ASCII-8BIT is `valid_encoding?`
-    // whatever its bytes while UTF-8 may be broken.
+    // whatever its bytes while UTF-8 may be broken. A UTF-8 receiver
+    // holding broken bytes is no more rebuildable as a Rust String than a
+    // EUC-JP one, so its code range is asked as well.
+    let recv_inner = self_.as_rstring_inner();
+    let recv_is_utf8 = recv_inner.encoding().is_utf8_compatible() && recv_inner.is_valid_encoding();
     let subst_is_utf8 = subst_inner.is_ascii_only()
         || (subst_inner.encoding().is_utf8_compatible() && subst_inner.is_valid_encoding());
-    if !self_.as_rstring_inner().encoding().is_utf8_compatible() || !subst_is_utf8 {
+    if !recv_is_utf8 || !subst_is_utf8 {
         let inner = self_.as_rstring_inner();
         let char_len = inner.char_length();
         if let Some(idx) = arg0_val.try_fixnum().or_else(|| {
@@ -10064,6 +10068,27 @@ mod tests {
             r#"s = [0, 255, 128, 3].pack("C*"); r = s.slice!(1, 2); [r.bytes, r.encoding.to_s, s.bytes]"#,
             r#"s = [0, 255, 128, 3].pack("C*"); r = s.slice!(1); [r.bytes, s.bytes]"#,
             r#"s = [0, 255, 128, 3].pack("C*"); r = s.slice!(1..2); [r.bytes, s.bytes]"#,
+        ]);
+    }
+
+    #[test]
+    fn splice_keeps_a_broken_encoding() {
+        // A splice that leaves the string invalid keeps the encoding
+        // `compatible_encoding` negotiated: CRuby reports
+        // `valid_encoding?` false rather than re-tagging it ASCII-8BIT,
+        // which would also claim the result valid.
+        run_tests(&[
+            r#"s = [255, 97, 98].pack("C*").force_encoding("UTF-8"); s.bytesplice(1, 1, "z"); [s.encoding.to_s, s.valid_encoding?, s.bytes]"#,
+            r#"s = [255, 97, 98].pack("C*").force_encoding("UTF-8"); s.bytesplice(1, 1, ""); [s.encoding.to_s, s.valid_encoding?, s.bytes]"#,
+            // The same receiver through `[]=`, which splices the same way.
+            r#"s = [255, 97, 98].pack("C*").force_encoding("UTF-8"); s[1] = "z"; [s.encoding.to_s, s.valid_encoding?, s.bytes]"#,
+            // Negotiation still decides the encoding where it applies.
+            r#"s = "abcdef".b; s.bytesplice(2, 2, "\u3042"); [s.encoding.to_s, s.valid_encoding?, s.bytes]"#,
+            r#"s = "abcdef".dup; s.bytesplice(2, 2, [255, 128].pack("C*")); [s.encoding.to_s, s.bytes]"#,
+            // And an incompatible pair still raises rather than demoting.
+            r#"begin; s = [255, 97, 98].pack("C*").force_encoding("UTF-8"); s.bytesplice(1, 1, [255, 128].pack("C*")); rescue => e; e.class.to_s; end"#,
+            // `bytesplice` keeps rejecting a non-boundary offset.
+            r#"begin; s = "\u3042\u3044".dup; s.bytesplice(1, 1, "z"); rescue => e; e.class.to_s; end"#,
         ]);
     }
 

--- a/monoruby/src/value/rvalue/string.rs
+++ b/monoruby/src/value/rvalue/string.rs
@@ -2385,9 +2385,9 @@ impl RStringInner {
     /// the post-mutation classification: when both sides are
     /// SevenBit/Valid and the splice falls on UTF-8 character
     /// boundaries we set the result cr in O(1) without re-walking
-    /// the whole buffer. Broken results on UTF-8-compatible
-    /// encodings demote to ASCII-8BIT, matching CRuby and
-    /// `bytesplice`.
+    /// the whole buffer. A broken result keeps the encoding
+    /// `compatible_encoding` negotiated, as CRuby's does, and is simply
+    /// classified Broken.
     pub fn bytesplice_with(
         &mut self,
         start: usize,
@@ -2437,16 +2437,12 @@ impl RStringInner {
         // Slow path: re-classify the whole buffer. Caching the
         // result keeps a chain of in-place splices O(N) rather than
         // O(N²).
-        let cr = self.ty.classify(self.as_bytes());
-        if matches!(cr, CodeRange::Broken) && self.ty.is_utf8_compatible() {
-            // CRuby downgrades to ASCII-8BIT when UTF-8-tagged
-            // content becomes invalid; under that tag every byte is
-            // valid.
-            self.ty = Encoding::Ascii8;
-            self.cr.set(CodeRange::Valid);
-        } else {
-            self.cr.set(cr);
-        }
+        // The encoding is whatever `compatible_encoding` negotiated, and a
+        // broken result does not change it: CRuby leaves the string under
+        // its own tag and lets `valid_encoding?` report false. Splicing
+        // ASCII into an already-broken UTF-8 string keeps it UTF-8 there,
+        // where re-tagging it ASCII-8BIT would also claim it valid.
+        self.cr.set(self.ty.classify(self.as_bytes()));
         Ok(())
     }
 
@@ -3490,18 +3486,22 @@ mod encoding_tests {
     }
 
     #[test]
-    fn bytesplice_with_breaks_utf8_boundary_demotes_to_ascii8() {
+    fn bytesplice_with_breaks_utf8_boundary_stays_utf8() {
         // Splicing into the middle of a multi-byte UTF-8 character
-        // produces broken bytes; under Utf8 tagging CRuby (and our
-        // implementation) demotes to ASCII-8BIT.
+        // produces broken bytes. The string keeps its UTF-8 tag and is
+        // classified Broken: re-tagging it ASCII-8BIT would also declare
+        // it valid, and CRuby reports `valid_encoding?` false instead.
+        // `String#bytesplice` itself never gets here, rejecting a
+        // non-boundary offset with IndexError as CRuby does; this is the
+        // helper that `index_assign` also splices through.
         let globals = Globals::new_test();
         let mut s = RStringInner::from_str_scanned("あ"); // 3 bytes
         let repl = RStringInner::from_str_scanned("X");
 
         // Replace byte 1 (middle of "あ") — boundary check fails.
         s.bytesplice_with(1, 0, &repl, &globals.store).unwrap();
-        assert_eq!(s.encoding(), Encoding::Ascii8);
-        assert_eq!(s.cr.get(), CodeRange::Valid);
+        assert_eq!(s.encoding(), Encoding::Utf8);
+        assert_eq!(s.cr.get(), CodeRange::Broken);
     }
 }
 


### PR DESCRIPTION
Splicing re-tagged a UTF-8 string ASCII-8BIT whenever the result came out broken. CRuby keeps the encoding and lets `valid_encoding?` report false:

```ruby
s = [0xff, 0x61, 0x62].pack("C*").force_encoding("UTF-8")
s.bytesplice(1, 1, "z")
[s.encoding.to_s, s.valid_encoding?]
# monoruby => ["ASCII-8BIT", true]
# CRuby    => ["UTF-8", false]
```

The re-tag lost the string's declared encoding and, worse, called the result *valid*, since every byte is valid under ASCII-8BIT. This is the follow-up promised in #1283.

## The rule

The comment justifying the demotion attributed it to CRuby, but CRuby's `String#bytesplice` never reaches the case it modelled: it rejects a non-boundary offset with `IndexError` first.

Encoding is settled by `compatible_encoding` alone now, and a broken result is simply classified `Broken`. That is the rule the cases which *already* agreed were following — a UTF-8 receiver taking non-ASCII binary still comes out ASCII-8BIT because negotiation says so, not because the result is broken.

## `String#[]=` on a broken receiver

With the demotion gone, `[]=` can take a broken UTF-8 receiver down the byte path and produce CRuby's answer. It used to raise `ArgumentError` there, because the `&str` path cannot rebuild such a receiver; #1283 left that alone rather than trade a loud error for a wrong encoding tag. The receiver's code range now joins its encoding in choosing the route.

## Verification

Byte-for-byte agreement with CRuby on ten `bytesplice` / `[]=` combinations — already-broken receivers, boundary-cutting splices, binary and multibyte replacements, and the incompatible pair that raises — and on the sixteen-case encoding matrix from #1283, which is unchanged.

The three cases that moved:

| | before | after / CRuby |
| --- | --- | --- |
| `bytesplice` into a broken UTF-8 receiver | `ASCII-8BIT`, valid | `UTF-8`, invalid |
| the same with an empty replacement | `ASCII-8BIT`, valid | `UTF-8`, invalid |
| `[]=` on a broken UTF-8 receiver | `ArgumentError` | `UTF-8`, invalid |

`cargo test -p monoruby --lib string` goes from 312 to 313 passing. Four tests fail identically with and without this change (`inspect_and_case_map_by_encoding`, `sprintf_string_coerce_kernel_float`, `unpack1g_dump_group`, `time_new_string_form`) — checked against a clean `master`; the oracle here is CRuby 3.3.6 rather than the 4.0+ the harness asks for.

One existing unit test asserted the old demotion and is updated: `bytesplice_with_breaks_utf8_boundary_stays_utf8`. Its premise about CRuby was the mistaken one above, and the new comment says why `String#bytesplice` cannot reach it.

I could not run the full `bin/test` locally: it wants CRuby 4.0, the pinned ruby/spec and optcarrot checkouts, nextest and llvm-cov.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CreYezJ9tefe5BjESSzd7Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01CreYezJ9tefe5BjESSzd7Q)_