### PR TITLE
JIT: let a frame-free leaf body fold a constant operand

### DIFF
--- a/monoruby/src/codegen/jitgen/compile/frameless.rs
+++ b/monoruby/src/codegen/jitgen/compile/frameless.rs
@@ -241,17 +241,18 @@ pub(super) struct LeafBody {
     /// Applied in order; the accumulator's final value is returned.
     pub ops: Vec<LeafOp>,
     ///
-    /// The constant sites whose cached values are baked into `ops`.
+    /// The salvage records for the constants baked into `ops`, built here
+    /// from the caches the fold actually read.
     ///
     /// A fold is only the right value at the const version it was resolved
     /// at. The body cannot redefine a constant itself (it contains no
     /// call), but anything else in the program can, between the caller's
-    /// compilation and a later execution of it. The call site therefore
-    /// re-validates these against its own compile-time version and takes
-    /// the same guard and salvage record a `LoadConst` in its own frame
-    /// would; see [`JitContext::expand_leaf_body`].
+    /// compilation and a later execution of it. The call site checks these
+    /// versions against its own and takes the same guard and salvage record
+    /// a `LoadConst` in its own frame would; see
+    /// [`JitContext::expand_leaf_body`].
     ///
-    pub consts: Vec<ConstSiteId>,
+    pub consts: Vec<ConstFoldSite>,
 }
 
 /// The most ops a body may have and still be expanded. Each guarding op is
@@ -343,7 +344,7 @@ pub(super) fn leaf_expr_body(store: &Store, iseq_id: ISeqId) -> Option<LeafBody>
     // committed to the accumulator so far; a slot's chain is spliced onto it
     // when the slot is finally used.
     let mut ops: Vec<LeafOp> = vec![];
