### PR TITLE
gosu/ffi: GC-owned native memory via IO::Buffer (fixes DOOM slowdown)

### DIFF
--- a/monoruby/gem/ffi_c.rb
+++ b/monoruby/gem/ffi_c.rb
@@ -18,6 +18,10 @@
 require "fiddle"
 
 module FFI
+  # ::IO::Buffer in a global variable, for allocation on hot paths that
+  # run with many receiver classes (FFI::Struct.new) — see the comment
+  # there for why those paths must not load a constant.
+  $__ffi_gc_buffer = ::IO::Buffer
   # VERSION is set by the ffi gem's lib/ffi/version.rb
 
   # `Fiddle.___prepare` flags (kept in sync with src/builtins/fiddle.rs).
@@ -578,8 +582,25 @@ module FFI
                    1
                  end
       total = elem_size * count
-      addr = Fiddle.___malloc(total, true)
-      raise NoMemoryError, "FFI::MemoryPointer malloc(#{total}) failed" if addr == 0
+      if total > 0
+        # GC-owned backing store rather than a raw ___malloc: the real ffi
+        # gem's MemoryPointer is autoreleased by the GC, and callers (every
+        # FFI::Struct.new, for one) rely on that and never call #free.
+        # monoruby runs finalizers only at exit, so raw malloc here would
+        # leak one allocation per struct; an IO::Buffer's bytes are freed
+        # when the buffer is swept, count as allocation pressure toward
+        # the GC trigger, and have a stable address (`__address`) for the
+        # lifetime of the buffer.
+        # Via the $__ffi_gc_buffer global — see FFI::Struct.new for why a
+        # method shared by several receiver classes (FFI::Buffer
+        # subclasses this) must not load a constant on its hot path.
+        @_backing = $__ffi_gc_buffer.new(total)
+        addr = @_backing.__address || 0
+        raise NoMemoryError, "FFI::MemoryPointer malloc(#{total}) failed" if addr == 0
+      else
+        @_backing = nil
+        addr = 0
+      end
       super(addr)
       @size = total
       @total = total
@@ -600,11 +621,14 @@ module FFI
     end
 
     def free
-      Fiddle.___free(@address) if @address != 0
+      if @_backing
+        @_backing.free
+        @_backing = nil
+      end
       @address = 0
     end
 
-    def autorelease=(flag); end  # manual for now
+    def autorelease=(flag); end  # GC-owned either way, so the flag is moot
 
     def inspect
       "#<#{self.class} address=0x#{@address.to_s(16)} size=#{@size}>"
@@ -986,9 +1010,10 @@ module FFI
   class Struct < AbstractMemory
     # Writers used by `Struct.new` and `Struct#read_field` to populate a
     # fresh allocate'd instance in pieces. AbstractMemory already exposes
-    # `address` / `size` readers.
+    # `address` / `size` readers. `_backing` keeps the IO::Buffer that owns
+    # an owned struct's memory alive (and lets #free release it early).
     attr_writer :address, :size
-    attr_accessor :owned
+    attr_accessor :owned, :_backing
 
     class << self
       attr_reader :layout
@@ -1041,9 +1066,24 @@ module FFI
       def new(*args)
         obj = allocate
         if args.empty?
-          # allocate fresh memory
-          addr = Fiddle.___malloc(size, true)
+          # Fresh backing memory. GC-owned (IO::Buffer) rather than a raw
+          # ___malloc: struct instances are created freely (a rect per
+          # draw call, say) and almost never explicitly freed — the real
+          # ffi gem lets the GC reclaim them, and monoruby runs finalizers
+          # only at exit, so raw malloc here leaked one block per struct.
+          #
+          # The buffer class is read from a global variable, not a
+          # constant: this method runs with every struct subclass as
+          # `self`, and monoruby's JIT keys a method's inline caches —
+          # constant loads included — on the receiver class, so two
+          # struct classes alternating through a constant load here would
+          # recompile this method on every call (burning time and
+          # accreting JIT code for as long as the program draws). A
+          # global-variable read has no such cache to miss.
+          backing = $__ffi_gc_buffer.new(size)
+          addr = backing.__address || 0
           raise NoMemoryError, "FFI::Struct malloc(#{size}) failed" if addr == 0
