### PR TITLE
Nokogiri stage 4: XML::Schema / RelaxNG validation, HTML4::ElementDescription

### DIFF
--- a/doc/nokogiri.md
+++ b/doc/nokogiri.md
@@ -229,7 +229,7 @@ libxml2 のビルドが付く。段階 1〜3 で ext の 6 割程度（Node 54 +
 B（C API 互換層）を将来やるなら、ここで作る `ObjTy::XML_*` の mark / drop の
 形がそのまま `TypedData` の受け皿になるので、A の作業は無駄にならない。
 
-## 6. 実装状況（段階 1〜3 と 5、2026-09）
+## 6. 実装状況（段階 1〜3、5、6 の Schema / RelaxNG、2026-09）
 
 `libxml2-src/`（libxml2 2.13.8 + nokogiri 1.18.9 の patches、`cc` でビルド、
 `config.h` は手書き、`xmlversion.h` は build.rs が生成）、
@@ -302,9 +302,17 @@ B（C API 互換層）を将来やるなら、ここで作る `ObjTy::XML_*` の
   コンテキストの `funcLookupData` に置く（`userData` は 2.13 の
   `xmlXPathSetErrorHandler` が上書きするので使えない）。
 
-まだ無いもの（段階 4〜6）: `XML::Schema` / `RelaxNG`、`XSLT`（定数は `0.0.0` の
-プレースホルダ）、HTML5（gumbo）、`HTML4::ElementDescription`
-（`Node#description`）。
+- `XML::Schema` / `XML::RelaxNG`（`schema.rs`）: `from_document`
+  （`xmlSchemaParse` / `xmlRelaxNGParse`、パースエラーは `@errors`、失敗は
+  aggregate を raise、NONET なら外部エンティティローダを `xmlNoNet` に差し替え、
+  空白テキストノードに Ruby オブジェクトがあるドキュメントはコピーしてから
+  コンパイル）、`validate_document` / `validate_file`（`SyntaxError` の配列）。
+- `HTML4::ElementDescription`（`misc.rs`、libxml2 の静的な要素表
+  `htmlTagLookup` の wrapper）: 名前・説明・各フラグ・サブ要素・属性リスト。
+  `Node#description` が動く。
+
+まだ無いもの（段階 4 と 6 の残り）: `XSLT`（libxslt が要る。定数は `0.0.0` の
+プレースホルダ）、HTML5（gumbo の同梱）。
 
 設計上わかったこと:
 

