### PR TITLE
Nokogiri stage 3: XML::Reader, Node#dup / Document#dup, XPath custom function handlers

### DIFF
--- a/doc/nokogiri.md
+++ b/doc/nokogiri.md
@@ -229,7 +229,7 @@ libxml2 のビルドが付く。段階 1〜3 で ext の 6 割程度（Node 54 +
 B（C API 互換層）を将来やるなら、ここで作る `ObjTy::XML_*` の mark / drop の
 形がそのまま `TypedData` の受け皿になるので、A の作業は無駄にならない。
 
-## 6. 実装状況（段階 1〜3 と 5 の SAX、2026-09）
+## 6. 実装状況（段階 1〜3 と 5、2026-09）
 
 `libxml2-src/`（libxml2 2.13.8 + nokogiri 1.18.9 の patches、`cc` でビルド、
 `config.h` は手書き、`xmlversion.h` は build.rs が生成）、
@@ -283,7 +283,13 @@ B（C API 互換層）を将来やるなら、ここで作る `ObjTy::XML_*` の
   エンコーディング指定無しで**パースできる（`<meta charset>` の検出と
   `EncodingFound` による再パース込み）。
 
-まだ無いもの（段階 4〜6）: `XML::Reader`、`XML::Schema` / `RelaxNG`、`XSLT`（定数は `0.0.0` の
+- `XML::Reader`（`reader.rs`、`xmlTextReader` の薄い wrapper）: `from_memory` /
+  `from_io`、`read` と Enumerable、名前・値・深さ・型・属性（`attribute` /
+  `attribute_at` / `attribute_hash` / `namespaces` / `attributes`）、
+  `inner_xml` / `outer_xml`、`base_uri` / `lang` / `xml_version` / `encoding`、
+  エラーは `errors` に積まれ `read` の失敗で aggregate を raise。
+
+まだ無いもの（段階 4〜6）: `XML::Schema` / `RelaxNG`、`XSLT`（定数は `0.0.0` の
 プレースホルダ）、HTML5（gumbo）、`HTML4::ElementDescription`
 （`Node#description`）、XPath のカスタム関数ハンドラ（`evaluate` の第 2
 引数は受け取るが無視）、`Node#dup` / `Document#dup`。

--- a/doc/nokogiri.md
+++ b/doc/nokogiri.md
@@ -289,10 +289,22 @@ B（C API 互換層）を将来やるなら、ここで作る `ObjTy::XML_*` の
   `inner_xml` / `outer_xml`、`base_uri` / `lang` / `xml_version` / `encoding`、
   エラーは `errors` に積まれ `read` の失敗で aggregate を raise。
 
+- `Node#dup` / `#clone`（`initialize_copy_with_args`: `Object#dup` が作った
+  ペイロード無しのコピーに `xmlDocCopyNode` の複製を持たせる。別ドキュメントへの
+  複製も可）、`Document#dup` / `#clone`（`xmlCopyDoc`）。`RValue::replace_native`
+  でペイロードを差し替える。
+- XPath のカスタム関数ハンドラ（`evaluate(expr, handler)`、CSS の
+  `:regex()` 等の擬似クラスも通る）: `xmlXPathRegisterFuncLookup` でハンドラが
+  応答する名前を Rust の invoker に解決し、引数を Ruby 値（NodeSet / String /
+  Float / bool）に、戻り値を XPath 値（数値 / 文字列 / 真偽 / NodeSet / Array →
+  NodeSet、nil は何も積まない）に変換する。ハンドラの例外は呼び出し状態に保存して
+  `xmlXPathErr` で評価を打ち切り、`evaluate` から投げ直す。呼び出し状態は
+  コンテキストの `funcLookupData` に置く（`userData` は 2.13 の
+  `xmlXPathSetErrorHandler` が上書きするので使えない）。
+
 まだ無いもの（段階 4〜6）: `XML::Schema` / `RelaxNG`、`XSLT`（定数は `0.0.0` の
 プレースホルダ）、HTML5（gumbo）、`HTML4::ElementDescription`
-（`Node#description`）、XPath のカスタム関数ハンドラ（`evaluate` の第 2
-引数は受け取るが無視）、`Node#dup` / `Document#dup`。
+（`Node#description`）。
 
 設計上わかったこと:
 

--- a/libxml2-src/glue/monoruby_glue.c
+++ b/libxml2-src/glue/monoruby_glue.c
@@ -154,3 +154,33 @@ mrb_xml_sax_error(void *ctx, const char *msg, ...)
     mrb_xml_sax_message(ctx, 1, msg, ap);
     va_end(ap);
 }
+
+/*
+ * `xmlXPathContext` accessors for the custom-function handler: the
+ * function being called (set by the evaluator before the call) and the
+ * function-lookup data (the running call).
+ */
+#include <libxml/xpath.h>
+
+const xmlChar *
+mrb_xpath_ctx_get_function(xmlXPathContextPtr ctx)
+{
+    return ctx->function;
+}
+
+const xmlChar *
+mrb_xpath_ctx_get_function_uri(xmlXPathContextPtr ctx)
+{
+    return ctx->functionURI;
+}
+
+/*
+ * The data registered with `xmlXPathRegisterFuncLookup` (`userData` is
+ * not usable for this: `xmlXPathSetErrorHandler` stores its own data
+ * pointer there).
+ */
+void *
+mrb_xpath_ctx_get_func_lookup_data(xmlXPathContextPtr ctx)
+{
+    return ctx->funcLookupData;
+}