+          obj._backing = backing
           obj.address = addr
           obj.size    = size
           obj.owned   = true
@@ -1091,7 +1131,10 @@ module FFI
 
     def free
       if @owned && @address != 0
-        Fiddle.___free(@address)
+        if @_backing
+          @_backing.free
+          @_backing = nil
+        end
         @address = 0
       end
     end

--- a/monoruby/gem/gosu.rb
+++ b/monoruby/gem/gosu.rb
@@ -23,6 +23,12 @@
 require "gosu/sdl2"
 
 module Gosu
+  # ::IO::Buffer under a module-local name. Image's per-frame paths load
+  # it; Image is the single receiver class of those methods, so a plain
+  # module constant keeps the JIT's constant cache monomorphic (see
+  # FFI::Struct.new for what happens when it isn't).
+  GcBuffer = ::IO::Buffer
+
   GP_0_BUTTON_0 = 293
   GP_0_BUTTON_1 = 294
   GP_0_BUTTON_10 = 303
@@ -778,7 +784,7 @@ module Gosu
       @_texture = nil
       @_renderer = nil  # the renderer the texture was created against
       @_owns_texture = true
-      @_rgba_blob = nil
+      @_pixels = nil
       @_retro = false
 
       if source.is_a?(String)
@@ -891,20 +897,20 @@ module Gosu
     # Captured once from the source surface; subsequent draws don't
     # affect the returned string.
     def to_blob
-      @_rgba_blob || ("\0".b * (@width.to_i * @height.to_i * 4))
+      @_pixels ? @_pixels.get_string : ("\0".b * (@width.to_i * @height.to_i * 4))
     end
 
     # Set by Gosu.render for a `retro: true` target; read by _ensure_texture.
     attr_writer :_retro
     def save(_path); end
     # Overwrites part of this image with `source`, as Gosu's Image#insert
-    # does, clipping a source that hangs over an edge. The pixel blob is
+    # does, clipping a source that hangs over an edge. The pixel buffer is
     # this image's truth and the texture is derived from it, so the texture
     # is dropped here and rebuilt from the new pixels on the next draw.
     def insert(source, x, y)
-      blob = @_rgba_blob
-      pixels, src_w, src_h = Image._pixels_of(source)
-      return self if blob.nil? || pixels.nil? || src_w <= 0 || src_h <= 0
+      dst = @_pixels
+      src_buf, src_w, src_h = Image._pixels_of(source)
+      return self if dst.nil? || src_buf.nil? || src_w <= 0 || src_h <= 0
 
       x = x.to_i
       y = y.to_i
@@ -917,30 +923,37 @@ module Gosu
       bottom = [src_h, dst_h - y].min
       return self if left >= right || top >= bottom
 
-      # Both are pixel buffers, so splice them by byte: String#[]= counts in
-      # characters, which is the wrong unit here.
-      blob = blob.force_encoding(Encoding::BINARY)
+      # One native memcpy per row, buffer to buffer.
       row_bytes = (right - left) * 4
       (top...bottom).each do |row|
         src_off = (row * src_w + left) * 4
         dst_off = ((y + row) * dst_w + (x + left)) * 4
-        blob.bytesplice(dst_off, row_bytes, pixels.byteslice(src_off, row_bytes))
+        dst.copy(src_buf, dst_off, row_bytes, src_off)
       end
-      _rebuild_from_blob(blob)
+      _destroy_texture
       self
     end
 
-    # The (pixels, width, height) of an Image or of anything shaped like
-    # `Image::BlobHelper`, the two things Gosu's #insert accepts.
+    # The (pixel IO::Buffer, width, height) of an Image or of anything
+    # shaped like `Image::BlobHelper`, the two things Gosu's #insert
+    # accepts. An Image's own buffer is handed over directly (no copy);
+    # a blob-shaped source is wrapped in a read-only String view.
     def self._pixels_of(source)
       if source.is_a?(Image)
