### PR TITLE
Nokogiri stage 2: SAX Parser / ParserContext / PushParser (XML and HTML4), HTML4 parsing from an IO

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,7 +373,8 @@ External crates (fetched from git):
 - `libxml2-src` (workspace crate) — libxml2 2.13.8 with nokogiri's patches,
   vendored under `libxml2-src/vendor/` and built with `cc` (hand-written
   `config.h`, generated `xmlversion.h`; no autotools / cmake), with a
-  hand-written FFI. Behind `Nokogiri` (`src/builtins/nokogiri/`): the gem's
+  hand-written FFI plus a small C glue file (`libxml2-src/glue/`) for the
+  `xmlParserCtxt` field accessors and the variadic SAX message callbacks. Behind `Nokogiri` (`src/builtins/nokogiri/`): the gem's
   Ruby half is vendored under `gem/nokogiri/` and `gem/nokogiri/nokogiri.rb`
   stands in for nokogiri.so. Objects wrapping libxml2 pointers are
   `ObjTy::NATIVE` RValues (`NativeData` payloads with their own `mark` /

--- a/doc/nokogiri.md
+++ b/doc/nokogiri.md
@@ -229,7 +229,7 @@ libxml2 のビルドが付く。段階 1〜3 で ext の 6 割程度（Node 54 +
 B（C API 互換層）を将来やるなら、ここで作る `ObjTy::XML_*` の mark / drop の
 形がそのまま `TypedData` の受け皿になるので、A の作業は無駄にならない。
 
-## 6. 実装状況（段階 1〜2 の一部、2026-09）
+## 6. 実装状況（段階 1〜3 と 5 の SAX、2026-09）
 
 `libxml2-src/`（libxml2 2.13.8 + nokogiri 1.18.9 の patches、`cc` でビルド、
 `config.h` は手書き、`xmlversion.h` は build.rs が生成）、
@@ -270,9 +270,20 @@ B（C API 互換層）を将来やるなら、ここで作る `ObjTy::XML_*` の
   （`attribute_type` / `default` / `enumeration`）、`ElementContent`（内容モデルの
   木、`NATIVE` クラスで `@document` を持つ）、`Document#create_entity`。
 
-まだ無いもの（段階 2〜6）: `XML::SAX::*`（`SAX::PushParser` は
-`HTML4::EncodingReader` が使うので **HTML の IO からのパース**もまだ）、
-`XML::Reader`、`XML::Schema` / `RelaxNG`、`XSLT`（定数は `0.0.0` の
+- SAX（`sax.rs`）: `XML::SAX::Parser`（`xmlSAXHandler` の全コールバック:
+  `xmldecl` / `start_document` / `start_element(_namespace)` /
+  `end_element(_namespace)` / `characters` / `comment` / `cdata_block` /
+  `processing_instruction` / `reference` / `warning` / `error`、DTD と
+  エンティティは libxml2 の SAX2 既定を使う）、`SAX::ParserContext`
+  （`native_memory` / `native_io` / `native_file`、`parse_with`、
+  `replace_entities` / `recovery`、`line` / `column`）、`SAX::PushParser`
+  （`xmlParseChunk`、`options`、RECOVER 無しのエラーは `SyntaxError`）、
+  `HTML4::SAX::Parser` / `ParserContext` / `PushParser`（HTML パーサ上）。
+  これで `HTML4::EncodingReader` が動くので、**`Nokogiri::HTML4(io)` を
+  エンコーディング指定無しで**パースできる（`<meta charset>` の検出と
+  `EncodingFound` による再パース込み）。
+
+まだ無いもの（段階 4〜6）: `XML::Reader`、`XML::Schema` / `RelaxNG`、`XSLT`（定数は `0.0.0` の
 プレースホルダ）、HTML5（gumbo）、`HTML4::ElementDescription`
 （`Node#description`）、XPath のカスタム関数ハンドラ（`evaluate` の第 2
 引数は受け取るが無視）、`Node#dup` / `Document#dup`。
@@ -292,6 +303,20 @@ B（C API 互換層）を将来やるなら、ここで作る `ObjTy::XML_*` の
   （`DEFAULT_HTML` に入っている）が付くと libxml2 はコンテキストのハンドラを
   素通りするが、グローバルのハンドラには依然として届く。nokogiri が
   `document.errors` を埋め、strict モードで raise できるのはこのため。
+- SAX のコールバックは libxml2 の C フレームの内側で Ruby を呼ぶ。Ruby の
+  例外は C を巻き戻せないので、コールバックは例外を `SaxCall`（`xmlParserCtxt`
+  の `_private` に置いた、呼び出し中だけ生きる構造体）に保存して
+  `xmlStopParser` し、以後のコールバックは何もせず、`xmlParseDocument` /
+  `xmlParseChunk` から戻ったネイティブメソッドが投げ直す（nokogiri は
+  longjmp で C を突き抜ける）。停止した PushParser にさらに書くと
+  `XML_ERR_USER_STOP` で RuntimeError になる（CRuby ではパーサ状態が壊れた
+  まま続く）。
+- `warning` / `error` の SAX コールバックは可変長引数（printf 形式）なので
+  Rust では書けない。`libxml2-src/glue/monoruby_glue.c` に C で置き、
+  `vsnprintf` で整形した文字列を起動時に登録した Rust の関数へ渡す。
+  同じファイルに `xmlParserCtxt` のフィールドアクセサ（`_private` / `sax` /
+  `userData` / `myDoc` / `standalone` / `encoding` / `version` / `options` /
+  行・桁）を置き、巨大でバージョン依存の構造体を Rust 側で写さずに済ませる。
 - ビルトインの中で作った `Value` を Ruby 呼び出し（`initialize`、`decorate`、
   `SyntaxError.new`）を跨いで持つときは `vm.temp_push` で根付けする
   （`doc/gc.md` §8.1）。`wrap_document` / `wrap_node_set` / `errors_to_array`

--- a/libxml2-src/build.rs
+++ b/libxml2-src/build.rs
@@ -120,6 +120,9 @@ fn main() {
     for src in SOURCES {
         build.file(vendor.join(format!("{src}.c")));
     }
+    // monoruby's helpers (parser-context accessors, the variadic SAX
+    // message callbacks), built into the same archive.
+    build.file(manifest.join("glue/monoruby_glue.c"));
     build.compile("xml2");
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
@@ -132,5 +135,6 @@ fn main() {
     }
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=config/config.h");
+    println!("cargo:rerun-if-changed=glue/monoruby_glue.c");
     println!("cargo:rerun-if-changed=vendor/libxml2");
 }

--- a/libxml2-src/glue/monoruby_glue.c
+++ b/libxml2-src/glue/monoruby_glue.c
@@ -1,0 +1,156 @@
+/*
+ * Small C helpers for monoruby's Nokogiri over the bundled libxml2:
+ *
+ * - accessors for the `xmlParserCtxt` fields the SAX layer reads and
+ *   writes (the struct is large and version-specific, so it is not
+ *   mirrored on the Rust side);
+ * - the SAX `warning` / `error` callbacks, which are variadic (printf
+ *   style): they format the message here and hand the text to a Rust
+ *   function registered at start-up.
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <libxml/parser.h>
+#include <libxml/HTMLparser.h>
+
+void *
+mrb_xml_ctxt_get_private(xmlParserCtxtPtr ctxt)
+{
+    return ctxt->_private;
+}
+
+void
+mrb_xml_ctxt_set_private(xmlParserCtxtPtr ctxt, void *p)
+{
+    ctxt->_private = p;
+}
+
+xmlSAXHandlerPtr
+mrb_xml_ctxt_get_sax(xmlParserCtxtPtr ctxt)
+{
+    return ctxt->sax;
+}
+
+void
+mrb_xml_ctxt_set_sax(xmlParserCtxtPtr ctxt, xmlSAXHandlerPtr sax)
+{
+    ctxt->sax = sax;
+}
+
+void
+mrb_xml_ctxt_set_user_data(xmlParserCtxtPtr ctxt, void *data)
+{
+    ctxt->userData = data;
+}
+
+xmlDocPtr
+mrb_xml_ctxt_get_my_doc(xmlParserCtxtPtr ctxt)
+{
+    return ctxt->myDoc;
+}
+
+int
+mrb_xml_ctxt_get_standalone(xmlParserCtxtPtr ctxt)
+{
+    return ctxt->standalone;
+}
+
+const xmlChar *
+mrb_xml_ctxt_get_encoding(xmlParserCtxtPtr ctxt)
+{
+    if (ctxt->encoding != NULL)
+        return ctxt->encoding;
+    if (ctxt->input != NULL)
+        return ctxt->input->encoding;
+    return NULL;
+}
+
+const xmlChar *
+mrb_xml_ctxt_get_version(xmlParserCtxtPtr ctxt)
+{
+    return ctxt->version;
+}
+
+int
+mrb_xml_ctxt_get_options(xmlParserCtxtPtr ctxt)
+{
+    return ctxt->options;
+}
+
+/* -1 when there is no input */
+int
+mrb_xml_ctxt_get_line(xmlParserCtxtPtr ctxt)
+{
+    return ctxt->input != NULL ? ctxt->input->line : -1;
+}
+
+int
+mrb_xml_ctxt_get_column(xmlParserCtxtPtr ctxt)
+{
+    return ctxt->input != NULL ? ctxt->input->col : -1;
+}
+
+/*
+ * The variadic SAX message callbacks. `is_error` is 0 for `warning`,
+ * 1 for `error`.
+ */
+typedef void (*mrb_sax_message_fn)(void *ctx, int is_error, const char *text);
+
+static mrb_sax_message_fn mrb_sax_message_handler = NULL;
+
+void
+mrb_xml_sax_set_message_handler(mrb_sax_message_fn fn)
+{
+    mrb_sax_message_handler = fn;
+}
+
+static void
+mrb_xml_sax_message(void *ctx, int is_error, const char *msg, va_list ap)
+{
+    char stack_buf[512];
+    char *buf = stack_buf;
+    va_list ap2;
+    int n;
+
+    if (mrb_sax_message_handler == NULL)
+        return;
+    va_copy(ap2, ap);
+    n = vsnprintf(stack_buf, sizeof(stack_buf), msg, ap);
+    if (n < 0) {
+        va_end(ap2);
+        return;
+    }
+    if ((size_t)n >= sizeof(stack_buf)) {
+        buf = malloc((size_t)n + 1);
+        if (buf == NULL) {
+            va_end(ap2);
+            return;
+        }
+        vsnprintf(buf, (size_t)n + 1, msg, ap2);
+    }
+    va_end(ap2);
+    mrb_sax_message_handler(ctx, is_error, buf);
+    if (buf != stack_buf)
+        free(buf);
+}
+
+void
+mrb_xml_sax_warning(void *ctx, const char *msg, ...)
+{
+    va_list ap;
+    va_start(ap, msg);
+    mrb_xml_sax_message(ctx, 0, msg, ap);
+    va_end(ap);
+}
+
+void
+mrb_xml_sax_error(void *ctx, const char *msg, ...)
+{
+    va_list ap;
+    va_start(ap, msg);
+    mrb_xml_sax_message(ctx, 1, msg, ap);
+    va_end(ap);
+}

--- a/libxml2-src/src/lib.rs
+++ b/libxml2-src/src/lib.rs
@@ -323,6 +323,155 @@ pub struct xmlError {
 pub struct xmlParserCtxt {
     _opaque: [u8; 0],
 }
+#[repr(C)]
+pub struct xmlParserInput {
+    _opaque: [u8; 0],
+}
+
+// ---- SAX ----
+
+/// `xmlSAXHandler.initialized` value selecting the SAX2 interface.
+pub const XML_SAX2_MAGIC: core::ffi::c_uint = 0xDEEDBEAF;
+
+/// `xmlCharEncoding` values used by the SAX push parsers.
+pub const XML_CHAR_ENCODING_ERROR: c_int = -1;
+pub const XML_CHAR_ENCODING_NONE: c_int = 0;
+
+pub type internalSubsetSAXFunc = Option<
+    unsafe extern "C" fn(ctx: *mut c_void, name: *const xmlChar, ExternalID: *const xmlChar, SystemID: *const xmlChar),
+>;
+pub type isStandaloneSAXFunc = Option<unsafe extern "C" fn(ctx: *mut c_void) -> c_int>;
+pub type resolveEntitySAXFunc = Option<
+    unsafe extern "C" fn(ctx: *mut c_void, publicId: *const xmlChar, systemId: *const xmlChar) -> *mut xmlParserInput,
+>;
+pub type getEntitySAXFunc = Option<unsafe extern "C" fn(ctx: *mut c_void, name: *const xmlChar) -> *mut xmlEntity>;
+pub type entityDeclSAXFunc = Option<
+    unsafe extern "C" fn(
+        ctx: *mut c_void,
+        name: *const xmlChar,
+        type_: c_int,
+        publicId: *const xmlChar,
+        systemId: *const xmlChar,
+        content: *mut xmlChar,
+    ),
+>;
+pub type unparsedEntityDeclSAXFunc = Option<
+    unsafe extern "C" fn(
+        ctx: *mut c_void,
+        name: *const xmlChar,
+        publicId: *const xmlChar,
+        systemId: *const xmlChar,
+        notationName: *const xmlChar,
+    ),
+>;
+pub type startDocumentSAXFunc = Option<unsafe extern "C" fn(ctx: *mut c_void)>;
+pub type startElementSAXFunc =
+    Option<unsafe extern "C" fn(ctx: *mut c_void, name: *const xmlChar, atts: *mut *const xmlChar)>;
+pub type endElementSAXFunc = Option<unsafe extern "C" fn(ctx: *mut c_void, name: *const xmlChar)>;
+pub type charactersSAXFunc = Option<unsafe extern "C" fn(ctx: *mut c_void, ch: *const xmlChar, len: c_int)>;
+pub type processingInstructionSAXFunc =
+    Option<unsafe extern "C" fn(ctx: *mut c_void, target: *const xmlChar, data: *const xmlChar)>;
+pub type commentSAXFunc = Option<unsafe extern "C" fn(ctx: *mut c_void, value: *const xmlChar)>;
+pub type warningSAXFunc = Option<unsafe extern "C" fn(ctx: *mut c_void, msg: *const c_char, ...)>;
+pub type startElementNsSAX2Func = Option<
+    unsafe extern "C" fn(
+        ctx: *mut c_void,
+        localname: *const xmlChar,
+        prefix: *const xmlChar,
+        URI: *const xmlChar,
+        nb_namespaces: c_int,
+        namespaces: *mut *const xmlChar,
+        nb_attributes: c_int,
+        nb_defaulted: c_int,
+        attributes: *mut *const xmlChar,
+    ),
+>;
+pub type endElementNsSAX2Func = Option<
+    unsafe extern "C" fn(ctx: *mut c_void, localname: *const xmlChar, prefix: *const xmlChar, URI: *const xmlChar),
+>;
+/// A callback this crate never sets (declared for the layout only).
+pub type unusedSAXFunc = Option<unsafe extern "C" fn()>;
+
+/// `struct _xmlSAXHandler` (`parser.h`, 2.13).
+#[repr(C)]
+pub struct xmlSAXHandler {
+    pub internalSubset: internalSubsetSAXFunc,
+    pub isStandalone: isStandaloneSAXFunc,
+    pub hasInternalSubset: isStandaloneSAXFunc,
+    pub hasExternalSubset: isStandaloneSAXFunc,
+    pub resolveEntity: resolveEntitySAXFunc,
+    pub getEntity: getEntitySAXFunc,
+    pub entityDecl: entityDeclSAXFunc,
+    pub notationDecl: unusedSAXFunc,
+    pub attributeDecl: unusedSAXFunc,
+    pub elementDecl: unusedSAXFunc,
+    pub unparsedEntityDecl: unparsedEntityDeclSAXFunc,
+    pub setDocumentLocator: unusedSAXFunc,
+    pub startDocument: startDocumentSAXFunc,
+    pub endDocument: startDocumentSAXFunc,
+    pub startElement: startElementSAXFunc,
+    pub endElement: endElementSAXFunc,
+    pub reference: endElementSAXFunc,
+    pub characters: charactersSAXFunc,
+    pub ignorableWhitespace: charactersSAXFunc,
+    pub processingInstruction: processingInstructionSAXFunc,
+    pub comment: commentSAXFunc,
+    pub warning: warningSAXFunc,
+    pub error: warningSAXFunc,
+    pub fatalError: warningSAXFunc,
+    pub getParameterEntity: getEntitySAXFunc,
+    pub cdataBlock: charactersSAXFunc,
+    pub externalSubset: internalSubsetSAXFunc,
+    pub initialized: core::ffi::c_uint,
+    pub _private: *mut c_void,
+    pub startElementNs: startElementNsSAX2Func,
+    pub endElementNs: endElementNsSAX2Func,
+    pub serror: xmlStructuredErrorFunc,
+}
+
+impl xmlSAXHandler {
+    /// An all-NULL handler (`xmlSAXHandler` zeroed, as
+    /// `TypedData_Make_Struct` gives nokogiri).
+    pub const fn zeroed() -> Self {
+        xmlSAXHandler {
+            internalSubset: None,
+            isStandalone: None,
+            hasInternalSubset: None,
+            hasExternalSubset: None,
+            resolveEntity: None,
+            getEntity: None,
+            entityDecl: None,
+            notationDecl: None,
+            attributeDecl: None,
+            elementDecl: None,
+            unparsedEntityDecl: None,
+            setDocumentLocator: None,
+            startDocument: None,
+            endDocument: None,
+            startElement: None,
+            endElement: None,
+            reference: None,
+            characters: None,
+            ignorableWhitespace: None,
+            processingInstruction: None,
+            comment: None,
+            warning: None,
+            error: None,
+            fatalError: None,
+            getParameterEntity: None,
+            cdataBlock: None,
+            externalSubset: None,
+            initialized: 0,
+            _private: core::ptr::null_mut(),
+            startElementNs: None,
+            endElementNs: None,
+            serror: None,
+        }
+    }
+}
+
+/// The formatted-message sink `mrb_xml_sax_set_message_handler` takes.
+pub type mrb_sax_message_fn = Option<unsafe extern "C" fn(ctx: *mut c_void, is_error: c_int, text: *const c_char)>;
 /// Only the leading fields are declared (the ones read or written); the
 /// struct is always allocated by libxml2.
 #[repr(C)]
@@ -619,6 +768,100 @@ unsafe extern "C" {
     pub fn xmlXPathErr(ctxt: *mut xmlXPathParserContext, error: c_int);
     pub fn xmlXPathCmpNodes(node1: *mut xmlNode, node2: *mut xmlNode) -> c_int;
     pub fn xmlXPathFreeNodeSetList(obj: *mut xmlXPathObject);
+
+    // ---- SAX parsing ----
+    pub fn xmlCreateIOParserCtxt(
+        sax: *mut xmlSAXHandler,
+        user_data: *mut c_void,
+        ioread: xmlInputReadCallback,
+        ioclose: xmlInputCloseCallback,
+        ioctx: *mut c_void,
+        enc: c_int,
+    ) -> *mut xmlParserCtxt;
+    pub fn xmlCreateFileParserCtxt(filename: *const c_char) -> *mut xmlParserCtxt;
+    pub fn xmlCreateMemoryParserCtxt(buffer: *const c_char, size: c_int) -> *mut xmlParserCtxt;
+    pub fn xmlCreatePushParserCtxt(
+        sax: *mut xmlSAXHandler,
+        user_data: *mut c_void,
+        chunk: *const c_char,
+        size: c_int,
+        filename: *const c_char,
+    ) -> *mut xmlParserCtxt;
+    pub fn xmlParseChunk(ctxt: *mut xmlParserCtxt, chunk: *const c_char, size: c_int, terminate: c_int) -> c_int;
+    pub fn xmlParseDocument(ctxt: *mut xmlParserCtxt) -> c_int;
+    pub fn xmlStopParser(ctxt: *mut xmlParserCtxt);
+    pub fn xmlSwitchEncodingName(ctxt: *mut xmlParserCtxt, encoding: *const c_char) -> c_int;
+    pub fn xmlCtxtSetOptions(ctxt: *mut xmlParserCtxt, options: c_int) -> c_int;
+    pub fn xmlCtxtGetLastError(ctx: *mut c_void) -> *const xmlError;
+    pub fn xmlParseCharEncoding(name: *const c_char) -> c_int;
+    pub fn htmlCreateMemoryParserCtxt(buffer: *const c_char, size: c_int) -> *mut xmlParserCtxt;
+    pub fn htmlCreateFileParserCtxt(filename: *const c_char, encoding: *const c_char) -> *mut xmlParserCtxt;
+    pub fn htmlCreatePushParserCtxt(
+        sax: *mut xmlSAXHandler,
+        user_data: *mut c_void,
+        chunk: *const c_char,
+        size: c_int,
+        filename: *const c_char,
+        enc: c_int,
+    ) -> *mut xmlParserCtxt;
+    pub fn htmlParseChunk(ctxt: *mut xmlParserCtxt, chunk: *const c_char, size: c_int, terminate: c_int) -> c_int;
+    pub fn htmlParseDocument(ctxt: *mut xmlParserCtxt) -> c_int;
+    // libxml2's default SAX2 callbacks, used for DTDs and entities.
+    pub fn xmlSAX2StartDocument(ctx: *mut c_void);
+    pub fn xmlSAX2GetEntity(ctx: *mut c_void, name: *const xmlChar) -> *mut xmlEntity;
+    pub fn xmlSAX2GetParameterEntity(ctx: *mut c_void, name: *const xmlChar) -> *mut xmlEntity;
+    pub fn xmlSAX2InternalSubset(
+        ctx: *mut c_void,
+        name: *const xmlChar,
+        ExternalID: *const xmlChar,
+        SystemID: *const xmlChar,
+    );
+    pub fn xmlSAX2ExternalSubset(
+        ctx: *mut c_void,
+        name: *const xmlChar,
+        ExternalID: *const xmlChar,
+        SystemID: *const xmlChar,
+    );
+    pub fn xmlSAX2IsStandalone(ctx: *mut c_void) -> c_int;
+    pub fn xmlSAX2HasInternalSubset(ctx: *mut c_void) -> c_int;
+    pub fn xmlSAX2HasExternalSubset(ctx: *mut c_void) -> c_int;
+    pub fn xmlSAX2ResolveEntity(
+        ctx: *mut c_void,
+        publicId: *const xmlChar,
+        systemId: *const xmlChar,
+    ) -> *mut xmlParserInput;
+    pub fn xmlSAX2EntityDecl(
+        ctx: *mut c_void,
+        name: *const xmlChar,
+        type_: c_int,
+        publicId: *const xmlChar,
+        systemId: *const xmlChar,
+        content: *mut xmlChar,
+    );
+    pub fn xmlSAX2UnparsedEntityDecl(
+        ctx: *mut c_void,
+        name: *const xmlChar,
+        publicId: *const xmlChar,
+        systemId: *const xmlChar,
+        notationName: *const xmlChar,
+    );
+    // monoruby's glue (`glue/monoruby_glue.c`): parser-context accessors
+    // and the variadic SAX message callbacks.
+    pub fn mrb_xml_ctxt_get_private(ctxt: *mut xmlParserCtxt) -> *mut c_void;
+    pub fn mrb_xml_ctxt_set_private(ctxt: *mut xmlParserCtxt, p: *mut c_void);
+    pub fn mrb_xml_ctxt_get_sax(ctxt: *mut xmlParserCtxt) -> *mut xmlSAXHandler;
+    pub fn mrb_xml_ctxt_set_sax(ctxt: *mut xmlParserCtxt, sax: *mut xmlSAXHandler);
+    pub fn mrb_xml_ctxt_set_user_data(ctxt: *mut xmlParserCtxt, data: *mut c_void);
+    pub fn mrb_xml_ctxt_get_my_doc(ctxt: *mut xmlParserCtxt) -> *mut xmlDoc;
+    pub fn mrb_xml_ctxt_get_standalone(ctxt: *mut xmlParserCtxt) -> c_int;
+    pub fn mrb_xml_ctxt_get_encoding(ctxt: *mut xmlParserCtxt) -> *const xmlChar;
+    pub fn mrb_xml_ctxt_get_version(ctxt: *mut xmlParserCtxt) -> *const xmlChar;
+    pub fn mrb_xml_ctxt_get_options(ctxt: *mut xmlParserCtxt) -> c_int;
+    pub fn mrb_xml_ctxt_get_line(ctxt: *mut xmlParserCtxt) -> c_int;
+    pub fn mrb_xml_ctxt_get_column(ctxt: *mut xmlParserCtxt) -> c_int;
+    pub fn mrb_xml_sax_set_message_handler(f: mrb_sax_message_fn);
+    pub fn mrb_xml_sax_warning(ctx: *mut c_void, msg: *const c_char, ...);
+    pub fn mrb_xml_sax_error(ctx: *mut c_void, msg: *const c_char, ...);
 
     // ---- HTML ----
     pub fn htmlNewParserCtxt() -> *mut xmlParserCtxt;

--- a/monoruby/src/builtins/nokogiri.rs
+++ b/monoruby/src/builtins/nokogiri.rs
@@ -24,6 +24,7 @@ mod dtd;
 mod misc;
 mod node;
 mod node_set;
+mod sax;
 mod xpath;
 
 pub(crate) fn init(globals: &mut Globals) {
@@ -62,6 +63,12 @@ pub(super) struct Classes {
     pub html4_document: ClassId,
     pub encoding_handler: ClassId,
     pub entity_lookup: ClassId,
+    pub sax_parser: ClassId,
+    pub sax_parser_context: ClassId,
+    pub sax_push_parser: ClassId,
+    pub html4_sax_parser: ClassId,
+    pub html4_sax_parser_context: ClassId,
+    pub html4_sax_push_parser: ClassId,
 }
 
 thread_local! {
@@ -129,9 +136,9 @@ fn nokogiri_init(_: &mut Executor, globals: &mut Globals, _: Lfp, _: BytecodePtr
     for m in ["Gumbo", "HTML4", "HTML5", "XSLT"] {
         module(globals, nokogiri, m);
     }
-    module(globals, xml_m, "SAX");
+    let xml_sax = module(globals, xml_m, "SAX");
     let html4 = module(globals, nokogiri, "HTML4");
-    module(globals, html4, "SAX");
+    let html4_sax = module(globals, html4, "SAX");
 
     let syntax_error = class(globals, nokogiri, "SyntaxError", standard_error);
     let xml_syntax_error = class(globals, xml_m, "SyntaxError", syntax_error);
@@ -159,6 +166,12 @@ fn nokogiri_init(_: &mut Executor, globals: &mut Globals, _: Lfp, _: BytecodePtr
     let encoding_handler = native_class(globals, nokogiri, "EncodingHandler", OBJECT_CLASS);
     let entity_lookup = class(globals, html4, "EntityLookup", OBJECT_CLASS);
     class(globals, html4, "ElementDescription", OBJECT_CLASS);
+    let sax_parser = native_class(globals, xml_sax, "Parser", OBJECT_CLASS);
+    let sax_parser_context = native_class(globals, xml_sax, "ParserContext", OBJECT_CLASS);
+    let sax_push_parser = native_class(globals, xml_sax, "PushParser", OBJECT_CLASS);
+    let html4_sax_parser = class(globals, html4_sax, "Parser", sax_parser);
+    let html4_sax_parser_context = class(globals, html4_sax, "ParserContext", sax_parser_context);
+    let html4_sax_push_parser = class(globals, html4_sax, "PushParser", sax_push_parser);
 
     let c = Classes {
         nokogiri,
@@ -189,6 +202,12 @@ fn nokogiri_init(_: &mut Executor, globals: &mut Globals, _: Lfp, _: BytecodePtr
         html4_document,
         encoding_handler,
         entity_lookup,
+        sax_parser,
+        sax_parser_context,
+        sax_push_parser,
+        html4_sax_parser,
+        html4_sax_parser_context,
+        html4_sax_push_parser,
     };
     CLASSES.with(|cell| *cell.borrow_mut() = Some(c));
 
@@ -197,6 +216,7 @@ fn nokogiri_init(_: &mut Executor, globals: &mut Globals, _: Lfp, _: BytecodePtr
     dtd::init(globals, &c);
     node::init(globals, &c);
     node_set::init(globals, &c);
+    sax::init(globals, &c);
     xpath::init(globals, &c);
 
     // Constants `Init_nokogiri` sets (version/info.rb reads them).
@@ -269,6 +289,20 @@ pub(super) unsafe fn xml_str_owned(p: *mut xml::xmlChar) -> Value {
             xml::xml_free()(p as *mut c_void);
         }
         v
+    }
+}
+
+/// The name `Check_Type` reports for a value of the wrong type: "nil" /
+/// "true" / "false" for the immediates, the class name otherwise.
+pub(super) fn builtin_type_name(globals: &Globals, v: Value) -> String {
+    if v.is_nil() {
+        "nil".to_string()
+    } else if v.id() == TRUE_VALUE {
+        "true".to_string()
+    } else if v.id() == FALSE_VALUE {
+        "false".to_string()
+    } else {
+        globals.store.get_class_name(v.class())
     }
 }
 

--- a/monoruby/src/builtins/nokogiri/node.rs
+++ b/monoruby/src/builtins/nokogiri/node.rs
@@ -141,7 +141,7 @@ fn text_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) 
     if args[0].try_bytes().is_none() {
         return Err(MonorubyErr::typeerr(format!(
             "wrong argument type {} (expected String)",
-            class_name(globals, args[0])
+            builtin_type_name(globals, args[0])
         )));
     }
     let content = cstr(args[0], &globals.store)?;
@@ -167,7 +167,7 @@ fn comment_new(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePt
     if args[1].try_bytes().is_none() {
         return Err(MonorubyErr::typeerr(format!(
             "wrong argument type {} (expected String)",
-            class_name(globals, args[1])
+            builtin_type_name(globals, args[1])
         )));
     }
     let content = cstr(args[1], &globals.store)?;

--- a/monoruby/src/builtins/nokogiri/sax.rs
+++ b/monoruby/src/builtins/nokogiri/sax.rs
@@ -1,0 +1,984 @@
+//! SAX: `Nokogiri::XML::SAX::Parser` (the `xmlSAXHandler` whose callbacks
+//! call the Ruby `SAX::Document`), `SAX::ParserContext` (a pull parse over
+//! a String / IO / file), `SAX::PushParser` (`xmlParseChunk`), and the
+//! `HTML4::SAX` variants over the HTML parser.
+//!
+//! libxml2 calls the handler from inside `xmlParseDocument` /
+//! `xmlParseChunk`; the callbacks find the running call (`SaxCall`: the
+//! executor, the parser object) through the context's `_private`. A Ruby
+//! exception raised by the document cannot unwind through C, so the
+//! callback stores it, stops the parser (`xmlStopParser`) and the native
+//! method re-raises it once the library call returns.
+
+use super::*;
+
+/// The payload of a `SAX::Parser`: the callback table libxml2 is handed.
+struct XmlSaxHandler {
+    handler: Box<xml::xmlSAXHandler>,
+}
+
+impl NativeData for XmlSaxHandler {
+    fn mark(&self, _alloc: &mut alloc::Allocator<RValue>) {}
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+/// The payload of a `SAX::ParserContext` (XML or HTML4): the parser
+/// context, the IO it reads (when made by `native_io`) and the parser
+/// whose handler it was last given.
+struct XmlSaxParserContext {
+    ctxt: *mut xml::xmlParserCtxt,
+    io: Option<Box<IoCtx>>,
+    /// The bytes of a `native_memory` input: the context reads them in
+    /// place, so they are kept (never read from Rust) until it is freed.
+    _buffer: Vec<u8>,
+    sax: Value,
+}
+
+impl NativeData for XmlSaxParserContext {
+    fn mark(&self, alloc: &mut alloc::Allocator<RValue>) {
+        if let Some(io) = &self.io {
+            io.io.mark(alloc);
+        }
+        self.sax.mark(alloc);
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+impl Drop for XmlSaxParserContext {
+    fn drop(&mut self) {
+        // SAFETY: the context is ours; its handler belongs to the parser
+        // object (`xml_sax_parser_context_type_free`).
+        unsafe { free_parser_ctxt(self.ctxt) };
+    }
+}
+
+/// The payload of a `SAX::PushParser` (XML or HTML4): NULL until
+/// `initialize_native`.
+struct XmlSaxPushParser {
+    ctxt: *mut xml::xmlParserCtxt,
+    sax: Value,
+}
+
+impl NativeData for XmlSaxPushParser {
+    fn mark(&self, alloc: &mut alloc::Allocator<RValue>) {
+        self.sax.mark(alloc);
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+impl Drop for XmlSaxPushParser {
+    fn drop(&mut self) {
+        // SAFETY: as `XmlSaxParserContext` (`xml_sax_push_parser_free`).
+        unsafe { free_parser_ctxt(self.ctxt) };
+    }
+}
+
+/// Free a parser context whose `sax` table (if any) is owned by a
+/// `SAX::Parser` object, with the document a SAX2 default may have built.
+unsafe fn free_parser_ctxt(ctxt: *mut xml::xmlParserCtxt) {
+    if ctxt.is_null() {
+        return;
+    }
+    // SAFETY: a live context that nothing else refers to.
+    unsafe {
+        xml::mrb_xml_ctxt_set_sax(ctxt, std::ptr::null_mut());
+        let doc = xml::mrb_xml_ctxt_get_my_doc(ctxt);
+        if !doc.is_null() {
+            xml::xmlFreeDoc(doc);
+        }
+        xml::xmlFreeParserCtxt(ctxt);
+    }
+}
+
+/// The state of one native call into libxml2 that runs SAX callbacks,
+/// reachable from the context's `_private` for its duration.
+struct SaxCall {
+    vm: *mut Executor,
+    globals: *mut Globals,
+    /// The `SAX::Parser` (its `@document` receives the events).
+    parser: Value,
+    /// The exception a callback raised: the parser was stopped, and it is
+    /// re-raised after the library call.
+    error: Option<MonorubyErr>,
+}
+
+/// Run `f` for a callback from libxml2: skipped once an exception is
+/// pending; an exception it raises is kept and stops the parser.
+unsafe fn with_call(ctx: *mut c_void, f: impl FnOnce(&mut Executor, &mut Globals, Value) -> Result<()>) {
+    let ctxt = ctx as *mut xml::xmlParserCtxt;
+    // SAFETY: `ctx` is the parser context (`userData`), whose `_private`
+    // is the `SaxCall` of the native method running the parse.
+    unsafe {
+        let call = xml::mrb_xml_ctxt_get_private(ctxt) as *mut SaxCall;
+        if call.is_null() {
+            return;
+        }
+        let call = &mut *call;
+        if call.error.is_some() {
+            return;
+        }
+        let vm = &mut *call.vm;
+        let globals = &mut *call.globals;
+        let doc = globals
+            .store
+            .get_ivar(call.parser, IdentId::get_id("@document"))
+            .unwrap_or_default();
+        if let Err(e) = f(vm, globals, doc) {
+            call.error = Some(e);
+            xml::xmlStopParser(ctxt);
+        }
+    }
+}
+
+fn call(vm: &mut Executor, globals: &mut Globals, doc: Value, method: &str, args: &[Value]) -> Result<()> {
+    vm.invoke_method_inner(globals, IdentId::get_id(method), doc, args, None, None)?;
+    Ok(())
+}
+
+// ---- the callbacks (`noko_xml_sax_parser_*_callback`) ----
+
+unsafe extern "C" fn cb_start_document(ctx: *mut c_void) {
+    // SAFETY: libxml2 passes the context registered as `userData`.
+    unsafe {
+        xml::xmlSAX2StartDocument(ctx);
+        let ctxt = ctx as *mut xml::xmlParserCtxt;
+        with_call(ctx, |vm, globals, doc| {
+            let standalone = xml::mrb_xml_ctxt_get_standalone(ctxt);
+            // -1: no XML declaration.
+            if standalone != -1 {
+                let encoding = xml_str(xml::mrb_xml_ctxt_get_encoding(ctxt));
+                let version = xml_str(xml::mrb_xml_ctxt_get_version(ctxt));
+                let standalone = match standalone {
+                    0 => Value::string_from_str("no"),
+                    1 => Value::string_from_str("yes"),
+                    _ => Value::nil(),
+                };
+                call(vm, globals, doc, "xmldecl", &[version, encoding, standalone])?;
+            }
+            call(vm, globals, doc, "start_document", &[])
+        });
+    }
+}
+
+unsafe extern "C" fn cb_html_start_document(ctx: *mut c_void) {
+    // SAFETY: as `cb_start_document`.
+    unsafe {
+        xml::xmlSAX2StartDocument(ctx);
+        with_call(ctx, |vm, globals, doc| call(vm, globals, doc, "start_document", &[]));
+    }
+}
+
+unsafe extern "C" fn cb_end_document(ctx: *mut c_void) {
+    // SAFETY: as `cb_start_document`.
+    unsafe { with_call(ctx, |vm, globals, doc| call(vm, globals, doc, "end_document", &[])) }
+}
+
+unsafe extern "C" fn cb_start_element(ctx: *mut c_void, name: *const xml::xmlChar, atts: *mut *const xml::xmlChar) {
+    // SAFETY: as `cb_start_document`; `atts` is a NULL-terminated list of
+    // name / value pairs.
+    unsafe {
+        with_call(ctx, |vm, globals, doc| {
+            let mut attributes = vec![];
+            if !atts.is_null() {
+                let mut i = 0;
+                while !(*atts.add(i)).is_null() {
+                    let attr = xml_str(*atts.add(i));
+                    let value = xml_str(*atts.add(i + 1));
+                    attributes.push(Value::array_from_vec(vec![attr, value]));
+                    i += 2;
+                }
+            }
+            let attributes = Value::array_from_vec(attributes);
+            call(vm, globals, doc, "start_element", &[xml_str(name), attributes])
+        })
+    }
+}
+
+unsafe extern "C" fn cb_end_element(ctx: *mut c_void, name: *const xml::xmlChar) {
+    // SAFETY: as `cb_start_document`.
+    unsafe { with_call(ctx, |vm, globals, doc| call(vm, globals, doc, "end_element", &[xml_str(name)])) }
+}
+
+unsafe extern "C" fn cb_start_element_ns(
+    ctx: *mut c_void,
+    localname: *const xml::xmlChar,
+    prefix: *const xml::xmlChar,
+    uri: *const xml::xmlChar,
+    nb_namespaces: c_int,
+    namespaces: *mut *const xml::xmlChar,
+    nb_attributes: c_int,
+    _nb_defaulted: c_int,
+    attributes: *mut *const xml::xmlChar,
+) {
+    // SAFETY: as `cb_start_document`; `namespaces` holds `nb_namespaces`
+    // prefix / URI pairs, `attributes` `nb_attributes` quintuples
+    // (localname, prefix, URI, value start, value end).
+    unsafe {
+        with_call(ctx, |vm, globals, doc| {
+            let attr_class = globals
+                .store
+                .get_constant_noautoload(classes().sax_parser, IdentId::get_id("Attribute"))
+                .ok_or_else(|| MonorubyErr::nameerr("uninitialized constant Nokogiri::XML::SAX::Parser::Attribute"))?;
+            let attr_ary = Value::array_from_vec(vec![]);
+            // `Attribute.new` runs Ruby: keep the array (and so the
+            // attributes made so far) rooted.
+            let len = vm.temp_len();
+            vm.temp_push(attr_ary);
+            let mut fill = || -> Result<()> {
+                if !attributes.is_null() {
+                    for i in (0..nb_attributes as usize * 5).step_by(5) {
+                        let start = *attributes.add(i + 3);
+                        let end = *attributes.add(i + 4);
+                        let value = std::slice::from_raw_parts(start, end.offset_from(start) as usize);
+                        let args = [
+                            xml_str(*attributes.add(i)),
+                            xml_str(*attributes.add(i + 1)),
+                            xml_str(*attributes.add(i + 2)),
+                            utf8(value),
+                        ];
+                        let attr = vm.invoke_method_inner(globals, IdentId::NEW, attr_class, &args, None, None)?;
+                        attr_ary.as_array_mut(&globals.store)?.push(attr);
+                    }
+                }
+                Ok(())
+            };
+            let r = fill();
+            vm.temp_clear(len);
+            r?;
+            let mut ns_list = vec![];
+            if !namespaces.is_null() {
+                for i in (0..nb_namespaces as usize * 2).step_by(2) {
+                    ns_list.push(Value::array_from_vec(vec![
+                        xml_str(*namespaces.add(i)),
+                        xml_str(*namespaces.add(i + 1)),
+                    ]));
+                }
+            }
+            let args = [
+                xml_str(localname),
+                attr_ary,
+                xml_str(prefix),
+                xml_str(uri),
+                Value::array_from_vec(ns_list),
+            ];
+            call(vm, globals, doc, "start_element_namespace", &args)
+        })
+    }
+}
+
+unsafe extern "C" fn cb_end_element_ns(
+    ctx: *mut c_void,
+    localname: *const xml::xmlChar,
+    prefix: *const xml::xmlChar,
+    uri: *const xml::xmlChar,
+) {
+    // SAFETY: as `cb_start_document`.
+    unsafe {
+        with_call(ctx, |vm, globals, doc| {
+            let args = [xml_str(localname), xml_str(prefix), xml_str(uri)];
+            call(vm, globals, doc, "end_element_namespace", &args)
+        })
+    }
+}
+
+unsafe extern "C" fn cb_characters(ctx: *mut c_void, ch: *const xml::xmlChar, len: c_int) {
+    // SAFETY: as `cb_start_document`; `ch` has `len` bytes.
+    unsafe {
+        with_call(ctx, |vm, globals, doc| {
+            let s = utf8(std::slice::from_raw_parts(ch, len as usize));
+            call(vm, globals, doc, "characters", &[s])
+        })
+    }
+}
+
+unsafe extern "C" fn cb_comment(ctx: *mut c_void, value: *const xml::xmlChar) {
+    // SAFETY: as `cb_start_document`.
+    unsafe { with_call(ctx, |vm, globals, doc| call(vm, globals, doc, "comment", &[xml_str(value)])) }
+}
+
+unsafe extern "C" fn cb_cdata_block(ctx: *mut c_void, value: *const xml::xmlChar, len: c_int) {
+    // SAFETY: as `cb_characters`.
+    unsafe {
+        with_call(ctx, |vm, globals, doc| {
+            let s = utf8(std::slice::from_raw_parts(value, len as usize));
+            call(vm, globals, doc, "cdata_block", &[s])
+        })
+    }
+}
+
+unsafe extern "C" fn cb_processing_instruction(ctx: *mut c_void, name: *const xml::xmlChar, content: *const xml::xmlChar) {
+    // SAFETY: as `cb_start_document`.
+    unsafe {
+        with_call(ctx, |vm, globals, doc| {
+            call(vm, globals, doc, "processing_instruction", &[xml_str(name), xml_str(content)])
+        })
+    }
+}
+
+unsafe extern "C" fn cb_reference(ctx: *mut c_void, name: *const xml::xmlChar) {
+    // SAFETY: as `cb_start_document`; the entity is the document's.
+    unsafe {
+        let entity = xml::xmlSAX2GetEntity(ctx, name);
+        with_call(ctx, |vm, globals, doc| {
+            let args = if !entity.is_null() && !(*entity).content.is_null() {
+                [xml_str((*entity).name), xml_str((*entity).content)]
+            } else {
+                [xml_str(name), Value::nil()]
+            };
+            call(vm, globals, doc, "reference", &args)
+        })
+    }
+}
+
+/// The formatted `warning` / `error` text from the glue's variadic
+/// callbacks.
+unsafe extern "C" fn cb_message(ctx: *mut c_void, is_error: c_int, text: *const c_char) {
+    // SAFETY: as `cb_start_document`; `text` is NUL-terminated.
+    unsafe {
+        let msg = utf8(CStr::from_ptr(text).to_bytes());
+        with_call(ctx, |vm, globals, doc| {
+            call(vm, globals, doc, if is_error != 0 { "error" } else { "warning" }, &[msg])
+        })
+    }
+}
+
+/// Fill the table as `noko_xml_sax_parser__initialize_native` does: the
+/// Ruby-facing callbacks, and libxml2's SAX2 defaults for DTDs and
+/// entities.
+fn fill_handler(h: &mut xml::xmlSAXHandler) {
+    h.startDocument = Some(cb_start_document);
+    h.endDocument = Some(cb_end_document);
+    h.startElement = Some(cb_start_element);
+    h.endElement = Some(cb_end_element);
+    h.startElementNs = Some(cb_start_element_ns);
+    h.endElementNs = Some(cb_end_element_ns);
+    h.characters = Some(cb_characters);
+    h.comment = Some(cb_comment);
+    h.warning = Some(xml::mrb_xml_sax_warning);
+    h.error = Some(xml::mrb_xml_sax_error);
+    h.cdataBlock = Some(cb_cdata_block);
+    h.processingInstruction = Some(cb_processing_instruction);
+    h.reference = Some(cb_reference);
+    h.getEntity = Some(xml::xmlSAX2GetEntity);
+    h.internalSubset = Some(xml::xmlSAX2InternalSubset);
+    h.externalSubset = Some(xml::xmlSAX2ExternalSubset);
+    h.isStandalone = Some(xml::xmlSAX2IsStandalone);
+    h.hasInternalSubset = Some(xml::xmlSAX2HasInternalSubset);
+    h.hasExternalSubset = Some(xml::xmlSAX2HasExternalSubset);
+    h.resolveEntity = Some(xml::xmlSAX2ResolveEntity);
+    h.getParameterEntity = Some(xml::xmlSAX2GetParameterEntity);
+    h.entityDecl = Some(xml::xmlSAX2EntityDecl);
+    h.unparsedEntityDecl = Some(xml::xmlSAX2UnparsedEntityDecl);
+    h.initialized = xml::XML_SAX2_MAGIC;
+}
+
+pub(super) fn init(globals: &mut Globals, c: &Classes) {
+    // SAFETY: registering the (single, static) message sink.
+    unsafe { xml::mrb_xml_sax_set_message_handler(Some(cb_message)) };
+
+    for parser in [c.sax_parser, c.html4_sax_parser] {
+        globals.store[parser].set_alloc_func(sax_parser_alloc);
+    }
+    globals.define_private_builtin_func(c.sax_parser, "initialize_native", initialize_native, 0);
+    globals.define_private_builtin_func(c.html4_sax_parser, "initialize_native", html_initialize_native, 0);
+
+    let x = c.sax_parser_context;
+    globals.define_builtin_class_func(x, "native_io", native_io, 2);
+    globals.define_builtin_class_func(x, "native_memory", native_memory, 2);
+    globals.define_builtin_class_func(x, "native_file", native_file, 2);
+    globals.define_builtin_func(x, "parse_with", parse_with, 1);
+    globals.define_builtin_func(x, "replace_entities=", ctx_set_replace_entities, 1);
+    globals.define_builtin_func(x, "replace_entities", ctx_replace_entities, 0);
+    globals.define_builtin_func(x, "recovery=", ctx_set_recovery, 1);
+    globals.define_builtin_func(x, "recovery", ctx_recovery, 0);
+    globals.define_builtin_func(x, "line", ctx_line, 0);
+    globals.define_builtin_func(x, "column", ctx_column, 0);
+    let h = c.html4_sax_parser_context;
+    globals.define_builtin_class_func(h, "native_memory", html_native_memory, 2);
+    globals.define_builtin_class_func(h, "native_file", html_native_file, 2);
+    globals.define_builtin_func(h, "parse_with", html_parse_with, 1);
+
+    for push in [c.sax_push_parser, c.html4_sax_push_parser] {
+        globals.store[push].set_alloc_func(push_parser_alloc);
+    }
+    let p = c.sax_push_parser;
+    globals.define_builtin_func(p, "options", push_options, 0);
+    globals.define_builtin_func(p, "options=", push_set_options, 1);
+    globals.define_builtin_func(p, "replace_entities", push_replace_entities, 0);
+    globals.define_builtin_func(p, "replace_entities=", push_set_replace_entities, 1);
+    globals.define_private_builtin_func(p, "initialize_native", push_initialize_native, 2);
+    globals.define_private_builtin_func(p, "native_write", push_native_write, 2);
+    let hp = c.html4_sax_push_parser;
+    globals.define_private_builtin_func(hp, "initialize_native", html_push_initialize_native, 3);
+    globals.define_private_builtin_func(hp, "native_write", html_push_native_write, 2);
+}
+
+// ---- SAX::Parser ----
+
+extern "C" fn sax_parser_alloc(class_id: ClassId, _globals: &mut Globals) -> Value {
+    Value::new_native(
+        class_id,
+        Box::new(XmlSaxHandler {
+            handler: Box::new(xml::xmlSAXHandler::zeroed()),
+        }),
+    )
+}
+
+/// The handler table of a `SAX::Parser`.
+fn handler_ptr(v: Value) -> Result<*mut xml::xmlSAXHandler> {
+    match v.try_native::<XmlSaxHandler>() {
+        Some(h) => Ok(&*h.handler as *const xml::xmlSAXHandler as *mut xml::xmlSAXHandler),
+        None => Err(MonorubyErr::argumenterr("argument must be a Nokogiri::XML::SAX::Parser")),
+    }
+}
+
+/// SAX::Parser#initialize_native -> self
+#[monoruby_builtin]
+fn initialize_native(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let h = handler_ptr(lfp.self_val())?;
+    // SAFETY: the table is owned by `self`.
+    unsafe { fill_handler(&mut *h) };
+    Ok(lfp.self_val())
+}
+
+/// HTML4::SAX::Parser#initialize_native -> self: the XML table with the
+/// HTML `start_document` (no XML declaration).
+#[monoruby_builtin]
+fn html_initialize_native(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let h = handler_ptr(lfp.self_val())?;
+    // SAFETY: as `initialize_native`.
+    unsafe {
+        fill_handler(&mut *h);
+        (*h).startDocument = Some(cb_html_start_document);
+    }
+    Ok(lfp.self_val())
+}
+
+// ---- SAX::ParserContext ----
+
+fn context_ptr(v: Value) -> Result<*mut xml::xmlParserCtxt> {
+    match v.try_native::<XmlSaxParserContext>() {
+        Some(c) => Ok(c.ctxt),
+        None => Err(MonorubyErr::argumenterr("expected a Nokogiri::XML::SAX::ParserContext")),
+    }
+}
+
+/// `nil` or an `Encoding`, else TypeError (nokogiri's check).
+fn check_encoding(globals: &Globals, enc: Value) -> Result<()> {
+    if enc.is_nil() {
+        return Ok(());
+    }
+    let encoding_class = globals
+        .store
+        .get_constant_noautoload(OBJECT_CLASS, IdentId::ENCODING)
+        .map(|v| v.as_class_id());
+    if encoding_class.is_some_and(|c| enc.is_kind_of(&globals.store, c)) {
+        return Ok(());
+    }
+    Err(MonorubyErr::typeerr("argument must be an Encoding object"))
+}
+
+/// `noko_xml_sax_parser_context_set_encoding`: switch the context to the
+/// `Encoding`'s name; on failure the context is freed and the libxml2
+/// errors raised.
+fn set_encoding(vm: &mut Executor, globals: &mut Globals, ctxt: *mut xml::xmlParserCtxt, enc: Value) -> Result<()> {
+    if enc.is_nil() {
+        return Ok(());
+    }
+    let name = vm.invoke_method_inner(globals, IdentId::get_id("name"), enc, &[], None, None)?;
+    let name = cstr(name, &globals.store)?;
+    let mut errors: Vec<ErrorRecord> = vec![];
+    // SAFETY: a live context; the handler is registered for the call.
+    let result = unsafe {
+        xml::xmlSetStructuredErrorFunc(&mut errors as *mut _ as *mut c_void, Some(collect_error));
+        let r = xml::xmlSwitchEncodingName(ctxt, name.as_ptr());
+        xml::xmlSetStructuredErrorFunc(std::ptr::null_mut(), None);
+        r
+    };
+    if result != 0 {
+        // SAFETY: the context is not wrapped yet.
+        unsafe { xml::xmlFreeParserCtxt(ctxt) };
+        let rb_errors = errors_to_array(vm, globals, &errors)?;
+        let klass = globals.store.get_module(classes().xml_syntax_error).as_val();
+        let ex = vm.invoke_method_inner(globals, IdentId::get_id("aggregate"), klass, &[rb_errors], None, None)?;
+        return Err(if ex.is_nil() { MonorubyErr::runtimeerr("could not set encoding") } else { raise(ex) });
+    }
+    Ok(())
+}
+
+/// The context's default SAX table is replaced by the parser's at
+/// `parse_with`: drop it now (`xmlFree(c_context->sax)`).
+unsafe fn drop_default_sax(ctxt: *mut xml::xmlParserCtxt) {
+    // SAFETY: a live context whose table libxml2 allocated.
+    unsafe {
+        let sax = xml::mrb_xml_ctxt_get_sax(ctxt);
+        if !sax.is_null() {
+            xml::xml_free()(sax as *mut c_void);
+            xml::mrb_xml_ctxt_set_sax(ctxt, std::ptr::null_mut());
+        }
+    }
+}
+
+fn wrap_context(
+    globals: &mut Globals,
+    class: ClassId,
+    ctxt: *mut xml::xmlParserCtxt,
+    io: Option<Box<IoCtx>>,
+    buffer: Vec<u8>,
+    input: Value,
+) -> Result<Value> {
+    let rb = Value::new_native(
+        class,
+        Box::new(XmlSaxParserContext {
+            ctxt,
+            io,
+            _buffer: buffer,
+            sax: Value::nil(),
+        }),
+    );
+    if !input.is_nil() {
+        globals.store.set_ivar(rb, IdentId::get_id("@input"), input)?;
+    }
+    Ok(rb)
+}
+
+/// SAX::ParserContext.native_io(io, encoding) -> ParserContext
+#[monoruby_builtin]
+fn native_io(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let class = lfp.self_val().as_class_id();
+    let io = lfp.arg(0);
+    let enc = lfp.arg(1);
+    if globals.store.check_method_for_class(io.class(), IdentId::get_id("read")).is_none() {
+        return Err(MonorubyErr::typeerr("argument expected to respond to :read"));
+    }
+    check_encoding(globals, enc)?;
+    let mut ioctx = Box::new(IoCtx::new(vm, globals, io));
+    // SAFETY: the IO context lives in the payload for as long as the
+    // parser context; its executor pointers are refreshed at each parse.
+    let ctxt = unsafe {
+        xml::xmlCreateIOParserCtxt(
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            Some(io_read),
+            Some(io_close),
+            &mut *ioctx as *mut IoCtx as *mut c_void,
+            xml::XML_CHAR_ENCODING_NONE,
+        )
+    };
+    if ctxt.is_null() {
+        return Err(MonorubyErr::runtimeerr("failed to create xml sax parser context"));
+    }
+    set_encoding(vm, globals, ctxt, enc)?;
+    // SAFETY: a live context.
+    unsafe { drop_default_sax(ctxt) };
+    wrap_context(globals, class, ctxt, Some(ioctx), vec![], io)
+}
+
+/// SAX::ParserContext.native_file(path, encoding) -> ParserContext
+#[monoruby_builtin]
+fn native_file(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let class = lfp.self_val().as_class_id();
+    let enc = lfp.arg(1);
+    check_encoding(globals, enc)?;
+    let path = cstr(lfp.arg(0), &globals.store)?;
+    // SAFETY: a NUL-terminated path.
+    let ctxt = unsafe { xml::xmlCreateFileParserCtxt(path.as_ptr()) };
+    if ctxt.is_null() {
+        return Err(MonorubyErr::runtimeerr("failed to create xml sax parser context"));
+    }
+    set_encoding(vm, globals, ctxt, enc)?;
+    // SAFETY: a live context.
+    unsafe { drop_default_sax(ctxt) };
+    wrap_context(globals, class, ctxt, None, vec![], Value::nil())
+}
+
+/// The bytes of a `native_memory` input (`Check_Type(T_STRING)`, then
+/// "input string cannot be empty").
+fn memory_input(globals: &Globals, input: Value) -> Result<Vec<u8>> {
+    let Some(bytes) = input.try_bytes() else {
+        return Err(MonorubyErr::typeerr(format!(
+            "wrong argument type {} (expected String)",
+            builtin_type_name(globals, input)
+        )));
+    };
+    if bytes.is_empty() {
+        return Err(MonorubyErr::runtimeerr("input string cannot be empty"));
+    }
+    Ok(bytes.to_vec())
+}
+
+/// SAX::ParserContext.native_memory(string, encoding) -> ParserContext
+#[monoruby_builtin]
+fn native_memory(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let class = lfp.self_val().as_class_id();
+    let buffer = memory_input(globals, lfp.arg(0))?;
+    let enc = lfp.arg(1);
+    check_encoding(globals, enc)?;
+    // SAFETY: the buffer moves into the payload, which outlives the
+    // context's reads of it.
+    let ctxt = unsafe { xml::xmlCreateMemoryParserCtxt(buffer.as_ptr() as *const c_char, buffer.len() as c_int) };
+    if ctxt.is_null() {
+        return Err(MonorubyErr::runtimeerr("failed to create xml sax parser context"));
+    }
+    set_encoding(vm, globals, ctxt, enc)?;
+    // SAFETY: a live context.
+    unsafe { drop_default_sax(ctxt) };
+    wrap_context(globals, class, ctxt, None, buffer, lfp.arg(0))
+}
+
+/// HTML4::SAX::ParserContext.native_memory(string, encoding) -> ParserContext
+#[monoruby_builtin]
+fn html_native_memory(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let class = lfp.self_val().as_class_id();
+    let buffer = memory_input(globals, lfp.arg(0))?;
+    let enc = lfp.arg(1);
+    check_encoding(globals, enc)?;
+    // SAFETY: as `native_memory`, with the HTML parser.
+    let ctxt = unsafe { xml::htmlCreateMemoryParserCtxt(buffer.as_ptr() as *const c_char, buffer.len() as c_int) };
+    if ctxt.is_null() {
+        return Err(MonorubyErr::runtimeerr("failed to create xml sax parser context"));
+    }
+    set_encoding(vm, globals, ctxt, enc)?;
+    // SAFETY: a live context.
+    unsafe { drop_default_sax(ctxt) };
+    wrap_context(globals, class, ctxt, None, buffer, Value::nil())
+}
+
+/// HTML4::SAX::ParserContext.native_file(path, encoding) -> ParserContext
+#[monoruby_builtin]
+fn html_native_file(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let class = lfp.self_val().as_class_id();
+    let enc = lfp.arg(1);
+    check_encoding(globals, enc)?;
+    let path = cstr(lfp.arg(0), &globals.store)?;
+    // SAFETY: a NUL-terminated path.
+    let ctxt = unsafe { xml::htmlCreateFileParserCtxt(path.as_ptr(), std::ptr::null()) };
+    if ctxt.is_null() {
+        return Err(MonorubyErr::runtimeerr("failed to create xml sax parser context"));
+    }
+    set_encoding(vm, globals, ctxt, enc)?;
+    // SAFETY: a live context.
+    unsafe { drop_default_sax(ctxt) };
+    wrap_context(globals, class, ctxt, None, vec![], Value::nil())
+}
+
+/// Give the context the parser's handler and run `parse` under a
+/// `SaxCall`; a pending exception is re-raised afterwards.
+fn parse_context(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    parse: unsafe extern "C" fn(*mut xml::xmlParserCtxt) -> c_int,
+) -> Result<Value> {
+    let self_val = lfp.self_val();
+    let ctxt = context_ptr(self_val)?;
+    let parser = lfp.arg(0);
+    if !parser.is_kind_of(&globals.store, classes().sax_parser) {
+        return Err(MonorubyErr::argumenterr("argument must be a Nokogiri::XML::SAX::Parser"));
+    }
+    let sax = handler_ptr(parser)?;
+    // SAFETY: the payload is ours for the call; the IO callbacks may run
+    // Ruby, with the pointers refreshed here.
+    unsafe {
+        let ctx = native_mut::<XmlSaxParserContext>(self_val).unwrap();
+        ctx.sax = parser;
+        if let Some(io) = &mut ctx.io {
+            io.vm = vm;
+            io.globals = globals;
+        }
+    }
+    let mut call = SaxCall {
+        vm,
+        globals,
+        parser,
+        error: None,
+    };
+    // SAFETY: a live context; the handler belongs to `parser`, which the
+    // payload now keeps alive; `call` outlives the parse.
+    unsafe {
+        xml::mrb_xml_ctxt_set_sax(ctxt, sax);
+        xml::mrb_xml_ctxt_set_user_data(ctxt, ctxt as *mut c_void);
+        xml::mrb_xml_ctxt_set_private(ctxt, &mut call as *mut SaxCall as *mut c_void);
+        xml::xmlSetStructuredErrorFunc(std::ptr::null_mut(), None);
+        parse(ctxt);
+        xml::mrb_xml_ctxt_set_private(ctxt, std::ptr::null_mut());
+    }
+    if let Some(e) = call.error {
+        return Err(e);
+    }
+    Ok(Value::nil())
+}
+
+/// SAX::ParserContext#parse_with(parser) -> nil
+#[monoruby_builtin]
+fn parse_with(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    parse_context(vm, globals, lfp, xml::xmlParseDocument)
+}
+
+/// HTML4::SAX::ParserContext#parse_with(parser) -> nil
+#[monoruby_builtin]
+fn html_parse_with(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    parse_context(vm, globals, lfp, xml::htmlParseDocument)
+}
+
+/// Set or clear a parse option on a context.
+fn set_option(ctxt: *mut xml::xmlParserCtxt, option: c_int, on: bool, what: &str) -> Result<()> {
+    // SAFETY: a live context.
+    let error = unsafe {
+        let options = xml::mrb_xml_ctxt_get_options(ctxt);
+        let options = if on { options | option } else { options & !option };
+        xml::xmlCtxtSetOptions(ctxt, options)
+    };
+    if error != 0 {
+        return Err(MonorubyErr::runtimeerr(format!("failed to set {what} ({error:x})")));
+    }
+    Ok(())
+}
+
+fn has_option(ctxt: *mut xml::xmlParserCtxt, option: c_int) -> Value {
+    // SAFETY: a live context.
+    Value::bool(unsafe { xml::mrb_xml_ctxt_get_options(ctxt) } & option != 0)
+}
+
+/// SAX::ParserContext#replace_entities=(value)
+#[monoruby_builtin]
+fn ctx_set_replace_entities(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let ctxt = context_ptr(lfp.self_val())?;
+    set_option(ctxt, xml::XML_PARSE_NOENT, lfp.arg(0).as_bool(), "parser context options")?;
+    Ok(lfp.arg(0))
+}
+
+/// SAX::ParserContext#replace_entities -> bool
+#[monoruby_builtin]
+fn ctx_replace_entities(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(has_option(context_ptr(lfp.self_val())?, xml::XML_PARSE_NOENT))
+}
+
+/// SAX::ParserContext#recovery=(value)
+#[monoruby_builtin]
+fn ctx_set_recovery(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let ctxt = context_ptr(lfp.self_val())?;
+    set_option(ctxt, xml::XML_PARSE_RECOVER, lfp.arg(0).as_bool(), "parser context options")?;
+    Ok(lfp.arg(0))
+}
+
+/// SAX::ParserContext#recovery -> bool
+#[monoruby_builtin]
+fn ctx_recovery(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(has_option(context_ptr(lfp.self_val())?, xml::XML_PARSE_RECOVER))
+}
+
+/// SAX::ParserContext#line -> Integer | nil
+#[monoruby_builtin]
+fn ctx_line(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let ctxt = context_ptr(lfp.self_val())?;
+    // SAFETY: a live context.
+    let line = unsafe { xml::mrb_xml_ctxt_get_line(ctxt) };
+    Ok(if line < 0 { Value::nil() } else { Value::integer(line as i64) })
+}
+
+/// SAX::ParserContext#column -> Integer | nil
+#[monoruby_builtin]
+fn ctx_column(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let ctxt = context_ptr(lfp.self_val())?;
+    // SAFETY: a live context.
+    let col = unsafe { xml::mrb_xml_ctxt_get_column(ctxt) };
+    Ok(if col < 0 { Value::nil() } else { Value::integer(col as i64) })
+}
+
+// ---- SAX::PushParser ----
+
+extern "C" fn push_parser_alloc(class_id: ClassId, _globals: &mut Globals) -> Value {
+    Value::new_native(
+        class_id,
+        Box::new(XmlSaxPushParser {
+            ctxt: std::ptr::null_mut(),
+            sax: Value::nil(),
+        }),
+    )
+}
+
+fn push_ptr(v: Value) -> Result<*mut xml::xmlParserCtxt> {
+    match v.try_native::<XmlSaxPushParser>() {
+        Some(p) if !p.ctxt.is_null() => Ok(p.ctxt),
+        Some(_) => Err(MonorubyErr::runtimeerr("push parser is not initialized")),
+        None => Err(MonorubyErr::argumenterr("expected a Nokogiri::XML::SAX::PushParser")),
+    }
+}
+
+/// Install a freshly created push context into `self`.
+fn install_push_ctxt(self_val: Value, ctxt: *mut xml::xmlParserCtxt, sax: Value) -> Result<Value> {
+    if ctxt.is_null() {
+        return Err(MonorubyErr::runtimeerr("Could not create a parser context"));
+    }
+    // SAFETY: the payload is ours; the context is live.
+    unsafe {
+        xml::mrb_xml_ctxt_set_user_data(ctxt, ctxt as *mut c_void);
+        let p = native_mut::<XmlSaxPushParser>(self_val)
+            .ok_or_else(|| MonorubyErr::argumenterr("expected a Nokogiri::XML::SAX::PushParser"))?;
+        free_parser_ctxt(p.ctxt);
+        p.ctxt = ctxt;
+        p.sax = sax;
+    }
+    Ok(self_val)
+}
+
+/// SAX::PushParser#initialize_native(sax, filename) -> self
+#[monoruby_builtin]
+fn push_initialize_native(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let sax = lfp.arg(0);
+    let handler = handler_ptr(sax)?;
+    let filename = opt_cstr(lfp.arg(1), &globals.store)?;
+    // SAFETY: the handler belongs to `sax`, kept alive by the payload.
+    let ctxt = unsafe {
+        xml::xmlCreatePushParserCtxt(
+            handler,
+            std::ptr::null_mut(),
+            std::ptr::null(),
+            0,
+            cptr(&filename) as *const c_char,
+        )
+    };
+    install_push_ctxt(lfp.self_val(), ctxt, sax)
+}
+
+/// HTML4::SAX::PushParser#initialize_native(sax, filename, encoding) -> self
+#[monoruby_builtin]
+fn html_push_initialize_native(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let sax = lfp.arg(0);
+    let handler = handler_ptr(sax)?;
+    let filename = opt_cstr(lfp.arg(1), &globals.store)?;
+    let mut enc = xml::XML_CHAR_ENCODING_NONE;
+    if !lfp.arg(2).is_nil() {
+        let name = cstr(lfp.arg(2), &globals.store)?;
+        // SAFETY: a NUL-terminated name.
+        enc = unsafe { xml::xmlParseCharEncoding(name.as_ptr()) };
+        if enc == xml::XML_CHAR_ENCODING_ERROR {
+            return Err(MonorubyErr::argumenterr("Unsupported Encoding"));
+        }
+    }
+    // SAFETY: as `push_initialize_native`.
+    let ctxt = unsafe {
+        xml::htmlCreatePushParserCtxt(
+            handler,
+            std::ptr::null_mut(),
+            std::ptr::null(),
+            0,
+            cptr(&filename) as *const c_char,
+            enc,
+        )
+    };
+    install_push_ctxt(lfp.self_val(), ctxt, sax)
+}
+
+/// Feed a chunk (`native_write`): a callback's exception is re-raised;
+/// otherwise a parse failure without `RECOVER` raises the context's last
+/// error.
+fn push_write(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    parse_chunk: unsafe extern "C" fn(*mut xml::xmlParserCtxt, *const c_char, c_int, c_int) -> c_int,
+) -> Result<Value> {
+    let self_val = lfp.self_val();
+    let ctxt = push_ptr(self_val)?;
+    let chunk = lfp.arg(0);
+    let chunk: Vec<u8> = if chunk.is_nil() { vec![] } else { chunk.expect_bytes(&globals.store)?.to_vec() };
+    let last = lfp.arg(1).id() == TRUE_VALUE;
+    let parser = self_val.try_native::<XmlSaxPushParser>().unwrap().sax;
+    let mut call = SaxCall {
+        vm,
+        globals,
+        parser,
+        error: None,
+    };
+    // SAFETY: a live context; `call` and `chunk` outlive the call.
+    let status = unsafe {
+        xml::mrb_xml_ctxt_set_private(ctxt, &mut call as *mut SaxCall as *mut c_void);
+        xml::xmlSetStructuredErrorFunc(std::ptr::null_mut(), None);
+        let status = parse_chunk(ctxt, chunk.as_ptr() as *const c_char, chunk.len() as c_int, last as c_int);
+        xml::mrb_xml_ctxt_set_private(ctxt, std::ptr::null_mut());
+        status
+    };
+    if let Some(e) = call.error {
+        return Err(e);
+    }
+    // SAFETY: a live context.
+    if status != 0 && unsafe { xml::mrb_xml_ctxt_get_options(ctxt) } & xml::XML_PARSE_RECOVER == 0 {
+        let mut errors: Vec<ErrorRecord> = vec![];
+        // SAFETY: the context's last error record (or NULL).
+        unsafe {
+            let e = xml::xmlCtxtGetLastError(ctxt as *mut c_void);
+            collect_error(&mut errors as *mut _ as *mut c_void, e);
+        }
+        if let Some(e) = errors.first() {
+            return Err(raise(syntax_error_value(vm, globals, e)?));
+        }
+        // No error record: the parser was stopped by an earlier
+        // callback exception (`XML_ERR_USER_STOP`) and takes no more.
+        return Err(MonorubyErr::runtimeerr(format!("parser is stopped ({status})")));
+    }
+    Ok(self_val)
+}
+
+/// SAX::PushParser#native_write(chunk, last_chunk) -> self
+#[monoruby_builtin]
+fn push_native_write(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    push_write(vm, globals, lfp, xml::xmlParseChunk)
+}
+
+/// HTML4::SAX::PushParser#native_write(chunk, last_chunk) -> self
+#[monoruby_builtin]
+fn html_push_native_write(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    push_write(vm, globals, lfp, xml::htmlParseChunk)
+}
+
+/// SAX::PushParser#options -> Integer
+#[monoruby_builtin]
+fn push_options(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let ctxt = push_ptr(lfp.self_val())?;
+    // SAFETY: a live context.
+    Ok(Value::integer(unsafe { xml::mrb_xml_ctxt_get_options(ctxt) } as i64))
+}
+
+/// SAX::PushParser#options=(options) -> nil
+#[monoruby_builtin]
+fn push_set_options(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let ctxt = push_ptr(lfp.self_val())?;
+    let options = lfp.arg(0).expect_integer(&globals.store)? as c_int;
+    // SAFETY: a live context.
+    let error = unsafe { xml::xmlCtxtSetOptions(ctxt, options) };
+    if error != 0 {
+        return Err(MonorubyErr::runtimeerr(format!("Cannot set XML parser context options ({error:x})")));
+    }
+    Ok(Value::nil())
+}
+
+/// SAX::PushParser#replace_entities -> bool
+#[monoruby_builtin]
+fn push_replace_entities(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    Ok(has_option(push_ptr(lfp.self_val())?, xml::XML_PARSE_NOENT))
+}
+
+/// SAX::PushParser#replace_entities=(value)
+#[monoruby_builtin]
+fn push_set_replace_entities(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let ctxt = push_ptr(lfp.self_val())?;
+    set_option(ctxt, xml::XML_PARSE_NOENT, lfp.arg(0).as_bool(), "parser context options")?;
+    Ok(lfp.arg(0))
+}

--- a/monoruby/tests/nokogiri.rs
+++ b/monoruby/tests/nokogiri.rs
@@ -733,6 +733,226 @@ fn nokogiri_reparenting_edge_cases() {
     );
 }
 
+/// A `SAX::Document` that records every event.
+const SAX_RECORDER: &str = r##"
+        class Recorder < Nokogiri::XML::SAX::Document
+          attr_reader :events
+          def initialize; super; @events = []; end
+          def xmldecl(v, e, s) = @events << [:xmldecl, v, e, s]
+          def start_document = @events << [:start_document]
+          def end_document = @events << [:end_document]
+          def start_element(name, attrs = []) = @events << [:start_element, name, attrs]
+          def end_element(name) = @events << [:end_element, name]
+          def start_element_namespace(name, attrs = [], prefix = nil, uri = nil, ns = [])
+            @events << [:start_element_namespace, name, attrs.map(&:to_a), prefix, uri, ns]
+            super
+          end
+          def end_element_namespace(name, prefix = nil, uri = nil)
+            @events << [:end_element_namespace, name, prefix, uri]
+            super
+          end
+          def characters(s) = @events << [:characters, s]
+          def comment(s) = @events << [:comment, s]
+          def cdata_block(s) = @events << [:cdata_block, s]
+          def processing_instruction(n, c) = @events << [:pi, n, c]
+          def reference(n, c) = @events << [:reference, n, c]
+          def warning(s) = @events << [:warning, s]
+          def error(s) = @events << [:error, s]
+        end
+"##;
+
+#[test]
+fn nokogiri_sax_parser() {
+    compare(&format!(
+        r##"
+        {SAX_RECORDER}
+        xml = <<~XML
+          <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+          <!DOCTYPE root [ <!ENTITY ent "entity text"> ]>
+          <root xmlns="http://d" xmlns:p="http://p" p:a="1" b="2"><!-- c -->
+            <p:child>text &amp; &ent;<![CDATA[cd<>]]></p:child>
+            <?pi data?><empty/>
+          </root>
+        XML
+        r = []
+        rec = Recorder.new
+        parser = Nokogiri::XML::SAX::Parser.new(rec)
+        parser.parse(xml)
+        r << rec.events
+        rec = Recorder.new
+        Nokogiri::XML::SAX::Parser.new(rec).parse(StringIO.new(xml))
+        r << rec.events.size
+        rec2 = Recorder.new
+        Nokogiri::XML::SAX::Parser.new(rec2).parse_memory("<a x='1'>&lt;</a>")
+        r << rec2.events
+        rec3 = Recorder.new
+        Nokogiri::XML::SAX::Parser.new(rec3).parse("<a><b></a>")
+        r << rec3.events
+        rec4 = Recorder.new
+        Nokogiri::XML::SAX::Parser.new(rec4).parse("<a><b></a>") {{ |ctx| ctx.recovery = true; r << [ctx.recovery, ctx.replace_entities, ctx.line, ctx.column] }}
+        r << rec4.events
+        rec5 = Recorder.new
+        Nokogiri::XML::SAX::Parser.new(rec5).parse("<a>&ent;</a>") {{ |ctx| ctx.replace_entities = true; r << ctx.replace_entities }}
+        r << rec5.events
+        ctx = Nokogiri::XML::SAX::ParserContext.new("<a/>")
+        r << [ctx.class, ctx.line, ctx.column, ctx.recovery, ctx.replace_entities]
+        ctx = Nokogiri::XML::SAX::ParserContext.io(StringIO.new("<a/>"), Encoding::UTF_8)
+        r << [ctx.class, ctx.line, ctx.column]
+        rec6 = Recorder.new
+        Nokogiri::XML::SAX::Parser.new(rec6).parse_memory("<a>é</a>".encode("ISO-8859-1"), Encoding::ISO_8859_1)
+        r << rec6.events
+        rec7 = Recorder.new
+        Nokogiri::XML::SAX::Parser.new(rec7, "UTF-8").parse_memory("<a>x</a>")
+        r << rec7.events
+        require "tempfile"
+        Tempfile.create(["sax", ".xml"]) do |f|
+          f.write("<f><g/></f>"); f.flush
+          rec8 = Recorder.new
+          Nokogiri::XML::SAX::Parser.new(rec8).parse_file(f.path)
+          r << rec8.events
+        end
+        [-> {{ Nokogiri::XML::SAX::Parser.new.parse_memory("") }},
+         -> {{ Nokogiri::XML::SAX::Parser.new.parse_memory(nil) }},
+         -> {{ Nokogiri::XML::SAX::Parser.new.parse_memory(42) }},
+         -> {{ Nokogiri::XML::SAX::ParserContext.memory("<a/>", 5) }},
+         -> {{ Nokogiri::XML::SAX::ParserContext.io(Object.new) }},
+         -> {{ Nokogiri::XML::SAX::ParserContext.new("<a/>").parse_with(Object.new) }},
+         -> {{ Nokogiri::XML::SAX::Parser.new.parse_file("/nonexistent/x.xml") }},
+         -> {{ Nokogiri::XML::SAX::Parser.new.parse_memory("<a/>", Encoding::UTF_8).class }},
+         -> {{ Nokogiri::XML::SAX::Parser.new.parse_memory("<a/>", "NOT-AN-ENCODING") }},
+         -> {{ Nokogiri::XML::SAX::ParserContext.memory("<a/>", Encoding.find("Big5")).class }}].each do |l|
+          begin
+            r << l.call
+          rescue => e
+            r << [e.class, e.message]
+          end
+        end
+        class Boom < Nokogiri::XML::SAX::Document
+          attr_reader :seen
+          def initialize(at); super(); @at = at; @seen = []; end
+          def start_element(name, attrs = []) = (@seen << name; raise ArgumentError, "boom at #{{name}}" if name == @at)
+          def end_document = @seen << :end
+        end
+        b = Boom.new("b")
+        begin
+          Nokogiri::XML::SAX::Parser.new(b).parse("<a><b/><c/></a>")
+          r << :no_raise
+        rescue ArgumentError => e
+          r << [e.class, e.message, b.seen]
+        end
+        b = Boom.new("b")
+        begin
+          Nokogiri::XML::SAX::Parser.new(b).parse(StringIO.new("<a><b/><c/></a>"))
+        rescue ArgumentError => e
+          r << [e.message, b.seen]
+        end
+        p r
+        "##
+    ));
+}
+
+#[test]
+fn nokogiri_sax_push_parser() {
+    compare(&format!(
+        r##"
+        {SAX_RECORDER}
+        r = []
+        rec = Recorder.new
+        pp = Nokogiri::XML::SAX::PushParser.new(rec)
+        r << [pp.options, pp.replace_entities]
+        pp << "<?xml version='1.0'?><root xmlns:p='http://p'><p:a k='v'>te"
+        pp << "xt</p:a><!-- c --><![CDATA[x]]>"
+        pp.write("<b/>", false)
+        pp.write("</root>")
+        pp.finish
+        r << rec.events
+        rec = Recorder.new
+        pp = Nokogiri::XML::SAX::PushParser.new(rec, "file.xml")
+        pp.replace_entities = true
+        pp.options = Nokogiri::XML::ParseOptions::RECOVER | Nokogiri::XML::ParseOptions::NOENT
+        r << [pp.replace_entities, pp.options]
+        pp << "<a><b></a>"
+        pp.finish
+        r << rec.events
+        rec = Recorder.new
+        pp = Nokogiri::XML::SAX::PushParser.new(rec)
+        begin
+          pp << "<a><b></a>"
+          pp.finish
+          r << :no_raise
+        rescue Nokogiri::XML::SyntaxError => e
+          r << [e.class, e.message, e.line, e.column]
+        end
+        r << rec.events
+        rec = Recorder.new
+        pp = Nokogiri::XML::SAX::PushParser.new(rec)
+        pp << "<a>x"
+        begin
+          pp.write(nil, true)
+          r << :no_raise
+        rescue Nokogiri::XML::SyntaxError => e
+          r << [e.class, e.message]
+        end
+        r << rec.events
+        class Boom < Nokogiri::XML::SAX::Document
+          attr_reader :seen
+          def initialize; super; @seen = []; end
+          def start_element(name, attrs = []) = (@seen << name; raise ArgumentError, "boom at #{{name}}" if name == "b")
+          def end_document = @seen << :end
+        end
+        b = Boom.new
+        pp = Nokogiri::XML::SAX::PushParser.new(b)
+        pp << "<a>"
+        begin
+          pp << "<b/><c/>"
+          r << :no_raise
+        rescue ArgumentError => e
+          r << [e.class, e.message, b.seen]
+        end
+        rec = Recorder.new
+        hp = Nokogiri::HTML4::SAX::PushParser.new(rec)
+        hp << "<html><body><p class='c'>Hello"
+        hp << " <b>w</b>&amp;&eacute;</p><br>"
+        hp.finish
+        r << rec.events
+        rec = Recorder.new
+        Nokogiri::HTML4::SAX::PushParser.new(rec, nil, "ISO-8859-1").write("<p>\xe9</p>".b, true)
+        r << rec.events
+        begin
+          Nokogiri::HTML4::SAX::PushParser.new(Recorder.new, nil, "NOT-AN-ENCODING")
+        rescue => e
+          r << [e.class, e.message]
+        end
+        rec = Recorder.new
+        Nokogiri::HTML4::SAX::Parser.new(rec).parse("<html><head><meta charset='utf-8'></head><body><p>x</p></body></html>")
+        r << rec.events
+        rec = Recorder.new
+        Nokogiri::HTML4::SAX::Parser.new(rec).parse(StringIO.new("<p>from io<p>two"))
+        r << rec.events
+        rec = Recorder.new
+        Nokogiri::HTML4::SAX::Parser.new(rec).parse_memory("<p>mem</p>", Encoding::UTF_8)
+        r << rec.events
+        require "tempfile"
+        Tempfile.create(["sax", ".html"]) do |f|
+          f.write("<p>file</p>"); f.flush
+          rec = Recorder.new
+          Nokogiri::HTML4::SAX::Parser.new(rec).parse_file(f.path)
+          r << rec.events
+        end
+        r << Nokogiri::HTML4::EncodingReader.detect_encoding("<html><head><meta http-equiv='Content-Type' content='text/html; charset=Shift_JIS'></head><body></body></html>")
+        r << Nokogiri::HTML4::EncodingReader.detect_encoding("<html><body><p>none</p></body></html>")
+        r << Nokogiri::HTML4::EncodingReader.detect_encoding("<?xml version='1.0' encoding='EUC-JP'?><html/>")
+        d = Nokogiri::HTML4(StringIO.new("<html><head><meta charset='ISO-8859-1'></head><body><p>\xe9t\xe9</p></body></html>".b))
+        r << [d.encoding, d.at_css("p").text, d.at_css("p").text.encoding.name]
+        d = Nokogiri::HTML4(StringIO.new("<html><body><p>plain io</p></body></html>"))
+        r << [d.encoding, d.at_css("p").text]
+        d = Nokogiri::HTML4(StringIO.new(("<html><head><title>T</title></head><body>" + "<p>x</p>" * 2000 + "<meta charset='UTF-8'></body></html>")))
+        r << [d.encoding, d.css("p").size, d.title]
+        p r
+        "##
+    ));
+}
+
 #[test]
 fn nokogiri_node_identity_across_gc() {
     // Every node wraps into one Ruby object that the document keeps alive;


### PR DESCRIPTION
Stage 2 of `doc/nokogiri.md`: the SAX half of nokogiri's C extension (`xml_sax_parser.c`, `xml_sax_parser_context.c`, `xml_sax_push_parser.c`, `html4_sax_*.c`) ported to `src/builtins/nokogiri/sax.rs` over the bundled libxml2. Follows #1306.

## What is in

- **`XML::SAX::Parser`**: a native object holding the `xmlSAXHandler`. Its callbacks dispatch to the `@document`: `xmldecl`, `start_document` / `end_document`, `start_element` / `end_element`, `start_element_namespace` / `end_element_namespace` (with `Parser::Attribute`), `characters`, `comment`, `cdata_block`, `processing_instruction`, `reference`, `warning`, `error`. DTDs and entities go through libxml2's SAX2 defaults, as in nokogiri.
- **`XML::SAX::ParserContext`**: `native_memory` / `native_io` (Ruby `read` callback) / `native_file`, `parse_with`, `replace_entities` / `recovery`, `line` / `column`, with the `Encoding` argument switched on the context (`xmlSwitchEncodingName`, errors aggregated into a `SyntaxError`).
- **`XML::SAX::PushParser`**: `xmlParseChunk` per `write`, `options` / `options=`, `replace_entities`; without `RECOVER` a failed chunk raises the context's last error as a `SyntaxError`.
- **`HTML4::SAX::Parser` / `ParserContext` / `PushParser`** over the HTML parser (`htmlParseDocument`, `htmlParseChunk`, the encoding argument via `xmlParseCharEncoding`).
- **Exceptions in callbacks.** A Ruby exception cannot unwind through libxml2's C frames (nokogiri longjmps through them). The callback stores it in the per-call `SaxCall` (reachable from the context's `_private`), stops the parser with `xmlStopParser`, later callbacks do nothing, and the native method re-raises it once `xmlParseDocument` / `xmlParseChunk` returns.
- **C glue** (`libxml2-src/glue/monoruby_glue.c`): the SAX `warning` / `error` callbacks are variadic (printf style), which Rust cannot define, so they are formatted in C and handed to a Rust sink registered at start-up. The same file holds accessors for the `xmlParserCtxt` fields (`_private`, `sax`, `userData`, `myDoc`, `standalone`, `encoding`, `version`, `options`, line / column), so the large version-specific struct is not mirrored in Rust.
- With `SAX::PushParser` available, `HTML4::EncodingReader` works: **`Nokogiri::HTML4(io)` now parses without an explicit encoding**, including `<meta charset>` detection and the `EncodingFound` re-parse.
- `Check_Type`-style messages report `nil` / `true` / `false` as CRuby does.

## Not yet (later stages)

Reader, Schema / RelaxNG, XSLT, HTML5 / gumbo, `ElementDescription`, `Node#dup`, XPath custom function handlers.

## Tests

`tests/nokogiri.rs` gains two comparison scripts, byte-identical to CRuby's nokogiri: the event stream of a recording `SAX::Document` for memory / IO / file pull parsing, push parsing chunk by chunk, options and encodings, recoverable and fatal errors, exception propagation from callbacks, the HTML4 variants, `EncodingReader.detect_encoding` and `HTML4(io)`. All 17 nokogiri tests pass; a GC / JIT stress run of the callbacks (collections inside `start_element`, 40 rounds of pull, push and IO parsing) gives the same totals as CRuby.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_