--- a/libxml2-src/src/lib.rs
+++ b/libxml2-src/src/lib.rs
@@ -331,6 +331,33 @@ pub struct xmlParserInput {
 pub struct xmlTextReader {
     _opaque: [u8; 0],
 }
+#[repr(C)]
+pub struct xmlSchema {
+    _opaque: [u8; 0],
+}
+#[repr(C)]
+pub struct xmlSchemaParserCtxt {
+    _opaque: [u8; 0],
+}
+#[repr(C)]
+pub struct xmlSchemaValidCtxt {
+    _opaque: [u8; 0],
+}
+#[repr(C)]
+pub struct xmlRelaxNG {
+    _opaque: [u8; 0],
+}
+#[repr(C)]
+pub struct xmlRelaxNGParserCtxt {
+    _opaque: [u8; 0],
+}
+#[repr(C)]
+pub struct xmlRelaxNGValidCtxt {
+    _opaque: [u8; 0],
+}
+pub type xmlExternalEntityLoader = Option<
+    unsafe extern "C" fn(URL: *const c_char, ID: *const c_char, context: *mut xmlParserCtxt) -> *mut xmlParserInput,
+>;
 
 // ---- SAX ----
 
@@ -503,6 +530,25 @@ pub struct xmlSaveCtxt {
 pub struct xmlCharEncodingHandler {
     pub name: *mut c_char,
     _rest: [u8; 0],
+}
+/// `htmlElemDesc` (`HTMLparser.h`): the static description of an HTML
+/// element in libxml2's table.
+#[repr(C)]
+pub struct htmlElemDesc {
+    pub name: *const c_char,
+    pub startTag: c_char,
+    pub endTag: c_char,
+    pub saveEndTag: c_char,
+    pub empty: c_char,
+    pub depr: c_char,
+    pub dtd: c_char,
+    pub isinline: c_char,
+    pub desc: *const c_char,
+    pub subelts: *const *const c_char,
+    pub defaultsubelt: *const c_char,
+    pub attrs_opt: *const *const c_char,
+    pub attrs_depr: *const *const c_char,
+    pub attrs_req: *const *const c_char,
 }
 #[repr(C)]
 pub struct htmlEntityDesc {
@@ -913,6 +959,50 @@ unsafe extern "C" {
     pub fn xmlTextReaderCurrentDoc(reader: *mut xmlTextReader) -> *mut xmlDoc;
     pub fn xmlTextReaderExpand(reader: *mut xmlTextReader) -> *mut xmlNode;
 
+    // ---- XML Schema / RELAX NG ----
+    pub fn xmlSchemaNewDocParserCtxt(doc: *mut xmlDoc) -> *mut xmlSchemaParserCtxt;
+    pub fn xmlSchemaFreeParserCtxt(ctxt: *mut xmlSchemaParserCtxt);
+    pub fn xmlSchemaSetParserStructuredErrors(
+        ctxt: *mut xmlSchemaParserCtxt,
+        serror: xmlStructuredErrorFunc,
+        ctx: *mut c_void,
+    );
+    pub fn xmlSchemaParse(ctxt: *mut xmlSchemaParserCtxt) -> *mut xmlSchema;
+    pub fn xmlSchemaFree(schema: *mut xmlSchema);
+    pub fn xmlSchemaNewValidCtxt(schema: *mut xmlSchema) -> *mut xmlSchemaValidCtxt;
+    pub fn xmlSchemaFreeValidCtxt(ctxt: *mut xmlSchemaValidCtxt);
+    pub fn xmlSchemaSetValidStructuredErrors(
+        ctxt: *mut xmlSchemaValidCtxt,
+        serror: xmlStructuredErrorFunc,
+        ctx: *mut c_void,
+    );
+    pub fn xmlSchemaValidateDoc(ctxt: *mut xmlSchemaValidCtxt, instance: *mut xmlDoc) -> c_int;
+    pub fn xmlSchemaValidateFile(ctxt: *mut xmlSchemaValidCtxt, filename: *const c_char, options: c_int) -> c_int;
+    pub fn xmlRelaxNGNewDocParserCtxt(doc: *mut xmlDoc) -> *mut xmlRelaxNGParserCtxt;
+    pub fn xmlRelaxNGFreeParserCtxt(ctxt: *mut xmlRelaxNGParserCtxt);
+    pub fn xmlRelaxNGSetParserStructuredErrors(
+        ctxt: *mut xmlRelaxNGParserCtxt,
+        serror: xmlStructuredErrorFunc,
+        ctx: *mut c_void,
+    );
+    pub fn xmlRelaxNGParse(ctxt: *mut xmlRelaxNGParserCtxt) -> *mut xmlRelaxNG;
+    pub fn xmlRelaxNGFree(schema: *mut xmlRelaxNG);
+    pub fn xmlRelaxNGNewValidCtxt(schema: *mut xmlRelaxNG) -> *mut xmlRelaxNGValidCtxt;
+    pub fn xmlRelaxNGFreeValidCtxt(ctxt: *mut xmlRelaxNGValidCtxt);
+    pub fn xmlRelaxNGSetValidStructuredErrors(
+        ctxt: *mut xmlRelaxNGValidCtxt,
+        serror: xmlStructuredErrorFunc,
+        ctx: *mut c_void,
+    );
+    pub fn xmlRelaxNGValidateDoc(ctxt: *mut xmlRelaxNGValidCtxt, doc: *mut xmlDoc) -> c_int;
+    pub fn xmlGetExternalEntityLoader() -> xmlExternalEntityLoader;
+    pub fn xmlSetExternalEntityLoader(f: xmlExternalEntityLoader);
+    pub fn xmlNoNetExternalEntityLoader(
+        URL: *const c_char,
+        ID: *const c_char,
+        ctxt: *mut xmlParserCtxt,
+    ) -> *mut xmlParserInput;
+
     // ---- HTML ----
     pub fn htmlNewParserCtxt() -> *mut xmlParserCtxt;
     pub fn htmlCtxtReadMemory(
@@ -953,6 +1043,7 @@ unsafe extern "C" {
     pub fn xmlDelEncodingAlias(alias: *const c_char) -> c_int;
     pub fn xmlCleanupEncodingAliases();
     pub fn htmlEntityLookup(name: *const xmlChar) -> *const htmlEntityDesc;
+    pub fn htmlTagLookup(tag: *const xmlChar) -> *const htmlElemDesc;
 
     // ---- serialization ----
     pub fn xmlSaveToIO(

--- a/monoruby/src/builtins/nokogiri.rs
+++ b/monoruby/src/builtins/nokogiri.rs
@@ -26,6 +26,7 @@ mod node;
 mod node_set;
 mod reader;
 mod sax;
+mod schema;
 mod xpath;
 
 pub(crate) fn init(globals: &mut Globals) {
@@ -71,6 +72,9 @@ pub(super) struct Classes {
     pub html4_sax_parser_context: ClassId,
     pub html4_sax_push_parser: ClassId,
     pub reader: ClassId,
+    pub schema: ClassId,
+    pub relax_ng: ClassId,
+    pub element_description: ClassId,
 }
 
 thread_local! {
@@ -167,7 +171,7 @@ fn nokogiri_init(_: &mut Executor, globals: &mut Globals, _: Lfp, _: BytecodePtr
     let html4_document = class(globals, html4, "Document", document);
     let encoding_handler = native_class(globals, nokogiri, "EncodingHandler", OBJECT_CLASS);
     let entity_lookup = class(globals, html4, "EntityLookup", OBJECT_CLASS);
-    class(globals, html4, "ElementDescription", OBJECT_CLASS);
+    let element_description = native_class(globals, html4, "ElementDescription", OBJECT_CLASS);
     let sax_parser = native_class(globals, xml_sax, "Parser", OBJECT_CLASS);
     let sax_parser_context = native_class(globals, xml_sax, "ParserContext", OBJECT_CLASS);
     let sax_push_parser = native_class(globals, xml_sax, "PushParser", OBJECT_CLASS);
@@ -175,6 +179,8 @@ fn nokogiri_init(_: &mut Executor, globals: &mut Globals, _: Lfp, _: BytecodePtr
     let html4_sax_parser_context = class(globals, html4_sax, "ParserContext", sax_parser_context);
     let html4_sax_push_parser = class(globals, html4_sax, "PushParser", sax_push_parser);
     let reader = native_class(globals, xml_m, "Reader", OBJECT_CLASS);
+    let schema = native_class(globals, xml_m, "Schema", OBJECT_CLASS);
+    let relax_ng = class(globals, xml_m, "RelaxNG", schema);
 
     let c = Classes {
         nokogiri,
@@ -212,6 +218,9 @@ fn nokogiri_init(_: &mut Executor, globals: &mut Globals, _: Lfp, _: BytecodePtr
         html4_sax_parser_context,
         html4_sax_push_parser,
         reader,
+        schema,
+        relax_ng,
+        element_description,
     };
     CLASSES.with(|cell| *cell.borrow_mut() = Some(c));
 
@@ -222,6 +231,7 @@ fn nokogiri_init(_: &mut Executor, globals: &mut Globals, _: Lfp, _: BytecodePtr
     node_set::init(globals, &c);
     reader::init(globals, &c);
     sax::init(globals, &c);
+    schema::init(globals, &c);
     xpath::init(globals, &c);
 
     // Constants `Init_nokogiri` sets (version/info.rb reads them).

--- a/monoruby/src/builtins/nokogiri/misc.rs
+++ b/monoruby/src/builtins/nokogiri/misc.rs
@@ -1,5 +1,7 @@
 //! `Nokogiri::EncodingHandler` (libxml2's character encoding handlers
-//! and aliases) and `Nokogiri::HTML4::EntityLookup`.
+//! and aliases), `Nokogiri::HTML4::EntityLookup` and
+//! `Nokogiri::HTML4::ElementDescription` (libxml2's static HTML element
+//! table, `html4_element_description.c`).
 
 use super::*;
 
@@ -33,6 +35,165 @@ pub(super) fn init(globals: &mut Globals, c: &Classes) {
     globals.define_builtin_class_func(e, "clear_aliases!", encoding_handler_clear_aliases, 0);
     globals.define_builtin_func(e, "name", encoding_handler_name, 0);
     globals.define_builtin_func(c.entity_lookup, "get", entity_lookup_get, 1);
+
+    let d = c.element_description;
+    globals.define_builtin_class_func(d, "[]", element_description_get, 1);
+    globals.define_builtin_func(d, "name", desc_name, 0);
+    globals.define_builtin_func(d, "implied_start_tag?", desc_implied_start_tag, 0);
+    globals.define_builtin_func(d, "implied_end_tag?", desc_implied_end_tag, 0);
+    globals.define_builtin_func(d, "save_end_tag?", desc_save_end_tag, 0);
+    globals.define_builtin_func(d, "empty?", desc_empty, 0);
+    globals.define_builtin_func(d, "deprecated?", desc_deprecated, 0);
+    globals.define_builtin_func(d, "inline?", desc_inline, 0);
+    globals.define_builtin_func(d, "description", desc_description, 0);
+    globals.define_builtin_func(d, "sub_elements", desc_sub_elements, 0);
+    globals.define_builtin_func(d, "default_sub_element", desc_default_sub_element, 0);
+    globals.define_builtin_func(d, "optional_attributes", desc_optional_attributes, 0);
+    globals.define_builtin_func(d, "deprecated_attributes", desc_deprecated_attributes, 0);
+    globals.define_builtin_func(d, "required_attributes", desc_required_attributes, 0);
+}
+
+/// The payload of an `ElementDescription`: an entry of libxml2's static
+/// element table (never freed).
+struct ElementDescription {
+    desc: *const xml::htmlElemDesc,
+}
+
+impl NativeData for ElementDescription {
+    fn mark(&self, _alloc: &mut alloc::Allocator<RValue>) {}
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+fn desc(lfp: Lfp) -> Result<*const xml::htmlElemDesc> {
+    match lfp.self_val().try_native::<ElementDescription>() {
+        Some(d) => Ok(d.desc),
+        None => Err(MonorubyErr::typeerr("expected a Nokogiri::HTML4::ElementDescription")),
+    }
+}
+
+/// An Array of the strings of a NULL-terminated list (empty for NULL).
+unsafe fn string_list(list: *const *const c_char) -> Value {
+    let mut out = vec![];
+    if !list.is_null() {
+        // SAFETY: a NULL-terminated list of NUL-terminated static strings.
+        unsafe {
+            let mut i = 0;
+            while !(*list.add(i)).is_null() {
+                out.push(xml_str(*list.add(i) as *const xml::xmlChar));
+                i += 1;
+            }
+        }
+    }
+    Value::array_from_vec(out)
+}
+
+/// ElementDescription[name] -> ElementDescription | nil
+#[monoruby_builtin]
+fn element_description_get(_: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let class = lfp.self_val().as_class_id();
+    let name = cstr(lfp.arg(0), &globals.store)?;
+    // SAFETY: a NUL-terminated name; the description is static.
+    let desc = unsafe { xml::htmlTagLookup(name.as_ptr() as *const xml::xmlChar) };
+    if desc.is_null() {
+        return Ok(Value::nil());
+    }
+    Ok(Value::new_native(class, Box::new(ElementDescription { desc })))
+}
+
+/// ElementDescription#name -> String | nil
+#[monoruby_builtin]
+fn desc_name(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let d = desc(lfp)?;
+    // SAFETY: a static description.
+    Ok(unsafe { xml_str((*d).name as *const xml::xmlChar) })
+}
+
+/// ElementDescription#description -> String
+#[monoruby_builtin]
+fn desc_description(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let d = desc(lfp)?;
+    // SAFETY: a static description.
+    Ok(unsafe { xml_str((*d).desc as *const xml::xmlChar) })
+}
+
+macro_rules! desc_flag {
+    ($name:ident, $field:ident) => {
+        #[monoruby_builtin]
+        fn $name(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+            let d = desc(lfp)?;
+            // SAFETY: a static description.
+            Ok(Value::bool(unsafe { (*d).$field } != 0))
+        }
+    };
+}
+
+// ElementDescription#implied_start_tag? / #implied_end_tag? /
+// #save_end_tag? / #empty? / #deprecated? / #inline?
+desc_flag!(desc_implied_start_tag, startTag);
+desc_flag!(desc_implied_end_tag, endTag);
+desc_flag!(desc_save_end_tag, saveEndTag);
+desc_flag!(desc_empty, empty);
+desc_flag!(desc_deprecated, depr);
+desc_flag!(desc_inline, isinline);
+
+/// ElementDescription#sub_elements -> Array of String
+#[monoruby_builtin]
+fn desc_sub_elements(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let d = desc(lfp)?;
+    // SAFETY: a static description.
+    Ok(unsafe { string_list((*d).subelts) })
+}
+
+/// ElementDescription#default_sub_element -> String | nil
+#[monoruby_builtin]
+fn desc_default_sub_element(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let d = desc(lfp)?;
+    // SAFETY: a static description.
+    Ok(unsafe { xml_str((*d).defaultsubelt as *const xml::xmlChar) })
+}
+
+/// ElementDescription#optional_attributes -> Array of String
+#[monoruby_builtin]
+fn desc_optional_attributes(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let d = desc(lfp)?;
+    // SAFETY: a static description.
+    Ok(unsafe { string_list((*d).attrs_opt) })
+}
+
+/// ElementDescription#deprecated_attributes -> Array of String
+#[monoruby_builtin]
+fn desc_deprecated_attributes(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let d = desc(lfp)?;
+    // SAFETY: a static description.
+    Ok(unsafe { string_list((*d).attrs_depr) })
+}
+
+/// ElementDescription#required_attributes -> Array of String. Nokogiri
+/// walks `attrs_req` for as long as `attrs_depr` has entries (a slip in
+/// `required_attributes`); reproduced, bounded by both lists, so the
+/// answers match.
+#[monoruby_builtin]
+fn desc_required_attributes(_: &mut Executor, _: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let d = desc(lfp)?;
+    let mut out = vec![];
+    // SAFETY: a static description with NULL-terminated lists.
+    unsafe {
+        let req = (*d).attrs_req;
+        let depr = (*d).attrs_depr;
+        if !req.is_null() && !depr.is_null() {
+            let mut i = 0;
+            while !(*depr.add(i)).is_null() && !(*req.add(i)).is_null() {
+                out.push(xml_str(*req.add(i) as *const xml::xmlChar));
+                i += 1;
+            }
+        }
+    }
+    Ok(Value::array_from_vec(out))
 }
 
 /// EncodingHandler[name] -> EncodingHandler | nil

--- a/monoruby/src/builtins/nokogiri/schema.rs
+++ b/monoruby/src/builtins/nokogiri/schema.rs
@@ -1,0 +1,275 @@
+//! `Nokogiri::XML::Schema` (XML Schema, `xml_schema.c`) and
+//! `Nokogiri::XML::RelaxNG` (`xml_relax_ng.c`): a compiled schema owned
+//! by the Ruby object, `from_document` to compile one and the private
+//! `validate_document` / `validate_file` the gem's `validate` calls,
+//! answering an array of `SyntaxError`s.
+
+use super::*;
+
+/// The payload of a `Schema` / `RelaxNG`.
+enum XmlSchema {
+    Xsd(*mut xml::xmlSchema),
+    RelaxNg(*mut xml::xmlRelaxNG),
+}
+
+impl NativeData for XmlSchema {
+    fn mark(&self, _alloc: &mut alloc::Allocator<RValue>) {}
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+impl Drop for XmlSchema {
+    fn drop(&mut self) {
+        // SAFETY: the compiled schema is ours.
+        unsafe {
+            match *self {
+                XmlSchema::Xsd(s) => xml::xmlSchemaFree(s),
+                XmlSchema::RelaxNg(s) => xml::xmlRelaxNGFree(s),
+            }
+        }
+    }
+}
+
+pub(super) fn init(globals: &mut Globals, c: &Classes) {
+    globals.define_builtin_class_func_rest(c.schema, "from_document", schema_from_document);
+    globals.define_private_builtin_func(c.schema, "validate_document", schema_validate_document, 1);
+    globals.define_private_builtin_func(c.schema, "validate_file", schema_validate_file, 1);
+    globals.define_builtin_class_func_rest(c.relax_ng, "from_document", relax_ng_from_document);
+    globals.define_private_builtin_func(c.relax_ng, "validate_document", relax_ng_validate_document, 1);
+}
+
+fn xsd(v: Value) -> Result<*mut xml::xmlSchema> {
+    match v.try_native::<XmlSchema>() {
+        Some(XmlSchema::Xsd(s)) => Ok(*s),
+        _ => Err(MonorubyErr::argumenterr("expected a Nokogiri::XML::Schema")),
+    }
+}
+
+fn relax_ng(v: Value) -> Result<*mut xml::xmlRelaxNG> {
+    match v.try_native::<XmlSchema>() {
+        Some(XmlSchema::RelaxNg(s)) => Ok(*s),
+        _ => Err(MonorubyErr::argumenterr("expected a Nokogiri::XML::RelaxNG")),
+    }
+}
+
+/// `(document, parse_options = DEFAULT_SCHEMA)` of `from_document`: the
+/// `xmlDoc` (a Node's document is accepted, as nokogiri does), the
+/// options object and its integer value.
+fn from_document_args(vm: &mut Executor, globals: &mut Globals, lfp: Lfp) -> Result<(*mut xml::xmlDoc, Value, c_int)> {
+    let args: Vec<Value> = lfp.arg(0).as_array().iter().cloned().collect();
+    if args.is_empty() || args.len() > 2 {
+        return Err(MonorubyErr::argumenterr(format!(
+            "wrong number of arguments (given {}, expected 1..2)",
+            args.len()
+        )));
+    }
+    let document = args[0];
+    if !is_node(document) {
+        return Err(MonorubyErr::typeerr(format!(
+            "expected parameter to be a Nokogiri::XML::Document, received {}",
+            globals.store.get_class_name(document.class())
+        )));
+    }
+    // SAFETY: a live node or document.
+    let doc = unsafe { (*node_ptr(document)?).doc };
+    let mut options = args.get(1).copied().unwrap_or_default();
+    if options.is_nil() {
+        let parse_options = globals
+            .store
+            .get_constant_noautoload(classes().xml, IdentId::get_id("ParseOptions"))
+            .ok_or_else(|| MonorubyErr::nameerr("uninitialized constant Nokogiri::XML::ParseOptions"))?;
+        options = globals
+            .store
+            .get_constant_noautoload(parse_options.as_class_id(), IdentId::get_id("DEFAULT_SCHEMA"))
+            .ok_or_else(|| MonorubyErr::nameerr("uninitialized constant Nokogiri::XML::ParseOptions::DEFAULT_SCHEMA"))?;
+    }
+    let to_i = vm.invoke_method_inner(globals, IdentId::get_id("to_i"), options, &[], None, None)?;
+    let c_options = to_i.expect_integer(&globals.store)? as c_int;
+    Ok((doc, options, c_options))
+}
+
+/// Whether a blank text node of `doc` has a Ruby object: the schema
+/// parser would strip it from under the wrapper, so the schema is then
+/// compiled from a copy (`noko_xml_document_has_wrapped_blank_nodes_p`,
+/// nokogiri #2001).
+unsafe fn has_wrapped_blank_nodes(doc: *mut xml::xmlDoc) -> bool {
+    // SAFETY: a live document; every cached wrapper's node is live.
+    unsafe {
+        let Some(d) = doc_native(doc) else {
+            return false;
+        };
+        d.node_cache.iter().any(|v| match v.try_native::<XmlNode>() {
+            Some(n) => xml::xmlIsBlankNode(n.node) != 0,
+            None => false,
+        })
+    }
+}
+
+/// The tail of `from_document`: wrap the compiled schema (`@errors`,
+/// `@parse_options`), or raise the collected errors.
+fn finish(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    class: ClassId,
+    schema: Option<XmlSchema>,
+    errors: &[ErrorRecord],
+    options: Value,
+) -> Result<Value> {
+    let rb_errors = errors_to_array(vm, globals, errors)?;
+    let Some(schema) = schema else {
+        let klass = globals.store.get_module(classes().xml_syntax_error).as_val();
+        let ex = vm.invoke_method_inner(globals, IdentId::get_id("aggregate"), klass, &[rb_errors], None, None)?;
+        return Err(if ex.as_bool() { raise(ex) } else { MonorubyErr::runtimeerr("Could not parse document") });
+    };
+    let rb = Value::new_native(class, Box::new(schema));
+    globals.store.set_ivar(rb, IdentId::get_id("@errors"), rb_errors)?;
+    globals.store.set_ivar(rb, IdentId::get_id("@parse_options"), options)?;
+    Ok(rb)
+}
+
+/// Schema.from_document(document, parse_options = DEFAULT_SCHEMA) -> Schema
+#[monoruby_builtin]
+fn schema_from_document(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let class = lfp.self_val().as_class_id();
+    let (doc, options, c_options) = from_document_args(vm, globals, lfp)?;
+    let mut errors: Vec<ErrorRecord> = vec![];
+    // SAFETY: a live document; the copy (if any), the parser context and
+    // the handlers are ours for the call; the entity loader is restored.
+    let schema = unsafe {
+        let copied = has_wrapped_blank_nodes(doc);
+        let doc = if copied { xml::xmlCopyDoc(doc, 1) } else { doc };
+        let ctxt = xml::xmlSchemaNewDocParserCtxt(doc);
+        let errs = &mut errors as *mut _ as *mut c_void;
+        xml::xmlSetStructuredErrorFunc(errs, Some(collect_error));
+        xml::xmlSchemaSetParserStructuredErrors(ctxt, Some(collect_error), errs);
+        let saved_loader = if c_options & xml::XML_PARSE_NONET != 0 {
+            let saved = xml::xmlGetExternalEntityLoader();
+            xml::xmlSetExternalEntityLoader(Some(xml::xmlNoNetExternalEntityLoader));
+            saved
+        } else {
+            None
+        };
+        let schema = xml::xmlSchemaParse(ctxt);
+        if saved_loader.is_some() {
+            xml::xmlSetExternalEntityLoader(saved_loader);
+        }
+        xml::xmlSchemaFreeParserCtxt(ctxt);
+        xml::xmlSetStructuredErrorFunc(std::ptr::null_mut(), None);
+        if copied {
+            xml::xmlFreeDoc(doc);
+        }
+        if schema.is_null() { None } else { Some(XmlSchema::Xsd(schema)) }
+    };
+    finish(vm, globals, class, schema, &errors, options)
+}
+
+/// RelaxNG.from_document(document, parse_options = DEFAULT_SCHEMA) -> RelaxNG
+#[monoruby_builtin]
+fn relax_ng_from_document(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let class = lfp.self_val().as_class_id();
+    // Only a Document (`noko_xml_document_unwrap`'s check).
+    if let Some(document) = lfp.arg(0).as_array().first()
+        && document.try_native::<XmlDocument>().is_none()
+    {
+        return Err(MonorubyErr::typeerr(format!(
+            "wrong argument type {} (expected xmlDoc)",
+            builtin_type_name(globals, *document)
+        )));
+    }
+    let (doc, options, _) = from_document_args(vm, globals, lfp)?;
+    let mut errors: Vec<ErrorRecord> = vec![];
+    // SAFETY: as `schema_from_document`.
+    let schema = unsafe {
+        let ctxt = xml::xmlRelaxNGNewDocParserCtxt(doc);
+        let errs = &mut errors as *mut _ as *mut c_void;
+        xml::xmlSetStructuredErrorFunc(errs, Some(collect_error));
+        xml::xmlRelaxNGSetParserStructuredErrors(ctxt, Some(collect_error), errs);
+        let schema = xml::xmlRelaxNGParse(ctxt);
+        xml::xmlRelaxNGFreeParserCtxt(ctxt);
+        xml::xmlSetStructuredErrorFunc(std::ptr::null_mut(), None);
+        if schema.is_null() { None } else { Some(XmlSchema::RelaxNg(schema)) }
+    };
+    finish(vm, globals, class, schema, &errors, options)
+}
+
+/// The validation errors as an array, with `fallback` when the
+/// validation failed without reporting any.
+fn validation_result(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    errors: &[ErrorRecord],
+    status: c_int,
+    fallback: Option<&str>,
+) -> Result<Value> {
+    let rb_errors = errors_to_array(vm, globals, errors)?;
+    if status != 0 && errors.is_empty() {
+        if let Some(msg) = fallback {
+            rb_errors.as_array_mut(&globals.store)?.push(Value::string_from_str(msg));
+        }
+    }
+    Ok(rb_errors)
+}
+
+/// Schema#validate_document(document) -> Array of SyntaxError
+#[monoruby_builtin]
+fn schema_validate_document(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let schema = xsd(lfp.self_val())?;
+    let doc = doc_ptr(lfp.arg(0))?;
+    let mut errors: Vec<ErrorRecord> = vec![];
+    // SAFETY: a live schema and document; the context is ours.
+    let status = unsafe {
+        let ctxt = xml::xmlSchemaNewValidCtxt(schema);
+        if ctxt.is_null() {
+            return Err(MonorubyErr::runtimeerr("Could not create a validation context"));
+        }
+        xml::xmlSchemaSetValidStructuredErrors(ctxt, Some(collect_error), &mut errors as *mut _ as *mut c_void);
+        let status = xml::xmlSchemaValidateDoc(ctxt, doc);
+        xml::xmlSchemaFreeValidCtxt(ctxt);
+        status
+    };
+    validation_result(vm, globals, &errors, status, Some("Could not validate document"))
+}
+
+/// Schema#validate_file(filename) -> Array of SyntaxError
+#[monoruby_builtin]
+fn schema_validate_file(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let schema = xsd(lfp.self_val())?;
+    let filename = cstr(lfp.arg(0), &globals.store)?;
+    let mut errors: Vec<ErrorRecord> = vec![];
+    // SAFETY: a live schema, a NUL-terminated path; the context is ours.
+    let status = unsafe {
+        let ctxt = xml::xmlSchemaNewValidCtxt(schema);
+        if ctxt.is_null() {
+            return Err(MonorubyErr::runtimeerr("Could not create a validation context"));
+        }
+        xml::xmlSchemaSetValidStructuredErrors(ctxt, Some(collect_error), &mut errors as *mut _ as *mut c_void);
+        let status = xml::xmlSchemaValidateFile(ctxt, filename.as_ptr(), 0);
+        xml::xmlSchemaFreeValidCtxt(ctxt);
+        status
+    };
+    validation_result(vm, globals, &errors, status, Some("Could not validate file."))
+}
+
+/// RelaxNG#validate_document(document) -> Array of SyntaxError
+#[monoruby_builtin]
+fn relax_ng_validate_document(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
+    let schema = relax_ng(lfp.self_val())?;
+    let doc = doc_ptr(lfp.arg(0))?;
+    let mut errors: Vec<ErrorRecord> = vec![];
+    // SAFETY: as `schema_validate_document`.
+    let status = unsafe {
+        let ctxt = xml::xmlRelaxNGNewValidCtxt(schema);
+        if ctxt.is_null() {
+            return Err(MonorubyErr::runtimeerr("Could not create a validation context"));
+        }
+        xml::xmlRelaxNGSetValidStructuredErrors(ctxt, Some(collect_error), &mut errors as *mut _ as *mut c_void);
+        let status = xml::xmlRelaxNGValidateDoc(ctxt, doc);
+        xml::xmlRelaxNGFreeValidCtxt(ctxt);
+        status
+    };
+    validation_result(vm, globals, &errors, status, None)
+}

--- a/monoruby/tests/nokogiri.rs
+++ b/monoruby/tests/nokogiri.rs
@@ -1108,6 +1108,136 @@ fn nokogiri_dup_and_xpath_handlers() {
 }
 
 #[test]
+fn nokogiri_schema_and_relax_ng() {
+    compare(
+        r##"
+        require "tempfile"
+        r = []
+        xsd = <<~XSD
+          <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:element name="shiporder">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="orderperson" type="xs:string"/>
+                  <xs:element name="item" maxOccurs="unbounded">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="title" type="xs:string"/>
+                        <xs:element name="quantity" type="xs:positiveInteger"/>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+                <xs:attribute name="orderid" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:schema>
+        XSD
+        good = "<shiporder orderid='1'><orderperson>A</orderperson><item><title>T</title><quantity>2</quantity></item></shiporder>"
+        bad = "<shiporder><orderperson>A</orderperson><item><title>T</title><quantity>-2</quantity></item><extra/></shiporder>"
+        schema = Nokogiri::XML::Schema(xsd)
+        r << [schema.class, schema.errors, schema.parse_options.class, schema.parse_options.to_i]
+        r << [schema.valid?(Nokogiri::XML(good)), schema.validate(Nokogiri::XML(good))]
+        errors = schema.validate(Nokogiri::XML(bad))
+        r << errors.map { |e| [e.class, e.message, e.line, e.column, e.level, e.domain, e.code, e.error?, e.path] }
+        r << schema.valid?(Nokogiri::XML(bad))
+        Tempfile.create(["doc", ".xml"]) do |f|
+          f.write(good); f.flush
+          r << schema.validate(f.path)
+          f.rewind; f.truncate(0); f.write(bad); f.flush
+          r << schema.validate(f.path).map(&:to_s)
+          r << schema.valid?(f.path)
+        end
+        r << Nokogiri::XML::Schema.new(xsd, Nokogiri::XML::ParseOptions::DEFAULT_SCHEMA).parse_options.to_i
+        r << Nokogiri::XML::Schema.new(xsd, Nokogiri::XML::ParseOptions.new(Nokogiri::XML::ParseOptions::NONET)).parse_options.class
+        r << Nokogiri::XML::Schema.read_memory(xsd).class
+        r << Nokogiri::XML::Schema.from_document(Nokogiri::XML(xsd)).class
+        r << Nokogiri::XML::Schema.from_document(Nokogiri::XML(xsd), nil).parse_options.to_i
+        blanks = Nokogiri::XML(xsd)
+        blanks.root.children.each { |c| c.text? }
+        r << Nokogiri::XML::Schema.from_document(blanks).valid?(Nokogiri::XML(good))
+        [-> { Nokogiri::XML::Schema("<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'><xs:element name='a' type='xs:nope'/></xs:schema>") },
+         -> { Nokogiri::XML::Schema("<not-a-schema/>") },
+         -> { Nokogiri::XML::Schema("<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'><xs:import schemaLocation='http://example.com/x.xsd'/></xs:schema>").errors.map(&:to_s) },
+         -> { Nokogiri::XML::Schema.from_document("<a/>") },
+         -> { Nokogiri::XML::Schema.from_document(Nokogiri::XML(xsd).root).class },
+         -> { schema.validate("not a file, not a doc") },
+         -> { schema.validate(Nokogiri::XML("")) },
+         -> { Nokogiri::XML::Schema.from_document }].each do |l|
+          begin
+            r << l.call
+          rescue => e
+            r << [e.class, e.message.lines.first.chomp]
+          end
+        end
+        rng = <<~RNG
+          <element name="addressBook" xmlns="http://relaxng.org/ns/structure/1.0">
+            <zeroOrMore>
+              <element name="card">
+                <element name="name"><text/></element>
+                <element name="email"><text/></element>
+              </element>
+            </zeroOrMore>
+          </element>
+        RNG
+        relax = Nokogiri::XML::RelaxNG(rng)
+        r << [relax.class, relax.class.superclass, relax.errors, relax.parse_options.to_i]
+        r << relax.validate(Nokogiri::XML("<addressBook><card><name>n</name><email>e</email></card></addressBook>"))
+        r << relax.validate(Nokogiri::XML("<addressBook><card><name>n</name><phone>p</phone></card></addressBook>")).map { |e| [e.class, e.message, e.line, e.domain] }
+        r << relax.valid?(Nokogiri::XML("<other/>"))
+        r << Nokogiri::XML::RelaxNG.read_memory(rng).class
+        r << Nokogiri::XML::RelaxNG.from_document(Nokogiri::XML(rng), nil).class
+        [-> { Nokogiri::XML::RelaxNG("<element xmlns='http://relaxng.org/ns/structure/1.0'><bogus/></element>") },
+         -> { Nokogiri::XML::RelaxNG("<nope/>") },
+         -> { Nokogiri::XML::RelaxNG.from_document(nil) },
+         -> { relax.validate("/nonexistent") }].each do |l|
+          begin
+            r << l.call
+          rescue => e
+            r << [e.class, e.message.lines.first.chomp]
+          end
+        end
+        keep = (1..30).map { Nokogiri::XML::Schema(xsd) }
+        GC.start
+        r << keep.map { |s| s.valid?(Nokogiri::XML(good)) }.uniq
+        p r
+        "##,
+    );
+}
+
+#[test]
+fn nokogiri_element_description() {
+    compare(
+        r##"
+        r = []
+        %w[a p br img table td html font center frame applet div span input nope].each do |tag|
+          d = Nokogiri::HTML4::ElementDescription[tag]
+          if d.nil?
+            r << [tag, nil]
+            next
+          end
+          r << [d.class, d.name, d.description, d.implied_start_tag?, d.implied_end_tag?, d.save_end_tag?, d.empty?,
+           d.deprecated?, d.inline?, d.block?, d.sub_elements.size, d.sub_elements.first(3), d.default_sub_element,
+           d.optional_attributes.size, d.optional_attributes.first(3), d.deprecated_attributes, d.required_attributes,
+           d.to_s, d.inspect]
+        end
+        h = Nokogiri::HTML4("<html><body><p>x<br><img src='a'></p></body></html>")
+        r << h.css("p, br, img").map { |n| [n.name, n.description&.name, n.description&.empty?] }
+        r << Nokogiri::XML("<p/>").root.description
+        begin
+          Nokogiri::HTML4::ElementDescription[nil]
+        rescue => e
+          r << [e.class, e.message]
+        end
+        keep = (1..20).map { Nokogiri::HTML4::ElementDescription["p"] }
+        GC.start
+        r << keep.map(&:name).uniq
+        p r
+        "##,
+    );
+}
+
+#[test]
 fn nokogiri_node_identity_across_gc() {
     // Every node wraps into one Ruby object that the document keeps alive;
     // unlinked nodes stay owned by their document.


### PR DESCRIPTION
The validation half of `doc/nokogiri.md`'s stage 6 (the part libxml2 already provides, no new C sources) and the last small HTML4 native. Follows #1308.

## What is in

- **`XML::Schema` and `XML::RelaxNG`** (`src/builtins/nokogiri/schema.rs`, the port of `xml_schema.c` / `xml_relax_ng.c`): `from_document` compiles the schema with `xmlSchemaParse` / `xmlRelaxNGParse`, the parse errors go to `@errors` and their aggregate is raised on failure, the external entity loader is switched to `xmlNoNetExternalEntityLoader` under `NONET` (the default), and a document whose blank text nodes have Ruby objects is compiled from a copy (nokogiri #2001, the schema parser strips them). The private `validate_document` / `validate_file` that the gem's `validate` / `valid?` call answer the `SyntaxError`s of a validation, with nokogiri's fallback strings when libxml2 fails without reporting one. `RelaxNG` inherits from `Schema` as in nokogiri.
- **`HTML4::ElementDescription`** (`misc.rs`): a native object over libxml2's static element table (`htmlTagLookup`): name, description, the implied / save / empty / deprecated / inline flags, sub-elements, default sub-element, optional / deprecated / required attributes. `Node#description` now works on HTML documents.

## Not yet

XSLT (needs libxslt bundled), HTML5 / gumbo.

## Tests

`tests/nokogiri.rs` gains two comparison scripts, byte-identical to CRuby's nokogiri: XSD and RELAX NG compilation and validation of documents and files (valid and invalid, error fields incl. `path`, `line`, `code`), parse-option handling, schema parse errors, the argument checks, schemas surviving a GC, and the element table for a dozen tags plus `Node#description`. All 21 nokogiri tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hf7QX3CQdiCRykYS6SeFM)_