-        [source.to_blob.b, source.width.to_i, source.height.to_i]
+        [source._pixel_buffer, source.width.to_i, source.height.to_i]
       elsif source.respond_to?(:to_blob) && source.respond_to?(:columns) &&
             source.respond_to?(:rows)
-        [source.to_blob.to_s.b, source.columns.to_i, source.rows.to_i]
+        [GcBuffer.for(source.to_blob.to_s.b),
+         source.columns.to_i, source.rows.to_i]
       else
         [nil, 0, 0]
       end
+    end
+
+    # Internal: this image's backing pixel buffer (IO::Buffer, or nil for
+    # an empty image). Exposed for Image#insert's zero-copy source path.
+    def _pixel_buffer
+      @_pixels
     end
     def subimage(_x, _y, _w, _h); Image.new; end
     def gl_tex_info; nil; end
@@ -960,65 +973,37 @@ module Gosu
     public
 
     # Adopt an already-loaded SDL surface. Used by `Image.from_text` to
-    # feed a TTF-rendered surface into a fresh Image instance. Also
-    # extracts an RGBA snapshot for `#to_blob` before the surface is
-    # eventually uploaded to a texture (and freed).
+    # feed a TTF-rendered surface into a fresh Image instance. The pixels
+    # are copied out into the image's own IO::Buffer and the surface is
+    # freed here — nothing native outlives this call.
     def _init_from_surface(surface)
-      @width  = @columns = surface.get_int32(SDL2::SURFACE_W_OFFSET)
-      @height = @rows    = surface.get_int32(SDL2::SURFACE_H_OFFSET)
-      @_rgba_blob = _surface_to_rgba(surface, @width, @height)
-      @_pending_surface  = surface  # converted to texture on first draw
-      @_texture = nil
-      @_renderer = nil
-      @_owns_texture = true
+      w = surface.get_int32(SDL2::SURFACE_W_OFFSET)
+      h = surface.get_int32(SDL2::SURFACE_H_OFFSET)
+      blob = _surface_to_rgba(surface, w, h)
+      SDL2.free_surface(surface)
+      _init_from_blob(blob, w, h)
     end
 
-    # Build a surface from raw RGBA bytes (Gosu blob layout: 4 bytes
-    # per pixel in memory order R, G, B, A).
+    # Seed the image from raw RGBA bytes (Gosu blob layout: 4 bytes per
+    # pixel in memory order R, G, B, A). The bytes live in an IO::Buffer —
+    # GC-owned memory the collector both reclaims and counts as pressure —
+    # not in an SDL surface: a texture is built from the buffer on demand
+    # in _ensure_texture, so an image that is never drawn allocates no
+    # native memory at all.
     def _init_from_blob(blob, w, h)
       needed = w * h * 4
       if blob.bytesize < needed
         raise ArgumentError,
               "blob too small: got #{blob.bytesize} bytes, need #{needed}"
       end
-      surface = SDL2.create_rgb_surface_with_format(
-        0, w, h, 32, SDL2::PIXELFORMAT_ABGR8888)
-      if surface.null?
-        raise RuntimeError,
-              "SDL_CreateRGBSurfaceWithFormat failed: #{SDL2.get_error}"
-      end
-      pitch      = surface.get_int32(SDL2::SURFACE_PITCH_OFFSET)
-      pixels_ptr = surface.get_pointer(SDL2::SURFACE_PIXELS_OFFSET)
-      row_bytes  = w * 4
-      SDL2.lock_surface(surface)
-      if pitch == row_bytes
-        pixels_ptr.put_bytes(0, blob, 0, needed)
-      else
-        h.times do |y|
-          pixels_ptr.put_bytes(y * pitch, blob, y * row_bytes, row_bytes)
-        end
-      end
-      SDL2.unlock_surface(surface)
+      pixels = GcBuffer.new(needed)
+      pixels.set_string(blob, 0, needed, 0)
       @width  = @columns = w
       @height = @rows    = h
