### PR TITLE
bytecodegen: emit `begin ... end while false` as a labeled block, not a loop

### DIFF
--- a/monoruby/src/bytecodegen/statement.rs
+++ b/monoruby/src/bytecodegen/statement.rs
@@ -197,6 +197,30 @@ impl<'a> BytecodeGen<'a> {
         };
         self.loop_push(break_dest, next_dest, loop_start, ret);
         let loc = body.loc;
+        // `begin ... end while false` (and `... until true`) runs the body
+        // exactly once and never takes the back edge: it is a labeled block
+        // whose `break` / `next` are forward jumps, not a loop. Code
+        // generators that lower a structured `block` into Ruby (dewasm's
+        // Ruby backend does) nest it deeply, and a `LoopStart` per level
+        // would make the JIT's back-edge analysis walk each nesting level's
+        // body once per enclosing level — exponential in the depth. Emit
+        // the body with no loop markers and no condition at all.
+        let single_shot = match cond.kind {
+            NodeKind::Bool(b) => b != cond_op,
+            NodeKind::Nil => cond_op,
+            _ => false,
+        };
+        if single_shot {
+            self.apply_label(loop_start);
+            self.gen_expr(body, UseMode2::NotUse)?;
+            self.apply_label(next_dest);
+            if use_value {
+                self.push_nil();
+            }
+            self.loop_pop();
+            self.apply_label(break_dest);
+            return Ok(());
+        }
         self.apply_label(loop_start);
         self.emit(BytecodeInst::LoopStart, loc);
         self.gen_expr(body, UseMode2::NotUse)?;

--- a/monoruby/tests/arith.rs
+++ b/monoruby/tests/arith.rs
@@ -324,6 +324,81 @@ fn bench_factorialpoly() {
     );
 }
 
