### PR TITLE
JIT: settle a constant store's range window at compile time

### DIFF
--- a/monoruby/src/builtins/io_buffer.rs
+++ b/monoruby/src/builtins/io_buffer.rs
@@ -500,6 +500,25 @@ fn get_value_inline(
     true
 }
 
+///
+/// Whether `slot` holds a compile-time constant that already satisfies the
+/// `NUM2UINT` / `NUM2INT` window `emit_io_buffer_write_int` tests for a
+/// narrower-than-64-bit store.
+///
+/// A constant outside the window answers `false`, so the check stays and the
+/// deopt hands the store to the builtin, which raises exactly as CRuby does.
+/// The window itself is the emitter's: `[-2^31, 2^32)` unsigned,
+/// `[-2^31, 2^31)` signed, read off the untagged value.
+///
+fn constant_fits_write_window(state: &AbstractState, slot: SlotId, signed: bool) -> bool {
+    let Some(v) = state.is_fixnum_literal(slot) else {
+        return false;
+    };
+    let v = v.get();
+    let hi = if signed { 1i64 << 31 } else { 1i64 << 32 };
+    (-(1i64 << 31)..hi).contains(&v)
+}
+
 fn set_value_inline(
     state: &mut AbstractState,
     ir: &mut AsmIr,
@@ -536,12 +555,16 @@ fn set_value_inline(
             });
         }
         _ => {
+            let signed = kind == ValKind::Signed;
+            // Read the value's link mode *before* `load_fixnum` materializes
+            // it: a constant it can see settles the store's range window here
+            // rather than in five instructions per store.
+            let check_range = !constant_fits_write_window(state, val_slot, signed);
             state.load_fixnum(ir, val_slot, GP::Rdx);
             let deopt = ir.new_deopt(state);
-            let signed = kind == ValKind::Signed;
             ir.inline(move |r#gen, _, labels, _| {
                 let d = r#gen.deopt_label(labels, deopt, DeoptCause::Value(GP::Rsi));
-                r#gen.emit_io_buffer_write_int(width, signed, &d);
+                r#gen.emit_io_buffer_write_int(width, signed, check_range, &d);
             });
         }
     }
@@ -2005,6 +2028,64 @@ mod tests {
             r << er.call { gr.resize("x") } << er.call { gr.resize(-1) }
             r
             "##,
+        );
+    }
+
+    #[test]
+    fn io_buffer_set_value_constant_range() {
+        // The inlined narrow store tests CRuby's `NUM2UINT` / `NUM2INT`
+        // window at run time, which a value the compiler can see settles
+        // statically instead. Both halves of that have to hold: a constant
+        // inside the window stores the same byte the checked path would,
+        // and one outside keeps the check, so the deopt still hands the
+        // store to the builtin and CRuby's own `RangeError` comes out.
+        //
+        // Both the type symbol and the value must be literal at the call
+        // site for the store to inline at all, so each case needs its own
+        // method rather than a lambda over a table.
+        run_test(
+            r#"
+            b = IO::Buffer.new(64)
+            def w_u8(b, n)  = (i=0; while i<n; b.set_value(:U8,  0, 200);         i+=1; end)
+            def w_s8(b, n)  = (i=0; while i<n; b.set_value(:S8,  0, -100);        i+=1; end)
+            def w_u16(b, n) = (i=0; while i<n; b.set_value(:u16, 2, 60000);       i+=1; end)
+            def w_s16(b, n) = (i=0; while i<n; b.set_value(:s16, 4, -30000);      i+=1; end)
+            def w_u32(b, n) = (i=0; while i<n; b.set_value(:u32, 8, 4000000000);  i+=1; end)
+            def w_s32(b, n) = (i=0; while i<n; b.set_value(:s32, 12, -2000000000); i+=1; end)
+            def w_u64(b, n) = (i=0; while i<n; b.set_value(:u64, 16, 12345);      i+=1; end)
+            # The window's own edges, which must stay inside it.
+            def w_lo(b, n)  = (i=0; while i<n; b.set_value(:u32, 24, -2147483648); i+=1; end)
+            def w_hi(b, n)  = (i=0; while i<n; b.set_value(:u32, 28, 4294967295);  i+=1; end)
+            def w_slo(b, n) = (i=0; while i<n; b.set_value(:s32, 32, -2147483648); i+=1; end)
+            # Outside it: the check stays, and the builtin raises.
+            def w_over(b, n)    = (i=0; while i<n; b.set_value(:u32, 36, 4294967296);  i+=1; end)
+            def w_under(b, n)   = (i=0; while i<n; b.set_value(:u32, 40, -2147483649); i+=1; end)
+            def w_s32over(b, n) = (i=0; while i<n; b.set_value(:s32, 44, 2147483648);  i+=1; end)
+            def w_u8over(b, n)  = (i=0; while i<n; b.set_value(:U8,  48, 4294967296);  i+=1; end)
+
+            r = []
+            [[:w_u8, :U8, 0], [:w_s8, :S8, 0], [:w_u16, :u16, 2], [:w_s16, :s16, 4],
+             [:w_u32, :u32, 8], [:w_s32, :s32, 12], [:w_u64, :u64, 16],
+             [:w_lo, :u32, 24], [:w_hi, :u32, 28], [:w_slo, :s32, 32]].each do |m, t, off|
+              send(m, b, 400)
+              r << [m, b.get_value(t, off)]
+            end
+            [:w_over, :w_under, :w_s32over, :w_u8over].each do |m|
+              r << [m, (begin; send(m, b, 400); :no_raise; rescue => e; [e.class, e.message]; end)]
+            end
+            # The wrapper shape a wasm backend emits: a literal argument makes
+            # the wrapper specializable, so the mask folds and the store's
+            # value is a compile-time constant one frame further in.
+            class Mem
+              def initialize(b) = @b = b
+              def iwsb(a, v) = @b.set_value(:U8, a, v & 0xff)
+              def iws(a, v)  = @b.set_value(:u32, a, v & 0xffffffff)
+            end
+            def drive(m, n) = (i=0; while i<n; m.iwsb(52, 300); m.iws(56, -1); i+=1; end)
+            drive(Mem.new(b), 500)
+            r << [:wrapped, b.get_value(:U8, 52), b.get_value(:u32, 56)]
+            r
+            "#,
         );
     }
 