--- a/libxml2-src/src/lib.rs
+++ b/libxml2-src/src/lib.rs
@@ -327,6 +327,10 @@ pub struct xmlParserCtxt {
 pub struct xmlParserInput {
     _opaque: [u8; 0],
 }
+#[repr(C)]
+pub struct xmlTextReader {
+    _opaque: [u8; 0],
+}
 
 // ---- SAX ----
 
@@ -862,6 +866,48 @@ unsafe extern "C" {
     pub fn mrb_xml_sax_set_message_handler(f: mrb_sax_message_fn);
     pub fn mrb_xml_sax_warning(ctx: *mut c_void, msg: *const c_char, ...);
     pub fn mrb_xml_sax_error(ctx: *mut c_void, msg: *const c_char, ...);
+
+    // ---- xmlreader ----
+    pub fn xmlReaderForMemory(
+        buffer: *const c_char,
+        size: c_int,
+        URL: *const c_char,
+        encoding: *const c_char,
+        options: c_int,
+    ) -> *mut xmlTextReader;
+    pub fn xmlReaderForIO(
+        ioread: xmlInputReadCallback,
+        ioclose: xmlInputCloseCallback,
+        ioctx: *mut c_void,
+        URL: *const c_char,
+        encoding: *const c_char,
+        options: c_int,
+    ) -> *mut xmlTextReader;
+    pub fn xmlFreeTextReader(reader: *mut xmlTextReader);
+    pub fn xmlTextReaderRead(reader: *mut xmlTextReader) -> c_int;
+    pub fn xmlTextReaderReadInnerXml(reader: *mut xmlTextReader) -> *mut xmlChar;
+    pub fn xmlTextReaderReadOuterXml(reader: *mut xmlTextReader) -> *mut xmlChar;
+    pub fn xmlTextReaderAttributeCount(reader: *mut xmlTextReader) -> c_int;
+    pub fn xmlTextReaderDepth(reader: *mut xmlTextReader) -> c_int;
+    pub fn xmlTextReaderHasValue(reader: *mut xmlTextReader) -> c_int;
+    pub fn xmlTextReaderIsDefault(reader: *mut xmlTextReader) -> c_int;
+    pub fn xmlTextReaderIsEmptyElement(reader: *mut xmlTextReader) -> c_int;
+    pub fn xmlTextReaderNodeType(reader: *mut xmlTextReader) -> c_int;
+    pub fn xmlTextReaderReadState(reader: *mut xmlTextReader) -> c_int;
+    pub fn xmlTextReaderConstLocalName(reader: *mut xmlTextReader) -> *const xmlChar;
+    pub fn xmlTextReaderConstName(reader: *mut xmlTextReader) -> *const xmlChar;
+    pub fn xmlTextReaderConstNamespaceUri(reader: *mut xmlTextReader) -> *const xmlChar;
+    pub fn xmlTextReaderConstPrefix(reader: *mut xmlTextReader) -> *const xmlChar;
+    pub fn xmlTextReaderConstXmlLang(reader: *mut xmlTextReader) -> *const xmlChar;
+    pub fn xmlTextReaderConstValue(reader: *mut xmlTextReader) -> *const xmlChar;
+    pub fn xmlTextReaderConstXmlVersion(reader: *mut xmlTextReader) -> *const xmlChar;
+    pub fn xmlTextReaderConstEncoding(reader: *mut xmlTextReader) -> *const xmlChar;
+    pub fn xmlTextReaderBaseUri(reader: *mut xmlTextReader) -> *mut xmlChar;
+    pub fn xmlTextReaderGetAttributeNo(reader: *mut xmlTextReader, no: c_int) -> *mut xmlChar;
+    pub fn xmlTextReaderGetAttribute(reader: *mut xmlTextReader, name: *const xmlChar) -> *mut xmlChar;
+    pub fn xmlTextReaderCurrentNode(reader: *mut xmlTextReader) -> *mut xmlNode;
+    pub fn xmlTextReaderCurrentDoc(reader: *mut xmlTextReader) -> *mut xmlDoc;
+    pub fn xmlTextReaderExpand(reader: *mut xmlTextReader) -> *mut xmlNode;
 
     // ---- HTML ----
     pub fn htmlNewParserCtxt() -> *mut xmlParserCtxt;

--- a/libxml2-src/src/lib.rs
+++ b/libxml2-src/src/lib.rs
@@ -589,6 +589,7 @@ unsafe extern "C" {
     // ---- documents ----
     pub fn xmlNewDoc(version: *const xmlChar) -> *mut xmlDoc;
     pub fn xmlFreeDoc(cur: *mut xmlDoc);
+    pub fn xmlCopyDoc(doc: *mut xmlDoc, recursive: c_int) -> *mut xmlDoc;
     pub fn xmlDocGetRootElement(doc: *const xmlDoc) -> *mut xmlNode;
     pub fn xmlDocSetRootElement(doc: *mut xmlDoc, root: *mut xmlNode) -> *mut xmlNode;
     pub fn xmlNewDocFragment(doc: *mut xmlDoc) -> *mut xmlNode;
@@ -864,6 +865,9 @@ unsafe extern "C" {
     pub fn mrb_xml_ctxt_get_line(ctxt: *mut xmlParserCtxt) -> c_int;
     pub fn mrb_xml_ctxt_get_column(ctxt: *mut xmlParserCtxt) -> c_int;
     pub fn mrb_xml_sax_set_message_handler(f: mrb_sax_message_fn);
+    pub fn mrb_xpath_ctx_get_function(ctx: *mut xmlXPathContext) -> *const xmlChar;
+    pub fn mrb_xpath_ctx_get_function_uri(ctx: *mut xmlXPathContext) -> *const xmlChar;
+    pub fn mrb_xpath_ctx_get_func_lookup_data(ctx: *mut xmlXPathContext) -> *mut c_void;
     pub fn mrb_xml_sax_warning(ctx: *mut c_void, msg: *const c_char, ...);
     pub fn mrb_xml_sax_error(ctx: *mut c_void, msg: *const c_char, ...);
 

--- a/monoruby/gem/nokogiri/nokogiri.rb
+++ b/monoruby/gem/nokogiri/nokogiri.rb
@@ -14,15 +14,3 @@ String.__nokogiri_init
 # rubygems loaded up front, monoruby autoloads it from the CLI but not in
 # every embedding (the test harness).
 require "rubygems" unless defined?(Gem::Version)
-
-module Nokogiri
-  module XML
-    # Not implemented yet (doc/nokogiri.md, stage 5): defined so the gem's
-    # reader.rb, which aliases it at load time, loads.
-    class Reader
-      def empty_element?
-        raise NotImplementedError, "Nokogiri::XML::Reader is not implemented in monoruby yet"
-      end
-    end
-  end
-end

--- a/monoruby/src/builtins/nokogiri.rs
+++ b/monoruby/src/builtins/nokogiri.rs
@@ -24,6 +24,7 @@ mod dtd;
 mod misc;
 mod node;
 mod node_set;
+mod reader;
 mod sax;
 mod xpath;
 
@@ -69,6 +70,7 @@ pub(super) struct Classes {
     pub html4_sax_parser: ClassId,
     pub html4_sax_parser_context: ClassId,
     pub html4_sax_push_parser: ClassId,
+    pub reader: ClassId,
 }
 
 thread_local! {
@@ -172,6 +174,7 @@ fn nokogiri_init(_: &mut Executor, globals: &mut Globals, _: Lfp, _: BytecodePtr
     let html4_sax_parser = class(globals, html4_sax, "Parser", sax_parser);
     let html4_sax_parser_context = class(globals, html4_sax, "ParserContext", sax_parser_context);
     let html4_sax_push_parser = class(globals, html4_sax, "PushParser", sax_push_parser);
+    let reader = native_class(globals, xml_m, "Reader", OBJECT_CLASS);
 
     let c = Classes {
         nokogiri,
@@ -208,6 +211,7 @@ fn nokogiri_init(_: &mut Executor, globals: &mut Globals, _: Lfp, _: BytecodePtr
         html4_sax_parser,
         html4_sax_parser_context,
         html4_sax_push_parser,
+        reader,
     };
     CLASSES.with(|cell| *cell.borrow_mut() = Some(c));
 
@@ -216,6 +220,7 @@ fn nokogiri_init(_: &mut Executor, globals: &mut Globals, _: Lfp, _: BytecodePtr
     dtd::init(globals, &c);
     node::init(globals, &c);
     node_set::init(globals, &c);
+    reader::init(globals, &c);
     sax::init(globals, &c);
     xpath::init(globals, &c);
 

--- a/monoruby/src/builtins/nokogiri.rs
+++ b/monoruby/src/builtins/nokogiri.rs
@@ -413,6 +413,18 @@ pub(super) unsafe fn native_mut<'a, T: NativeData>(mut v: Value) -> Option<&'a m
     }
 }
 
+/// Give `v` (a native object, e.g. the `EmptyNative` copy `Object#dup`
+/// makes) the payload `inner`.
+pub(super) fn replace_native(mut v: Value, inner: Box<dyn NativeData>) -> Result<()> {
+    match v.try_rvalue_mut() {
+        Some(rv) if rv.ty() == ObjTy::NATIVE => {
+            rv.replace_native(inner);
+            Ok(())
+        }
+        _ => Err(MonorubyErr::typeerr("expected a native object")),
+    }
+}
+
 pub(super) unsafe fn doc_native<'a>(doc: *mut xml::xmlDoc) -> Option<&'a mut XmlDocument> {
     // SAFETY: as `native_mut`.
     unsafe { native_mut::<XmlDocument>(doc_value(doc)?) }

--- a/monoruby/src/builtins/nokogiri/document.rs
+++ b/monoruby/src/builtins/nokogiri/document.rs
@@ -14,6 +14,7 @@ pub(super) fn init(globals: &mut Globals, c: &Classes) {
     globals.define_builtin_func(d, "encoding=", set_encoding, 1);
     globals.define_builtin_func(d, "version", version, 0);
     globals.define_builtin_func(d, "url", url, 0);
+    globals.define_builtin_func(d, "initialize_copy_with_args", doc_initialize_copy_with_args, 2);
 
     let h = c.html4_document;
     globals.define_builtin_class_func(h, "read_memory", html_read_memory, 4);
@@ -346,6 +347,36 @@ fn version(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Resul
     let doc = this(lfp)?;
     // SAFETY: a live document.
     Ok(unsafe { xml_str((*doc).version) })
+}
+
+/// Document#initialize_copy_with_args(other, level) -> self: the tail of
+/// `Document#dup` / `#clone` — `self` is the payload-less copy `Object#dup`
+/// made; it becomes the owner of a copy of `other`'s tree
+/// (`rb_xml_document_initialize_copy_with_args`).
+#[monoruby_builtin]
+fn doc_initialize_copy_with_args(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_val = lfp.self_val();
+    let other = doc_ptr(lfp.arg(0))?;
+    let level = lfp.arg(1).expect_integer(&globals.store)? as c_int;
+    // SAFETY: a live document; the copy is ours.
+    let copy = unsafe { xml::xmlCopyDoc(other, level) };
+    if copy.is_null() {
+        return Ok(Value::nil());
+    }
+    // SAFETY: a fresh document.
+    unsafe {
+        (*copy).type_ = (*other).type_;
+        (*copy)._private = self_val.id() as *mut c_void;
+    }
+    replace_native(
+        self_val,
+        Box::new(XmlDocument {
+            doc: copy,
+            node_cache: vec![],
+            unlinked: HashSet::new(),
+        }),
+    )?;
+    Ok(self_val)
 }
 
 /// Document#url -> String | nil

--- a/monoruby/src/builtins/nokogiri/node.rs
+++ b/monoruby/src/builtins/nokogiri/node.rs
@@ -46,6 +46,7 @@ pub(super) fn init(globals: &mut Globals, c: &Classes) {
     globals.define_builtin_func(n, "previous_element", previous_element, 0);
     globals.define_builtin_func(n, "previous_sibling", previous_sibling, 0);
     globals.define_builtin_func(n, "unlink", unlink, 0);
+    globals.define_builtin_func(n, "initialize_copy_with_args", initialize_copy_with_args, 3);
     globals.define_private_builtin_func(n, "add_child_node", add_child_node, 1);
     globals.define_private_builtin_func(n, "add_next_sibling_node", add_next_sibling_node, 1);
     globals.define_private_builtin_func(n, "add_previous_sibling_node", add_previous_sibling_node, 1);
@@ -823,6 +824,35 @@ fn create_internal_subset(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _:
         xml::xmlCreateIntSubset(doc, cptr(&name), cptr(&external_id), cptr(&system_id))
     };
     wrap_node_or_nil(vm, globals, dtd as *mut xml::xmlNode)
+}
+
+/// Node#initialize_copy_with_args(other, level, new_parent_doc) -> self:
+/// the tail of `Node#dup` / `#clone` — `self` is the payload-less copy
+/// `Object#dup` made; it becomes the wrapper of a copy of `other` in
+/// `new_parent_doc` (`rb_xml_node_initialize_copy_with_args`).
+#[monoruby_builtin]
+fn initialize_copy_with_args(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let self_val = lfp.self_val();
+    let other = node_ptr(lfp.arg(0))?;
+    let level = lfp.arg(1).expect_integer(&globals.store)? as c_int;
+    let new_doc_val = lfp.arg(2);
+    let new_doc = doc_ptr(new_doc_val)?;
+    // SAFETY: live nodes; the copy is ours until the document takes it.
+    let copy = unsafe { xml::xmlDocCopyNode(other, new_doc, level) };
+    if copy.is_null() {
+        return Ok(Value::nil());
+    }
+    replace_native(self_val, Box::new(XmlNode { node: copy }))?;
+    // SAFETY: a live copy in a live document.
+    unsafe {
+        (*copy)._private = self_val.id() as *mut c_void;
+        pin_node(copy);
+        if let Some(d) = doc_native(new_doc) {
+            d.node_cache.push(self_val);
+        }
+    }
+    vm.invoke_method_inner(globals, IdentId::get_id("decorate"), new_doc_val, &[self_val], None, None)?;
+    Ok(self_val)
 }
 
 // ---- tree editing ----

--- a/monoruby/src/builtins/nokogiri/reader.rs
+++ b/monoruby/src/builtins/nokogiri/reader.rs
@@ -1,0 +1,489 @@
+//! `Nokogiri::XML::Reader`: a cursor over `xmlTextReader` (`xml_reader.c`).
+//! The reader owns its `xmlTextReader`, the IO it pulls from (when made by
+//! `from_io`) and the bytes of a `from_memory` input; parse errors are
+//! collected into the Ruby `errors` array as they happen.
+
+use super::*;
+
+/// The payload of a `Reader`.
+struct XmlReader {
+    reader: *mut xml::xmlTextReader,
+    io: Option<Box<IoCtx>>,
+    /// The bytes of a `from_memory` input, read in place by the reader.
+    _buffer: Vec<u8>,
+}
+
+impl NativeData for XmlReader {
+    fn mark(&self, alloc: &mut alloc::Allocator<RValue>) {
+        if let Some(io) = &self.io {
+            io.io.mark(alloc);
+        }
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+impl Drop for XmlReader {
+    fn drop(&mut self) {
+        // SAFETY: the reader is ours. Its document is freed separately:
+        // `xmlTextReaderCurrentDoc` (called by `read`) marks it preserved,
+        // so `xmlFreeTextReader` leaves it (`xml_reader_deallocate`).
+        unsafe {
+            let doc = xml::xmlTextReaderCurrentDoc(self.reader);
+            xml::xmlFreeTextReader(self.reader);
+            if !doc.is_null() {
+                xml::xmlFreeDoc(doc);
+            }
+        }
+    }
+}
+
+pub(super) fn init(globals: &mut Globals, c: &Classes) {
+    let r = c.reader;
+    globals.define_builtin_class_func_rest(r, "from_memory", from_memory);
+    globals.define_builtin_class_func_rest(r, "from_io", from_io);
+    globals.define_builtin_func(r, "attribute", attribute, 1);
+    globals.define_builtin_func(r, "attribute_at", attribute_at, 1);
+    globals.define_builtin_func(r, "attribute_count", attribute_count, 0);
+    globals.define_builtin_func(r, "attribute_hash", attribute_hash, 0);
+    globals.define_builtin_func(r, "attributes?", has_attributes_p, 0);
+    globals.define_builtin_func(r, "base_uri", base_uri, 0);
+    globals.define_builtin_func(r, "default?", is_default, 0);
+    globals.define_builtin_func(r, "depth", depth, 0);
+    globals.define_builtin_func(r, "empty_element?", empty_element, 0);
+    globals.define_builtin_func(r, "encoding", encoding, 0);
+    globals.define_builtin_func(r, "inner_xml", inner_xml, 0);
+    globals.define_builtin_func(r, "lang", lang, 0);
+    globals.define_builtin_func(r, "local_name", local_name, 0);
+    globals.define_builtin_func(r, "name", name, 0);
+    globals.define_builtin_func(r, "namespace_uri", namespace_uri, 0);
+    globals.define_builtin_func(r, "namespaces", namespaces, 0);
+    globals.define_builtin_func(r, "node_type", node_type, 0);
+    globals.define_builtin_func(r, "outer_xml", outer_xml, 0);
+    globals.define_builtin_func(r, "prefix", prefix, 0);
+    globals.define_builtin_func(r, "read", read, 0);
+    globals.define_builtin_func(r, "state", state, 0);
+    globals.define_builtin_func(r, "value", value, 0);
+    globals.define_builtin_func(r, "value?", has_value, 0);
+    globals.define_builtin_func(r, "xml_version", xml_version, 0);
+}
+
+/// The reader of `self`, with the IO callbacks' executor pointers made
+/// current (any call may pull more input).
+fn this(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<*mut xml::xmlTextReader> {
+    // SAFETY: the payload is ours for the call.
+    let Some(r) = (unsafe { native_mut::<XmlReader>(lfp.self_val()) }) else {
+        return Err(MonorubyErr::argumenterr("expected a Nokogiri::XML::Reader"));
+    };
+    if let Some(io) = &mut r.io {
+        io.vm = vm;
+        io.globals = globals;
+    }
+    Ok(r.reader)
+}
+
+/// `reader.errors` (the Ruby array the parse errors go to).
+fn errors_of(vm: &mut Executor, globals: &mut Globals, reader: Value) -> Result<Value> {
+    vm.invoke_method_inner(globals, IdentId::get_id("errors"), reader, &[], None, None)
+}
+
+/// Append the errors of a library call to `reader.errors`.
+fn push_errors(vm: &mut Executor, globals: &mut Globals, reader: Value, errors: &[ErrorRecord]) -> Result<Value> {
+    let rb_errors = errors_of(vm, globals, reader)?;
+    if !errors.is_empty() {
+        let new_errors = errors_to_array(vm, globals, errors)?;
+        vm.invoke_method_inner(globals, IdentId::get_id("concat"), rb_errors, &[new_errors], None, None)?;
+    }
+    Ok(rb_errors)
+}
+
+/// Make a reader over `source` and `initialize(source, url, encoding)`
+/// (`from_memory` / `from_io`); `make` builds the `xmlTextReader`.
+fn construct(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    what: &str,
+    make: impl FnOnce(&mut Globals, Value, Option<CString>, Option<CString>, c_int) -> Result<(*mut xml::xmlTextReader, Option<Box<IoCtx>>, Vec<u8>)>,
+) -> Result<Value> {
+    let class = lfp.self_val().as_class_id();
+    let args: Vec<Value> = lfp.arg(0).as_array().iter().cloned().collect();
+    if args.is_empty() || args.len() > 4 {
+        return Err(MonorubyErr::argumenterr(format!(
+            "wrong number of arguments (given {}, expected 1..4)",
+            args.len()
+        )));
+    }
+    let arg = |i: usize| args.get(i).copied().unwrap_or_default();
+    let source = arg(0);
+    if !source.as_bool() {
+        return Err(MonorubyErr::argumenterr(format!("{what} cannot be nil")));
+    }
+    let url = if arg(1).as_bool() { Some(cstr(arg(1), &globals.store)?) } else { None };
+    let enc = if arg(2).as_bool() { Some(cstr(arg(2), &globals.store)?) } else { None };
+    let options = if arg(3).as_bool() { arg(3).expect_integer(&globals.store)? as c_int } else { 0 };
+    let (reader, io, buffer) = make(globals, source, url, enc, options)?;
+    if reader.is_null() {
+        return Err(MonorubyErr::runtimeerr("couldn't create a parser"));
+    }
+    let rb = Value::new_native(
+        class,
+        Box::new(XmlReader {
+            reader,
+            io,
+            _buffer: buffer,
+        }),
+    );
+    // `initialize` is private: call it as a function call; root the new
+    // object across it.
+    let len = vm.temp_len();
+    vm.temp_push(rb);
+    let r = vm.invoke_method_inner_vis(globals, IdentId::INITIALIZE, rb, &[source, arg(1), arg(2)], None, None, true);
+    vm.temp_clear(len);
+    r?;
+    Ok(rb)
+}
+
+/// Reader.from_memory(string, url = nil, encoding = nil, options = 0) -> Reader
+#[monoruby_builtin]
+fn from_memory(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    construct(vm, globals, lfp, "string", |globals, source, url, enc, options| {
+        let buffer = source.expect_bytes(&globals.store)?.to_vec();
+        // SAFETY: the buffer moves into the payload, outliving the reader.
+        let reader = unsafe {
+            xml::xmlReaderForMemory(
+                buffer.as_ptr() as *const c_char,
+                buffer.len() as c_int,
+                cptr(&url) as *const c_char,
+                cptr(&enc) as *const c_char,
+                options,
+            )
+        };
+        Ok((reader, None, buffer))
+    })
+}
+
+/// Reader.from_io(io, url = nil, encoding = nil, options = 0) -> Reader
+#[monoruby_builtin]
+fn from_io(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let vm_ptr: *mut Executor = vm;
+    construct(vm, globals, lfp, "io", |globals, source, url, enc, options| {
+        // SAFETY: the executor outlives the call; the IO context lives in
+        // the payload, its pointers refreshed at each native call.
+        let mut io = Box::new(IoCtx::new(unsafe { &mut *vm_ptr }, globals, source));
+        let reader = unsafe {
+            xml::xmlReaderForIO(
+                Some(io_read),
+                Some(io_close),
+                &mut *io as *mut IoCtx as *mut c_void,
+                cptr(&url) as *const c_char,
+                cptr(&enc) as *const c_char,
+                options,
+            )
+        };
+        Ok((reader, Some(io), vec![]))
+    })
+}
+
+/// Reader#read -> self | nil: advance; errors go to `errors`, and a
+/// failed read raises their aggregate.
+#[monoruby_builtin]
+fn read(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let reader = this(vm, globals, lfp)?;
+    let mut errors: Vec<ErrorRecord> = vec![];
+    // SAFETY: a live reader; the handler is registered for the call.
+    let status = unsafe {
+        xml::xmlSetStructuredErrorFunc(&mut errors as *mut _ as *mut c_void, Some(collect_error));
+        let status = xml::xmlTextReaderRead(reader);
+        xml::xmlSetStructuredErrorFunc(std::ptr::null_mut(), None);
+        status
+    };
+    let rb_errors = push_errors(vm, globals, lfp.self_val(), &errors)?;
+    // SAFETY: the document, if any, is live (and now preserved).
+    unsafe {
+        let doc = xml::xmlTextReaderCurrentDoc(reader);
+        if !doc.is_null() && (*doc).encoding.is_null() {
+            let encoding_id = IdentId::get_id("@encoding");
+            let enc = globals.store.get_ivar(lfp.self_val(), encoding_id).unwrap_or_default();
+            let enc = if enc.as_bool() {
+                cstr(enc, &globals.store)?
+            } else {
+                globals.store.set_ivar(lfp.self_val(), encoding_id, Value::string_from_str("UTF-8"))?;
+                CString::new("UTF-8").unwrap()
+            };
+            (*doc).encoding = xml::xmlStrdup(enc.as_ptr() as *const xml::xmlChar);
+        }
+    }
+    match status {
+        1 => Ok(lfp.self_val()),
+        0 => Ok(Value::nil()),
+        _ => {
+            let klass = globals.store.get_module(classes().xml_syntax_error).as_val();
+            let ex = vm.invoke_method_inner(globals, IdentId::get_id("aggregate"), klass, &[rb_errors], None, None)?;
+            Err(if ex.as_bool() { raise(ex) } else { MonorubyErr::runtimeerr(format!("Error pulling: {status}")) })
+        }
+    }
+}
+
+/// `has_attributes`: an element with attributes or namespace definitions.
+unsafe fn has_attributes(reader: *mut xml::xmlTextReader) -> bool {
+    // SAFETY: a live reader; its current node, if any, is live.
+    unsafe {
+        let node = xml::xmlTextReaderCurrentNode(reader);
+        !node.is_null()
+            && (*node).type_ == xml::XML_ELEMENT_NODE
+            && (!(*node).properties.is_null() || !(*node).nsDef.is_null())
+    }
+}
+
+/// Expand the current node for `attribute_hash` / `namespaces`; a failure
+/// raises the first collected error.
+fn expand(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, reader: *mut xml::xmlTextReader) -> Result<*mut xml::xmlNode> {
+    let mut errors: Vec<ErrorRecord> = vec![];
+    // SAFETY: a live reader.
+    let node = unsafe {
+        xml::xmlSetStructuredErrorFunc(&mut errors as *mut _ as *mut c_void, Some(collect_error));
+        let node = xml::xmlTextReaderExpand(reader);
+        xml::xmlSetStructuredErrorFunc(std::ptr::null_mut(), None);
+        node
+    };
+    let rb_errors = push_errors(vm, globals, lfp.self_val(), &errors)?;
+    if node.is_null() {
+        let first = vm.invoke_method_inner(globals, IdentId::get_id("first"), rb_errors, &[], None, None)?;
+        if !first.is_nil() {
+            let msg = vm.invoke_method_inner(globals, IdentId::get_id("to_s"), first, &[], None, None)?;
+            let klass = globals.store.get_module(classes().xml_syntax_error).as_val();
+            let ex = vm.invoke_method_inner(globals, IdentId::NEW, klass, &[msg], None, None)?;
+            return Err(raise(ex));
+        }
+    }
+    Ok(node)
+}
+
+/// Reader#attribute_hash -> Hash of name => value
+#[monoruby_builtin]
+fn attribute_hash(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let reader = this(vm, globals, lfp)?;
+    let hash = Value::hash_with_capacity(0);
+    // SAFETY: a live reader.
+    if !unsafe { has_attributes(reader) } {
+        return Ok(hash);
+    }
+    let node = expand(vm, globals, lfp, reader)?;
+    if node.is_null() {
+        return Ok(Value::nil());
+    }
+    // SAFETY: a live node and its attributes.
+    unsafe {
+        let mut prop = (*node).properties;
+        while !prop.is_null() {
+            let name = xml_str((*prop).name);
+            let value = xml_str_owned(xml::xmlNodeGetContent(prop as *mut xml::xmlNode));
+            hash.as_hash_mut(&globals.store)?.insert(name, value, vm, globals)?;
+            prop = (*prop).next;
+        }
+    }
+    Ok(hash)
+}
+
+/// Reader#namespaces -> Hash of "xmlns[:prefix]" => href
+#[monoruby_builtin]
+fn namespaces(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let reader = this(vm, globals, lfp)?;
+    let hash = Value::hash_with_capacity(0);
+    // SAFETY: a live reader.
+    if !unsafe { has_attributes(reader) } {
+        return Ok(hash);
+    }
+    let node = expand(vm, globals, lfp, reader)?;
+    if node.is_null() {
+        return Ok(Value::nil());
+    }
+    // SAFETY: a live element and its namespace definitions.
+    unsafe {
+        if (*node).type_ != xml::XML_ELEMENT_NODE {
+            return Ok(hash);
+        }
+        let mut ns = (*node).nsDef;
+        while !ns.is_null() {
+            let mut key = b"xmlns".to_vec();
+            if !(*ns).prefix.is_null() {
+                key.push(b':');
+                key.extend_from_slice(CStr::from_ptr((*ns).prefix as *const c_char).to_bytes());
+            }
+            hash.as_hash_mut(&globals.store)?.insert(utf8(&key), xml_str((*ns).href), vm, globals)?;
+            ns = (*ns).next;
+        }
+    }
+    Ok(hash)
+}
+
+/// Reader#attribute(name) -> String | nil
+#[monoruby_builtin]
+fn attribute(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let reader = this(vm, globals, lfp)?;
+    if lfp.arg(0).is_nil() {
+        return Ok(Value::nil());
+    }
+    let name = cstr(lfp.arg(0), &globals.store)?;
+    // SAFETY: a live reader; the value is ours to free.
+    Ok(unsafe { xml_str_owned(xml::xmlTextReaderGetAttribute(reader, name.as_ptr() as *const xml::xmlChar)) })
+}
+
+/// Reader#attribute_at(index) -> String | nil
+#[monoruby_builtin]
+fn attribute_at(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let reader = this(vm, globals, lfp)?;
+    if lfp.arg(0).is_nil() {
+        return Ok(Value::nil());
+    }
+    // `rb_Integer`: `Kernel#Integer` conversion (an ArgumentError for a
+    // non-numeric String).
+    let index = vm.invoke_method_inner_vis(globals, IdentId::get_id("Integer"), lfp.self_val(), &[lfp.arg(0)], None, None, true)?;
+    let index = index.expect_integer(&globals.store)? as c_int;
+    // SAFETY: a live reader; the value is ours to free.
+    Ok(unsafe { xml_str_owned(xml::xmlTextReaderGetAttributeNo(reader, index)) })
+}
+
+/// A count-like answer: -1 is nil.
+fn count_or_nil(n: c_int) -> Value {
+    if n == -1 { Value::nil() } else { Value::integer(n as i64) }
+}
+
+/// A yes / no / unknown answer: 0 false, 1 true, else nil.
+fn tri(n: c_int) -> Value {
+    match n {
+        0 => Value::bool(false),
+        1 => Value::bool(true),
+        _ => Value::nil(),
+    }
+}
+
+/// Reader#attribute_count -> Integer | nil
+#[monoruby_builtin]
+fn attribute_count(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let reader = this(vm, globals, lfp)?;
+    // SAFETY: a live reader.
+    Ok(count_or_nil(unsafe { xml::xmlTextReaderAttributeCount(reader) }))
+}
+
+/// Reader#attributes? -> bool | nil
+#[monoruby_builtin]
+fn has_attributes_p(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let reader = this(vm, globals, lfp)?;
+    // SAFETY: a live reader.
+    Ok(Value::bool(unsafe { has_attributes(reader) }))
+}
+
+/// Reader#default? -> bool | nil
+#[monoruby_builtin]
+fn is_default(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let reader = this(vm, globals, lfp)?;
+    // SAFETY: a live reader.
+    Ok(tri(unsafe { xml::xmlTextReaderIsDefault(reader) }))
+}
+
+/// Reader#value? -> bool | nil
+#[monoruby_builtin]
+fn has_value(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let reader = this(vm, globals, lfp)?;
+    // SAFETY: a live reader.
+    Ok(tri(unsafe { xml::xmlTextReaderHasValue(reader) }))
+}
+
+/// Reader#depth -> Integer | nil
+#[monoruby_builtin]
+fn depth(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let reader = this(vm, globals, lfp)?;
+    // SAFETY: a live reader.
+    Ok(count_or_nil(unsafe { xml::xmlTextReaderDepth(reader) }))
+}
+
+/// Reader#empty_element? -> bool
+#[monoruby_builtin]
+fn empty_element(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let reader = this(vm, globals, lfp)?;
+    // SAFETY: a live reader.
+    Ok(Value::bool(unsafe { xml::xmlTextReaderIsEmptyElement(reader) } != 0))
+}
+
+/// Reader#encoding -> String | nil: the parser's, else the constructor's.
+#[monoruby_builtin]
+fn encoding(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let reader = this(vm, globals, lfp)?;
+    // SAFETY: a live reader.
+    let enc = unsafe { xml_str(xml::xmlTextReaderConstEncoding(reader)) };
+    if !enc.is_nil() {
+        return Ok(enc);
+    }
+    let enc = globals
+        .store
+        .get_ivar(lfp.self_val(), IdentId::get_id("@encoding"))
+        .unwrap_or_default();
+    Ok(if enc.as_bool() { enc } else { Value::nil() })
+}
+
+/// Reader#inner_xml -> String | nil
+#[monoruby_builtin]
+fn inner_xml(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let reader = this(vm, globals, lfp)?;
+    // SAFETY: a live reader; the string is ours to free.
+    Ok(unsafe { xml_str_owned(xml::xmlTextReaderReadInnerXml(reader)) })
+}
+
+/// Reader#outer_xml -> String | nil
+#[monoruby_builtin]
+fn outer_xml(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let reader = this(vm, globals, lfp)?;
+    // SAFETY: a live reader; the string is ours to free.
+    Ok(unsafe { xml_str_owned(xml::xmlTextReaderReadOuterXml(reader)) })
+}
+
+/// Reader#base_uri -> String | nil
+#[monoruby_builtin]
+fn base_uri(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let reader = this(vm, globals, lfp)?;
+    // SAFETY: a live reader; the string is ours to free.
+    Ok(unsafe { xml_str_owned(xml::xmlTextReaderBaseUri(reader)) })
+}
+
+macro_rules! const_string {
+    ($name:ident, $f:ident) => {
+        #[monoruby_builtin]
+        fn $name(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+            let reader = this(vm, globals, lfp)?;
+            // SAFETY: a live reader; the string belongs to it.
+            Ok(unsafe { xml_str(xml::$f(reader)) })
+        }
+    };
+}
+
+// Reader#lang / #local_name / #name / #namespace_uri / #prefix / #value /
+// #xml_version -> String | nil
+const_string!(lang, xmlTextReaderConstXmlLang);
+const_string!(local_name, xmlTextReaderConstLocalName);
+const_string!(name, xmlTextReaderConstName);
+const_string!(namespace_uri, xmlTextReaderConstNamespaceUri);
+const_string!(prefix, xmlTextReaderConstPrefix);
+const_string!(value, xmlTextReaderConstValue);
+const_string!(xml_version, xmlTextReaderConstXmlVersion);
+
+/// Reader#state -> Integer
+#[monoruby_builtin]
+fn state(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let reader = this(vm, globals, lfp)?;
+    // SAFETY: a live reader.
+    Ok(Value::integer(unsafe { xml::xmlTextReaderReadState(reader) } as i64))
+}
+
+/// Reader#node_type -> Integer
+#[monoruby_builtin]
+fn node_type(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let reader = this(vm, globals, lfp)?;
+    // SAFETY: a live reader.
+    Ok(Value::integer(unsafe { xml::xmlTextReaderNodeType(reader) } as i64))
+}

--- a/monoruby/src/builtins/nokogiri/xpath.rs
+++ b/monoruby/src/builtins/nokogiri/xpath.rs
@@ -1,6 +1,8 @@
 //! `Nokogiri::XML::XPathContext`: an `xmlXPathContext` bound to a node,
 //! with nokogiri's two built-in XPath functions (`css-class`,
-//! `local-name-is`) that the CSS-to-XPath translation relies on.
+//! `local-name-is`) that the CSS-to-XPath translation relies on, and the
+//! custom-function handler of `evaluate(expr, handler)`: a Ruby object
+//! whose methods XPath calls as `nokogiri:name(...)`.
 
 use super::node_set::wrap_node_set;
 use super::*;
@@ -201,21 +203,177 @@ fn register_variable(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytec
     Ok(lfp.self_val())
 }
 
+/// The state of one `evaluate` with a handler, reachable from the XPath
+/// context's function-lookup data while it runs.
+struct XPathCall {
+    vm: *mut Executor,
+    globals: *mut Globals,
+    handler: Value,
+    document: Value,
+    /// The exception a handler method raised (or a bad return type):
+    /// the evaluation is aborted and it is re-raised afterwards.
+    error: Option<MonorubyErr>,
+}
+
+/// The XPath value `obj` as a Ruby value (`_noko_xml_xpath_context__xpath2ruby`);
+/// a node set is taken over by the new `NodeSet`.
+unsafe fn xpath_to_ruby(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    obj: *mut xml::xmlXPathObject,
+    document: Value,
+) -> Result<Value> {
+    // SAFETY: a live XPath object.
+    unsafe {
+        Ok(match (*obj).type_ {
+            xml::XPATH_STRING => xml_str((*obj).stringval),
+            xml::XPATH_NODESET => {
+                let set = (*obj).nodesetval;
+                (*obj).nodesetval = std::ptr::null_mut();
+                wrap_node_set(vm, globals, set, document)?
+            }
+            xml::XPATH_NUMBER => Value::float((*obj).floatval),
+            xml::XPATH_BOOLEAN => Value::bool((*obj).boolval == 1),
+            _ => xml_str_owned(xml::xmlXPathCastToString(obj)),
+        })
+    }
+}
+
+/// The function lookup registered for a handler: any XPath function the
+/// handler responds to is `handler_invoke`.
+unsafe extern "C" fn handler_lookup(data: *mut c_void, name: *const xml::xmlChar, _ns_uri: *const xml::xmlChar) -> xml::xmlXPathFunction {
+    // SAFETY: `data` is the `XPathCall` of the running `evaluate`.
+    unsafe {
+        let call = &*(data as *const XPathCall);
+        let globals = &*call.globals;
+        let name = CStr::from_ptr(name as *const c_char).to_string_lossy();
+        let method = IdentId::get_id(&name);
+        if globals.store.check_method_for_class(call.handler.class(), method).is_some() {
+            Some(handler_invoke)
+        } else {
+            None
+        }
+    }
+}
+
+/// Convert the arguments, call the handler method named by the context,
+/// push its result (`Nokogiri_marshal_xpath_funcall_and_return_values`).
+unsafe extern "C" fn handler_invoke(ctxt: *mut xml::xmlXPathParserContext, nargs: c_int) {
+    // SAFETY: libxml2 calls this with its live parser context whose
+    // XPath context carries the running `XPathCall`.
+    unsafe {
+        let ctx = (*ctxt).context;
+        let call = &mut *(xml::mrb_xpath_ctx_get_func_lookup_data(ctx) as *mut XPathCall);
+        if call.error.is_some() {
+            xml::xmlXPathErr(ctxt, XPATH_INVALID_TYPE);
+            return;
+        }
+        let vm = &mut *call.vm;
+        let globals = &mut *call.globals;
+        let name = CStr::from_ptr(xml::mrb_xpath_ctx_get_function(ctx) as *const c_char).to_string_lossy().into_owned();
+        // The arguments (popped last first); each conversion may run Ruby,
+        // so the ones made so far stay rooted.
+        let len = vm.temp_len();
+        let mut convert = || -> Result<Vec<Value>> {
+            let mut args = vec![Value::nil(); nargs as usize];
+            for j in (0..nargs as usize).rev() {
+                let obj = xml::valuePop(ctxt);
+                let v = xpath_to_ruby(vm, globals, obj, call.document);
+                xml::xmlXPathFreeObject(obj);
+                let v = v?;
+                vm.temp_push(v);
+                args[j] = v;
+            }
+            Ok(args)
+        };
+        let args = convert();
+        let result = args.and_then(|args| vm.invoke_method_inner(globals, IdentId::get_id(&name), call.handler, &args, None, None));
+        vm.temp_clear(len);
+        let result = match result {
+            Ok(v) => v,
+            Err(e) => {
+                call.error = Some(e);
+                xml::xmlXPathErr(ctxt, XPATH_INVALID_TYPE);
+                return;
+            }
+        };
+        // The result as an XPath value (nil pushes nothing).
+        let pushed: Result<()> = (|| {
+            if result.is_nil() {
+                return Ok(());
+            }
+            let number = match result.unpack() {
+                RV::Float(f) => Some(f),
+                RV::Fixnum(i) => Some(i as f64),
+                RV::BigInt(b) => Some(b.to_f64().unwrap_or(f64::NAN)),
+                _ => None,
+            };
+            if let Some(f) = number {
+                xml::valuePush(ctxt, xml::xmlXPathNewFloat(f));
+            } else if result.id() == TRUE_VALUE {
+                xml::valuePush(ctxt, xml::xmlXPathNewBoolean(1));
+            } else if result.id() == FALSE_VALUE {
+                xml::valuePush(ctxt, xml::xmlXPathNewBoolean(0));
+            } else if result.try_bytes().is_some() {
+                let s = cstr(result, &globals.store)?;
+                xml::valuePush(ctxt, xml::xmlXPathNewString(s.as_ptr() as *const xml::xmlChar));
+            } else if result.try_native::<super::node_set::XmlNodeSet>().is_some() {
+                let set = super::node_set::set_ptr(result)?;
+                xml::valuePush(ctxt, xml::xmlXPathWrapNodeSet(xml::xmlXPathNodeSetMerge(std::ptr::null_mut(), set)));
+            } else if result.ty() == Some(ObjTy::ARRAY) {
+                let klass = globals.store.get_module(classes().node_set).as_val();
+                let set = vm.invoke_method_inner(globals, IdentId::NEW, klass, &[call.document, result], None, None)?;
+                let set = super::node_set::set_ptr(set)?;
+                xml::valuePush(ctxt, xml::xmlXPathWrapNodeSet(xml::xmlXPathNodeSetMerge(std::ptr::null_mut(), set)));
+            } else {
+                return Err(MonorubyErr::runtimeerr("Invalid return type"));
+            }
+            Ok(())
+        })();
+        if let Err(e) = pushed {
+            call.error = Some(e);
+            xml::xmlXPathErr(ctxt, XPATH_INVALID_TYPE);
+        }
+    }
+}
+
 /// XPathContext#evaluate(expression, handler = nil) -> NodeSet | String | Float | bool
 #[monoruby_builtin]
 fn evaluate(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
     let ctx = this(lfp)?;
     let expr = cstr(lfp.arg(0), &globals.store)?;
     let document = lfp.self_val().try_native::<XPathContext>().unwrap().document;
+    let handler = lfp.try_arg(1).unwrap_or_default();
     let mut errors: Vec<ErrorRecord> = vec![];
-    // SAFETY: a live context; the error list is registered for this
-    // evaluation only; the result object is ours.
+    let mut call = XPathCall {
+        vm,
+        globals,
+        handler,
+        document,
+        error: None,
+    };
+    // SAFETY: a live context; the error list, the function lookup and the
+    // call state are registered for this evaluation only; the result
+    // object is ours.
     let obj = unsafe {
+        if !handler.is_nil() {
+            xml::xmlXPathRegisterFuncLookup(ctx, Some(handler_lookup), &mut call as *mut XPathCall as *mut c_void);
+        }
         xml::xmlXPathSetErrorHandler(ctx, Some(collect_error), &mut errors as *mut _ as *mut c_void);
         let obj = xml::xmlXPathEval(expr.as_ptr() as *const xml::xmlChar, ctx);
         xml::xmlXPathSetErrorHandler(ctx, None, std::ptr::null_mut());
+        if !handler.is_nil() {
+            xml::xmlXPathRegisterFuncLookup(ctx, None, std::ptr::null_mut());
+        }
         obj
     };
+    if let Some(e) = call.error {
+        if !obj.is_null() {
+            // SAFETY: a result nobody else holds.
+            unsafe { xml::xmlXPathFreeObject(obj) };
+        }
+        return Err(e);
+    }
     if obj.is_null() {
         return Err(match errors.first() {
             Some(e) => raise(syntax_error_value(vm, globals, e)?),

--- a/monoruby/src/value/rvalue.rs
+++ b/monoruby/src/value/rvalue.rs
@@ -2728,6 +2728,18 @@ impl RValue {
         unsafe { &mut **self.kind.native }
     }
 
+    /// Replace the native payload, dropping the old one (a copy made by
+    /// `Object#dup` carries an `EmptyNative` until its constructor fills
+    /// it in).
+    pub(crate) fn replace_native(&mut self, inner: Box<dyn NativeData>) {
+        assert_eq!(self.ty(), ObjTy::NATIVE);
+        // SAFETY: type checked above; the old box is dropped exactly once.
+        unsafe {
+            ManuallyDrop::drop(&mut self.kind.native);
+            self.kind.native = ManuallyDrop::new(inner);
+        }
+    }
+
     pub(super) unsafe fn as_arithmetic_sequence(&self) -> &ArithmeticSequenceInner {
         unsafe { &self.kind.arithmetic_sequence }
     }

--- a/monoruby/tests/nokogiri.rs
+++ b/monoruby/tests/nokogiri.rs
@@ -954,6 +954,85 @@ fn nokogiri_sax_push_parser() {
 }
 
 #[test]
+fn nokogiri_reader() {
+    compare(
+        r##"
+        require "stringio"
+        xml = <<~XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!-- top -->
+          <root xmlns="http://d" xmlns:p="http://p" xml:lang="en" p:a="1" b="2" xml:base="http://base/">
+            <p:child id="c1">text &amp; more<![CDATA[cd]]><?pi data?></p:child>
+            <empty/>
+            <deep><x><y>z</y></x></deep>
+          </root>
+        XML
+        r = []
+        reader = Nokogiri::XML::Reader(xml)
+        r << [reader.class, reader.source.class, reader.errors, reader.encoding, reader.state, reader.node_type, reader.name]
+        reader.each do |node|
+          r << [node.node_type, node.name, node.local_name, node.prefix, node.namespace_uri, node.depth, node.value,
+           node.value?, node.attributes?, node.attribute_count, node.empty_element?, node.self_closing?, node.default?,
+           node.lang, node.xml_version, node.state, node.base_uri]
+          if node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
+            r << [node.attribute_hash, node.namespaces, node.attributes, node.attribute("id"), node.attribute("p:a"),
+             node.attribute_at(0), node.attribute_at(9), node.attribute(nil), node.attribute_at(nil)]
+            r << [node.inner_xml, node.outer_xml] if node.name == "deep" || node.name == "empty"
+          end
+        end
+        r << [reader.state, reader.read, reader.encoding]
+        io_reader = Nokogiri::XML::Reader(StringIO.new("<a><b>1</b><c x='y'/></a>"), "http://u/", "UTF-8")
+        r << io_reader.map { |n| [n.name, n.node_type, n.depth, n.attribute_hash, n.base_uri] }
+        r << [io_reader.encoding, io_reader.source.class]
+        r << Nokogiri::XML::Reader.from_memory("<a>x</a>").map(&:name)
+        r << Nokogiri::XML::Reader.from_io(StringIO.new("<a>x</a>"), nil, nil, 0).map(&:name)
+        r << Nokogiri::XML::Reader.new("<a>x</a>", nil, "ISO-8859-1").tap(&:read).encoding
+        bad = Nokogiri::XML::Reader("<root><a></root>")
+        begin
+          bad.each { |n| }
+          r << :no_raise
+        rescue Nokogiri::XML::SyntaxError => e
+          r << [e.class, e.message, bad.errors.map(&:to_s), bad.errors.map(&:class).uniq]
+        end
+        rec = Nokogiri::XML::Reader("<root><a></root>") { |c| c.recover }
+        begin
+          r << rec.map(&:name)
+        rescue Nokogiri::XML::SyntaxError => e
+          r << [e.class, e.message]
+        end
+        r << rec.errors.map(&:to_s)
+        ent = Nokogiri::XML::Reader("<!DOCTYPE r [<!ENTITY e 'v'><!ATTLIST r x CDATA 'dflt'>]><r>&e;</r>")
+        r << ent.map { |n| [n.name, n.node_type, n.value, n.default?, n.attribute_hash, n.attribute_count] }
+        ent2 = Nokogiri::XML::Reader("<!DOCTYPE r [<!ENTITY e 'v'>]><r>&e;</r>", nil, nil, Nokogiri::XML::ParseOptions::NOENT | Nokogiri::XML::ParseOptions::DTDATTR)
+        r << ent2.map { |n| [n.name, n.node_type, n.value] }
+        [-> { Nokogiri::XML::Reader(nil) }, -> { Nokogiri::XML::Reader.from_io(nil) }, -> { Nokogiri::XML::Reader.from_memory(nil) },
+         -> { Nokogiri::XML::Reader.from_memory }, -> { Nokogiri::XML::Reader.from_memory("<a/>", 1) },
+         -> { Nokogiri::XML::Reader("").map(&:name) }, -> { Nokogiri::XML::Reader("<a/>").attribute_at("x") },
+         -> { Nokogiri::XML::Reader("<a/>").attribute(1) }].each do |l|
+          begin
+            r << l.call
+          rescue => e
+            r << [e.class, e.message]
+          end
+        end
+        class Boom
+          def read(n) = raise(IOError, "boom")
+        end
+        begin
+          r << Nokogiri::XML::Reader.from_io(Boom.new).map(&:name)
+        rescue => e
+          r << [e.class, e.message]
+        end
+        rd = Nokogiri::XML::Reader("<r>" + "<i k='v'>t</i>" * 200 + "</r>")
+        n = 0
+        rd.each { |node| n += node.attribute_hash.size + node.namespaces.size; GC.start if n % 50 == 0 }
+        r << n
+        p r
+        "##,
+    );
+}
+
+#[test]
 fn nokogiri_node_identity_across_gc() {
     // Every node wraps into one Ruby object that the document keeps alive;
     // unlinked nodes stay owned by their document.

--- a/monoruby/tests/nokogiri.rs
+++ b/monoruby/tests/nokogiri.rs
@@ -1033,6 +1033,81 @@ fn nokogiri_reader() {
 }
 
 #[test]
+fn nokogiri_dup_and_xpath_handlers() {
+    compare(
+        r##"
+        r = []
+        doc = Nokogiri::XML("<r xmlns:p='http://p'><a id='1'><b>t</b></a><p:c k='v'/></r>")
+        a = doc.at_css("a")
+        d1 = a.dup
+        r << [d1.class, d1.parent, d1.document.equal?(doc), d1.to_xml, d1.equal?(a), d1.children.size, d1["id"]]
+        d0 = a.dup(0)
+        r << [d0.to_xml, d0.children.size]
+        other = Nokogiri::XML("<o/>")
+        d2 = a.dup(1, other)
+        r << [d2.document.equal?(other), d2.to_xml]
+        other.root << d2
+        r << other.to_xml
+        r << [a.clone.to_xml, a.clone.equal?(a)]
+        r << doc.at_css("b").children.first.dup.to_xml
+        r << doc.at_css("a").attribute("id").dup.to_xml
+        r << [doc.at_xpath("//p:c").dup.to_xml, doc.at_xpath("//p:c").dup.namespace&.prefix]
+        doc.root << a.dup
+        r << doc.to_xml
+        dd = doc.dup
+        r << [dd.class, dd.equal?(doc), dd.to_xml, dd.root.equal?(doc.root), dd.root.document.equal?(dd), dd.errors]
+        dd.root << Nokogiri::XML::Node.new("added", dd)
+        r << [doc.to_xml == dd.to_xml, dd.root.children.last.name]
+        r << doc.dup(0).to_xml
+        r << doc.clone.root.name
+        h = Nokogiri::HTML4("<p>x</p>").dup
+        r << [h.class, h.to_html, h.root.name]
+        frag = Nokogiri::XML::DocumentFragment.parse("<x/><y/>")
+        r << frag.dup.to_xml
+        keep = (1..50).map { |i| doc.dup }
+        GC.start
+        r << [dd.root.children.map(&:name), keep.map { |d| d.root.name }.uniq]
+        handler = Class.new {
+          def regex(set, re) = set.find_all { |n| n.text =~ /#{re}/ }
+          def upcase(s) = s.upcase
+          def count_nodes(set) = set.length
+          def half(n) = n / 2.0
+          def big(*) = 2**70
+          def yes(*) = true
+          def no(*) = false
+          def nothing(*) = nil
+          def bad(*) = Object.new
+          def boom(*) = raise(ArgumentError, "boom in handler")
+          def echo(*args) = args.map(&:class).inspect
+        }.new
+        doc = Nokogiri::XML("<r><a>foo</a><a>bar</a><a>baz</a></r>")
+        r << doc.xpath("//a[nokogiri:regex(., 'ba')]", handler).map(&:text)
+        r << doc.xpath("nokogiri:upcase(string(//a))", handler)
+        r << doc.xpath("nokogiri:count_nodes(//a)", handler)
+        r << doc.xpath("nokogiri:half(7)", handler)
+        r << doc.xpath("nokogiri:big()", handler)
+        r << doc.xpath("//a[nokogiri:yes()]", handler).size
+        r << doc.xpath("//a[nokogiri:no()]", handler).size
+        r << doc.css("a:regex('^b')", handler).map(&:text)
+        r << doc.xpath("nokogiri:regex(//a, 'z')", handler).map(&:text)
+        r << doc.xpath("nokogiri:echo(1, 'two', true, //a, count(//a))", handler)
+        r << doc.at_css("a").xpath("nokogiri:count_nodes(../a)", handler)
+        [-> { doc.xpath("//a[nokogiri:nothing()]", handler) }, -> { doc.xpath("//a[nokogiri:bad()]", handler) },
+         -> { doc.xpath("//a[nokogiri:boom()]", handler) }, -> { doc.xpath("//a[nokogiri:undefined()]", handler) },
+         -> { doc.xpath("//a[nokogiri:regex(., 'x')]") }].each do |l|
+          begin
+            r << l.call.size
+          rescue => e
+            r << [e.class, e.message]
+          end
+        end
+        r << doc.xpath("//a[nokogiri:regex(., 'o')]", handler).map(&:text)
+        p r
+        "##,
+    );
+}
+
+#[test]
 fn nokogiri_node_identity_across_gc() {
     // Every node wraps into one Ruby object that the document keeps alive;
     // unlinked nodes stay owned by their document.


### PR DESCRIPTION
The next batch of `doc/nokogiri.md`: `XML::Reader` (stage 5's other half) and the two small natives stage 1 had left out. Follows #1307.

## What is in

- **`XML::Reader`** (`src/builtins/nokogiri/reader.rs`, the port of `xml_reader.c` over `xmlTextReader`): `from_memory` / `from_io` (the IO read through the Ruby `read` callback; its executor pointers are refreshed at every native call, since any of them may pull more input), `read` (parse errors collected into `reader.errors`, a failed read raising their aggregate, the document's encoding defaulted as nokogiri does), the cursor accessors (`name`, `local_name`, `prefix`, `namespace_uri`, `value`, `depth`, `node_type`, `state`, `lang`, `xml_version`, `base_uri`, `encoding`, the `?` predicates), the attribute accessors (`attribute`, `attribute_at` with `Kernel#Integer` conversion, `attribute_count`, `attribute_hash` and `namespaces` over `xmlTextReaderExpand`, so `attributes`), and `inner_xml` / `outer_xml`. The reader's document is freed separately from the reader, as it is preserved by `xmlTextReaderCurrentDoc`. The placeholder `Reader#empty_element?` in the extension stand-in is gone.
- **`Node#dup` / `#clone` and `Document#dup` / `#clone`**: `initialize_copy_with_args`, the tails of the gem's Ruby `dup`. `Object#dup` makes a payload-less copy of a native object; the native gives it a `xmlDocCopyNode` / `xmlCopyDoc` copy (`RValue::replace_native` swaps the payload), pinned to and cached by the target document, so copies into another document work too.
- **XPath custom function handlers**: `XPathContext#evaluate(expr, handler)` registers a function lookup for the evaluation that resolves every function the handler responds to (`nokogiri:name(...)`, hence also the CSS pseudo-class handlers like `a:regex('^b')`) to an invoker converting the XPath arguments to Ruby (NodeSet / String / Float / bool), calling the method, and pushing the result back (numbers, strings, booleans, a NodeSet, or an Array of nodes; `nil` pushes nothing; anything else is "Invalid return type"). A handler exception aborts the evaluation and is re-raised from `evaluate`. The call state lives in the context's `funcLookupData` through a glue accessor: libxml2 2.13's `xmlXPathSetErrorHandler` stores its own data pointer in `userData`, which nokogiri uses for this (it collects errors through the global handler instead).

## Not yet (later stages)

Schema / RelaxNG, XSLT, HTML5 / gumbo, `ElementDescription`.

## Tests

`tests/nokogiri.rs` gains two comparison scripts, byte-identical to CRuby's nokogiri: the whole Reader cursor API over memory and IO sources (encodings, entities and DTD defaults, errors with and without recovery, a GC pass while iterating), and deep / shallow / cross-document node copies, XML and HTML4 document copies surviving a GC, and handlers returning each value kind, raising, unregistered, and called without a handler. All 19 nokogiri tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_