-      # Blob is already in RGBA; reuse it directly for to_blob.
-      @_rgba_blob        = blob.byteslice(0, needed).dup
-      @_pending_surface  = surface
+      @_pixels = pixels
       @_texture = nil
       @_renderer = nil
       @_owns_texture = true
-    end
-
-    # Re-seed the surface from pixels that changed under us, releasing what
-    # the old ones own first: _init_from_blob overwrites both handles
-    # without freeing them, and #insert runs per frame.
-    def _rebuild_from_blob(blob)
-      if @_pending_surface && !@_pending_surface.null?
-        SDL2.free_surface(@_pending_surface)
-        @_pending_surface = nil
-      end
-      _destroy_texture
-      _init_from_blob(blob, @width.to_i, @height.to_i)
     end
 
     # Reset instance state used by allocate + _init_from_blob (bypassing
@@ -1027,7 +1012,7 @@ module Gosu
       @_texture = nil
       @_renderer = nil
       @_owns_texture = true
-      @_rgba_blob = nil
+      @_pixels = nil
       @_retro = false
     end
 
@@ -1069,15 +1054,22 @@ module Gosu
       return true if @_texture && @_renderer == ren
 
       _destroy_texture
-      surface = @_pending_surface
-      surface = nil unless surface && !surface.null?
+      w = @width.to_i
+      h = @height.to_i
+      addr = @_pixels && @_pixels.__address
+      return false unless addr && w > 0 && h > 0
 
-      if surface
+      # Zero-copy upload: wrap the buffer's memory in a non-owning surface
+      # (IO::Buffer#__address is stable for owned storage), build the
+      # texture from it, and free the wrapper — the texture holds its own
+      # copy of the pixels.
+      surface = SDL2.create_rgb_surface_with_format_from(
+        addr, w, h, 32, w * 4, SDL2::PIXELFORMAT_ABGR8888)
+      return false if surface.null?
+      begin
         @_texture = SDL2.create_texture_from_surface(ren, surface)
+      ensure
         SDL2.free_surface(surface)
-        @_pending_surface = nil
-      else
-        return false
       end
       if @_texture.null?
         @_texture = nil
@@ -1169,6 +1161,11 @@ module Gosu
       @_cache = {}
     end
 
