### PR TITLE
JIT: one flat walk per loop-nest fixpoint instead of a fixpoint per inner head

### DIFF
--- a/monoruby/src/basic_block.rs
+++ b/monoruby/src/basic_block.rs
@@ -11,7 +11,7 @@ use std::iter::Step;
 use crate::bytecode::BcIndex;
 use crate::bytecodegen::inst::BytecodeIr;
 
-#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub(crate) struct BasicBlockId(pub usize);
 
 impl std::fmt::Debug for BasicBlockId {
@@ -200,6 +200,26 @@ impl BasicBlockInfo {
             .iter()
             .find(|(begin, _)| *begin == bb_id)
             .cloned()
+    }
+
+    ///
+    /// Every loop whose blocks lie within `start..=end` — the loop
+    /// headed at `start` itself first, then the loops nested inside it in
+    /// order of their heads.
+    ///
+    pub(crate) fn loops_within(
+        &self,
+        start: BasicBlockId,
+        end: BasicBlockId,
+    ) -> Vec<(BasicBlockId, BasicBlockId)> {
+        let mut loops: Vec<_> = self
+            .loops
+            .iter()
+            .filter(|(begin, last)| start <= *begin && *last <= end)
+            .cloned()
+            .collect();
+        loops.sort_by_key(|(begin, _)| *begin);
+        loops
     }
 }
 

--- a/monoruby/src/bytecodegen/statement.rs
+++ b/monoruby/src/bytecodegen/statement.rs
@@ -197,6 +197,30 @@ impl<'a> BytecodeGen<'a> {
         };
         self.loop_push(break_dest, next_dest, loop_start, ret);
         let loc = body.loc;
+        // `begin ... end while false` (and `... until true`) runs the body
+        // exactly once and never takes the back edge: it is a labeled block
+        // whose `break` / `next` are forward jumps, not a loop. Code
+        // generators that lower a structured `block` into Ruby (dewasm's
+        // Ruby backend does) nest it deeply, and a `LoopStart` per level
+        // would make the JIT's back-edge analysis walk each nesting level's
+        // body once per enclosing level — exponential in the depth. Emit
+        // the body with no loop markers and no condition at all.
+        let single_shot = match cond.kind {
+            NodeKind::Bool(b) => b != cond_op,
+            NodeKind::Nil => cond_op,
+            _ => false,
+        };
+        if single_shot {
+            self.apply_label(loop_start);
+            self.gen_expr(body, UseMode2::NotUse)?;
+            self.apply_label(next_dest);
+            if use_value {
+                self.push_nil();
+            }
+            self.loop_pop();
+            self.apply_label(break_dest);
+            return Ok(());
+        }
         self.apply_label(loop_start);
         self.emit(BytecodeInst::LoopStart, loc);
         self.gen_expr(body, UseMode2::NotUse)?;

--- a/monoruby/src/codegen/jitgen/compile/loop_analysis.rs
+++ b/monoruby/src/codegen/jitgen/compile/loop_analysis.rs
@@ -1,63 +1,119 @@
 use super::*;
 