--- a/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/builtin.rs
@@ -1801,10 +1801,16 @@ impl Codegen {
     /// value is in Rdx (x2); narrower-than-64-bit types deopt outside
     /// CRuby's `NUM2UINT` / `NUM2INT` window. Returns `offset + width`
     /// tagged in x0.
-    pub(crate) fn emit_io_buffer_write_int(&mut self, width: u8, signed: bool, deopt: &DestLabel) {
+    pub(crate) fn emit_io_buffer_write_int(
+        &mut self,
+        width: u8,
+        signed: bool,
+        check_range: bool,
+        deopt: &DestLabel,
+    ) {
         self.emit_io_buffer_addr(width, true, deopt);
         monoasm_arm64!(&mut self.jit, asr x2, x2, #(1););
-        if width < 8 {
+        if width < 8 && check_range {
             let limit: u64 = if signed { 1 << 32 } else { (1 << 32) + (1 << 31) };
             monoasm_arm64!(&mut self.jit,
                 mov x9, (1u64 << 31);

--- a/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/builtin.rs
@@ -1554,10 +1554,22 @@ impl Codegen {
     /// window (`[-2^31, 2^32)` / `[-2^31, 2^31)`) and deopt outside it, where
     /// the builtin raises; the low `width` bytes are stored. Returns
     /// `offset + width` as a fixnum in rax, as the builtin does.
-    pub(crate) fn emit_io_buffer_write_int(&mut self, width: u8, signed: bool, deopt: &DestLabel) {
+    ///
+    /// `check_range` is what the caller could not settle at compile time. A
+    /// value it can see (a literal, or a slot the JIT folded to one) decides
+    /// the window itself, so the five instructions below are emitted only for
+    /// a value the code has to inspect at run time. Width 8 has no window and
+    /// ignores it.
+    pub(crate) fn emit_io_buffer_write_int(
+        &mut self,
+        width: u8,
+        signed: bool,
+        check_range: bool,
+        deopt: &DestLabel,
+    ) {
         self.emit_io_buffer_addr(width, true, deopt);
         monoasm! { &mut self.jit, sarq rdx, 1; }
-        if width < 8 {
+        if width < 8 && check_range {
             // rdi / rsi are free once the address is formed; r8-r11 are
             // not (they are the GP allocation set and may hold live values).
             let limit: i64 = if signed { 1 << 32 } else { (1 << 32) + (1 << 31) };

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -1521,6 +1521,7 @@
 7427c64af89bec062257a676328a3d4f	[603.0, 304.0, true, 302.5, 302.5, 606, 307, true, 304, 304, [4.0, 7]]	class F\n              def initialize(x, y); @x = x; @y = y; end\n   
 742cf7259eae88dd4512794b3c9d16ad	[:i, :j]	def m; [1].each { |i| j = i * 2; return local_variables.sort }; end; m
 7441660ef7a2d951150dad613bc4907b	[:x, :x=, :y, :y=]	$added = []\n        class Module\n          alias_method :orig_method_ad
+74659f3c30edb7085fa7ff3fdb1203d2	[[:w_u8, 200], [:w_s8, -100], [:w_u16, 60000], [:w_s16, -30000], [:w_u32, 4000000000], [:w_s32, -2000000000], [:w_u64, 12345], [:w_lo, 2147483648], [:w_hi, 4294967295], [:w_slo, -2147483648], [:w_over, [RangeError, "integer 4294967296 too big to convert to 'unsigned int'"]], [:w_under, [RangeError, "integer -2147483649 too small to convert to 'unsigned int'"]], [:w_s32over, [RangeError, "integer 2147483648 too big to convert to 'int'"]], [:w_u8over, [RangeError, "integer 4294967296 too big to convert to 'unsigned int'"]], [:wrapped, 44, 4294967295]]	b = IO::Buffer.new(64)\n            def w_u8(b, n)  = (i=0; while i<
 7483001417ab19fd0c97c04334cd3e4a	[-1.0, -0.5, 0.0, 0.5, 1.0]	def test\n          res = []\n          i = 0\n          lo  = -2.0\n      
 7487c3bf6df41321ad221f8888a96604	:OVERRIDDEN	class Integer; def ~; :OVERRIDDEN; end; end; ~(3)
 748e241d7044c339274b01953e5a3301	[[:a, :a=, :b, :b=, :c, :c=], [:d=, :e=], [:f, :g]]	class C\n              def self.method_added(name)\n                G


### PR DESCRIPTION
`emit_io_buffer_write_int` tests CRuby's `NUM2UINT` / `NUM2INT` window on every narrower-than-64-bit store, whatever the value is. When the value is one the compiler can see — a literal, or a slot folded to one — the window is decided at compile time and those five instructions are dead weight.

## What changed

**`io_buffer.rs`** — `set_value_inline` reads the value's link mode *before* `load_fixnum` materializes it, and passes the verdict through as `check_range`:

```rust
fn constant_fits_write_window(state: &AbstractState, slot: SlotId, signed: bool) -> bool {
    let Some(v) = state.is_fixnum_literal(slot) else { return false };
    let v = v.get();
    let hi = if signed { 1i64 << 31 } else { 1i64 << 32 };
    (-(1i64 << 31)..hi).contains(&v)
}
```

**Both arch emitters** — `emit_io_buffer_write_int` takes `check_range` and gates on `width < 8 && check_range`.

A constant *outside* the window answers `false`, so the check stays, the store deopts, and the builtin raises CRuby's own `RangeError`. Width 8 has no window and is unaffected either way. The fixnum class guard was already elided for a constant by `guard_class_state`; this is the other half.

## Where it applies

The wasm-backend shape reaches it one frame further in. `@b.set_value(:U8, a, v & 0xff)` is not itself constant, but a literal argument at the wrapper's call site makes the wrapper specializable, the mask folds, and the store's value becomes a compile-time constant. In dewasm's generated DOOM, 763 of the 2362 narrow store sites pass a literal:

| | call sites | literal value | |
| --- | --- | --- | --- |
| `iws` (u32) | 2034 | 641 | 32% |
| `iwsb` (U8) | 189 | 71 | 38% |
| `iwsh` (u16) | 139 | 51 | 37% |
| `ids` (u64) | 110 | 42 | width 8: no window anyway |

## Measurements

Emitted code for one method of 200 constant `:u32` stores, and its variable-valued twin as the control:

| | before | after | |
| --- | --- | --- | --- |
| 200 constant stores | 22969 B | **16569 B** | −27.9%, exactly 32 B/site |
| 200 variable stores | 24172 B | 24172 B | unchanged |

32 bytes is what the five x86 instructions occupy (two `movabs` at 10 B, `add` 3 B, `cmp` 3 B, `jae` 6 B).

**No wall-clock figure is claimed.** The difference is below the noise of a store microbenchmark — the unaffected control rows drift by as much as the affected ones — and this host's perf counters are unavailable, so the instruction count could not be measured directly either. The DOOM end-to-end run is not a clean comparison: the two runs diverge in compile count (212 vs 215). The code-size reduction is the demonstrated benefit.

## Tests

`io_buffer_set_value_constant_range` covers both halves: constants inside the window store what the checked path stored (every width, both signs, and the window's own edges `-2^31` and `2^32-1`), and constants outside it still raise with CRuby's exact messages. It also covers the wrapper shape above.

It is a real regression test: widening the window in `constant_fits_write_window` turns the four out-of-window cases into `:no_raise`. That the optimization fires was confirmed directly with a temporary compile-time probe, not inferred from timings — literal values report `check_range=false`, the variable control reports `true`.

Full suite: 2438 passed, 0 failed, against CRuby 4.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CreYezJ9tefe5BjESSzd7Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01CreYezJ9tefe5BjESSzd7Q)_