+    # Upper bound on cached glyph-run textures per Font. 256 full-width
+    # strings are a few MB of texture memory; insertion order doubles as
+    # LRU-enough for the eviction in _texture_for.
+    FONT_CACHE_LIMIT = 256
+
     # draw_text(text, x, y, z = 0, scale_x = 1, scale_y = 1,
     #           color = WHITE, mode = :default)
     def draw_text(text, x, y, _z = 0, scale_x = 1.0, scale_y = 1.0,
@@ -1251,6 +1248,15 @@ module Gosu
       SDL2.free_surface(surface)
       return [nil, 0, 0] if tex.null?
       SDL2.set_texture_blend_mode(tex, 1)  # BLEND
+      # Ever-changing strings (a frame counter, a clock) would otherwise
+      # grow the cache — and its textures — without bound; evict the
+      # oldest entry past the cap. SDL_DestroyTexture flushes any batched
+      # render commands that still reference the texture, so evicting a
+      # texture drawn earlier this frame is safe.
+      if @_cache.size >= FONT_CACHE_LIMIT
+        _, (old_tex, _, _) = @_cache.shift
+        SDL2.destroy_texture(old_tex) if old_tex && !old_tex.null?
+      end
       @_cache[key] = [tex, w, h]
     end
 

--- a/monoruby/gem/gosu/sdl2.rb
+++ b/monoruby/gem/gosu/sdl2.rb
@@ -112,6 +112,11 @@ module Gosu
     attach_function :create_rgb_surface_with_format,
       :SDL_CreateRGBSurfaceWithFormat,
       [:uint32, :int, :int, :int, :uint32], :pointer
+    # Wraps existing pixel memory without copying or owning it; the caller
+    # must keep the memory alive until the surface is freed.
+    attach_function :create_rgb_surface_with_format_from,
+      :SDL_CreateRGBSurfaceWithFormatFrom,
+      [:pointer, :int, :int, :int, :int, :uint32], :pointer
     attach_function :convert_surface_format,  :SDL_ConvertSurfaceFormat,
       [:pointer, :uint32, :uint32], :pointer
     attach_function :lock_surface,            :SDL_LockSurface,

--- a/monoruby/src/builtins/io_buffer.rs
+++ b/monoruby/src/builtins/io_buffer.rs
@@ -107,6 +107,7 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(IO_BUFFER_CLASS, "resize", resize, 1);
     globals.define_builtin_func_with(IO_BUFFER_CLASS, "slice", slice, 0, 2, false);
     globals.define_builtin_func_with(IO_BUFFER_CLASS, "clear", clear, 0, 3, false);
+    globals.define_builtin_func(IO_BUFFER_CLASS, "__address", __address, 0);
     globals.define_builtin_func(IO_BUFFER_CLASS, "to_s", to_s, 0);
     globals.define_builtin_func(IO_BUFFER_CLASS, "inspect", inspect, 0);
     globals.define_builtin_func(IO_BUFFER_CLASS, "<=>", cmp, 1);
@@ -1261,6 +1262,25 @@ fn free(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Re
 }
 
 ///
+/// ### IO::Buffer#__address
+///
+/// - __address -> Integer | nil
+///
+/// monoruby extension (no CRuby counterpart): the base address of the
+/// buffer's bytes, or nil when the storage has no stable address (a
+/// string-backed view, a slice, an empty buffer). The address stays valid
+/// while the buffer is alive and un-resized — the same stability contract
+/// the JIT's inlined `get_value`/`set_value` rely on. Used by the FFI
+/// shims (e.g. the gosu stub) to pass buffer memory to C without a copy.
+#[monoruby_builtin]
+fn __address(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    match lfp.self_val().as_iobuffer_inner().stable_address() {
+        Some(addr) => Ok(Value::integer(addr as i64)),
+        None => Ok(Value::nil()),
+    }
+}
+
+///
 /// ### IO::Buffer#transfer
 ///
 /// - transfer -> IO::Buffer
@@ -2341,5 +2361,33 @@ mod tests {
             r
             "##,
         );
+    }
+
+    /// `__address` is a monoruby extension (no CRuby counterpart, so no
+    /// oracle comparison): an Integer for stable storages that really
+    /// points at the bytes (cross-checked through a Fiddle read), nil for
+    /// storages whose bytes can move and for null/freed buffers.
+    #[test]
+    fn io_buffer_address() {
+        let res = run_test_no_result_check(
+            r##"
+            require "fiddle"
+            b = IO::Buffer.new(16)
+            a = b.__address
+            ok = a.is_a?(Integer) && a > 0
+            # The address is the storage itself, not a copy.
+            b.set_string("ABC")
+            ok &&= Fiddle::Pointer.new(a)[0, 3] == "ABC"
+            ok &&= b.__address == a
+            # No stable address: empty, string-backed, slice, freed.
+            ok &&= IO::Buffer.new(0).__address.nil?
+            ok &&= IO::Buffer.for("hello").__address.nil?
+            ok &&= b.slice(4, 8).__address.nil?
+            b.free
+            ok &&= b.__address.nil?
+            ok
+            "##,
+        );
+        assert_eq!(res, crate::Value::bool(true));
     }
 }

--- a/monoruby/src/value/rvalue/io_buffer.rs
+++ b/monoruby/src/value/rvalue/io_buffer.rs
@@ -168,6 +168,20 @@ impl IoBufferInner {
         }
     }
 