+///
+/// What one analysis walk over a loop's blocks learned, per loop head in
+/// the walked range: the head of the walked loop itself and every loop
+/// nested inside it.
+///
+struct LoopWalk {
+    /// Per head: the liveness of its loop (joined at the loop's back
+    /// edges and at every leaving path inside it).
+    liveness: indexmap::IndexMap<BasicBlockId, Liveness>,
+    /// Per head: the join of the states arriving on its back edges, if
+    /// any back edge was reached.
+    backedge: indexmap::IndexMap<BasicBlockId, Option<AbstractState>>,
+    /// Stage-C loop adoption vetoes, for the walked loop's own head.
+    vetoes: (bool, Vec<(usize, SlotId)>),
+}
+
 impl<'a> JitContext<'a> {
+    ///
+    /// Compute the back-edge fixpoint of the loop `loop_start..=loop_end`.
+    ///
+    /// One walk covers the whole nest: an inner loop head met during the
+    /// walk does not run a fixpoint of its own (`analyse_basic_block`
+    /// merges it with the back edge recorded by the previous walk, if
+    /// any), and the back edges of every head in the range are collected
+    /// at the end of the walk and recorded in this frame's `loop_info`.
+    /// The walk repeats until no head's back edge moved. A nest of depth
+    /// d thus costs a handful of linear walks instead of the ~3^d walks
+    /// that recursing into each inner head's fixpoint (and then walking
+    /// its body again as part of the enclosing body) used to cost — a
+    /// 12-deep nest in dewasm-generated code took seconds per compile.
+    ///
+    /// The recorded inner-head information is what the inner heads' own
+    /// merges (`incoming_context`, when the real compile reaches them)
+    /// start their fixpoint from, so those converge on their first walk.
+    ///
     pub(in crate::codegen::jitgen) fn analyse_backedge_fixpoint(
         &mut self,
         state: AbstractState,
         loop_start: BasicBlockId,
         loop_end: BasicBlockId,
     ) -> JitResult<()> {
-        for x in 0..10 {
+        let heads: Vec<BasicBlockId> = self
+            .iseq()
+            .bb_info
+            .loops_within(loop_start, loop_end)
+            .into_iter()
+            .map(|(begin, _)| begin)
+            .collect();
+        debug_assert_eq!(heads[0], loop_start);
+        // Each walk can carry a back edge one nesting level further out,
+        // so the bound grows with the number of heads.
+        let limit = 10 * heads.len();
+        for x in 0..limit {
             #[cfg(feature = "jit-debug")]
             eprintln!("########## analyse iteration[{x}]");
-            let (liveness, backedge, vetoes) =
-                self.analyse_loop(loop_start, loop_end, state.clone())?;
+            let walk = self.analyse_loop(loop_start, loop_end, &heads, state.clone())?;
             // Stage-C loop adoption: park the walk's vetoes for the
             // loop-entry merge (overwritten per iteration). The float-read
             // marks themselves ride the analysed states and are read off
-            // the back edge there.
-            self.record_loop_adoption_vetoes(loop_start, vetoes);
-            if let Some(backedge) = backedge {
-                if let Some(be) = self.loop_backedge(loop_start)
-                    && be.equiv(&backedge)
-                {
-                    #[cfg(feature = "jit-debug")]
-                    eprintln!(
-                        "fixed: {x} {:?}=={:?}",
-                        (be.slot_state()),
-                        backedge.slot_state()
-                    );
-                    break;
+            // the back edge there. Inner heads get theirs from their own
+            // fixpoint when the real compile reaches them.
+            self.record_loop_adoption_vetoes(loop_start, walk.vetoes);
+            let mut changed = false;
+            for (head, backedge) in walk.backedge {
+                let liveness = walk.liveness[&head].clone();
+                if let Some(backedge) = backedge {
+                    if let Some(be) = self.loop_backedge(head)
+                        && be.equiv(&backedge)
+                    {
+                        #[cfg(feature = "jit-debug")]
+                        eprintln!(
+                            "fixed: {x} {head:?} {:?}=={:?}",
+                            (be.slot_state()),
+                            backedge.slot_state()
+                        );
+                    } else {
+                        #[cfg(feature = "jit-debug")]
+                        eprintln!(
+                            "analyse_loop[{x}] backedge: ->{head:?} {:?}",
+                            backedge.slot_state()
+                        );
+                        self.add_loop_info(head, liveness, Some(backedge));
+                        changed = true;
+                    }
                 } else {
-                    #[cfg(feature = "jit-debug")]
-                    eprintln!(
-                        "analyse_loop[{x}] backedge: {loop_end:?}->{loop_start:?} {:?}",
-                        backedge.slot_state()
-                    );
-                    self.add_loop_info(loop_start, liveness, Some(backedge));
+                    // This walk found no back edge for this head. If an
+                    // earlier walk already recorded one, keep it: the
+                    // back-edge fixpoint must be *monotone* (a back edge,
+                    // once present, cannot disappear). A later walk's
+                    // refined entry state can statically prune the
+                    // back-edge branch (it decides the loop always exits),
+                    // but the real forward compilation still emits that
+                    // back edge, whose state then bridges to the loop-head
+                    // merge target. Overwriting with `None` would drop the
+                    // back-edge join from that target, leaving loop-carried
+                    // slots at their stale pre-header concrete types (e.g.
+                    // an uninitialized local's `C(nil)`) that the real back
+                    // edge (e.g. `S(Fixnum)`) contradicts — tripping the
+                    // `bridge` `S -> C` unreachable. Refresh liveness but
+                    // retain the recorded back edge.
+                    //
+                    // A head seen for the first time is a change even so:
+                    // the next walk applies its liveness at the merge, as
+                    // the walk that recorded it would have.
+                    let first = self.loop_info(head).is_none();
+                    let be = self.loop_backedge(head).cloned();
+                    self.add_loop_info(head, liveness, be);
+                    changed |= first;
                 }
-            } else {
-                // This iteration found no back-edge. If an earlier iteration
-                // already recorded one, keep it: the back-edge fixpoint must be
-                // *monotone* (a back-edge, once present, cannot disappear). A
-                // later iteration's refined entry state can statically prune the
-                // back-edge branch (it decides the loop always exits), but the
-                // real forward compilation still emits that back-edge, whose
-                // state then bridges to the loop-head merge target. Overwriting
-                // with `None` would drop the back-edge join from that target,
-                // leaving loop-carried slots at their stale pre-header concrete
-                // types (e.g. an uninitialized local's `C(nil)`) that the real
-                // back-edge (e.g. `S(Fixnum)`) contradicts — tripping the
-                // `bridge` `S -> C` unreachable. Refresh liveness but retain the
-                // recorded back-edge and treat the fixpoint as converged.
-                if let Some(be) = self.loop_backedge(loop_start).cloned() {
-                    self.add_loop_info(loop_start, liveness, Some(be));
-                } else {
-                    self.add_loop_info(loop_start, liveness, None);
-                }
+            }
+            if !changed {
                 break;
             }
-            if x == 9 {
+            if x == limit - 1 {
                 panic!("not fixed")
             }
         }
@@ -68,11 +124,15 @@ impl<'a> JitContext<'a> {
         &self,
         loop_start: BasicBlockId,
         loop_end: BasicBlockId,
+        heads: &[BasicBlockId],
         mut state: AbstractState,
-    ) -> JitResult<(Liveness, Option<AbstractState>, (bool, Vec<(usize, SlotId)>))> {
+    ) -> JitResult<LoopWalk> {
         let pc = self.iseq().get_bb_pc(loop_start);
-        let mut ctx = JitContext::loop_analysis(self, pc);
-        let mut liveness = Liveness::new(ctx.total_reg_num());
+        let mut ctx = JitContext::loop_analysis(self, pc, loop_start);
+        let mut liveness: indexmap::IndexMap<BasicBlockId, Liveness> = heads
+            .iter()
+            .map(|head| (*head, Liveness::new(ctx.total_reg_num())))
+            .collect();
 
         if let Some(backedge) = self.loop_backedge(loop_start) {
             state.join(backedge);
@@ -80,26 +140,32 @@ impl<'a> JitContext<'a> {
         ctx.branch_continue(loop_start, state);
 
         for bbid in loop_start..=loop_end {
-            ctx.analyse_basic_block(&mut liveness, bbid, bbid == loop_start, bbid == loop_end)?;
+            ctx.analyse_basic_block(&mut liveness, bbid, bbid == loop_end)?;
         }
 
-        let mut backedge: Option<AbstractState> = None;
-        if let Some(branches) = ctx.remove_branch(loop_start) {
-            for BranchEntry { src_bb, state, .. } in branches {
-                liveness.join(&state);
-                assert!(src_bb.unwrap() >= loop_start);
-                // backegde
-                if let Some(backedge) = &mut backedge {
-                    backedge.join(&state);
-                } else {
-                    backedge = Some(state);
+        let mut backedge: indexmap::IndexMap<BasicBlockId, Option<AbstractState>> =
+            heads.iter().map(|head| (*head, None)).collect();
+        for head in heads {
+            // Entries left for a head after its block was walked all come
+            // from blocks behind it: its back edges.
+            if let Some(branches) = ctx.remove_branch(*head) {
+                let liveness = liveness.get_mut(head).unwrap();
+                let backedge = backedge.get_mut(head).unwrap();
+                for BranchEntry { src_bb, state, .. } in branches {
+                    liveness.join(&state);
+                    assert!(src_bb.unwrap() >= *head);
+                    if let Some(backedge) = backedge {
+                        backedge.join(&state);
+                    } else {
+                        *backedge = Some(state);
+                    }
                 }
             }
         }
         #[cfg(feature = "jit-debug")]
         eprintln!(
             "analyse_end: {loop_start:?}->{loop_end:?} {}",
-            backedge
+            backedge[&loop_start]
                 .as_ref()
                 .map_or("no backedge".to_string(), |b| format!(
                     "{:?}",
@@ -111,18 +177,28 @@ impl<'a> JitContext<'a> {
         // adopting an outer view (the marks themselves ride the states).
         let vetoes = ctx.export_loop_adoption_vetoes(self);
 
-        Ok((liveness, backedge, vetoes))
+        Ok(LoopWalk {
+            liveness,
+            backedge,
+            vetoes,
+        })
     }
 
+    ///
+    /// One analysis walk over the block *bbid*. A loop head — the walked
+    /// loop's own or an inner one — is merged with the back edge recorded
+    /// for it, never with a nested fixpoint of its own (see
+    /// `analyse_backedge_fixpoint`). A leaving path joins into the
+    /// liveness of every loop that contains it.
+    ///
     fn analyse_basic_block(
         &mut self,
-        liveness: &mut Liveness,
+        liveness: &mut indexmap::IndexMap<BasicBlockId, Liveness>,
         bbid: BasicBlockId,
-        is_start: bool,
         is_last: bool,
     ) -> JitResult<()> {
         let mut ir = AsmIr::new(self);
-        let mut state = match self.incoming_context(bbid, is_start)? {
+        let mut state = match self.incoming_context(bbid, true)? {
             Some(bb) => bb,
             None => return Ok(()),
         };
@@ -145,7 +221,12 @@ impl<'a> JitContext<'a> {
                 | CompileResult::Recompile(_)
                 | CompileResult::Deopt
                 | CompileResult::ExitLoop => {
-                    liveness.join(&state);
+                    for (head, liveness) in liveness.iter_mut() {
+                        let (_, loop_end) = self.iseq().bb_info.is_loop_begin(*head).unwrap();
+                        if *head <= bbid && bbid <= loop_end {
+                            liveness.join(&state);
+                        }
+                    }
                     return Ok(());
                 }
                 CompileResult::Abort => {

--- a/monoruby/src/codegen/jitgen/context.rs
+++ b/monoruby/src/codegen/jitgen/context.rs
@@ -1009,9 +1009,25 @@ impl<'a> JitContext<'a> {
         }
     }
 
-    pub(super) fn loop_analysis(&self, pc: BytecodePtr) -> Self {
+    ///
+    /// The throwaway context for one analysis walk over the loop headed at
+    /// *loop_start* (whose `LoopStart` is at *pc*). The walk merges every
+    /// inner loop head with the back edge recorded for it by the previous
+    /// walks, so those entries come along; the walked loop's own entry
+    /// does not — its recorded back edge is joined into the walk's entry
+    /// state by `analyse_loop`, and its liveness belongs to the real merge.
+    ///
+    pub(super) fn loop_analysis(&self, pc: BytecodePtr, loop_start: BasicBlockId) -> Self {
         let mut ctx = self.analysis_clone();
-        ctx.stack_frame.last_mut().unwrap().jit_type = JitType::Loop(pc);
+        let frame = ctx.stack_frame.last_mut().unwrap();
+        frame.jit_type = JitType::Loop(pc);
+        frame.loop_info = self
+            .current_frame()
+            .loop_info
+            .iter()
+            .filter(|(head, _)| **head != loop_start)
+            .map(|(head, info)| (*head, info.clone()))
+            .collect();
         ctx
     }
 

--- a/monoruby/tests/arith.rs
+++ b/monoruby/tests/arith.rs
@@ -399,6 +399,62 @@ fn test_postfix_while_literal_false() {
     );
 }
 
+/// A ten-deep `while true` nest. The back-edge fixpoint analysis walks the
+/// whole nest per outer iteration; before it stopped recursing into each
+/// inner head's own fixpoint the innermost body was walked ~3^10 times and
+/// this did not finish in any reasonable time.
+#[test]
+fn test_deep_loop_nest_compiles() {
+    run_test(
+        r#"
+        n = 0
+        acc = 1
+        while true
+          n += 1
+          while true
+            n += 1
+            while true
+              n += 1
+              while true
+                n += 1
+                while true
+                  n += 1
+                  while true
+                    n += 1
+                    while true
+                      n += 1
+                      while true
+                        n += 1
+                        while true
+                          n += 1
+                          while true
+                            n += 1
+                            acc = acc * 3 + n & 0xffff
+                            break if n % 11 == 0
+                          end
+                          break if n % 10 == 0
+                        end
+                        break if n % 9 == 0
+                      end
+                      break if n % 8 == 0
+                    end
+                    break if n % 7 == 0
+                  end
+                  break if n % 6 == 0
+                end
+                break if n % 5 == 0
+              end
+              break if n % 4 == 0
+            end
+            break if n % 3 == 0
+          end
+          break if n % 2 == 0
+        end
+        [n, acc]
+        "#,
+    );
+}
+
 #[test]
 fn bench_while_until_for() {
     run_tests2(&[

--- a/monoruby/tests/arith.rs
+++ b/monoruby/tests/arith.rs
@@ -324,6 +324,81 @@ fn bench_factorialpoly() {
     );
 }
 
+/// `begin ... end while false` (and its `until true` / `while nil` twins) is a
+/// labeled block: the body runs once and `break` / `next` are forward jumps.
+/// bytecodegen emits it without loop markers, so this pins the semantics of
+/// every exit form against CRuby, deeply nested the way generated code nests it.
+#[test]
+fn test_postfix_while_literal_false() {
+    run_test(
+        r#"
+        r = []
+        begin
+          r << 1
+          break if r.size == 1
+          r << :unreachable
+        end while false
+        begin
+          r << 2
+          next if r.size == 2
+          r << :unreachable
+        end while false
+        v = begin
+          r << 3
+        end while false
+        r << v
+        u = begin
+          r << 4
+        end until true
+        r << u
+        n = 0
+        begin
+          n += 1
+          redo if n < 3
+        end while false
+        r << n
+        i = 0
+        begin
+          i += 1
+        end while nil
+        r << i
+        x = begin; 7; end while false
+        r << x
+        def m
+          begin
+            return :from_block
+          end while false
+          :after
+        end
+        r << m
+        # dewasm's lowering of a wasm `block` nest: a pending branch id in
+        # `__br` is relayed outward through each level's epilogue.
+        def nest(k)
+          __br = nil
+          out = []
+          begin
+            begin
+              begin
+                out << :a
+                if k == 1 then __br = 1; break end
+                out << :b
+                if k == 2 then __br = 3; break end
+                out << :c
+              end while false
+              if __br == 3 then __br = nil elsif __br then break end
+              out << :d
+            end while false
+            if __br == 2 then __br = nil elsif __br then break end
+            out << :e
+          end while false
+          out
+        end
+        r << nest(0) << nest(1) << nest(2)
+        r
+        "#,
+    );
+}
+
 #[test]
 fn bench_while_until_for() {
     run_tests2(&[

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -163,6 +163,7 @@
 09e1a701e3fe1cd8ef94aa693e0b655b	[1.5, 1.5, 1.5, 2.5]	def __f(x)\n          \n        a = x > 30 ? 1.5 : x\n        b = a\n      
 0a0748b8809f0e8d7f80297870a4da1e	[200000, 0, 999]	a = []\n            200000.times { |i| a << [(i * 7919) % 1000] }\n  
 0a0f30d8ebe55e1e0abe73391dfb071f	[true, true, true, true, 2]	(o=Object.new; def o.to_path; "/tmp/mono_tp_#{Process.pid}"; end; p2=Object.new;
+0a5b4d0ac946d24249dbf3aa75d75a4f	[27720, 62874]	n = 0\n        acc = 1\n        while true\n          n += 1\n          whi
 0a8fcb3472ef6869da4abdbb99763b0d	[2, :redefined, false]	def probe(a, b) = a == b\n                def probe_ne(a, b) = a
 0aa2fa3cce375400b399c989bb80cc19	[1, 0, 0, 2, 1, 1, 3, 2, 2, 5, 3, 3, 8, 4, 4, 13, 5, 5, 21, 6, 6, 34, 7, 7, 55, 8, 8, 89, 9, 9, 144, 10, 10, 233, 11, 11, 377, 12, 12, 610, 13, 13, 987, 14, 14, 1597, 15, 15]	e = Enumerator.new do |y|\n            a = b = 1\n            loop do\n   
 0abce90d3ad088b0bf89b96ec125cc4a	[5.25, 0.75, 4.5]	def call_block\n      yield\n    end\n    def call_block_twice\n      yield\n   

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -2318,6 +2318,7 @@ b041b0aaea8a7d40b26a35b251c0f897	[[:req, :a], [:nokey]]	def m(a, **nil); end\n  
 b050bdfac1ec47f5eeda5dc5e12bd05a	45.0	def call_block\n      yield\n    end\n    def call_block_twice\n      yield\n   
 b06f00715b283fa26e9acda37466978d	[1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub, 1, 8, :sub]	class MyArray < Array\n              def [](i) = :sub\n            en
 b07897e1515470c5f367e6c838cd3ca3	true	h = {a: 1}.compare_by_identity\n            Marshal.load(Marshal.dum
+b0a6a8263e7c30eec12325762ab54dc5	[1, 2, nil, nil, 3, 1, nil, :from_block, [:a, :b, :c, :d, :e], [:a], [:a, :b, :d, :e]]	r = []\n        begin\n          r << 1\n          break if r.size == 1\n  
 b127614a38e6a826e83df4733ad1c138	[true, true]	require "openssl"\n        [OpenSSL::Cipher::CipherError < OpenSSL::Open
 b13eb772180c210a5c10579da6ea6cfb	true	a = []\n            a << a\n            b = Marshal.load(Marshal.dump
 b15052c5abbd93a1a9004be3b57beb9c	[:foo, :bar]	$res = []\n            obj = Object.new\n            def obj.singleto


### PR DESCRIPTION
Stacked on #1286 (its commit is included; rebases cleanly once that merges).

## Problem

`analyse_backedge_fixpoint` walked a loop's body once per fixpoint iteration and, at every inner loop head the walk met, ran that head's own fixpoint (two walks of the inner body, recursively) before walking the inner body again as part of the outer one. The innermost body of a nest of depth d was walked about 3^d times per compile. dewasm lowers nested wasm `loop`s to `while true` nests (up to thirteen deep in its DOOM port); with #1286 in place these were what remained of the compile stalls: a 102-line method still took seconds.

The nested fixpoint existed because the analysis clone (`JitStackFrame::dup`) starts with an empty `loop_info`, so an inner head met during an outer walk had no recorded back edge to merge with.

## Change

One walk now covers the whole nest (`compile/loop_analysis.rs`):

- `loop_analysis` seeds the clone's frame with the recorded `loop_info` of every head *inside* the walked loop (not the walked loop's own, whose back edge `analyse_loop` joins into the entry state as before and whose liveness belongs to the real merge).
- `analyse_basic_block` merges every head with `no_calc_backedge` (`incoming_context(bbid, true)`): an inner head joins the back edge the previous walks recorded, never a nested fixpoint.
- The back edges left for every head in the range (`BasicBlockInfo::loops_within`) are collected at the end of the walk and recorded; the walk repeats until no head's back edge moved (bound `10 × heads`). Liveness is kept per head, joined at the head's back edges and at every leaving path inside its loop, exactly as the nested walks joined it.
- The recorded inner-head information is what the inner heads' own merges start from when the real compile reaches them, so those converge on their first walk. Stage-C adoption vetoes are recorded for the walked loop's own head only: an inner head gets its own when its real merge runs, the only place they are read.

The first version seeded nothing and miscompiled DOOM's `_f866` (`%17 S(Value)->C(nil)` at a back-edge bridge): the inner head kept its first-walk `C` entry, so its exit path was statically pruned in every analysis walk while the real walk took it. Seeding the clone is what makes the flat walk see the same states the nested one did.

## Result

| | before | after |
|---|---|---|
| synthetic `while true` nest, depth 8 | 565 ms | 6 ms |
| depth 12 | (not measured) | 10 ms |
| DOOM `initGame` (JIT compiles during init) | 1.72 s | 0.72 s |
| DOOM longest JIT compile | 16.5 s (master) / 5.5 s (#1286) | 80 ms |
| DOOM 250 ticks, total JIT time | 36.7 s (master) / 1.8 s (#1286) | 1.66 s |

`test_deep_loop_nest_compiles` (a ten-deep `while true` nest) guards the growth.

## Verification

- `cargo test`: all pass.
- emit-asm byte comparison against master on the nine benchmarks: identical except so_mandelbrot, where the code is 25 bytes shorter and the only differences are fpr register numbers (the inner-loop arithmetic is the same instruction sequence with `xmm2/xmm5` ↔ `xmm4/xmm8` etc.); wall time is unchanged (0.15–0.16 s both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_