+/// `begin ... end while false` (and its `until true` / `while nil` twins) is a
+/// labeled block: the body runs once and `break` / `next` are forward jumps.
+/// bytecodegen emits it without loop markers, so this pins the semantics of
+/// every exit form against CRuby, deeply nested the way generated code nests it.
+#[test]
+fn test_postfix_while_literal_false() {
+    run_test(
+        r#"
+        r = []
+        begin
+          r << 1
+          break if r.size == 1
+          r << :unreachable
+        end while false
+        begin
+          r << 2
+          next if r.size == 2
+          r << :unreachable
+        end while false
+        v = begin
+          r << 3
+        end while false
+        r << v
+        u = begin
+          r << 4
+        end until true
+        r << u
+        n = 0
+        begin
+          n += 1
+          redo if n < 3
+        end while false
+        r << n
+        i = 0
+        begin
+          i += 1
+        end while nil
+        r << i
+        x = begin; 7; end while false
+        r << x
+        def m
+          begin
+            return :from_block
+          end while false
+          :after
+        end
+        r << m
+        # dewasm's lowering of a wasm `block` nest: a pending branch id in
+        # `__br` is relayed outward through each level's epilogue.
+        def nest(k)
+          __br = nil
+          out = []
+          begin
+            begin
+              begin
+                out << :a
+                if k == 1 then __br = 1; break end
+                out << :b
+                if k == 2 then __br = 3; break end
+                out << :c
+              end while false
+              if __br == 3 then __br = nil elsif __br then break end
+              out << :d
+            end while false
+            if __br == 2 then __br = nil elsif __br then break end
+            out << :e
+          end while false
+          out
+        end
+        r << nest(0) << nest(1) << nest(2)
+        r
+        "#,
+    );
+}
+
 #[test]
 fn bench_while_until_for() {
     run_tests2(&[

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -2318,6 +2318,7 @@ b041b0aaea8a7d40b26a35b251c0f897	[[:req, :a], [:nokey]]	def m(a, **nil); end\n  
 b050bdfac1ec47f5eeda5dc5e12bd05a	45.0	def call_block\n      yield\n    end\n    def call_block_twice\n      yield\n   
 b06f00715b283fa26e9acda37466978d	[1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub]	class MyArray < Array\n              def [](i) = :sub\n            en
 b07897e1515470c5f367e6c838cd3ca3	true	h = {a: 1}.compare_by_identity\n            Marshal.load(Marshal.dum
+b0a6a8263e7c30eec12325762ab54dc5	[1, 2, nil, nil, 3, 1, nil, :from_block, [:a, :b, :c, :d, :e], [:a], [:a, :b, :d, :e]]	r = []\n        begin\n          r << 1\n          break if r.size == 1\n  
 b127614a38e6a826e83df4733ad1c138	[true, true]	require "openssl"\n        [OpenSSL::Cipher::CipherError < OpenSSL::Open
 b13eb772180c210a5c10579da6ea6cfb	true	a = []\n            a << a\n            b = Marshal.load(Marshal.dump
 b15052c5abbd93a1a9004be3b57beb9c	[:foo, :bar]	$res = []\n            obj = Object.new\n            def obj.singleto


### PR DESCRIPTION
## Problem

dewasm's Ruby backend lowers every wasm `block` to `begin ... end while false` (and every `loop` to `while true`), nested as deeply as the wasm structured control flow is. Its DOOM port (`examples/doom/ruby-gosu`) froze for seconds at a time under monoruby: in a 400-tick headless run the longest tick was **16.0 s** (CRuby+YJIT: 1.86 s, the level-load tick), and 29 ticks over 150 ms totalled 35.8 s of a 60 s run. `--no-jit` has no such stalls, and a jit-log build showed 36.7 s of a 52 s run inside the JIT compiler: one *recompile* of `_f717` (a 184-line method) took 16.5 s, `_f875` (102 lines, twelve nesting levels) 5.5 s.

gdb sampling put almost all of that in the front end (`traceir_to_asmir` → `incoming_context`), none in machine-code generation. The loop-head merge runs `analyse_backedge_fixpoint`, which walks the loop body once per fixpoint iteration; every inner loop head that walk meets runs the inner loop's own fixpoint and is then walked again as part of the outer body. The innermost body of a nest of depth d is therefore analysed about 2^d times (about 3^d for real `while true` nests, which take two iterations each). Measured with a synthetic nest (`scratchpad/nest.rb`):

| depth | `begin…end while false` | `while true` nest |
|---|---|---|
| 4 | 2.6 ms | 11 ms |
| 6 | 8.0 ms | 64 ms |
| 8 | 28 ms | 565 ms |

## Change

A postfix `while` whose condition is the literal `false` or `nil` (or an `until` with literal `true`) runs its body exactly once and never takes the back edge: it is a labeled block whose `break` / `next` are forward jumps. `gen_while_begin_postfix` now emits such a body with no `LoopStart` / `LoopEnd` and no condition branch. `loop_push` still provides the `break` / `next` / `redo` targets and the value slot, so the semantics are untouched; only the JIT stops seeing a loop.

The new `test_postfix_while_literal_false` pins every exit form (`break`, `next`, `redo`, `return`, value use, `until true`, `while nil`) and the three-deep `__br` relay nest dewasm generates, against CRuby.

## Result

Same DOOM run, 400 ticks:

| | ticks/sec | median tick | longest tick | ticks > 150 ms | init |
|---|---|---|---|---|---|
| CRuby 4.0.2 + YJIT | 16.1 | 55.7 ms | 1.86 s | 2 (2.0 s) | 0.79 s |
| master | 6.6 | 65.5 ms | 16.0 s | 29 (35.8 s) | 3.25 s |
| this branch | 13.8 | 65.3 ms | 1.40 s | 2 (2.6 s) | 1.72 s |

Total JIT compile time over 250 ticks: 36.7 s → 1.8 s (857 compiles). The synthetic nest is linear now (depth 16: 4.2 ms).

Real `while true` nests still pay 3^d; that needs the loop analysis itself to stop recomputing inner fixpoints per outer iteration, which is a separate change.

## Verification

- `cargo test`: all pass.
- emit-asm byte comparison against master on app_fib, so_mandelbrot, so_nbody, app_aobench, binarytrees, quick_sort, bf, tarai, loop_whileloop: identical, except app_aobench's known run-to-run flip (`:00135 %13 = %13 + %14 [<INVALID>]` vs `[Float]`), which the branch binary reproduces on both sides across three runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_