+    /// Base address of the buffer's bytes, when the storage guarantees a
+    /// stable one (owned heap memory, a file mapping) — the same guarantee
+    /// the JIT's `fast_ptr` view relies on. `None` for storages whose
+    /// bytes can move under the caller (string-backed views, slices) and
+    /// for empty buffers. Backs `IO::Buffer#__address`, which the FFI
+    /// shims use to hand buffer memory to C without a copy.
+    pub fn stable_address(&self) -> Option<usize> {
+        if self.fast_ptr.is_null() {
+            None
+        } else {
+            Some(self.fast_ptr as usize)
+        }
+    }
+
     pub(crate) fn mark(&self, alloc: &mut crate::alloc::Allocator<RValue>) {
         match &self.storage {
             BufStorage::Str { s, .. } => s.mark(alloc),


### PR DESCRIPTION
## Problem

Running the dewasm DOOM frontend (`dewasm/examples/doom/ruby-gosu`) on monoruby slows to a crawl a few minutes in. The wasm tick itself is innocent — a headless 6000-tick run holds a steady ~70 ticks/sec — the window path is what degrades, through three independent native-memory leaks that add up to roughly 10MB/s at 35fps until memory pressure stalls everything:

1. **`Gosu::Image` retained an SDL surface per `from_blob`** (256KB each, ~9MB/s): the surface was created eagerly and only the canvas-rebuild path ever freed it, so the per-frame temporary image leaked its surface outright. monoruby runs `ObjectSpace` finalizers only at exit, so no finalizer could save it.
2. **`FFI::MemoryPointer` / `FFI::Struct.new` allocated via raw `Fiddle.___malloc`** and nothing ever freed them — the real ffi gem autoreleases these through the GC, and callers (an `SDL_Rect` per draw call) rely on that.
3. **`FFI::Struct.new` recompiled on every call**: the method runs with every struct subclass as `self`, and the JIT keys inline caches — constant loads included — on the receiver class. With `Rect` and `FRect` alternating through one constant load, every call deopted and triggered a `NotCached` recompile (1023 recompiles in 600 frames), accreting JIT code and metadata without bound. `Font#draw_text`'s texture cache also grew unboundedly under ever-changing HUD strings.

## Fix

Per the suggestion to use `IO::Buffer` as the backing store:

- **`IO::Buffer#__address`** (new builtin, monoruby extension): the stable base address of owned storage (the same stability contract the JIT's `fast_ptr` view relies on), nil for string-backed views/slices/empty buffers. Lets the fiddle-based FFI layer hand GC-owned memory to C with no copy.
- **gosu `Image`**: pixels live in a GC-owned `IO::Buffer`; no SDL surface is retained at all. The texture is built on demand by wrapping the buffer memory in a non-owning surface (`SDL_CreateRGBSurfaceWithFormatFrom`, zero-copy) freed right after upload. `#insert` splices rows buffer-to-buffer. `Font` cache capped at 256 entries with oldest-first eviction.
- **`ffi_c`**: `MemoryPointer` and owned `Struct` memory is an `IO::Buffer` — reclaimed at sweep, counted as GC allocation pressure. The buffer class is read from a global variable on those paths (not a constant) to sidestep the per-receiver-class constant-cache recompile loop above.

## Verification (x86-64 Linux, SDL dummy driver)

| scenario | before | after |
|---|---|---|
| 5000× `Image.from_blob` | RSS 51→**1303MB** | 51→55MB, flat |
| 300k× `SDL2::Rect.new` | +55B/each, linear | flat |
| DoomWindow-equivalent loop, 4500 frames (from_blob + insert + draw + HUD text) | ~2.2MB/300 frames, linear | **RSS byte-for-byte flat** (69892kB for 4500 frames) |
| real DoomWindow soak, 3000 ticks | — | tick rate steady 31–33 t/s, RSS flat apart from one-time JIT compile steps |
| `--smoke` | passes | passes (240 colors, PNG written) |

`cargo test --release --lib` passes (includes a new `io_buffer_address` test). The remaining per-call deopt on `FFI::Struct#[]=` (`self.class.layout` polymorphic over struct classes) costs time but provably no memory; it is the known JIT polymorphic-dispatch limitation and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)