### PR TITLE
Builtin and stdlib gaps behind the ruby-bench failures: String#concat, Ractor, Date._parse, gzip, YAML scalars

### DIFF
--- a/monoruby/builtins/ractor.rb
+++ b/monoruby/builtins/ractor.rb
@@ -1,0 +1,351 @@
+# Ractor — a sequential-consistency emulation on top of monoruby's green
+# threads.
+#
+# monoruby has no parallel execution and no object-isolation machinery;
+# every Ractor here is a Thread with an inbox (`#send` / `Ractor.receive`)
+# and an outbox (`Ractor.yield` / `#take`), and the block's return value is
+# the thread's value (`#value` / `#take` after completion). Objects are
+# passed by reference, never copied or moved; `Ractor.make_shareable`
+# deep-freezes as CRuby does, so code that relies on it still gets frozen
+# data, but the isolation errors CRuby raises for unshareable captures are
+# not reproduced.
+#
+# What is covered is the API surface a program written for real Ractors
+# touches when it just wants its work done: `Ractor.new(*args) { |*args| }`,
+# `#value`, `#take`, `#join`, `#send` / `#<<`, `Ractor.receive` /
+# `Ractor.recv`, `Ractor.yield`, `Ractor.current` / `.main` / `.main?` /
+# `.count`, `Ractor.make_shareable` / `.shareable?`, `#name`, `#inspect`.
+class Ractor
+  class Error < StandardError; end
+  class IsolationError < ArgumentError; end
+  class MovedError < Error; end
+  class ClosedError < StopIteration; end
+  class UnsafeError < Error; end
+
+  # Raised by `#value` / `#take` when the block raised; the original
+  # exception is `#cause`, as in CRuby.
+  class RemoteError < Error
+    attr_reader :ractor
+
+    def initialize(ractor, message = "thrown by remote Ractor.")
+      super(message)
+      @ractor = ractor
+    end
+  end
+
+  class MovedObject < BasicObject
+    def method_missing(*)
+      ::Kernel.raise ::Ractor::MovedError, "can not send any methods to a moved object"
+    end
+
+    def respond_to_missing?(*)
+      false
+    end
+  end
+
+  @count = 0
+  @main = nil
+  @sequence = 0
+
+  class << self
+    # Every Ractor other than the main one runs its block on its own
+    # (green) thread; the thread's value is the Ractor's value.
+    def new(*args, name: nil, &block)
+      raise ArgumentError, "must be called with a block" unless block
+      unless name.nil? || name.is_a?(String)
+        raise TypeError, "no implicit conversion of #{name.class} into String"
+      end
+      r = allocate
+      r.__send__(:__ractor_init, args, name, block)
+      r
+    end
+
+    def current
+      Thread.current.thread_variable_get(:__ractor__) || main
+    end
+
+    def main
+      @main ||= begin
+        r = allocate
+        r.__send__(:__ractor_init_main)
+        r
+      end
+    end
+
+    def main?
+      current.equal?(main)
+    end
+
+    # Live (unfinished) ractors, the main one included.
+    def count
+      @count + 1
+    end
+
+    def receive
+      current.__send__(:__receive)
+    end
+    alias recv receive
+
+    def receive_if(&block)
+      raise ArgumentError, "no block given" unless block
+      current.__send__(:__receive_if, &block)
+    end
+
+    def yield(obj, move: false)
+      current.__send__(:__yield, obj)
+      nil
+    end
+
+    # Deep-freeze `obj` (its instance variables, elements, keys, values and
+    # struct members) and return it. With `copy: true` a deep copy is
+    # frozen instead and the original is left untouched.
+    def make_shareable(obj, copy: false)
+      obj = __deep_copy(obj, {}.compare_by_identity) if copy
+      __deep_freeze(obj, {}.compare_by_identity)
+      obj
+    end
+
+    # Immediates, frozen leaves, and objects whose entire reachable graph
+    # is frozen. Modules and classes are shareable as in CRuby.
+    def shareable?(obj)
+      __shareable?(obj, {}.compare_by_identity)
+    end
+
+    def select(*ractors, yield_value: nil, move: false)
+      raise ArgumentError, "specify at least one ractor or `yield_value`" if ractors.empty?
+      loop do
+        ractors.each do |r|
+          if r.__send__(:__ready?)
+            return [r, r.take]
+          end
+        end
+        Thread.pass
+      end
+    end
+
+    def __next_id
+      @sequence += 1
+    end
+
+    def __started
+      @count += 1
+    end
+
+    def __finished
+      @count -= 1
+    end
+
+    private
+
+    def __deep_freeze(obj, seen)
+      return if seen.key?(obj)
+      return if obj.is_a?(Module)
+      seen[obj] = true
+      case obj
+      when Array
+        obj.each { |e| __deep_freeze(e, seen) }
+      when Hash
+        obj.each { |k, v| __deep_freeze(k, seen); __deep_freeze(v, seen) }
+      when Struct
+        obj.each { |e| __deep_freeze(e, seen) }
+      when Range
+        __deep_freeze(obj.begin, seen)
+        __deep_freeze(obj.end, seen)
+      end
+      if obj.respond_to?(:instance_variables)
+        obj.instance_variables.each do |iv|
+          __deep_freeze(obj.instance_variable_get(iv), seen)
+        end
+      end
+      obj.freeze unless obj.frozen?
+    end
+
+    def __deep_copy(obj, seen)
+      return obj if obj.is_a?(Module) || obj.is_a?(Symbol) || obj.is_a?(Numeric) ||
+                    obj.nil? || obj == true || obj == false
+      return seen[obj] if seen.key?(obj)
+      copy = case obj
+             when Array
+               seen[obj] = obj.class.new
+               obj.each { |e| seen[obj] << __deep_copy(e, seen) }
+               seen[obj]
+             when Hash
+               h = seen[obj] = obj.class.new
+               h.compare_by_identity if obj.compare_by_identity?
+               obj.each { |k, v| h[__deep_copy(k, seen)] = __deep_copy(v, seen) }
+               h
+             when String
+               seen[obj] = obj.dup
+             else
+               seen[obj] = obj.dup
+             end
+      if copy.respond_to?(:instance_variables)
+        copy.instance_variables.each do |iv|
+          copy.instance_variable_set(iv, __deep_copy(copy.instance_variable_get(iv), seen))
+        end
+      end
+      copy
+    end
+
+    def __shareable?(obj, seen)
+      return true if obj.is_a?(Module) || obj.is_a?(Symbol) || obj.is_a?(Numeric) ||
+                     obj.nil? || obj == true || obj == false || obj.is_a?(Ractor)
+      return true if seen.key?(obj)
+      return false unless obj.frozen?
+      seen[obj] = true
+      case obj
+      when Array, Struct
+        return false unless obj.all? { |e| __shareable?(e, seen) }
+      when Hash
+        return false unless obj.all? { |k, v| __shareable?(k, seen) && __shareable?(v, seen) }
+      when Range
+        return false unless __shareable?(obj.begin, seen) && __shareable?(obj.end, seen)
+      when Proc, Method, UnboundMethod, Binding
+        return false
+      end
+      if obj.respond_to?(:instance_variables)
+        obj.instance_variables.each do |iv|
+          return false unless __shareable?(obj.instance_variable_get(iv), seen)
+        end
+      end
+      true
+    end
+  end
+
+  attr_reader :name
+
+  def send(obj, move: false)
+    raise ClosedError, "The incoming-port is already closed" if @inbox_closed
+    @inbox.push(obj)
+    self
+  end
+  alias << send
+
+  # The next value the Ractor yielded, or its final value once the block
+  # has returned. Raises `ClosedError` once the final value was consumed.
+  def take
+    raise ClosedError, "The outgoing-port is already closed" if @outbox_closed
+    v = @outbox.pop
+    if v.equal?(@terminator)
+      @outbox_closed = true
+      __final_value
+    else
+      v
+    end
+  end
+
+  # The block's return value; raises `RemoteError` (with the original
+  # exception as `cause`) when the block raised.
+  def value
+    __final_value
+  end
+
+  def join
+    @thread.join if @thread
+    self
+  end
+
+  def close_incoming
+    was = @inbox_closed
+    @inbox_closed = true
+    was
+  end
+
+  def close_outgoing
+    was = @outbox_closed
+    @outbox_closed = true
+    was
+  end
+
+  def alive?
+    @thread.nil? ? true : @thread.alive?
+  end
+
+  def inspect
+    loc = @loc ? " #{@loc}" : ""
+    name = @name ? " #{@name}" : ""
+    state = @thread.nil? ? "running" : (@thread.alive? ? "running" : "terminated")
+    "#<Ractor:##{@id}#{name}#{loc} #{state}>"
+  end
+  alias to_s inspect
+
+  def [](sym)
+    (@locals ||= {})[sym.to_sym]
+  end
+
+  def []=(sym, val)
+    (@locals ||= {})[sym.to_sym] = val
+  end
+
+  private
+
+  def __ractor_init(args, name, block)
+    @id = Ractor.__next_id
+    @name = name
+    @inbox = Thread::Queue.new
+    @outbox = Thread::Queue.new
+    @terminator = Object.new
+    @inbox_closed = false
+    @outbox_closed = false
+    @loc = block.source_location&.join(":")
+    ractor = self
+    Ractor.__started
+    @thread = Thread.new do
+      Thread.current.thread_variable_set(:__ractor__, ractor)
+      begin
+        block.call(*args)
+      ensure
+        Ractor.__finished
+        @outbox.push(@terminator)
+      end
+    end
+    @thread.report_on_exception = false
+  end
+
+  def __ractor_init_main
+    @id = Ractor.__next_id
+    @name = nil
+    @inbox = Thread::Queue.new
+    @outbox = Thread::Queue.new
+    @terminator = Object.new
+    @inbox_closed = false
+    @outbox_closed = false
+    @thread = nil
+  end
+
+  def __final_value
+    raise Error, "the main Ractor has no value" if @thread.nil?
+    begin
+      @thread.value
+    rescue Exception => e
+      raise RemoteError.new(self), "thrown by remote Ractor.", cause: e
+    end
+  end
+
+  def __receive
+    raise ClosedError, "The incoming-port is already closed" if @inbox_closed && @inbox.empty?
+    @inbox.pop
+  end
+
+  def __receive_if
+    kept = []
+    begin
+      loop do
+        v = @inbox.pop
+        return v if yield(v)
+        kept << v
+      end
+    ensure
+      kept.each { |v| @inbox.push(v) }
+    end
+  end
+
+  def __yield(obj)
+    raise ClosedError, "The outgoing-port is already closed" if @outbox_closed
+    @outbox.push(obj)
+  end
+
+  def __ready?
+    !@outbox.empty?
+  end
+end