-    let mut consts: Vec<ConstSiteId> = vec![];
+    let mut consts: Vec<ConstFoldSite> = vec![];
     let mut ret: Option<SlotId> = None;
     for idx in begin..=end {
         match TraceIr::from_pc(iseq.get_pc(idx), store) {
@@ -370,7 +371,17 @@ pub(super) fn leaf_expr_body(store: &Store, iseq_id: ISeqId) -> Option<LeafBody>
                 {
                     return None;
                 }
-                consts.push(id);
+                // The salvage record is built from this cache, so the call
+                // site never has to re-read the site: the value it guards is
+                // the value the fold used.
+                let site = &store[id];
+                let mut names = site.prefix.clone();
+                names.push(site.name);
+                consts.push(ConstFoldSite {
+                    id,
+                    cache: cache.clone(),
+                    names,
+                });
                 slots.insert(dst, Chain::leaf(LeafValue::Fixnum(cache.value)));
             }
             TraceIr::LoadIvar(dst, name, _) => {

--- a/monoruby/src/codegen/jitgen/compile/frameless.rs
+++ b/monoruby/src/codegen/jitgen/compile/frameless.rs
@@ -183,7 +183,7 @@ pub(super) enum LeafValue {
     Param(u16),
     /// `@name` of the receiver.
     SelfIvar(IdentId),
-    /// A fixnum literal.
+    /// A fixnum literal, or a constant whose cached value is one.
     Fixnum(Value),
 }
 
@@ -240,6 +240,18 @@ impl LeafOp {
 pub(super) struct LeafBody {
     /// Applied in order; the accumulator's final value is returned.
     pub ops: Vec<LeafOp>,
+    ///
+    /// The constant sites whose cached values are baked into `ops`.
+    ///
+    /// A fold is only the right value at the const version it was resolved
+    /// at. The body cannot redefine a constant itself (it contains no
+    /// call), but anything else in the program can, between the caller's
+    /// compilation and a later execution of it. The call site therefore
+    /// re-validates these against its own compile-time version and takes
+    /// the same guard and salvage record a `LoadConst` in its own frame
+    /// would; see [`JitContext::expand_leaf_body`].
+    ///
+    pub consts: Vec<ConstSiteId>,
 }
 
 /// The most ops a body may have and still be expanded. Each guarding op is
@@ -331,6 +343,7 @@ pub(super) fn leaf_expr_body(store: &Store, iseq_id: ISeqId) -> Option<LeafBody>
     // committed to the accumulator so far; a slot's chain is spliced onto it
     // when the slot is finally used.
     let mut ops: Vec<LeafOp> = vec![];
+    let mut consts: Vec<ConstSiteId> = vec![];
     let mut ret: Option<SlotId> = None;
     for idx in begin..=end {
         match TraceIr::from_pc(iseq.get_pc(idx), store) {
@@ -338,6 +351,27 @@ pub(super) fn leaf_expr_body(store: &Store, iseq_id: ISeqId) -> Option<LeafBody>
             TraceIr::FrozenLiteral(dst, v) | TraceIr::Literal(dst, v) => {
                 v.try_fixnum()?;
                 slots.insert(dst, Chain::leaf(LeafValue::Fixnum(v)));
+            }
+            TraceIr::LoadConst(dst, id) => {
+                let cache = store[id].cache.as_ref()?;
+                // Only an immediate may be baked into the caller's code:
+                // the expansion records no GC root for the operand, and a
+                // fixnum is the only thing the arithmetic below accepts
+                // anyway. Same test the literal arm applies.
+                cache.value.try_fixnum()?;
+                // `Foo::BAR` needs a guard on the base slot, and a
+                // singleton-cref resolution one on the frame's `self`:
+                // both are guards on the *callee's* frame, which is the
+                // thing this expansion removes. Decline rather than
+                // approximate them.
+                if store[id].base.is_some()
+                    || cache.self_class.is_some()
+                    || iseq.in_singleton_lexical
+                {
+                    return None;
+                }
+                consts.push(id);
+                slots.insert(dst, Chain::leaf(LeafValue::Fixnum(cache.value)));
             }
             TraceIr::LoadIvar(dst, name, _) => {
                 slots.insert(dst, Chain::leaf(LeafValue::SelfIvar(name)));
@@ -413,7 +447,7 @@ pub(super) fn leaf_expr_body(store: &Store, iseq_id: ISeqId) -> Option<LeafBody>
     {
         return None;
     }
-    Some(LeafBody { ops })
+    Some(LeafBody { ops, consts })
 }
 
 ///

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -1455,24 +1455,18 @@ impl<'a> JitContext<'a> {
         // this compilation and a later execution of the code emitted here.
         // So the expansion carries the same guard and salvage record a
         // `LoadConst` in this frame would (`load_constant`) — one guard per
-        // trace covers them all — and declines a site whose cache has moved
-        // on, since the ordinary call is correct.
-        let mut const_folds: Vec<ConstFoldSite> = Vec::with_capacity(body.consts.len());
-        for &id in &body.consts {
-            let site = &self.store[id];
-            let Some(cache) = site.cache.clone() else {
-                return false;
-            };
-            if cache.version as u64 != self.const_version() {
-                return false;
-            }
-            let mut names = site.prefix.clone();
-            names.push(site.name);
-            const_folds.push(ConstFoldSite { id, cache, names });
+        // trace covers them all — and declines a fold resolved at another
+        // version, since the ordinary call is correct.
+        if body
+            .consts
+            .iter()
+            .any(|site| site.cache.version as u64 != self.const_version())
+        {
+            return false;
         }
         // Emitted before anything else, so a miss still hands the whole call
         // back — the all-or-nothing property every other guard here keeps.
-        if let Some(version) = const_folds.first().map(|site| site.cache.version) {
+        if let Some(version) = body.consts.first().map(|site| site.cache.version) {
             self.guard_const_version(state, ir, version);
         }
 
@@ -1580,7 +1574,7 @@ impl<'a> JitContext<'a> {
         for (class, name) in bop_deps {
             self.record_bop_dep(class, name);
         }
-        self.const_fold_cache.extend(const_folds);
+        self.const_fold_cache.extend(body.consts.iter().cloned());
         state.def_reg2acc(ir, GP::Rax, dst);
         state.unset_side_effect_guard();
         true

--- a/monoruby/src/codegen/jitgen/compile/method_call.rs
+++ b/monoruby/src/codegen/jitgen/compile/method_call.rs
@@ -1448,6 +1448,34 @@ impl<'a> JitContext<'a> {
             }
         }
 
+        // The constants the body folded. Their values were baked in against
+        // the *callee's* inline caches, which are only right at the version
+        // they were resolved at: the body cannot redefine a constant (it
+        // contains no call), but anything else in the program can, between
+        // this compilation and a later execution of the code emitted here.
+        // So the expansion carries the same guard and salvage record a
+        // `LoadConst` in this frame would (`load_constant`) — one guard per
+        // trace covers them all — and declines a site whose cache has moved
+        // on, since the ordinary call is correct.
+        let mut const_folds: Vec<ConstFoldSite> = Vec::with_capacity(body.consts.len());
+        for &id in &body.consts {
+            let site = &self.store[id];
+            let Some(cache) = site.cache.clone() else {
+                return false;
+            };
+            if cache.version as u64 != self.const_version() {
+                return false;
+            }
+            let mut names = site.prefix.clone();
+            names.push(site.name);
+            const_folds.push(ConstFoldSite { id, cache, names });
+        }
+        // Emitted before anything else, so a miss still hands the whole call
+        // back — the all-or-nothing property every other guard here keeps.
+        if let Some(version) = const_folds.first().map(|site| site.cache.version) {
+            self.guard_const_version(state, ir, version);
+        }
+
         state.flush_gp(ir);
         // The receiver, for every inline ivar access and the frozen guard.
         state.load(ir, recv, GP::Rdi);
@@ -1552,6 +1580,7 @@ impl<'a> JitContext<'a> {
         for (class, name) in bop_deps {
             self.record_bop_dep(class, name);
         }
+        self.const_fold_cache.extend(const_folds);
         state.def_reg2acc(ir, GP::Rax, dst);
         state.unset_side_effect_guard();
         true
@@ -4123,6 +4152,97 @@ mod tests {
               def ==(o); :redefined_eq; end
             end
             res << run(c, 500)
+            res
+            "#,
+        );
+    }
+
+    /// A constant operand. `def size = @size / PAGE_SIZE` is the shape that
+    /// motivates it: without the constant the recogniser turned away every
+    /// leaf body that names one, which is most of the ones worth expanding.
+    ///
+    /// The value is the callee's inline cache, so it is folded into the
+    /// caller exactly as a `LoadConst` in the caller's own frame would be —
+    /// same fixnum-only test, same version guard, same salvage record.
+    #[test]
+    fn frameless_leaf_bodies_const() {
+        run_test(
+            r#"
+            module M
+              N = 7
+            end
+            class C
+              K = 10
+              S = "abc"
+              F = 2.5
+              def initialize; @n = 100; end
+              def div_k; @n / K; end
+              def sum(x); @n + K + x; end
+              def just_k; K; end
+              def gt_k; @n > K; end
+              def store_k; @m = @n * K; end
+              # Declined, each for its own reason: a non-fixnum constant
+              # cannot be baked into the caller (no GC root, and the
+              # arithmetic is fixnum-only), and a constant reached through a
+              # runtime base needs a guard on the callee's own slot.
+              def flt; @n + F; end
+              def str_size; @n / S.size; end
+              def based(m); @n / m::N; end
+              # A prefix qualifier is not a runtime base: it resolves at
+              # compile time and its names go into the salvage record, so
+              # this one is folded like any other.
+              def prefixed; @n / M::N; end
+              attr_reader :m
+            end
+            c = C.new
+            300.times { c.div_k; c.sum(1); c.just_k; c.gt_k; c.store_k;
+                        c.flt; c.str_size; c.based(M); c.prefixed }
+            [c.div_k, c.sum(5), c.just_k, c.gt_k, c.store_k, c.m,
+             c.flt, c.str_size, c.based(M), c.prefixed]
+            "#,
+        );
+    }
+
+    /// The folded value is only right at the const version it was resolved
+    /// at. The body cannot redefine a constant itself — it contains no call
+    /// — but anything else in the program can, between the caller's
+    /// compilation and a later execution of it, and the caller then holds a
+    /// stale immediate in its instruction stream. So the expansion emits
+    /// the same `GuardConstVersion` a `LoadConst` in the caller's frame
+    /// would, and records the fold for salvage.
+    ///
+    /// `loop_div` is compiled on its first call, with `K` folded in as 10;
+    /// every later call must see the current `K`. Dropping the guard makes
+    /// the second and third rows below keep answering 10.
+    #[test]
+    fn frameless_leaf_bodies_const_redefine() {
+        run_test_once(
+            r#"
+            class C
+              K = 10
+              def initialize; @n = 100; end
+              def div_k; @n / K; end
+            end
+            def loop_div(c, n)
+              r = 0
+              i = 0
+              while i < n
+                r = c.div_k
+                i += 1
+              end
+              r
+            end
+            c = C.new
+            res = [loop_div(c, 500)]
+            C.send(:remove_const, :K); C.const_set(:K, 4)
+            res << loop_div(c, 500)
+            # A constant that stops being a fixnum has to leave the fold
+            # behind entirely, not just re-fold: the recompiled body
+            # declines and the ordinary call runs.
+            C.send(:remove_const, :K); C.const_set(:K, 2.5)
+            res << loop_div(c, 500)
+            C.send(:remove_const, :K); C.const_set(:K, 20)
+            res << loop_div(c, 500)
             res
             "#,
         );

--- a/monoruby/src/codegen/jitgen/compile/variables.rs
+++ b/monoruby/src/codegen/jitgen/compile/variables.rs
@@ -159,7 +159,12 @@ impl<'a> JitContext<'a> {
     /// assigning constants: at worst 10 deopts and one recompile per version
     /// move, instead of one deopt per call for the rest of the run.
     ///
-    fn guard_const_version(&self, state: &mut AbstractState, ir: &mut AsmIr, version: usize) {
+    pub(super) fn guard_const_version(
+        &self,
+        state: &mut AbstractState,
+        ir: &mut AsmIr,
+        version: usize,
+    ) {
         if state.const_version_guard() {
             return;
         }

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -411,6 +411,7 @@
 1d061f190c766b447c0ce49d2254a833	"miss"	if /(?<w>foo)/ =~ "nope" then "hit" else "miss" end
 1d3b62c9ac33620fface000347a8abc0	"missing keywords: :x, :y"	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; def m(x:,
 1d68e692e3b7f47da7c6ea7772f726dc	[:raised, :wait_readable, :raised, :wait_readable, "hi", "hi", ["yo", "Addrinfo"]]	require "socket"\n            res = []\n            a, b = UNIXSocket
+1d7e301a02dad991c924273414bc4664	[10, 115, 10, true, 1000, 1000, 102.5, 33, 14, 14]	module M\n              N = 7\n            end\n            class C\n  
 1db5d35ff78d7fa83b8c03967ca12192	true	def foo; end\n            public :foo\n            private :foo\n     
 1dbac381063982c828c61a6698e1e664	[42, 42, 42]	$a = 1\n            alias $b $a\n            alias $c $b\n            
 1dc4e6b9d13cbb4bda8ad0cf13be134b	[2, "hi"]	(f="/tmp/mono_oa_#{Process.pid}"; n=IO.write(f, "hi", open_args: ["w", nil, {enc
@@ -2773,6 +2774,7 @@ d192f501e35fa1bc0e0242a09104fe74	[["warning: non-nil '$/' is deprecated", "warni
 d19be72e25b9de2024bf0d36a3f8d563	{"a" => 1, "b" => [2, 3]}	require "json"\n            JSON.parse("  {  \\"a\\" : 1 ,  \\"b\\" :  [
 d1a295f75a785d2141f8551da1a6f041	Array	class C < Array; end\nC[1,2,3].map { |x| x }.class
 d1a2f6b3b40a551652027bc197b91882	[:deferred]	def run_masked(timing, blocking = true)\n              klass = Class
+d1b6c360f244221f8cbf36738a39be5a	[10, 25, 40.0, 5]	class C\n              K = 10\n              def initialize; @n = 100
 d1b8a6b7678b598205d8118224d254db	"99"	class HasToI; def to_i; 99; end; end\n            sprintf("%d", HasT
 d1fb6e221ee581e85d0263cbc4321970	[false, false, false]	[$VERBOSE, $-v, $-w]
 d22622fcd363dab097a0d4aa0bfe2e93	30	def f(a:, b:)\n          a + b\n        end\n        \n\n        f(a: 10, b:


### PR DESCRIPTION
`leaf_expr_body` turned away every body that names a constant, because `TraceIr::LoadConst` was not among the instructions it recognises. That is most of the leaf methods worth expanding: `def size = @size / PAGE_SIZE` is the shape, and it paid a full method frame per call while the literal-operand twin ran frame-free.

## What changed

**`frameless.rs`** — a `LoadConst` arm in `leaf_expr_body`. The value comes from the callee's inline cache and is admitted only when it is a fixnum, the same test the literal arm applies: the expansion records no GC root for the operand, and the arithmetic is fixnum-only anyway. Declined are a constant reached through a runtime base (`m::N`) and a singleton-cref resolution, both of which need a guard on the *callee's* own frame, which is the thing this expansion removes. The folded sites are carried out in `LeafBody.consts`.

**`method_call.rs`** — `expand_leaf_body` re-validates each folded site against its own compile-time const version (declining, so the ordinary call runs, if a cache has moved on), emits `guard_const_version` before anything else, and records a `ConstFoldSite` for salvage after. One guard per trace covers them all, so a caller that already folded a constant pays nothing extra.

**`variables.rs`** — `guard_const_version` is now `pub(super)`.

## Why the guard is not optional

The body itself cannot redefine a constant (it contains no call), but anything else in the program can, between the caller's compilation and a later execution of it, leaving a stale immediate baked into the caller's instruction stream. `frameless_leaf_bodies_const_redefine` is the regression: with the `guard_const_version` call removed, it answers

```
[10, 10, 10, 10] != [10, 25, 40.0, 5]
```

— the folded `K = 10` survives `remove_const` / `const_set` to 4, to 2.5, and to 20.

Emitting the guard before any of the body's own instructions keeps the all-or-nothing property the other guards here rely on: a miss still hands the whole call back.

## Measurements

`@size / PAGE_SIZE`, 30M calls, best of 5, same machine and moment:

| shape | before | after | |
| --- | --- | --- | --- |
| `@size / PAGE_SIZE` | 0.217s | **0.130s** | 1.67x |
| `@size / 65536` | 0.145s | 0.150s | control: already expanded |
| `@size % 65536` | 0.176s | 0.180s | control: `Rem` still declined |

The two controls being unchanged is what identifies the constant reference as the sole blocker.

## Tests

Two added, `frameless_leaf_bodies_const` (the fold, plus the four declines) and `frameless_leaf_bodies_const_redefine` (the guard). Full suite: 2437 passed, 0 failed, against CRuby 4.0.2.

Redefinition was checked along every axis, each matching CRuby exactly: redefining the leaf method itself, `prepend` after compilation, redefining the inlined arithmetic operator, a singleton method on the receiver, a subclass override, `remove_method`, and `define_method`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CreYezJ9tefe5BjESSzd7Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01CreYezJ9tefe5BjESSzd7Q)_