### PR TITLE
Keep installed-gem lib dirs out of $LOAD_PATH; resolve them as a require fallback

### DIFF
--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -348,6 +348,16 @@ pub struct Globals {
     encoding_objects: HashMap<crate::value::rvalue::Encoding, Value>,
     /// library directries.
     load_path: Value,
+    /// `lib/` directories of the host's installed (non-default) gems,
+    /// consulted by `require` only after `$LOAD_PATH` misses. CRuby does
+    /// not list them in `$LOAD_PATH` either: rubygems activates a gem on
+    /// demand and only then splices its `lib/` in. Keeping them out of
+    /// the visible array lets `Bundler.setup` (which prepends the
+    /// bundle's paths) win over every other installed version of a gem,
+    /// and keeps `$LOAD_PATH` scans (`$LOAD_PATH.detect { … }`) from
+    /// landing on an unrelated gem. A hit here is appended to
+    /// `$LOAD_PATH`, like an activation.
+    gem_lib_dirs: Vec<String>,
     /// standard PRNG
     random: Box<Prng>,
     /// `$LOADED_FEATURES` / `$"` — Array of canonicalised paths
@@ -784,6 +794,7 @@ impl Globals {
             encoding_of_object: HashMap::default(),
             encoding_objects: HashMap::default(),
             load_path: Value::array_empty(),
+            gem_lib_dirs: vec![],
             random: Box::new(Prng::new()),
             loaded_features,
             loading_features: std::collections::HashMap::default(),
@@ -942,12 +953,33 @@ impl Globals {
         // Skip blank lines (the cache file ends with a newline): an
         // empty `$LOAD_PATH` entry would make bare `require`s resolve
         // against the CWD, which CRuby forbids for security.
-        let list: Vec<_> = path_list
+        //
+        // The cached list is the host's `$LOAD_PATH` followed by every
+        // installed gem's `lib/` (see `ruby_probe`). Only the former goes
+        // into `$LOAD_PATH`; a gem `lib/` — anything under a gem root's
+        // `gems/` or `bundler/gems/` — is kept aside as a `require`
+        // fallback (`Store::gem_lib_dirs`).
+        let gem_roots: Vec<String> = std::env::var("GEM_PATH")
+            .map(|s| {
+                s.split(':')
+                    .filter(|r| !r.is_empty())
+                    .map(|r| r.trim_end_matches('/').to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+        let is_gem_lib = |dir: &str| {
+            gem_roots.iter().any(|root| {
+                dir.starts_with(&format!("{root}/gems/"))
+                    || dir.starts_with(&format!("{root}/bundler/gems/"))
+            })
+        };
+        let (gem_libs, list): (Vec<String>, Vec<String>) = path_list
             .split('\n')
             .filter(|s| !s.is_empty())
             .map(|s| s.to_string())
-            .collect();
+            .partition(|s| is_gem_lib(s));
         globals.extend_load_path(list.iter().cloned());
+        globals.gem_lib_dirs = gem_libs;
 
         // set constants
         let pcg_name = env!("CARGO_PKG_NAME");

--- a/monoruby/src/globals/require.rs
+++ b/monoruby/src/globals/require.rs
@@ -315,7 +315,19 @@ impl Globals {
                 return Some(p);
             }
         }
-        None
+
+        // Installed-gem fallback (what rubygems' `require` does through
+        // `Gem.try_activate` on a miss): the first gem `lib/` holding the
+        // file is spliced into `$LOAD_PATH` — so the gem's other files
+        // resolve through the ordinary walk from now on — and answers.
+        let hit = self
+            .gem_lib_dirs
+            .iter()
+            .position(|lib| std::path::Path::new(lib).join(cand).exists())?;
+        let lib = self.gem_lib_dirs.remove(hit);
+        let p = probe(std::path::Path::new(&lib), cand);
+        self.extend_load_path(std::iter::once(lib));
+        p
     }
 
     ///


### PR DESCRIPTION
monoruby seeded `$LOAD_PATH` with every installed gem's `lib/` (the runtime probe's list), ahead of anything `Bundler.setup` later prepends. CRuby never lists gem directories there: rubygems activates a gem on demand from its `require` hook and only then splices the `lib/` in. Two consequences showed up in ruby-bench's liquid-render / liquid-compile (triage priority 3; stacked on the builtins PR):

- `$LOAD_PATH.detect { |p| File.exist?(File.join(p, "liquid.rb")) }` found the host's liquid-5.13.0 gem instead of the bundle's git checkout (`performance/theme_runner` does not exist there → LoadError).
- `Bundler.setup` could not remove the stray entries (`clean_load_path` only knows paths of activated specs), so any gem installed on the host shadowed the bundled version of the same gem.

Now the probe's list is partitioned at startup: entries under a `GEM_PATH` root's `gems/` or `bundler/gems/` go to `Globals::gem_lib_dirs`, everything else stays in `$LOAD_PATH`. `require` consults the gem dirs only after `$LOAD_PATH` misses, and a hit is spliced into `$LOAD_PATH` (like an activation) so the gem's other files resolve through the ordinary walk from then on. `$LOAD_PATH` at boot now has CRuby's shape (stdlib + site/vendor dirs); the gem-prelude / require / rubygems-activation / predefined-gvar tests are unchanged and pass.

ruby-bench after this PR: liquid-render and liquid-compile pass (172 ms / 49 ms per iteration here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_