--- a/monoruby/builtins/startup.rb
+++ b/monoruby/builtins/startup.rb
@@ -20,6 +20,7 @@ require_relative 'warning'
 require_relative 'process'
 require_relative 'file'
 require_relative 'thread'
+require_relative 'ractor'
 require_relative 'boolean'
 require_relative 'marshal'
 require_relative 'gc'
@@ -163,6 +164,18 @@ if host_rubylibprefix && !host_rubylibprefix.empty? && ruby_api_version && !ruby
   # meaningful for the host case; leave the vendored value otherwise.
   RbConfig::CONFIG['ENABLE_SHARED']  = 'yes' if host_configured
 end
+
+# The Unicode version RbConfig reports is the one the *regexp engine's*
+# property tables were generated from (CRuby: Onigmo's enc/unicode). The
+# vendored rbconfig snapshot carries the host CRuby's value, but the Onigmo
+# monoruby bundles ships the Unicode 12.1 tables — it knows
+# `\p{Emoji_Presentation}` but not the later property aliases
+# (`\p{EPres}`, `\p{ExtPict}`, …). Report the bundled tables' version so
+# gems that pick "native" regexps by version (unicode-emoji,
+# unicode-display_width) fall back to their portable tables instead of
+# tripping over an unknown property name at load.
+RbConfig::CONFIG['UNICODE_VERSION'] = '12.1.0'
+RbConfig::CONFIG['UNICODE_EMOJI_VERSION'] = '12.1'
 
 # CRuby's default $LOAD_PATH ends with the "gem prelude" tail — the
 # site_ruby / vendor_ruby / rubylib directories derived from RbConfig,

--- a/monoruby/builtins/string.rb
+++ b/monoruby/builtins/string.rb
@@ -30,19 +30,22 @@ class String
     # entry — `str.concat str, str` triples it rather than quadrupling
     # it. The buffer carries the receiver's encoding so a codepoint
     # argument is interpreted as it would have been against `self`.
+    #
+    # The append goes through the hidden `__shl` primitive rather than
+    # `<<`: a subclass may alias `<<` to `concat` and call `super` from
+    # there (ActiveSupport::SafeBuffer), which would recurse forever.
     if args.size > 1
       buf = +""
       buf.force_encoding(encoding)
       args.each do |arg|
-        buf << arg
+        buf.__shl(arg)
       end
-      self << buf
+      __shl(buf)
     elsif args.size == 1
-      self << args[0]
+      __shl(args[0])
     end
     self
   end
-  alias append concat
 
   def prepend(*args)
     args.reverse_each do |arg|

--- a/monoruby/src/builtins/string.rs
+++ b/monoruby/src/builtins/string.rs
@@ -48,6 +48,10 @@ pub(super) fn init(globals: &mut Globals) {
     globals.define_builtin_func(STRING_CLASS, "<=", le, 1);
     globals.define_builtin_func(STRING_CLASS, "<", lt, 1);
     globals.define_builtin_inline_func(STRING_CLASS, "<<", shl, inline_gen2!(string_shl_gen), 1);
+    // Hidden primitive behind the Ruby-level `String#concat`/`#append`: it
+    // must not dispatch through `<<`, which a subclass may alias *to*
+    // `concat` (ActiveSupport::SafeBuffer) — that would recurse forever.
+    globals.define_builtin_func(STRING_CLASS, "__shl", shl, 1);
     globals.define_builtin_func(STRING_CLASS, "%", rem, 1);
     globals.define_builtin_func(STRING_CLASS, "=~", match_, 1);
     globals.define_builtin_funcs_with(STRING_CLASS, "[]", &["slice"], index, 1, 2, false);

--- a/monoruby/stdlib/date_core.rb
+++ b/monoruby/stdlib/date_core.rb
@@ -50,14 +50,452 @@ class Date
     civil(year, month, day, sg)
   end
 
-  def self.parse(str, comp = true)
-    if str =~ /\A(\d{4})-(\d{1,2})-(\d{1,2})/
-      civil($1.to_i, $2.to_i, $3.to_i)
-    elsif str =~ /\A(\d{1,2})\/(\d{1,2})\/(\d{4})/
-      civil($3.to_i, $1.to_i, $2.to_i)
-    else
-      raise ArgumentError, "invalid date: #{str.inspect}"
+  def self.parse(str = "-4712-01-01", comp = true, start = ITALY, limit: 128)
+    h = _parse(str, comp, limit: limit)
+    y, m, d = _complete_frags(h, str)
+    civil(y, m, d, start)
+  end
+
+  # ---------------------------------------------------------------------
+  # Date._parse — the heuristic parser behind Date.parse, DateTime.parse
+  # and Time.parse (`time.rb` calls it directly).
+  #
+  # A Ruby transcription of the sub-parsers in CRuby's date_parse.c
+  # (`date__parse`): the string is normalized, the weekday and the time
+  # are cut out, then the date sub-parsers run in CRuby's order and the
+  # first one that matches wins. Returns the same hash CRuby does:
+  # :year, :mon, :mday, :yday, :cwyear/:cweek/:cwday, :wday, :hour,
+  # :min, :sec, :sec_fraction (Rational), :zone (String) and :offset
+  # (seconds, or nil for an unknown zone name).
+
+  ABBR_MONTH_TABLE = {
+    "jan" => 1, "feb" => 2, "mar" => 3, "apr" => 4, "may" => 5, "jun" => 6,
+    "jul" => 7, "aug" => 8, "sep" => 9, "oct" => 10, "nov" => 11, "dec" => 12,
+  }.freeze
+  ABBR_DAY_TABLE = {
+    "sun" => 0, "mon" => 1, "tue" => 2, "wed" => 3, "thu" => 4, "fri" => 5, "sat" => 6,
+  }.freeze
+  # Zone abbreviation => UTC offset in hours (zonetab.list, abridged to
+  # the common entries plus the military single letters).
+  ZONE_TABLE = {
+    "ut" => 0, "utc" => 0, "gmt" => 0, "z" => 0, "wet" => 0,
+    "est" => -5, "edt" => -4, "cst" => -6, "cdt" => -5, "mst" => -7, "mdt" => -6,
+    "pst" => -8, "pdt" => -7, "akst" => -9, "akdt" => -8, "hst" => -10, "hast" => -10,
+    "hadt" => -9, "ast" => -4, "adt" => -3, "nst" => -3.5, "ndt" => -2.5,
+    "bst" => 1, "cet" => 1, "cest" => 2, "met" => 1, "mest" => 2, "mez" => 1, "mesz" => 2,
+    "west" => 1, "eet" => 2, "eest" => 3, "msk" => 3, "msd" => 4, "ist" => 5.5,
+    "jst" => 9, "kst" => 9, "hkt" => 8, "sgt" => 8, "wib" => 7, "wit" => 9, "wita" => 8,
+    "awst" => 8, "acst" => 9.5, "acdt" => 10.5, "aest" => 10, "aedt" => 11,
+    "nzst" => 12, "nzdt" => 13, "sast" => 2, "cat" => 2, "eat" => 3, "wat" => 1,
+    "brt" => -3, "art" => -3, "clt" => -4, "clst" => -3,
+    "a" => 1, "b" => 2, "c" => 3, "d" => 4, "e" => 5, "f" => 6, "g" => 7, "h" => 8,
+    "i" => 9, "k" => 10, "l" => 11, "m" => 12, "n" => -1, "o" => -2, "p" => -3,
+    "q" => -4, "r" => -5, "s" => -6, "t" => -7, "u" => -8, "v" => -9, "w" => -10,
+    "x" => -11, "y" => -12,
+  }.freeze
+  JIS_ERA_BASE = { "m" => 1867, "t" => 1911, "s" => 1925, "h" => 1988, "r" => 2018 }.freeze
+  MONTH_PAT = "jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec"
+  BC_PAT = "c(?:e|\\.e\\.)|b(?:ce|\\.c\\.e\\.)|a(?:d|\\.d\\.)|b(?:c|\\.c\\.)"
+
+  def self._parse(str, comp = true, limit: 128)
+    unless str.is_a?(String)
+      raise TypeError, "no implicit conversion of #{str.class} into String" unless str.respond_to?(:to_str)
+      str = str.to_str
     end
+    if limit && str.length > limit
+      raise ArgumentError, "string length (#{str.length}) exceeds the limit #{limit}"
+    end
+    str = str.gsub(/[^-+',.\/:@[:alnum:]\[\]]+/, " ")
+    h = {}
+    __parse_day(str, h)
+    __parse_time(str, h)
+    __parse_eu(str, h) || __parse_us(str, h) || __parse_iso(str, h) ||
+      __parse_jis(str, h) || __parse_vms(str, h) || __parse_sla(str, h) ||
+      __parse_dot(str, h) || __parse_iso2(str, h) || __parse_year(str, h) ||
+      __parse_mon(str, h) || __parse_mday(str, h) || __parse_ddd(str, h)
+    __parse_bc(str, h)
+    __parse_frag(str, h)
+    if h.delete(:_bc)
+      h[:cwyear] = -h[:cwyear] + 1 if h[:cwyear]
+      h[:year] = -h[:year] + 1 if h[:year]
+    end
+    if comp && h.delete(:_comp) != false
+      [:cwyear, :year].each do |k|
+        y = h[k]
+        h[k] = y + (y >= 69 ? 1900 : 2000) if y && y >= 0 && y <= 99
+      end
+    else
+      h.delete(:_comp)
+    end
+    h[:offset] = zone_to_diff(h[:zone]) if h.key?(:zone)
+    h
+  end
+
+  # Offset in seconds for a zone string ("+09:00", "-0500", "UTC+9",
+  # "EST", "Pacific Standard Time"); nil when it is not recognized.
+  # Private in CRuby too (`Date.send(:zone_to_diff, ...)`).
+  def self.zone_to_diff(zone)
+    return nil unless zone.is_a?(String)
+    z = zone.downcase.strip
+    dst = false
+    if z.sub!(/\s+(standard)\s+time\z/, "")
+      # nothing
+    elsif z.sub!(/\s+daylight\s+time\z/, "")
+      dst = true
+    elsif z.sub!(/\s+dst\z/, "")
+      dst = true
+    end
+    if (off = ZONE_TABLE[z])
+      return (off * 3600).to_i + (dst ? 3600 : 0)
+    end
+    if z =~ /\A(?:gmt|utc?)?([-+])(\d+)(?:([,.:])(\d+)(?::(\d+))?)?\z/
+      sign = $1 == "-" ? -1 : 1
+      digits = $2
+      if $3 == ","  || $3 == "."
+        secs = digits.to_i * 3600 + Rational("0.#{$4}") * 3600
+        return (sign * secs).to_i
+      elsif $3 == ":"
+        hour = digits.to_i
+        min = $4.to_i
+        sec = $5.to_i
+        return sign * (hour * 3600 + min * 60 + sec)
+      else
+        hour, min, sec = case digits.length
+                         when 1, 2 then [digits.to_i, 0, 0]
+                         when 3 then [digits[0, 1].to_i, digits[1, 2].to_i, 0]
+                         when 4 then [digits[0, 2].to_i, digits[2, 2].to_i, 0]
+                         when 5 then [digits[0, 1].to_i, digits[1, 2].to_i, digits[3, 2].to_i]
+                         else [digits[0, 2].to_i, digits[2, 2].to_i, digits[4, 2].to_i]
+                         end
+        return sign * (hour * 3600 + min * 60 + sec)
+      end
+    end
+    nil
+  end
+
+  class << self
+    private :zone_to_diff
+    private
+
+    def __mon_num(s)
+      ABBR_MONTH_TABLE[s[0, 3].downcase]
+    end
+
+    def __parse_day(str, h)
+      if str.sub!(/\b(sun|mon|tue|wed|thu|fri|sat)[^-\/\d\s]*/i, " ")
+        h[:wday] = ABBR_DAY_TABLE[$1.downcase]
+        true
+      end
+    end
+
+    TIME_PAT = /(
+        (?:\d+\s*:\s*\d+(?:\s*:\s*\d+(?:[,.]\d*)?)?
+          |\d+\s*h(?:\s*\d+m?(?:\s*\d+s?)?)?)
+        (?:\s*[ap](?:m\b|\.m\.))?
+      |\d+\s*[ap](?:m\b|\.m\.)
+      )
+      (?:\s*
+        ((?:gmt|utc?)?[-+]\d+(?:[,.:]\d+(?::\d+)?)?
+         |(?-i:[[:alpha:].\s]+)(?:standard|daylight)\stime\b
+         |(?-i:[[:alpha:]]+)(?:\sdst)?\b)
+      )?/xi
+
+    def __parse_time(str, h)
+      return unless str.sub!(TIME_PAT, " ")
+      time = $1
+      zone = $2
+      h[:zone] = zone if zone
+      if time =~ /\A(\d+)h?(?:\s*:?\s*(\d+)m?(?:\s*:?\s*(\d+)(?:[,.](\d+))?s?)?)?(?:\s*([ap])(?:m\b|\.m\.))?/i
+        hour = $1.to_i
+        min = $2
+        sec = $3
+        frac = $4
+        merid = $5
+        if merid
+          hour %= 12
+          hour += 12 if merid.downcase == "p"
+        end
+        h[:hour] = hour
+        h[:min] = min.to_i if min
+        h[:sec] = sec.to_i if sec
+        h[:sec_fraction] = Rational(frac.to_i, 10**frac.length) if frac
+      end
+      true
+    end
+
+    # `s3e`: assign (year, mon, mday) from three loosely ordered fields,
+    # rotating them as CRuby does when the "year" is not year-like and
+    # another field is (a 3+ digit or apostrophe-prefixed number).
+    def __s3e(h, y, m, d, bc = false)
+      m = m.to_s unless m.nil? || m.is_a?(String)
+      if !y.nil? && !m.nil? && d.nil?
+        y, m, d = d, y, m
+      end
+      if y.nil?
+        if !d.nil? && d.length > 2
+          y, d = d, nil
+        end
+        if !d.nil? && d.start_with?("'")
+          y, d = d, nil
+        end
+      end
+      unless y.nil?
+        s = y.sub(/\A[^-+\d]*/, "")
+        digits = s.match(/\A[-+]?\d+/)
+        if digits && digits.end(0) < s.length
+          # trailing non-digits ("14th"): this was the day
+          y, d = d, y
+        end
+      end
+      if !m.nil? && (m.start_with?("'") || m.length > 2)
+        # us -> be
+        y, m, d = m, d, y
+      end
+      if !d.nil? && (d.start_with?("'") || d.length > 2)
+        y, d = d, y
+      end
+      unless y.nil?
+        if y =~ /([-+]?)(\d+)/
+          iy = $2.to_i
+          iy = -iy if $1 == "-"
+          iy = -iy + 1 if bc
+          h[:year] = iy
+          h[:_comp] = false if $2.length > 2
+        end
+      end
+      h[:_bc] = true if bc
+      h[:mon] = m[/\d+/].to_i unless m.nil?
+      h[:mday] = d[/\d+/].to_i unless d.nil?
+      true
+    end
+
+    def __parse_eu(str, h)
+      re = /'?(\d+)[^-\d\s]*\s*(#{MONTH_PAT})[^-\d\s']*(?:\s*(#{BC_PAT})?\s*('?-?\d+(?:(?:st|nd|rd|th)\b)?))?/i
+      return unless str.sub!(re, " ")
+      d, mon, bc, y = $1, $2, $3, $4
+      __s3e(h, y, __mon_num(mon), d, !!(bc && bc =~ /\Ab/i))
+    end
+
+    def __parse_us(str, h)
+      re = /\b(#{MONTH_PAT})[^-\d\s']*\s*('?\d+)[^-\d\s']*(?:\s*,?\s*(#{BC_PAT})?\s*('?-?\d+))?/i
+      return unless str.sub!(re, " ")
+      mon, d, bc, y = $1, $2, $3, $4
+      __s3e(h, y, __mon_num(mon), d, !!(bc && bc =~ /\Ab/i))
+    end
+
+    def __parse_iso(str, h)
+      return unless str.sub!(/('?[-+]?\d+)-(\d+)-('?-?\d+)/, " ")
+      __s3e(h, $1, $2, $3)
+    end
+
+    def __parse_jis(str, h)
+      return unless str.sub!(/\b([mtshr])(\d+)\.(\d+)\.(\d+)/i, " ")
+      h[:year] = JIS_ERA_BASE[$1.downcase] + $2.to_i
+      h[:mon] = $3.to_i
+      h[:mday] = $4.to_i
+      true
+    end
+
+    def __parse_vms(str, h)
+      if str.sub!(/('?-?\d+)-(#{MONTH_PAT})[^-\/.]*-('?-?\d+)/i, " ")
+        __s3e(h, $3, __mon_num($2), $1)
+      elsif str.sub!(/\b(#{MONTH_PAT})[^-\/.]*-('?-?\d+)(?:-('?-?\d+))?/i, " ")
+        __s3e(h, $3, __mon_num($1), $2)
+      end
+    end
+
+    def __parse_sla(str, h)
+      return unless str.sub!(%r{('?-?\d+)/\s*('?\d+)(?:\D\s*('?-?\d+))?}, " ")
+      __s3e(h, $1, $2, $3)
+    end
+
+    def __parse_dot(str, h)
+      return unless str.sub!(/('?-?\d+)\.\s*('?\d+)\.\s*('?-?\d+)/, " ")
+      __s3e(h, $1, $2, $3)
+    end
+
+    def __parse_iso2(str, h)
+      if str.sub!(/\b(\d{2}|\d{4})?-?w(\d{2})(?:-?(\d))?\b/i, " ")
+        h[:cwyear] = $1.to_i if $1
+        h[:cweek] = $2.to_i
+        h[:cwday] = $3.to_i if $3
+        true
+      elsif str.sub!(/-w-(\d)\b/i, " ")
+        h[:cwday] = $1.to_i
+        true
+      elsif str.sub!(/--(\d{2})?-(\d{2})\b/, " ")
+        h[:mon] = $1.to_i if $1
+        h[:mday] = $2.to_i
+        true
+      elsif str.sub!(/--(\d{2})(\d{2})?\b/, " ")
+        h[:mon] = $1.to_i
+        h[:mday] = $2.to_i if $2
+        true
+      elsif str.sub!(/[-']?(\d{2}|\d{4})-(\d{3})\b/, " ")
+        h[:year] = $1.to_i
+        h[:yday] = $2.to_i
+        h[:_comp] = false if $1.length > 2
+        true
+      elsif str.sub!(/\b-(\d{3})\b/, " ")
+        h[:yday] = $1.to_i
+        true
+      end
+    end
+
+    def __parse_year(str, h)
+      return unless str.sub!(/'(\d+)\b/, " ")
+      h[:year] = $1.to_i
+      true
+    end
+
+    def __parse_mon(str, h)
+      return unless str.sub!(/\b(#{MONTH_PAT})\S*/i, " ")
+      h[:mon] = __mon_num($1)
+      true
+    end
+
+    def __parse_mday(str, h)
+      return unless str.sub!(/(\d+)(st|nd|rd|th)\b/i, " ")
+      h[:mday] = $1.to_i
+      true
+    end
+
+    # Digit runs without separators: "20130814", "20130814T150000Z", …
+    def __parse_ddd(str, h)
+      re = /([-+]?)(\d{2,14})(?:\s*t?\s*(\d{2,6})?(?:[,.](\d*))?)?(?:\s*(z\b|[-+]\d{1,4}\b|\[[-+]?\d[^\]]*\]))?/i
+      return unless str.sub!(re, " ")
+      sign, s2, s3, s4, s5 = $1, $2, $3, $4, $5
+      case s2.length
+      when 2
+        if sign.empty? && s3.nil?
+          h[:mday] = s2.to_i
+        else
+          h[:hour] = s2.to_i
+        end
+      when 3
+        h[:yday] = s2.to_i
+      when 4
+        if s3.nil?
+          h[:mon] = s2[0, 2].to_i
+          h[:mday] = s2[2, 2].to_i
+        else
+          h[:hour] = s2[0, 2].to_i
+          h[:min] = s2[2, 2].to_i
+        end
+      when 5
+        h[:year] = s2[0, 2].to_i
+        h[:yday] = s2[2, 3].to_i
+      when 6
+        h[:year] = s2[0, 2].to_i
+        h[:mon] = s2[2, 2].to_i
+        h[:mday] = s2[4, 2].to_i
+      when 7
+        h[:year] = s2[0, 4].to_i
+        h[:yday] = s2[4, 3].to_i
+        h[:_comp] = false
+      when 8, 10, 12, 14
+        h[:year] = s2[0, 4].to_i
+        h[:mon] = s2[4, 2].to_i
+        h[:mday] = s2[6, 2].to_i
+        h[:hour] = s2[8, 2].to_i if s2.length >= 10
+        h[:min] = s2[10, 2].to_i if s2.length >= 12
+        h[:sec] = s2[12, 2].to_i if s2.length >= 14
+        h[:_comp] = false
+      when 9
+        h[:year] = s2[0, 4].to_i
+        h[:yday] = s2[4, 3].to_i
+        h[:hour] = s2[7, 2].to_i
+        h[:_comp] = false
+      when 11
+        h[:year] = s2[0, 4].to_i
+        h[:yday] = s2[4, 3].to_i
+        h[:hour] = s2[7, 2].to_i
+        h[:min] = s2[9, 2].to_i
+        h[:_comp] = false
+      when 13
+        h[:year] = s2[0, 4].to_i
+        h[:yday] = s2[4, 3].to_i
+        h[:hour] = s2[7, 2].to_i
+        h[:min] = s2[9, 2].to_i
+        h[:sec] = s2[11, 2].to_i
+        h[:_comp] = false
+      end
+      h[:year] = -h[:year] if sign == "-" && h[:year]
+      if s3
+        h[:hour] = s3[0, 2].to_i
+        h[:min] = s3[2, 2].to_i if s3.length >= 4
+        h[:sec] = s3[4, 2].to_i if s3.length >= 6
+      end
+      h[:sec_fraction] = Rational(s4.to_i, 10**s4.length) if s4 && !s4.empty?
+      if s5
+        zone = s5.start_with?("[") ? s5[1..-2] : s5
+        h[:zone] = zone
+      end
+      true
+    end
+
+    def __parse_bc(str, h)
+      if str.sub!(/\b(bc\b|bce\b|b\.c\.|b\.c\.e\.)/i, " ")
+        h[:_bc] = true
+      end
+    end
+
+    # A lone 1- or 2-digit number left over is the day (or hour when a
+    # date is already known).
+    def __parse_frag(str, h)
+      if str =~ /\A\s*(\d{1,2})\s*\z/
+        n = $1.to_i
+        if h.key?(:hour) && !h.key?(:mday)
+          h[:mday] = n if n >= 1 && n <= 31
+        elsif h.key?(:mday) && !h.key?(:hour)
+          h[:hour] = n if n >= 0 && n <= 24
+        end
+      end
+    end
+  end
+
+  # Turn a `_parse` hash into (year, mon, mday), filling what the string
+  # did not say from today the way CRuby's `rt_complete_frags` does, and
+  # rejecting a hash that names no date at all.
+  def self._complete_frags(h, str)
+    if h[:year] && h[:yday]
+      d = Date.civil(h[:year], 1, 1) + (h[:yday] - 1)
+      return [d.year, d.month, d.day]
+    end
+    if h[:cwyear] || h[:cweek]
+      raise ArgumentError, "invalid date" unless h[:cwyear] && h[:cweek]
+      jan4 = Date.civil(h[:cwyear], 1, 4)
+      monday = jan4 - ((jan4.wday + 6) % 7)
+      d = monday + (h[:cweek] - 1) * 7 + ((h[:cwday] || 1) - 1)
+      return [d.year, d.month, d.day]
+    end
+    y, m, d = h[:year], h[:mon], h[:mday]
+    if y.nil? && m.nil? && d.nil?
+      if h[:wday] && !h.key?(:hour)
+        t = Date.today
+        dd = t + ((h[:wday] - t.wday) % 7)
+        return [dd.year, dd.month, dd.day]
+      end
+      raise ArgumentError, "invalid date" unless h[:hour] || h[:yday]
+      if h[:yday]
+        dd = Date.civil(Date.today.year, 1, 1) + (h[:yday] - 1)
+        return [dd.year, dd.month, dd.day]
+      end
+      t = Date.today
+      return [t.year, t.month, t.day]
+    end
+    t = Date.today
+    if y.nil?
+      y = t.year
+    end
+    if m.nil?
+      m = d.nil? ? 1 : (h[:year] ? 1 : t.month)
+    end
+    d = 1 if d.nil?
+    unless m.between?(1, 12) && d.between?(1, Date._days_in_month(y, m))
+      raise ArgumentError, "invalid date"
+    end
+    [y, m, d]
   end
 
   def jd
@@ -67,8 +505,9 @@ class Date
     @day + (153 * m + 2) / 5 + 365 * y + y / 4 - y / 100 + y / 400 - 32045
   end
 
+  # JD 0 was a Monday, so Sunday (Ruby's wday 0) is `jd % 7 == 6`.
   def wday
-    jd % 7
+    (jd + 1) % 7
   end
 
   def yday
@@ -233,26 +672,115 @@ class DateTime < Date
     civil(t.year, t.month, t.day, t.hour, t.min, t.sec, Rational(off, 86400), sg)
   end
 
-  def self.parse(str, comp = true)
-    if str =~ /\A(\d{4})-(\d{1,2})-(\d{1,2})T(\d{1,2}):(\d{1,2}):(\d{1,2})/
-      civil($1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i)
-    elsif str =~ /\A(\d{4})-(\d{1,2})-(\d{1,2})/
-      civil($1.to_i, $2.to_i, $3.to_i)
-    else
-      raise ArgumentError, "invalid date: #{str.inspect}"
+  def self.parse(str = "-4712-01-01T00:00:00+00:00", comp = true, start = ITALY, limit: 128)
+    h = Date._parse(str, comp, limit: limit)
+    y, m, d = Date._complete_frags(h, str)
+    hour = h[:hour] || 0
+    min = h[:min] || 0
+    sec = h[:sec] || 0
+    sec = 59 if sec == 60
+    unless hour.between?(0, 24) && min.between?(0, 59) && sec.between?(0, 59)
+      raise ArgumentError, "invalid date"
     end
+    if hour == 24
+      raise ArgumentError, "invalid date" unless min == 0 && sec == 0
+      hour = 0
+      d1 = Date.civil(y, m, d) + 1
+      y, m, d = d1.year, d1.month, d1.day
+    end
+    offset = h[:offset] ? Rational(h[:offset], 86400) : 0
+    dt = civil(y, m, d, hour, min, sec, offset, start)
+    dt.instance_variable_set(:@sec_fraction, h[:sec_fraction]) if h[:sec_fraction]
+    dt
+  end
+
+  def self.iso8601(str = "-4712-01-01T00:00:00+00:00", start = ITALY, limit: 128)
+    parse(str, true, start, limit: limit)
+  end
+
+  alias minute min
+  alias second sec
+
+  # The UTC offset as a fraction of a day (always a Rational, as in
+  # CRuby, whatever `civil` was handed).
+  def offset
+    off = @offset || 0
+    off.is_a?(Rational) ? off : Rational(off, 1)
+  end
+
+  # Fraction of the second as a Rational (0 unless the parsed string
+  # carried one).
+  def sec_fraction
+    @sec_fraction || Rational(0, 1)
+  end
+  alias second_fraction sec_fraction
+
+  # The UTC offset in seconds (the `offset` attribute is the CRuby
+  # Rational fraction of a day).
+  def __offset_seconds
+    off = @offset || 0
+    (off * 86400).round
+  end
+
+  def zone
+    s = __offset_seconds
+    sign = s < 0 ? "-" : "+"
+    s = s.abs
+    format("%s%02d:%02d", sign, s / 3600, (s % 3600) / 60)
+  end
+
+  def new_offset(offset = 0)
+    off = case offset
+          when String then Rational(Date.send(:zone_to_diff, offset) || 0, 86400)
+          when Rational, Integer, Float then offset
+          else raise TypeError, "invalid offset"
+          end
+    t = to_time.getutc + (off * 86400).to_i
+    dt = self.class.civil(t.year, t.month, t.day, t.hour, t.min, t.sec, off)
+    dt.instance_variable_set(:@sec_fraction, @sec_fraction) if @sec_fraction
+    dt
   end
 
   def to_s
-    format("%04d-%02d-%02dT%02d:%02d:%02d+00:00", @year, @month, @day, @hour, @min, @sec)
+    format("%04d-%02d-%02dT%02d:%02d:%02d%s", @year, @month, @day, @hour, @min, @sec, zone)
   end
+
+  def iso8601(n = 0)
+    s = to_s
+    return s if n <= 0
+    frac = format("%.#{n}f", sec_fraction)[1..]
+    s.sub(/(?=[-+]\d\d:\d\d\z)/, frac)
+  end
+  alias xmlschema iso8601
 
   def inspect
     "#<DateTime: #{to_s}>"
   end
 
+  def <=>(other)
+    case other
+    when DateTime
+      [to_time.to_r, sec_fraction] <=> [other.to_time.to_r, other.sec_fraction]
+    when Date
+      [year, month, day] <=> [other.year, other.month, other.day]
+    else
+      nil
+    end
+  end
+
   def to_time
-    Time.new(@year, @month, @day, @hour, @min, @sec)
+    Time.new(@year, @month, @day, @hour, @min, @sec + sec_fraction, __offset_seconds)
+  end
+
+  def strftime(fmt = "%FT%T%:z")
+    to_time.strftime(fmt)
+  end
+
+  def deconstruct_keys(keys)
+    all = { year: @year, month: @month, day: @day, yday: yday, wday: wday,
+            hour: @hour, min: @min, sec: @sec, sec_fraction: sec_fraction, zone: zone }
+    return all if keys.nil?
+    keys.each_with_object({}) { |k, h| h[k] = all[k] if all.key?(k) }
   end
 
   def to_date

--- a/monoruby/stdlib/psych.rb
+++ b/monoruby/stdlib/psych.rb
@@ -181,6 +181,14 @@ module Psych
       end
 
       @pos += 1
+      # A quoted scalar whose closing quote is on a later line
+      # (`key:\n  "first line\n  second line"`).
+      if (stripped.start_with?('"') || stripped.start_with?("'")) &&
+         !quoted_string_terminated?(stripped, stripped.getbyte(0))
+        return resolve_scalar(consume_multiline_quoted(stripped))
+      end
+      # A plain multi-line scalar: contiguous continuation lines fold
+      # into one line, the line breaks becoming single spaces.
       parts = [stripped]
       while @pos < @lines.size
         nxt = @lines[@pos]
@@ -192,7 +200,7 @@ module Psych
         parts << nxt.strip
         @pos += 1
       end
-      resolve_scalar(parts.join("\n"))
+      resolve_scalar(parts.join(" "))
     end
 
     def block_mapping_line?(line)
@@ -592,8 +600,11 @@ module Psych
           end
           return inner
         end
-      when 0x27 # '...'  single-quoted
-        return str[1..-2] if str.end_with?("'") && str.size >= 2
+      when 0x27 # '...'  single-quoted (`''` is the escaped quote)
+        if str.end_with?("'") && str.size >= 2
+          inner = str[1..-2]
+          return inner.include?("''") ? inner.gsub("''", "'") : inner
+        end
       when 0x2A # '*'    alias
         return @anchors[str[1..-1]] if str.size > 1 && !str.include?(" ")
       when 0x7E # '~'

--- a/monoruby/stdlib/zlib.rb
+++ b/monoruby/stdlib/zlib.rb
@@ -15,10 +15,15 @@
 #   produced by a real zlib (PNG image data, compressed text chunks)
 #   decode correctly.
 # - The streaming `Deflate.new` / `Inflate.new` objects, buffered: input
-#   accumulates and the whole stream is processed at `finish`.
+#   accumulates and the whole stream is processed at `finish`. The
+#   `window_bits` argument selects the framing as in zlib: positive for
+#   the zlib wrapper, negative for a raw deflate stream, `+16` for gzip
+#   and `+32` (inflate only) to auto-detect zlib/gzip.
+# - gzip framing (RFC 1952): `Zlib.gzip` / `Zlib.gunzip`, and the
+#   `GzipReader` / `GzipWriter` objects over an IO (header fields, CRC-32
+#   and length trailer checks, the line-oriented reader API).
 #
-# Not provided: gzip framing (`GzipReader` / `GzipWriter` fall back to a
-# plain file), preset dictionaries, and incremental output before
+# Not provided: preset dictionaries and incremental output before
 # `finish`.
 
 module Zlib
@@ -287,6 +292,7 @@ module Zlib
       level = __to_level(level)
       raise Zlib::StreamError, "stream error" if level < -1 || level > 9
       @level = level
+      @framing = Zlib.__framing_of(window_bits, false)
     end
 
     def deflate(string, flush = NO_FLUSH)
@@ -309,20 +315,33 @@ module Zlib
       level.to_int
     end
 
-    # RFC 1950 header, RFC 1951 stored blocks, Adler-32 trailer.
+    # RFC 1950 header, RFC 1951 stored blocks, Adler-32 trailer (or the
+    # bare blocks / the gzip frame, per `window_bits`).
     def __finish_stream
       data = @input
+      @output = case @framing
+                when :raw then Deflate.__raw_blocks(data)
+                when :gzip then Zlib.__gzip_frame(data, @level)
+                else
+                  out = "".b
+                  flevel = case @level
+                           when 0, 1 then 0
+                           when 2, 3, 4, 5 then 1
+                           when 7, 8, 9 then 3
+                           else 2
+                           end
+                  cmf = 0x78
+                  flg = flevel << 6
+                  flg += 31 - ((cmf << 8) | flg) % 31
+                  out << cmf.chr << flg.chr
+                  out << Deflate.__raw_blocks(data)
+                  out << [Zlib.adler32(data)].pack("N")
+                end
+    end
+
+    # The RFC 1951 payload: stored (uncompressed) blocks.
+    def self.__raw_blocks(data)
       out = "".b
-      flevel = case @level
-               when 0, 1 then 0
-               when 2, 3, 4, 5 then 1
-               when 7, 8, 9 then 3
-               else 2
-               end
-      cmf = 0x78
-      flg = flevel << 6
-      flg += 31 - ((cmf << 8) | flg) % 31
-      out << cmf.chr << flg.chr
       size = data.bytesize
       pos = 0
       loop do
@@ -337,8 +356,7 @@ module Zlib
         pos += len
         break if final
       end
-      out << [Zlib.adler32(data)].pack("N")
-      @output = out
+      out
     end
   end
 
@@ -354,11 +372,19 @@ module Zlib
 
     def initialize(window_bits = MAX_WBITS)
       super()
+      @framing = Zlib.__framing_of(window_bits, true)
     end
 
     def inflate(string = nil)
       self << string unless string.nil?
       "".b
+    end
+
+    # Decode the RFC 1951 blocks starting at byte `pos` of `data`;
+    # returns `[decoded, position after the final block]`.
+    def self.__inflate_raw(data, pos = 0)
+      i = new(-MAX_WBITS)
+      i.__send__(:__blocks_at, data, pos)
     end
 
     def sync_point?
@@ -395,19 +421,42 @@ module Zlib
     end
 
     def __finish_stream
-      @data = @input
-      @pos = 0
+      data = @input
+      framing = @framing
+      if framing == :auto
+        framing = (data.getbyte(0) == 0x1f && data.getbyte(1) == 0x8b) ? :gzip : :zlib
+      end
+      @output = case framing
+                when :raw
+                  __blocks_at(data, 0)[0]
+                when :gzip
+                  Zlib.__gunzip_frame(data)[0]
+                else
+                  size = data.bytesize
+                  raise Zlib::BufError, "buffer error" if size < 2
+                  cmf = data.getbyte(0)
+                  flg = data.getbyte(1)
+                  if ((cmf << 8) | flg) % 31 != 0 || cmf & 0x0F != 8 || (cmf >> 4) > 7
+                    raise Zlib::DataError, "incorrect header check"
+                  end
+                  raise Zlib::NeedDict, "need dictionary" if flg & 0x20 != 0
+                  out, pos = __blocks_at(data, 2)
+                  # Check the Adler-32 trailer.
+                  raise Zlib::BufError, "buffer error" if pos + 4 > size
+                  expected = (data.getbyte(pos) << 24) | (data.getbyte(pos + 1) << 16) |
+                             (data.getbyte(pos + 2) << 8) | data.getbyte(pos + 3)
+                  raise Zlib::DataError, "incorrect data check" if Zlib.adler32(out) != expected
+                  out
+                end
+    end
+
+    # The block loop: decode from `pos` to the final block, return the
+    # output and the byte position just past it (bit buffer dropped).
+    def __blocks_at(data, pos)
+      @data = data
+      @pos = pos
       @bitbuf = 0
       @bitcnt = 0
-      size = @data.bytesize
-      raise Zlib::BufError, "buffer error" if size < 2
-      cmf = @data.getbyte(0)
-      flg = @data.getbyte(1)
-      if ((cmf << 8) | flg) % 31 != 0 || cmf & 0x0F != 8 || (cmf >> 4) > 7
-        raise Zlib::DataError, "incorrect header check"
-      end
-      raise Zlib::NeedDict, "need dictionary" if flg & 0x20 != 0
-      @pos = 2
       out = "".b
       loop do
         final = __bits(1)
@@ -419,14 +468,9 @@ module Zlib
         end
         break if final == 1
       end
-      # Drop to a byte boundary, then check the Adler-32 trailer.
       @bitbuf = 0
       @bitcnt = 0
-      raise Zlib::BufError, "buffer error" if @pos + 4 > size
-      expected = (@data.getbyte(@pos) << 24) | (@data.getbyte(@pos + 1) << 16) |
-                 (@data.getbyte(@pos + 2) << 8) | @data.getbyte(@pos + 3)
-      raise Zlib::DataError, "incorrect data check" if Zlib.adler32(out) != expected
-      @output = out
+      [out, @pos]
     end
 
     def __bits(need)
@@ -557,22 +601,475 @@ module Zlib
     end
   end
 
+  # ---------------------------------------------------------------------
+  # gzip framing (RFC 1952).
+
+  # `window_bits` → framing, as zlib reads it: 8..15 zlib wrapper, -8..-15
+  # raw deflate, 24..31 gzip, and for inflate 40..47 auto-detect.
+  def self.__framing_of(window_bits, inflate)
+    wb = window_bits.to_int
+    if wb < 0
+      :raw
+    elsif wb >= 40 && inflate
+      :auto
+    elsif wb >= 24
+      :gzip
+    else
+      :zlib
+    end
+  end
+
+  def self.__gzip_frame(data, level = DEFAULT_COMPRESSION, mtime: 0, orig_name: nil, comment: nil, os_code: OS_CODE)
+    out = "".b
+    flg = 0
+    flg |= 0x08 if orig_name
+    flg |= 0x10 if comment
+    xfl = case level
+          when 1 then 4
+          when 9 then 2
+          else 0
+          end
+    out << [0x1f, 0x8b, 8, flg, mtime.to_i, xfl, os_code].pack("CCCCVCC")
+    out << orig_name.b << "\0" if orig_name
+    out << comment.b << "\0" if comment
+    out << Deflate.__raw_blocks(data)
+    out << [Zlib.crc32(data), data.bytesize & 0xFFFFFFFF].pack("VV")
+    out
+  end
+
+  # Parse one gzip member: `[data, header, bytes consumed]`. `header` is
+  # `{mtime:, orig_name:, comment:, os_code:, level:}`.
+  def self.__gunzip_frame(data)
+    data = data.b
+    raise GzipFile::Error, "not in gzip format" if data.bytesize < 10 ||
+                                                   data.getbyte(0) != 0x1f || data.getbyte(1) != 0x8b
+    raise GzipFile::Error, "unsupported compression method #{data.getbyte(2)}" if data.getbyte(2) != 8
+    flg = data.getbyte(3)
+    mtime = data.byteslice(4, 4).unpack1("V")
+    xfl = data.getbyte(8)
+    os_code = data.getbyte(9)
+    pos = 10
+    if flg & 0x04 != 0
+      xlen = data.byteslice(pos, 2).unpack1("v")
+      pos += 2 + xlen
+    end
+    orig_name = nil
+    if flg & 0x08 != 0
+      nul = data.index("\0", pos)
+      raise GzipFile::Error, "unexpected end of file" if nul.nil?
+      orig_name = data.byteslice(pos, nul - pos)
+      pos = nul + 1
+    end
+    comment = nil
+    if flg & 0x10 != 0
+      nul = data.index("\0", pos)
+      raise GzipFile::Error, "unexpected end of file" if nul.nil?
+      comment = data.byteslice(pos, nul - pos)
+      pos = nul + 1
+    end
+    pos += 2 if flg & 0x02 != 0
+    raise GzipFile::Error, "unexpected end of file" if pos > data.bytesize
+    out, pos = Inflate.__inflate_raw(data, pos)
+    raise GzipFile::NoFooter, "footer is not found" if pos + 8 > data.bytesize
+    crc, isize = data.byteslice(pos, 8).unpack("VV")
+    raise GzipFile::CRCError, "invalid compressed data -- crc error" if crc != Zlib.crc32(out)
+    raise GzipFile::LengthError, "invalid compressed data -- length error" if isize != (out.bytesize & 0xFFFFFFFF)
+    level = case xfl
+            when 2 then BEST_COMPRESSION
+            when 4 then BEST_SPEED
+            else DEFAULT_COMPRESSION
+            end
+    [out, { mtime: mtime, orig_name: orig_name, comment: comment, os_code: os_code, level: level }, pos + 8]
+  end
+
+  def self.gzip(src, level: nil, strategy: nil)
+    src = String.try_convert(src) || raise(TypeError, "no implicit conversion of #{src.class} into String")
+    __gzip_frame(src.b, level || DEFAULT_COMPRESSION)
+  end
+
+  def self.gunzip(src)
+    src = String.try_convert(src) || raise(TypeError, "no implicit conversion of #{src.class} into String")
+    # The String API reports a truncated frame (or one too short to even
+    # hold a header) as a plain GzipFile::Error.
+    raise GzipFile::Error, "unexpected end of string" if src.bytesize < 10
+    begin
+      __gunzip_frame(src)[0]
+    rescue GzipFile::NoFooter
+      raise GzipFile::Error, "unexpected end of string"
+    end
+  end
+
   class GzipFile
-    class Error < Zlib::Error; end
+    class Error < Zlib::Error
+      attr_reader :input
+    end
     class CRCError < Error; end
     class NoFooter < Error; end
     class LengthError < Error; end
+
+    # Run the block with a fresh reader/writer over `io`, closing it
+    # afterwards; without a block just return the object.
+    def self.wrap(io, *args, **opts)
+      obj = new(io, *args, **opts)
+      return obj unless block_given?
+      begin
+        yield obj
+      ensure
+        obj.close unless obj.closed?
+      end
+    end
+
+    attr_reader :os_code, :orig_name, :comment, :level
+
+    def mtime
+      Time.at(@mtime || 0)
+    end
+
+    def to_io
+      @io
+    end
+
+    def closed?
+      @closed
+    end
+
+    def sync
+      @sync ||= false
+    end
+
+    def sync=(flag)
+      @sync = flag
+    end
+
+    def crc
+      @crc || 0
+    end
+
+    private
+
+    def __check_open
+      raise GzipFile::Error, "closed gzip stream" if @closed
+    end
   end
 
   class GzipReader < GzipFile
-    def self.open(filename, &block)
-      File.open(filename, "rb", &block)
+    include Enumerable
+
+    def self.open(filename, **opts, &block)
+      io = File.open(filename, "rb")
+      wrap(io, **opts, &block)
+    end
+
+    # Decompress every gzip member of `io` and write the result to `out`
+    # (or return it as a String).
+    def self.zcat(io, out = +"", **opts)
+      data = io.read.b
+      until data.empty?
+        body, _hdr, used = Zlib.__gunzip_frame(data)
+        out << body
+        data = data.byteslice(used..)
+      end
+      out
+    end
+
+    def initialize(io, external_encoding: nil, internal_encoding: nil, encoding: nil, **_opts)
+      @io = io
+      @closed = false
+      raw = io.read
+      raw = raw.nil? ? "".b : raw.b
+      body, header, used = Zlib.__gunzip_frame(raw)
+      @unused = used < raw.bytesize ? raw.byteslice(used..) : nil
+      @mtime = header[:mtime]
+      @orig_name = header[:orig_name]
+      @comment = header[:comment]
+      @os_code = header[:os_code]
+      @level = header[:level]
+      @crc = Zlib.crc32(body)
+      enc = external_encoding || encoding || Encoding.default_external
+      enc = Encoding.find(enc) if enc.is_a?(String)
+      @encoding = enc
+      @data = body.force_encoding(enc)
+      @pos = 0
+      @lineno = 0
+    end
+
+    attr_accessor :lineno
+
+    def unused
+      @unused
+    end
+
+    def pos
+      @pos
+    end
+    alias tell pos
+
+    def eof?
+      __check_open
+      @pos >= @data.bytesize
+    end
+    alias eof eof?
+
+    def rewind
+      __check_open
+      @pos = 0
+      @lineno = 0
+      0
+    end
+
+    def read(length = nil, outbuf = nil)
+      __check_open
+      if length.nil?
+        s = @data.byteslice(@pos..).force_encoding(@encoding)
+        @pos = @data.bytesize
+      else
+        raise ArgumentError, "negative length #{length} given" if length < 0
+        return (outbuf ? outbuf.replace("") : "".b) if length == 0
+        return nil if eof?
+        s = @data.byteslice(@pos, length)
+        @pos += s.bytesize
+      end
+      outbuf ? outbuf.replace(s) : s
+    end
+
+    def readpartial(maxlen, outbuf = nil)
+      __check_open
+      raise ArgumentError, "negative length #{maxlen} given" if maxlen < 0
+      raise EOFError, "end of file reached" if eof? && maxlen > 0
+      read(maxlen, outbuf)
+    end
+
+    def getc
+      __check_open
+      return nil if eof?
+      c = @data.byteslice(@pos..).force_encoding(@encoding)[0]
+      @pos += c.bytesize
+      c
+    end
+
+    def readchar
+      getc || raise(EOFError, "end of file reached")
+    end
+
+    def getbyte
+      __check_open
+      return nil if eof?
+      b = @data.getbyte(@pos)
+      @pos += 1
+      b
+    end
+
+    def readbyte
+      getbyte || raise(EOFError, "end of file reached")
+    end
+
+    def each_byte
+      return enum_for(:each_byte) unless block_given?
+      while (b = getbyte)
+        yield b
+      end
+      nil
+    end
+
+    def each_char
+      return enum_for(:each_char) unless block_given?
+      while (c = getc)
+        yield c
+      end
+      nil
+    end
+
+    def ungetc(s)
+      __check_open
+      s = s.chr if s.is_a?(Integer)
+      s = s.to_s.b
+      @data = (@data.byteslice(0, @pos) + s + @data.byteslice(@pos..)).force_encoding(@encoding)
+      nil
+    end
+
+    def ungetbyte(b)
+      ungetc(b.is_a?(Integer) ? (b & 0xFF).chr : b)
+    end
+
+    def gets(sep = $/, limit = nil, chomp: false)
+      __check_open
+      if sep.is_a?(Integer) && limit.nil?
+        limit = sep
+        sep = $/
+      end
+      return nil if eof?
+      rest = @data.byteslice(@pos..)
+      line = if sep.nil?
+               rest
+             elsif sep == ""
+               # Paragraph mode: up to the next run of blank lines.
+               rest = rest.sub(/\A\n+/, "")
+               @pos += (@data.bytesize - @pos) - rest.bytesize
+               idx = rest.index(/\n\n+/)
+               idx ? rest[0, idx + 2] : rest
+             else
+               idx = rest.index(sep)
+               idx ? rest.byteslice(0, idx + sep.bytesize) : rest
+             end
+      line = line.byteslice(0, limit) if limit && limit >= 0 && line.bytesize > limit
+      @pos += line.bytesize
+      @lineno += 1
+      line = line.force_encoding(@encoding)
+      line = line.chomp(sep == "" ? "\n" : sep) if chomp && !sep.nil?
+      line
+    end
+
+    def readline(*args, **opts)
+      gets(*args, **opts) || raise(EOFError, "end of file reached")
+    end
+
+    def each_line(*args, **opts)
+      return enum_for(:each_line, *args, **opts) unless block_given?
+      while (line = gets(*args, **opts))
+        yield line
+      end
+      self
+    end
+    alias each each_line
+
+    def readlines(*args, **opts)
+      lines = []
+      while (line = gets(*args, **opts))
+        lines << line
+      end
+      lines
+    end
+
+    def external_encoding
+      @encoding
+    end
+
+    def close
+      __check_open
+      @closed = true
+      @io.close if @io.respond_to?(:close)
+      @io
+    end
+
+    def finish
+      __check_open
+      @closed = true
+      @io
     end
   end
 
   class GzipWriter < GzipFile
-    def self.open(filename, level = nil, &block)
-      File.open(filename, "wb", &block)
+    def self.open(filename, level = nil, strategy = nil, **opts, &block)
+      io = File.open(filename, "wb")
+      wrap(io, level, strategy, **opts, &block)
+    end
+
+    def initialize(io, level = nil, strategy = nil, **_opts)
+      @io = io
+      @level = level.nil? ? DEFAULT_COMPRESSION : level
+      @closed = false
+      @buffer = "".b
+      @mtime = nil
+      @orig_name = nil
+      @comment = nil
+      @os_code = OS_CODE
+      @sync = false
+    end
+
+    def mtime=(time)
+      __check_open
+      @mtime = time.to_i
+      time
+    end
+
+    def orig_name=(name)
+      __check_open
+      @orig_name = name.to_str
+    end
+
+    def comment=(text)
+      __check_open
+      @comment = text.to_str
+    end
+
+    def write(*strs)
+      __check_open
+      n = 0
+      strs.each do |s|
+        s = s.to_s
+        @buffer << s.b
+        n += s.bytesize
+      end
+      n
+    end
+
+    def <<(obj)
+      write(obj)
+      self
+    end
+
+    def print(*args)
+      args = [$_] if args.empty?
+      args.each { |a| write(a.to_s) }
+      nil
+    end
+
+    def puts(*args)
+      if args.empty?
+        write("\n")
+      else
+        args.flatten.each do |a|
+          s = a.to_s
+          write(s.end_with?("\n") ? s : s + "\n")
+        end
+      end
+      nil
+    end
+
+    def printf(fmt, *args)
+      write(format(fmt, *args))
+      nil
+    end
+
+    def putc(ch)
+      write(ch.is_a?(Integer) ? (ch & 0xFF).chr : ch.to_s[0])
+      ch
+    end
+
+    def pos
+      @buffer.bytesize
+    end
+    alias tell pos
+
+    def flush(_flush = SYNC_FLUSH)
+      __check_open
+      self
+    end
+
+    # Write the gzip frame to the IO and close it; returns the IO.
+    def close
+      __check_open
+      __emit
+      @closed = true
+      @io.close if @io.respond_to?(:close)
+      @io
+    end
+
+    # Like `close`, but leaves the IO open.
+    def finish
+      __check_open
+      __emit
+      @closed = true
+      @io
+    end
+
+    private
+
+    def __emit
+      @crc = Zlib.crc32(@buffer)
+      @io.write(Zlib.__gzip_frame(@buffer, @level, mtime: @mtime || Time.now.to_i,
+                                  orig_name: @orig_name, comment: @comment, os_code: @os_code))
+      @io.flush if @io.respond_to?(:flush)
     end
   end
 end

--- a/monoruby/tests/date_parse.rs
+++ b/monoruby/tests/date_parse.rs
@@ -1,0 +1,54 @@
+extern crate monoruby;
+use monoruby::tests::*;
+
+// `Date._parse` (stdlib/date_core.rb) is a transcription of CRuby's
+// date_parse.c sub-parsers; `DateTime.parse` / `Date.parse` / `Time.parse`
+// are built on it. Inputs that depend on today's date are avoided.
+
+#[test]
+fn date_underscore_parse_matches_cruby() {
+    run_test_once(
+        r#"
+        require "date"
+        [
+          "8 May 2005 19:09:13 +0000", "Sun, 8 May 2005 19:09:13 +0000",
+          "Wed, 14 Aug 2013 15:00:00 -0500", "2013-08-14", "2013-08-14T15:00:00Z",
+          "2013-08-14T15:00:00.123456+09:00", "2013-08-14 15:00:00 UTC", "20130814",
+          "20130814T150000Z", "2013-226", "2013-08-14 15:00", "15:00", "3:04pm",
+          "3:04:05 PM EST", "Aug 14 2013", "Aug 14, 2013", "August 14th, 2013 3pm",
+          "14 Aug 2013", "14th August 2013", "Wed Aug 14 15:00:00 +0000 2013",
+          "Wed Aug 14 15:00:00 2013", "08/14/2013", "8/14/13", "2013/08/14", "14.08.2013",
+          "2013.08.14", "14-Aug-2013", "Aug-14-2013", "H25.08.14", "--08-14", "May 2005",
+          "Tuesday", "Sat Aug 28 21:00:00 GMT+9 2010", "12/25", "1999-12-31 23:59:59.5 +0530",
+          "Thu, 01 Jan 1970 00:00:00 GMT", "2005-05-08T19:09:13-07:00", "8 May 05 19:09:13 +0000",
+          "8 May 69 19:09:13 +0000", "19:09:13.250Z", "1:02:03 am JST", "2013-08-14T15:00:00+0900",
+          "Wednesday, August 14, 2013", "'13-08-14", "2013-W33-3", "12:00 noon", "T15:00:00",
+          "", "garbage", "13:00:00 A.M.", "5pm", "2013-08-14T15",
+        ].map { |s| [s, Date._parse(s)] } +
+        [["8 May 05", Date._parse("8 May 05", false)], ["8/14/13", Date._parse("8/14/13", false)]]
+        "#,
+    );
+}
+
+#[test]
+fn datetime_parse_and_time_parse() {
+    run_test_once(
+        r#"
+        require "date"
+        require "time"
+        r = []
+        ["8 May 2005 19:09:13 +0000", "2013-08-14 15:00:00", "Aug 14 2013 3pm PST",
+         "2013-08-14T15:00:00.5+09:00", "Wed, 14 Aug 2013 15:00:00 -0500"].each do |s|
+          d = DateTime.parse(s)
+          r << [s, d.to_s, d.year, d.month, d.day, d.hour, d.min, d.sec, d.offset, d.zone,
+                d.sec_fraction, d.to_time.utc.to_s, d.iso8601(3)]
+          t = Time.parse(s)
+          r << [t.utc.to_s, t.utc_offset, t.usec]
+        end
+        r << Date.parse("14 Aug 2013").to_s << Date.parse("2013-226").to_s << Date.parse("2013-W33-3").to_s
+        r << (begin; Date.parse("garbage"); rescue ArgumentError => e; e.message; end)
+        r << (begin; Date._parse("x" * 200); rescue ArgumentError => e; e.message; end)
+        r
+        "#,
+    );
+}

--- a/monoruby/tests/ractor.rs
+++ b/monoruby/tests/ractor.rs
@@ -1,0 +1,42 @@
+extern crate monoruby;
+use monoruby::tests::*;
+
+// Ractor is emulated on green threads (builtins/ractor.rb): the API
+// surface a program uses to get work done behaves as in CRuby, without
+// parallelism or object isolation.
+
+#[test]
+fn ractor_new_value_and_make_shareable() {
+    run_test_once(
+        r#"
+        seq = Ractor.make_shareable("GGTATT" * 100)
+        rs = [1, 2, 3].map { |n| Ractor.new(seq, n) { |s, len| s.scan(/G{#{len}}/).size } }
+        vals = rs.map(&:value)
+        h = Ractor.make_shareable({ a: [1, "x"], b: { c: +"y" } })
+        deep = h.frozen? && h[:a].frozen? && h[:a][1].frozen? && h[:b][:c].frozen?
+        orig = { k: +"v" }
+        copy = Ractor.make_shareable(orig, copy: true)
+        [vals, seq.frozen?, deep, copy.frozen?, copy[:k].frozen?, orig.frozen?,
+         Ractor.shareable?(h), Ractor.shareable?(+"m"), Ractor.shareable?(:s),
+         Ractor.main?, Ractor.current.equal?(Ractor.main)]
+        "#,
+    );
+}
+
+#[test]
+fn ractor_send_receive_and_remote_error() {
+    run_test_once(
+        r#"
+        r = Ractor.new { Ractor.receive * 2 }
+        r.send(21)
+        r2 = Ractor.new { raise "boom" }
+        err = begin
+          r2.value
+        rescue Ractor::RemoteError => e
+          [e.class, e.cause.class, e.cause.message, e.ractor.equal?(r2)]
+        end
+        r3 = Ractor.new(name: "worker") { :done }
+        [r.value, err, r3.name, r3.join.equal?(r3), r3.value]
+        "#,
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -174,6 +174,7 @@
 0b006d8d0b7c3b6cbbde169c66a256f9	"hello\\n"	require "socket"\n            s = TCPServer.new("127.0.0.1", 0)\n    
 0b02d3e203d76b6ec36d970414527996	[[2.5, 4.0, 4.5, 6.0], 1.1805916207174113e+21, 1.5]	def probe(x) = x + 1.5\n            vals = [1, 2.5, 3, 4.5]\n        
 0b0604dcfa5aa2a90ccb9b55c158b24e	101	def get_binding\n              x = 100\n              binding\n       
+0b26a87ee5c24531531b5106bb440366	[[200, 100, 0], true, true, true, true, false, true, false, true, true, true]	seq = Ractor.make_shareable("GGTATT" * 100)\n        rs = [1, 2, 3].map 
 0b272bc1eee3862ebd5afe122f6530ac	[0, 50, "custom", true, false, false]	def check(x) = x.is_a?(Integer)\n            def fro(x) = x.frozen?\n
 0b360a7151ca4646f547e0ecffd6cf13	[true, true, true, true, true, ArgumentError, ArgumentError, TypeError, TypeError, Hash, false]	(ENV["MONO_T_ZZ"]="hi"; a=ENV["MONO_T_ZZ"].frozen?; b=ENV.method(:has_key?)==ENV
 0b40f53074d9e48c2b4d7383337aaada	[[1, 1, 2, 3], ArgumentError, -2, nil]	class Diff\n          attr_reader :v\n          def initialize(v) = @v = 
@@ -890,6 +891,7 @@
 442cc99068d79c4d0b979f548fff9db2	[[[1, 2, 3], {}], [[], {a: 1, b: 2}], [[9], {x: 3}], [[1, 2, 3], {}], [[:rest, :*], [:keyrest, :**]]]	def target(*a, **k); [a, k]; end\n        def d_rest(*); target(*); end\n
 442ded55291eaab4990a26fee7bf8cdc	"undef caught: foo [10, 20]"	class C\n          def foo(*args)\n            args\n          end\n       
 4433d71bfa1c5cc6691d2dd71800fbe7	[:range, :range, :type]	h = { a: 1, b: 2 }\n            if h.respond_to?(:__key_at)\n        
+443aad2a3386503f4b479987364002ff	[[31, 139, 8, 0], true, "abcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\n", "abcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\nabcabcabc\\n", "line1\\nline2\\nline3\\nxA", "a.txt", 1000000, 3, "line1\\n", 1, "line2", false, "lin", "e3\\nxA", true, nil, "", ["line1\\n", "line2\\n", "line3\\n", "xA"], nil, true, "file contents\\nfile contents\\n", Zlib::GzipFile::Error, ["file contents", "file contents"], "file contents\\nfile contents\\n", "unexpected end of string", "invalid compressed data -- crc error", [Zlib::GzipFile::Error, "unexpected end of string"], true, true, true]	require "zlib"\nrequire "stringio"\nrequire "tmpdir"\nr = []\ntext = "hello gzip\\ns
 443bfeb84d9c2d708f478b4cd0860091	[true, true, false]	r, w = IO.pipe\n            a = [r.close_on_exec?, w.close_on_exec?]
 44528032436bdb6e6e366e913d073a06	"v1\\n"	r, w = IO.pipe\n            Process.wait Process.spawn({"SPAWN_T1" =
 4452ae427b2a0862038f7f2a87830617	89.76394847667156	def call_block\n          yield\n        end\n        def w7(s, flag)\n    
@@ -1714,6 +1716,7 @@
 823f7b6229174b0da18f59b5a5c7cca0	[1, 2, "constant"]	module QTopA; X = 1; module Inner; Y = 2; end; end\n            [QTo
 82447060301c9a64b3ac42318f460e62	[1, 2, 3]	class C\n          def foo(*x)\n            x\n          end\n        end\n 
 8256e9068f6e136c99b87f2f7f97fdb8	[[ArgumentError, "negative signal name: -HUP"], "negative signal name: -INT"]	[(begin; Signal.trap("-HUP") {}; rescue => e; [e.class, e.message]; end), (begin
+82575417647315f480a84e42f3ee1d81	[{"a" => [{"k" => "line one line two", "n" => 1}, {"k" => 2}]}, {"a" => [{"k" => "line one line two", "n" => 1}, {"k" => 2}]}, {"a" => [{"k" => "plain one plain two", "n" => 1}, {"k" => 2}]}, {"a" => [{"k" => "it's two", "n" => 1}]}, {"a" => "x\\ny", "b" => "tab\\there", "c" => "don't"}, {"k" => "<p>You can (555) 567-2222.</p> <p>Our store is at <em>Rue d'Avignon 32</em>.</p>", "created_at" => "2005-04-04 12:00"}, {"pages" => [{"id" => 1, "content" => "first second", "at" => "x"}, {"id" => 2, "content" => "plain"}]}]	require "yaml"\n        docs = [\n          "a:\\n  - k:\\n      \\"line one
 829f48ebfbc6e4030ced77aaec24c37b	[200, 2]	def a4\n          v = [1, 2, 3].each do |i|\n            begin\n          
 82abda467be3a95b2f6d81fbf7dfb3da	"a:a b:{x: 100, y: 200}"	def f(a, b)\n          "a:#{a} b:#{b}"\n        end\n        \n\n        f("
 82afafb55f0b808c4e046dd1d983831d	["ASCII-8BIT", "US-ASCII", "US-ASCII"]	[/\\xc2\\xa1/n.encoding.to_s, /abc/n.encoding.to_s, /\\x7f/n.encoding.to_s]
@@ -2777,6 +2780,7 @@ d02239e9ea6a9ec41f97d63367a30a78	52230	class Loc\n          attr_reader :a, :b\n
 d03f3da52be16a5382075d9aea65e40c	[0, true]	class Symbol; def ==(o) = true; end\n        [[:a, :b].index(:z), [:a, :
 d044b1d1eedcdda6f15b67ec84350344	4	"hello".byteindex("o")
 d05976bbfb14033f00937939ab90a32c	36000000	class Lib; def twice(n); n + n; end; end\n        $lib = Lib.new\n       
+d067e8092ba68c29f3fd731c4bbc1200	[42, [Ractor::RemoteError, RuntimeError, "boom", true], "worker", true, :done]	r = Ractor.new { Ractor.receive * 2 }\n        r.send(21)\n        r2 = R
 d07ee4e87e21212dcf67ec14eaa4fbbc	Object	include Math\n        
 d08434c822205293acd0c331ff42f857	"Object"	Time.superclass.to_s
 d08702c38e94487e4a318ebe2df55f9b	["A1\\n", "A2\\n", "B1\\nB2\\n", nil, "A1\\n", "A", "2", "ASCII-8BIT", "A1\\n", "end of file reached"]	require 'tmpdir'\n            f1 = File.join(Dir.tmpdir, "argf_t1_#{

--- a/monoruby/tests/string_concat.rs
+++ b/monoruby/tests/string_concat.rs
@@ -1,0 +1,28 @@
+extern crate monoruby;
+use monoruby::tests::*;
+
+#[test]
+fn string_concat_does_not_dispatch_through_shl() {
+    // `String#concat` appends through a hidden primitive: a subclass that
+    // aliases `<<` to its own `concat` and calls `super` from there
+    // (ActiveSupport::SafeBuffer) must not recurse.
+    run_test(
+        r#"
+        class SafeBuf < String
+          attr_reader :log
+          def concat(value)
+            (@log ||= []) << value.to_s
+            super(value.to_s.upcase)
+          end
+          alias << concat
+        end
+        b = SafeBuf.new("x")
+        b << "a"
+        b.concat("b")
+        s = +"s"
+        s.concat("t", "u", 118)
+        s << "v"
+        [b, b.log, s, "ab".concat, "q".concat("r", "q"), "".respond_to?(:append)]
+        "#,
+    );
+}

--- a/monoruby/tests/yaml_scalars.rs
+++ b/monoruby/tests/yaml_scalars.rs
@@ -1,0 +1,26 @@
+extern crate monoruby;
+use monoruby::tests::*;
+
+// stdlib/psych.rb: multi-line flow scalars fold their line breaks into
+// single spaces (double-quoted, single-quoted and plain, whether the value
+// starts on the key's line or the next one), and `''` is the escaped quote
+// inside a single-quoted scalar.
+
+#[test]
+fn yaml_multi_line_flow_scalars_fold() {
+    run_test_once(
+        r##"
+        require "yaml"
+        docs = [
+          "a:\n  - k:\n      \"line one\n      line two\"\n    n: 1\n  - k: 2\n",
+          "a:\n  - k: \"line one\n      line two\"\n    n: 1\n  - k: 2\n",
+          "a:\n  - k:\n      plain one\n      plain two\n    n: 1\n  - k: 2\n",
+          "a:\n  - k: 'it''s\n      two'\n    n: 1\n",
+          "a: \"x\\ny\"\nb: \"tab\\there\"\nc: 'don''t'\n",
+          "k:\n  \"<p>You can (555) 567-2222.</p>\n  <p>Our store is at <em>Rue d'Avignon 32</em>.</p>\"\ncreated_at: 2005-04-04 12:00\n",
+          "pages:\n  - &p1\n    id: 1\n    content:\n      \"first\n      second\"\n    at: x\n\n  - &p2\n    id: 2\n    content: plain\n",
+        ]
+        docs.map { |d| YAML.unsafe_load(d) }
+        "##,
+    );
+}

--- a/monoruby/tests/zlib_gzip.rs
+++ b/monoruby/tests/zlib_gzip.rs
@@ -1,0 +1,60 @@
+extern crate monoruby;
+use monoruby::tests::*;
+
+// gzip framing in stdlib/zlib.rb: `Zlib.gzip` / `Zlib.gunzip`, the
+// GzipReader / GzipWriter objects (header fields, trailer checks, the
+// line-oriented reader API) and the `window_bits` framing selection of
+// the streaming Deflate / Inflate objects. `real` is a stream produced by
+// CRuby's zlib at level 9 (fixed-Huffman blocks), the rest round-trips
+// monoruby's own stored-block output.
+
+#[test]
+fn gzip_round_trips_and_reader_writer_api() {
+    run_test_once(
+        r#"
+require "zlib"
+require "stringio"
+require "tmpdir"
+r = []
+text = "hello gzip\nsecond line\nthird\n" * 3
+gz = Zlib.gzip(text)
+r << gz.byteslice(0, 4).bytes
+r << (Zlib.gunzip(gz) == text)
+# a real gzip stream (produced by CRuby/zlib at level 9): "abcabcabc\n"
+real = ["1f8b0800eaaca06a02034b4c4a4e0423aec421cd0200b7cbc922c8000000"].pack("H*")
+r << Zlib.gunzip(real)
+r << Zlib::GzipReader.new(StringIO.new(real)).read
+sio = StringIO.new("".b)
+w = Zlib::GzipWriter.new(sio)
+w.mtime = Time.at(1_000_000)
+w.orig_name = "a.txt"
+w.write("line1\n"); w << "line2\n"; w.puts("line3"); w.print("x"); w.putc(0x41)
+w.close
+data = sio.string
+r << Zlib.gunzip(data)
+rd = Zlib::GzipReader.new(StringIO.new(data))
+r << rd.orig_name << rd.mtime.to_i << rd.os_code << rd.gets << rd.lineno << rd.gets.chomp << rd.eof?
+r << rd.read(3) << rd.read << rd.eof? << rd.read(1) << rd.read
+rd.rewind
+r << rd.readlines << rd.unused
+rd.close
+r << rd.closed?
+Dir.mktmpdir do |d|
+  path = File.join(d, "t.gz")
+  Zlib::GzipWriter.open(path) { |g| g.write("file contents\n" * 2) }
+  r << Zlib::GzipReader.open(path) { |g| g.read }
+  r << Zlib::GzipReader.open(path, &:each_line).to_a rescue r << $!.class
+  File.open(path, "rb") { |f| r << Zlib::GzipReader.wrap(f) { |g| g.each_line.map(&:chomp) } }
+  r << Zlib::GzipReader.zcat(File.open(path, "rb"))
+end
+r << (begin; Zlib.gunzip("not gzip"); rescue Zlib::GzipFile::Error => e; e.message; end)
+bad = gz.dup; bad.setbyte(bad.bytesize - 5, bad.getbyte(bad.bytesize - 5) ^ 1)
+r << (begin; Zlib.gunzip(bad); rescue Zlib::GzipFile::CRCError => e; e.message; end)
+r << (begin; Zlib.gunzip(gz.byteslice(0, gz.bytesize - 3)); rescue Zlib::GzipFile::Error => e; [e.class, e.message]; end)
+i = Zlib::Inflate.new(Zlib::MAX_WBITS + 32); i << gz; r << (i.finish == text)
+i = Zlib::Inflate.new(-Zlib::MAX_WBITS); i << Zlib::Deflate.new(6, -Zlib::MAX_WBITS).deflate(text, Zlib::FINISH); r << (i.finish == text)
+d = Zlib::Deflate.new(6, Zlib::MAX_WBITS + 16); d << text; r << (Zlib.gunzip(d.finish) == text)
+r
+        "#,
+    );
+}


### PR DESCRIPTION
Built-in class and standard-library gaps behind the remaining ruby-bench failures (erubi-rails / lobsters / shipit, knucleotide-ractor, sequel, mail, rubocop, liquid-render / liquid-compile). Stacked on the priority-1 PR (triage priorities 2 and 3).

## `String#concat` recursed through `<<` (ActiveSupport::SafeBuffer)

The Ruby-level `String#concat` appended with `self << x`. `SafeBuffer` aliases `<<` to its own `concat` and calls `super` from there, so `concat → << → concat → …` overflowed the stack on every Rails boot. `concat` now appends through a hidden `String#__shl` primitive (the same Rust function as `<<`, registered under a name no subclass aliases). The non-CRuby `String#append` alias is dropped.

## `Ractor` (knucleotide-ractor)

`builtins/ractor.rb` emulates Ractor on monoruby's green threads: `Ractor.new(*args) { }`, `#value` / `#take` / `#join`, `#send` / `Ractor.receive` (inbox), `Ractor.yield` (outbox), `.current` / `.main` / `.main?` / `.count`, `make_shareable` (deep freeze, `copy:`) / `shareable?`, `RemoteError` with the original exception as `cause`, `#name` / `#inspect`. No parallelism and no isolation errors — objects are shared by reference — but a program that just wants its Ractors to compute runs.

## `Date._parse` and friends (sequel, mail)

`date_core.rb` had ISO-only `Date.parse` / `DateTime.parse` and no `Date._parse`, which `Time.parse` calls directly. `Date._parse` is now a transcription of date_parse.c's sub-parsers (weekday, time with meridian / fraction / zone, eu, us, iso, jis, vms, slash, dot, iso2 week/ordinal, year, mon, mday, digit runs, BC, 2-digit-year completion, `zone_to_diff` with the common zone table) — on a corpus of 57 inputs it produces the same hash as CRuby. `Date.parse` / `DateTime.parse` complete the fragments like `rt_complete_frags`; `DateTime` gains `offset` (Rational), `zone`, `sec_fraction`, `new_offset`, `iso8601`, a zone-aware `to_time` / `to_s` / `<=>` / `strftime`. `Date#wday` was off by one (JD 0 is a Monday), which the ISO week-date completion exposed.

## gzip framing in `Zlib` (rubocop → unicode-display_width)

`Zlib.gzip` / `Zlib.gunzip`, `GzipReader` (header fields, CRC-32 / ISIZE trailer checks, `read` / `gets` / `each_line` / `readlines` / `getc` / `getbyte` / `ungetc` / `rewind` / `unused`, `.open` / `.wrap` / `.zcat`) and `GzipWriter` (`write` / `<<` / `puts` / `print` / `putc`, `mtime=` / `orig_name=` / `comment=`, `.open` / `.wrap`). `Inflate.new(window_bits)` / `Deflate.new(level, window_bits)` honour zlib's framing selection (negative = raw, `+16` = gzip, `+32` = auto-detect). The Inflate block loop was split out (`__blocks_at`) so raw and gzip streams share the decoder.

## YAML multi-line flow scalars (liquid's vision database)

`psych.rb` kept the line breaks of a quoted or plain scalar that continues on following lines (`content:\n  "<p>…</p>\n  <p>…</p>"`), and did not unescape `''` in single-quoted scalars. Continuation lines now fold into single spaces as in YAML 1.1, whether the value starts on the key's line or the next one.

## Reported Unicode version (rubocop → unicode-emoji)

The vendored rbconfig snapshot reported the host CRuby's `UNICODE_VERSION` (17.0.0), but the bundled Onigmo ships the Unicode 12.1 property tables — it knows `\p{Emoji_Presentation}` but not the later aliases (`\p{EPres}`), so unicode-emoji picked its "native" regexps and died at load with an invalid property name. `startup.rb` now reports the bundled tables' version (12.1.0 / emoji 12.1) so such gems take their portable tables.

## Tests

`string_concat_does_not_dispatch_through_shl`, `ractor.rs` (2), `date_parse.rs` (2: the corpus, and `Time.parse` / `DateTime.parse` round trips), `zlib_gzip.rs`, `yaml_scalars.rs`. All compared against CRuby 4.0.2. Full `cargo test` green on the stack.

ruby-bench after this PR: knucleotide-ractor, sequel and mail pass; erubi-rails / lobsters / shipit get past the SafeBuffer overflow and stop at nokogiri, rubocop gets past GzipReader / Marshal / unicode-emoji and stops at the prism gem — both C extensions, out of reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_