### PR TITLE
sqlite3: implement create_aggregate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -412,8 +412,12 @@ External crates (fetched from git):
   `Executor` through a thread-local map keyed by **connection**, saved
   and restored rather than pushed and popped: green-thread switches are
   not LIFO, so a callback that parks would otherwise let another thread
-  pop its entry. `create_aggregate` and a `collation` with a real
-  comparator are still unsupported.
+  pop its entry. `create_aggregate` rides the same machinery with
+  `xStep` / `xFinal`: each aggregation group gets one instance of the
+  gem's proxy class, held in `DbHandle::aggregates` (where `mark` finds
+  it) and addressed by a slot number kept in SQLite's per-group
+  `sqlite3_aggregate_context`, which is C memory the collector cannot
+  see. A `collation` with a real comparator is still unsupported.
 
 ---
 

--- a/monoruby/src/builtins/sqlite3.rs
+++ b/monoruby/src/builtins/sqlite3.rs
@@ -152,12 +152,24 @@ struct DbHandle {
     /// The blocks handed to `create_function` / `create_aggregate`, kept
     /// as GC roots for as long as SQLite may call them.
     funcs: Vec<Value>,
+    /// One live aggregate instance per group being accumulated.
+    ///
+    /// SQLite's per-group memory (`sqlite3_aggregate_context`) is C
+    /// memory the collector cannot see, so it holds a slot number and
+    /// the instance itself lives here, where `mark` finds it. A slot is
+    /// freed by `xFinal`, and reused by the next group; a query with
+    /// `GROUP BY` keeps one entry per group in flight at a time, or all
+    /// of them at once when SQLite groups by hash.
+    aggregates: Vec<Option<Value>>,
 }
 
 impl NativeData for DbHandle {
     fn mark(&self, alloc: &mut crate::alloc::Allocator<RValue>) {
         for f in &self.funcs {
             f.mark(alloc);
+        }
+        for a in self.aggregates.iter().flatten() {
+            a.mark(alloc);
         }
     }
     fn as_any(&self) -> &dyn std::any::Any {
@@ -280,6 +292,7 @@ extern "C" fn database_alloc_func(class_id: ClassId, _globals: &mut Globals) -> 
         Box::new(DbHandle {
             db: std::ptr::null_mut(),
             funcs: vec![],
+            aggregates: vec![],
         }),
     )
 }
@@ -940,7 +953,7 @@ fn db_exec_batch(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecode
         loop {
             // A user function in this statement reaches the interpreter
             // through this guard, as in `stmt_step`.
-            let mut call = CallGuard::new(vm, globals, db);
+            let mut call = CallGuard::new(vm, globals, db, lfp.self_val());
             // SAFETY: a live statement.
             let rc = unsafe { sq::sqlite3_step(stmt) };
             let err = call.take_error();
@@ -1024,8 +1037,12 @@ fn db_authorizer_assign(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: B
 /// is defined, so it is a leaked `Box` freed by the `xDestroy` below. The
 /// same Proc is also held in `DbHandle::funcs`, which is what roots it
 /// for the collector — this copy is never the only reference.
-struct FuncEntry {
-    block: Value,
+enum FuncEntry {
+    /// `create_function`: one block, run per row.
+    Scalar { block: Value },
+    /// `create_aggregate`: a class, instantiated once per group. Its
+    /// instances answer `step(*args)` per row and `finalize` once.
+    Aggregate { klass: Value },
 }
 
 /// `xDestroy`: SQLite calls this when the function is replaced or its
@@ -1048,6 +1065,11 @@ unsafe extern "C" fn func_destroy(app: *mut c_void) {
 struct CallState {
     vm: *mut Executor,
     globals: *mut Globals,
+    /// The `SQLite3::Database` this step is running on, so an aggregate
+    /// callback can reach the instance table in its `DbHandle`. Rooted
+    /// for the whole step by whatever is being stepped: the statement
+    /// holds it in `@connection`, and `exec_batch` is a method on it.
+    db_obj: Value,
     error: Option<MonorubyErr>,
 }
 
@@ -1100,15 +1122,26 @@ struct CallGuardInner {
     state: Box<CallState>,
 }
 
+/// Whether anything could call back, so a step needs a guard at all.
+fn guard_needed() -> bool {
+    FUNC_COUNT.with(|n| n.get()) != 0
+}
+
 impl CallGuard {
-    fn new(vm: &mut Executor, globals: &mut Globals, db: *mut sq::sqlite3) -> Self {
-        if FUNC_COUNT.with(|n| n.get()) == 0 {
+    fn new(
+        vm: &mut Executor,
+        globals: &mut Globals,
+        db: *mut sq::sqlite3,
+        db_obj: Value,
+    ) -> Self {
+        if !guard_needed() {
             return Self { inner: None };
         }
         // Boxed so the address stays put however the map grows.
         let mut state = Box::new(CallState {
             vm,
             globals,
+            db_obj,
             error: None,
         });
         let p: *mut CallState = &mut *state;
@@ -1274,7 +1307,11 @@ unsafe extern "C" fn func_invoke(
             vm.temp_push(v);
             args.push(v);
         }
-        let result = match entry.block.is_proc() {
+        let FuncEntry::Scalar { block } = entry else {
+            result_error(ctx, "not a scalar function");
+            return;
+        };
+        let result = match block.is_proc() {
             Some(p) => vm.invoke_proc(globals, &p, &args),
             None => Err(err_sqlite3(vm, globals, "function block is not a Proc")),
         };
@@ -1290,6 +1327,247 @@ unsafe extern "C" fn func_invoke(
             }
         }
     }
+}
+
+/// The instance accumulating this group, creating it on the first row.
+///
+/// SQLite's per-group memory is a slot number into the connection's
+/// instance table; zero means "not started", so slots are stored
+/// one-based. `n` is the size to allocate — zero asks without
+/// allocating, which is what `xFinal` does to tell an empty group from
+/// one that stepped.
+///
+/// # Safety
+/// A live context belonging to `state`'s connection.
+unsafe fn aggregate_instance(
+    state: &mut CallState,
+    ctx: *mut sq::sqlite3_context,
+    klass: Value,
+    create: bool,
+) -> Result<Option<Value>> {
+    // SAFETY: the caller's contract.
+    let slot_ptr = unsafe {
+        sq::sqlite3_aggregate_context(ctx, if create { 4 } else { 0 }) as *mut u32
+    };
+    if slot_ptr.is_null() {
+        // Out of memory, or `xFinal` on a group that never stepped.
+        return Ok(None);
+    }
+    // SAFETY: four bytes SQLite zeroed for us and keeps for this group.
+    let slot = unsafe { *slot_ptr };
+    let vm = unsafe { &mut *state.vm };
+    let globals = unsafe { &mut *state.globals };
+    if slot != 0 {
+        let table = &native_mut::<DbHandle>(state.db_obj)?.aggregates;
+        return Ok(table.get(slot as usize - 1).copied().flatten());
+    }
+    if !create {
+        return Ok(None);
+    }
+    // First row of this group: one instance of the proxy class, which
+    // holds the caller's `FunctionProxy` as its context.
+    let inst = vm.invoke_method_inner(globals, IdentId::NEW, klass, &[], None, None)?;
+    let table = &mut native_mut::<DbHandle>(state.db_obj)?.aggregates;
+    let index = match table.iter().position(|e| e.is_none()) {
+        Some(i) => {
+            table[i] = Some(inst);
+            i
+        }
+        None => {
+            table.push(Some(inst));
+            table.len() - 1
+        }
+    };
+    // SAFETY: as above; SQLite hands back the same four bytes for every
+    // row of this group.
+    unsafe { *slot_ptr = index as u32 + 1 };
+    Ok(Some(inst))
+}
+
+/// Drop this group's instance, freeing its slot for the next group.
+///
+/// # Safety
+/// As `aggregate_instance`.
+unsafe fn release_aggregate(state: &mut CallState, ctx: *mut sq::sqlite3_context) {
+    // SAFETY: the caller's contract; asking with 0 never allocates.
+    let slot_ptr = unsafe { sq::sqlite3_aggregate_context(ctx, 0) as *mut u32 };
+    if slot_ptr.is_null() {
+        return;
+    }
+    // SAFETY: four bytes SQLite kept for this group.
+    let slot = unsafe { *slot_ptr };
+    if slot == 0 {
+        return;
+    }
+    if let Ok(h) = native_mut::<DbHandle>(state.db_obj)
+        && let Some(e) = h.aggregates.get_mut(slot as usize - 1)
+    {
+        *e = None;
+    }
+    // SAFETY: as above.
+    unsafe { *slot_ptr = 0 };
+}
+
+/// Recover the running step and this function's registration, or report
+/// to SQLite why the callback cannot run.
+///
+/// # Safety
+/// A live context, inside a callback SQLite is making.
+unsafe fn callback_state(
+    ctx: *mut sq::sqlite3_context,
+) -> Option<(&'static mut CallState, &'static FuncEntry)> {
+    // SAFETY: the caller's contract.
+    unsafe {
+        let Some(state) = current_call(sq::sqlite3_context_db_handle(ctx)) else {
+            result_error(ctx, "sqlite3 function called outside a query");
+            return None;
+        };
+        let state = &mut *state;
+        if state.error.is_some() {
+            result_error(ctx, "aborted");
+            return None;
+        }
+        Some((state, &*(sq::sqlite3_user_data(ctx) as *const FuncEntry)))
+    }
+}
+
+/// `xStep`: once per row the aggregate sees, from inside `sqlite3_step`.
+unsafe extern "C" fn agg_step(
+    ctx: *mut sq::sqlite3_context,
+    argc: c_int,
+    argv: *mut *mut sq::sqlite3_value,
+) {
+    // SAFETY: SQLite passes a live context and `argc` live values.
+    unsafe {
+        let Some((state, entry)) = callback_state(ctx) else {
+            return;
+        };
+        let FuncEntry::Aggregate { klass } = entry else {
+            result_error(ctx, "not an aggregate function");
+            return;
+        };
+        let vm = &mut *state.vm;
+        let globals = &mut *state.globals;
+        // The instance and the arguments stay rooted while the rest are
+        // built: each is fresh, and allocating the next may collect.
+        let len = vm.temp_len();
+        let result = (|| -> Result<()> {
+            let Some(inst) = aggregate_instance(state, ctx, *klass, true)? else {
+                return Err(MonorubyErr::runtimeerr("out of memory"));
+            };
+            let vm = &mut *state.vm;
+            let globals = &mut *state.globals;
+            vm.temp_push(inst);
+            let mut args = Vec::with_capacity(argc.max(0) as usize);
+            for i in 0..argc as isize {
+                let v = arg_value(*argv.offset(i));
+                vm.temp_push(v);
+                args.push(v);
+            }
+            vm.invoke_method_inner(globals, IdentId::get_id("step"), inst, &args, None, None)?;
+            Ok(())
+        })();
+        vm.temp_clear(len);
+        if let Err(e) = result {
+            result_error(ctx, &e.get_error_message(&globals.store));
+            state.error = Some(e);
+        }
+    }
+}
+
+/// `xFinal`: once per group, after its last row.
+///
+/// SQLite calls this even for a group that never stepped — an aggregate
+/// over no rows — and the C extension answers what a fresh instance's
+/// `finalize` returns, so one is created here in that case.
+unsafe extern "C" fn agg_final(ctx: *mut sq::sqlite3_context) {
+    // SAFETY: SQLite passes a live context.
+    unsafe {
+        let Some((state, entry)) = callback_state(ctx) else {
+            return;
+        };
+        let FuncEntry::Aggregate { klass } = entry else {
+            result_error(ctx, "not an aggregate function");
+            return;
+        };
+        let vm = &mut *state.vm;
+        let len = vm.temp_len();
+        let result = (|| -> Result<()> {
+            // `create` here is what makes an empty group answer.
+            let Some(inst) = aggregate_instance(state, ctx, *klass, true)? else {
+                return Err(MonorubyErr::runtimeerr("out of memory"));
+            };
+            let vm = &mut *state.vm;
+            let globals = &mut *state.globals;
+            vm.temp_push(inst);
+            let v =
+                vm.invoke_method_inner(globals, IdentId::get_id("finalize"), inst, &[], None, None)?;
+            vm.temp_push(v);
+            set_result(globals, ctx, v)
+        })();
+        let vm = &mut *state.vm;
+        vm.temp_clear(len);
+        // The group is over either way: its instance must not outlive it.
+        release_aggregate(state, ctx);
+        if let Err(e) = result {
+            let globals = &mut *state.globals;
+            result_error(ctx, &e.get_error_message(&globals.store));
+            state.error = Some(e);
+        }
+    }
+}
+
+/// Database#define_aggregator2(klass, name) -> self
+///
+/// The C-level half of `create_aggregate` and `create_aggregate_handler`.
+/// The gem hands over a class, not a block: it answers `arity`, and each
+/// group gets one instance whose `step` runs per row and whose
+/// `finalize` answers the result.
+///
+/// Unlike a scalar function, the arity really is registered — SQLite
+/// refuses `mysum(a, b)` for an aggregate declared with one.
+#[monoruby_builtin]
+fn db_define_aggregator(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    _: BytecodePtr,
+) -> Result<Value> {
+    let db = db_of(vm, globals, lfp.self_val())?;
+    let klass = lfp.arg(0);
+    let name = lfp.arg(1).expect_string(&globals.store)?;
+    let bytes = name.as_bytes();
+    let upto = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
+    let cname = CString::new(&bytes[..upto]).expect("no NUL before the first NUL");
+    let arity = vm
+        .invoke_method_inner(globals, IdentId::get_id("arity"), klass, &[], None, None)?
+        .coerce_to_i64(globals)? as c_int;
+    // Rooted for as long as SQLite may instantiate it.
+    native_mut::<DbHandle>(lfp.self_val())?.funcs.push(klass);
+    let entry = Box::into_raw(Box::new(FuncEntry::Aggregate { klass }));
+    FUNC_COUNT.with(|n| n.set(n.get() + 1));
+    // SAFETY: a live connection and a NUL-terminated name; `entry` goes
+    // to SQLite, which gives it back to `func_destroy`.
+    let rc = unsafe {
+        sq::sqlite3_create_function_v2(
+            db,
+            cname.as_ptr(),
+            arity,
+            sq::SQLITE_UTF8,
+            entry as *mut c_void,
+            None,
+            Some(agg_step),
+            Some(agg_final),
+            Some(func_destroy),
+        )
+    };
+    if rc != sq::SQLITE_OK {
+        // SAFETY: the box just leaked, still unshared.
+        drop(unsafe { Box::from_raw(entry) });
+        FUNC_COUNT.with(|n| n.set(n.get() - 1));
+        check(vm, globals, db, rc)?;
+    }
+    Ok(lfp.self_val())
 }
 
 /// Database#define_function_with_flags(name, flags, &block) -> self
@@ -1357,7 +1635,7 @@ fn register_function(
     if let Some(mut h) = funcs.try_hash_ty() {
         h.insert(Value::string_from_str(&name), block, vm, globals)?;
     }
-    let entry = Box::into_raw(Box::new(FuncEntry { block }));
+    let entry = Box::into_raw(Box::new(FuncEntry::Scalar { block }));
     // From here on `stmt_step` installs a guard: something can call back.
     FUNC_COUNT.with(|n| n.set(n.get() + 1));
     // SAFETY: a live connection and a NUL-terminated name; `entry` is
@@ -1384,17 +1662,6 @@ fn register_function(
         check(vm, globals, db, rc)?;
     }
     Ok(lfp.self_val())
-}
-
-/// Database#define_aggregator2(klass, name) -> raises
-#[monoruby_builtin]
-fn db_define_aggregator(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    db_of(vm, globals, lfp.self_val())?;
-    Err(err_sqlite3(
-        vm,
-        globals,
-        "create_aggregate is not supported by monoruby's sqlite3 binding",
-    ))
 }
 
 /// Database#complete?(sql) -> bool
@@ -1550,7 +1817,18 @@ fn stmt_step(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
     // leaves an exception on it rather than unwinding through SQLite.
     // SAFETY: a live statement.
     let db = unsafe { sq::sqlite3_db_handle(stmt) };
-    let mut guard = CallGuard::new(vm, globals, db);
+    // The statement's connection, which an aggregate callback needs to
+    // reach its instance table. Read only when a callback is possible:
+    // this is one call per row, and an ivar lookup on it is not free.
+    let db_obj = if guard_needed() {
+        globals
+            .store
+            .get_ivar(lfp.self_val(), IdentId::get_id("@connection"))
+            .unwrap_or_default()
+    } else {
+        Value::nil()
+    };
+    let mut guard = CallGuard::new(vm, globals, db, db_obj);
     // SAFETY: a live statement.
     let rc = unsafe { sq::sqlite3_step(stmt) };
     if let Some(e) = guard.take_error() {

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -1308,6 +1308,7 @@
 5f4db5ebb75f3bf2b8fad5e3973d2488	false	Signal.list.key?("STKFLT")
 5f502389a3a181f8cfec5b92a9db85e4	true	class C; def to_hash; {a: 1, b: 2}; end; end; o = C.new\n{a: 1} < o
 5f637862fb315cc465da084fe56c166d	["hello", "text"]	sup = Class.new do\n          def self.message; "text"; end\n          de
+5f7bb3d687ecacaf94783d8a4a690725	[[[63]], [["a", 3], ["b", 60]], [[0]], ["SQLite3::SQLException", "wrong number of arguments to function mysum():"], [[63, 68]], [[126]], [[30]]]	require "rubygems"\n        require "sqlite3"\n        db = SQLite3::Data
 5f968c34cfb703342017f7f54f8c80f2	[[[:p, 1], [:q, 2]], [[:p, 1], [:q, 2]], [[[:p, 1]], [[:q, 2]]]]	cls = Class.new(Hash)\n            h = cls.new\n            h[:p] = 1
 5fb588dcb4947000799dc1e9785f944e	["[1, 2] {a: 100}", "[3] {e: 70, f: 80, g: 90}", "[2, 50, 3] {e: 70, f: 80, g: 90}"]	class C\n          def g(*rest, **kw)\n            $res << "#{rest} #{kw}
 5fcac55c31908b7b4a4a1adfec76e1e7	[:x, :y]	D = Data.define(:x, :y)\nClass.new(D).members
@@ -1779,6 +1780,7 @@
 82447060301c9a64b3ac42318f460e62	[1, 2, 3]	class C\n          def foo(*x)\n            x\n          end\n        end\n 
 8256e9068f6e136c99b87f2f7f97fdb8	[[ArgumentError, "negative signal name: -HUP"], "negative signal name: -INT"]	[(begin; Signal.trap("-HUP") {}; rescue => e; [e.class, e.message]; end), (begin
 82575417647315f480a84e42f3ee1d81	[{"a" => [{"k" => "line one line two", "n" => 1}, {"k" => 2}]}, {"a" => [{"k" => "line one line two", "n" => 1}, {"k" => 2}]}, {"a" => [{"k" => "plain one plain two", "n" => 1}, {"k" => 2}]}, {"a" => [{"k" => "it's two", "n" => 1}]}, {"a" => "x\\ny", "b" => "tab\\there", "c" => "don't"}, {"k" => "<p>You can (555) 567-2222.</p> <p>Our store is at <em>Rue d'Avignon 32</em>.</p>", "created_at" => "2005-04-04 12:00"}, {"pages" => [{"id" => 1, "content" => "first second", "at" => "x"}, {"id" => 2, "content" => "plain"}]}]	require "yaml"\n        docs = [\n          "a:\\n  - k:\\n      \\"line one
+8271dea172f15ee665f12b31debc89bb	[60, ["g0", 93], ["g9", 93], [93], [5580]]	require "rubygems"\n        require "sqlite3"\n        db = SQLite3::Data
 829f48ebfbc6e4030ced77aaec24c37b	[200, 2]	def a4\n          v = [1, 2, 3].each do |i|\n            begin\n          
 82abda467be3a95b2f6d81fbf7dfb3da	"a:a b:{x: 100, y: 200}"	def f(a, b)\n          "a:#{a} b:#{b}"\n        end\n        \n\n        f("
 82afafb55f0b808c4e046dd1d983831d	["ASCII-8BIT", "US-ASCII", "US-ASCII"]	[/\\xc2\\xa1/n.encoding.to_s, /abc/n.encoding.to_s, /\\x7f/n.encoding.to_s]
@@ -2090,6 +2092,7 @@
 9a0db96111752b4a7ebf036bac1d4c9d	[nil, nil]	[\n              NameError.new.name,\n              NameError.new("ju
 9a1505ab976bab44314875f75f0aad94	true	o = Object.new\n            def o.to_str = "CORE"\n            Proces
 9a22f6dc0c7579d2bfa1447443b56f1f	[42, "nil"]	def bar\n              begin\n                raise "err"\n           
+9a29e613d3183de95f2d0f2acb84a31a	[["ArgumentError", "step boom"], ["RuntimeError", "final boom"], [[3]], [[6]]]	require "rubygems"\n        require "sqlite3"\n        db = SQLite3::Data
 9a380b66d043485e0a0a37c95be6a53e	["LoadError", "nonexistent_file_that_does_not_exist_12345"]	begin\n              require "nonexistent_file_that_does_not_exist_1
 9a6e41140cc5bce63cf4551de96c121c	[{a: 1, b: "x"}, 1, nil]	Fiber[:a] = 1\n            Fiber[:b] = "x"\n            [Fiber.curren
 9a7c12c16e1ba0fafa05ddfb9e353d1b	[7, 3]	def leaky\n          [1].each { return 9 }\n        ensure\n          retu

--- a/monoruby/tests/sqlite3.rs
+++ b/monoruby/tests/sqlite3.rs
@@ -452,26 +452,18 @@ fn sqlite3_statements_are_finalized_when_collected() {
 /// binding refuses loudly instead, with a `SQLite3::Exception` naming
 /// the feature, rather than appearing to work.
 ///
-/// `create_function` is no longer among them — see
-/// `sqlite3_create_function`.
+/// `create_function` and `create_aggregate` are no longer among them —
+/// see `sqlite3_create_function` and `sqlite3_create_aggregate`.
 #[test]
 fn sqlite3_unsupported_callbacks_refuse() {
     let v = run_test_no_result_check(
         r##"
         require "sqlite3"
         db = SQLite3::Database.new(":memory:")
-        agg = Class.new do
-          def self.arity; 1; end
-          def self.name; "myagg"; end
-          def step(x); end
-          def finalize; 0; end
-        end
         r = []
-        r << (begin; db.create_aggregate_handler(agg); rescue => e; [e.class.name, e.message]; end)
         r << (begin; db.collation("c", Object.new); rescue => e; [e.class.name, e.message]; end)
         r << (begin; db.load_extension("x"); rescue => e; [e.class.name, e.message]; end)
         expected = [
-          ["SQLite3::Exception", "create_aggregate is not supported by monoruby's sqlite3 binding"],
           ["SQLite3::Exception", "collation is not supported by monoruby's sqlite3 binding"],
           ["SQLite3::Exception", "load_extension is not available: monoruby's SQLite is built without extension loading"],
         ]
@@ -493,7 +485,7 @@ fn sqlite3_unsupported_callbacks_refuse() {
         r.size + r2.size
         "##,
     );
-    assert_eq!(v.try_fixnum(), Some(8));
+    assert_eq!(v.try_fixnum(), Some(7));
 }
 
 /// The failure paths of opening a connection, and `open16`, which the
@@ -744,6 +736,130 @@ fn sqlite3_function_reentrancy() {
         db.create_function("wrap", 0) { |fp| fp.result = db.execute("SELECT inner_bad()").flatten.first }
         res << (begin; db.execute("SELECT wrap()"); rescue StandardError => e; [e.class.name, e.message]; end)
         res << db.execute("SELECT COUNT(*) FROM t")
+        db.close
+        res
+        "##,
+    );
+}
+
+/// `create_aggregate` over the native binding. The gem builds a class
+/// whose instances hold a `FunctionProxy`; the binding makes one per
+/// aggregation group, steps it per row, and finalizes it once.
+#[test]
+fn sqlite3_create_aggregate() {
+    run_test_once(
+        r##"
+        require "rubygems"
+        require "sqlite3"
+        db = SQLite3::Database.new(":memory:")
+        db.execute("CREATE TABLE t (g, v)")
+        [["a", 1], ["a", 2], ["b", 10], ["b", 20], ["b", 30]].each { |g, v|
+          db.execute("INSERT INTO t VALUES (?, ?)", [g, v])
+        }
+        db.create_aggregate("mysum", 1) do
+          step { |ctx, v| ctx[:sum] = (ctx[:sum] || 0) + v.to_i }
+          finalize { |ctx| ctx.result = ctx[:sum] || 0 }
+        end
+        res = [db.execute("SELECT mysum(v) FROM t")]
+        res << db.execute("SELECT g, mysum(v) FROM t GROUP BY g ORDER BY g")
+        # A group with no rows still finalizes, on a fresh instance.
+        res << db.execute("SELECT mysum(v) FROM t WHERE g = 'zzz'")
+        # Unlike a scalar function, an aggregate's arity is registered.
+        res << (begin
+                  db.execute("SELECT mysum(v, v) FROM t")
+                rescue SQLite3::Exception => e
+                  [e.class.name, e.message.lines.first.chomp]
+                end)
+        # Two aggregates in one query accumulate independently.
+        res << db.execute("SELECT mysum(v), mysum(v + 1) FROM t")
+        # And one composed with a scalar function.
+        db.create_function("dbl", 1) { |fp, v| fp.result = v.to_i * 2 }
+        res << db.execute("SELECT mysum(dbl(v)) FROM t")
+        # `create_aggregate_handler` takes a class directly.
+        handler = Class.new do
+          def self.arity = 1
+          def self.name = "handlermax"
+          def initialize; @m = nil; end
+          def step(ctx, v); @m = v.to_i if @m.nil? || v.to_i > @m; end
+          def finalize(ctx); ctx.result = @m; end
+        end
+        db.create_aggregate_handler(handler)
+        res << db.execute("SELECT handlermax(v) FROM t")
+        db.close
+        res
+        "##,
+    );
+}
+
+/// A raise from either callback must not unwind through SQLite's C
+/// frames: it is carried out of the step and re-raised unchanged, and
+/// the connection stays usable.
+#[test]
+fn sqlite3_aggregate_exceptions() {
+    run_test_once(
+        r##"
+        require "rubygems"
+        require "sqlite3"
+        db = SQLite3::Database.new(":memory:")
+        db.execute("CREATE TABLE t (v)")
+        db.execute("INSERT INTO t VALUES (1), (2), (3)")
+        res = []
+        db.create_aggregate("boomstep", 1) do
+          step { |ctx, v| raise ArgumentError, "step boom" if v.to_i == 2 }
+          finalize { |ctx| ctx.result = 0 }
+        end
+        res << (begin
+                  db.execute("SELECT boomstep(v) FROM t")
+                rescue StandardError => e
+                  [e.class.name, e.message]
+                end)
+        db.create_aggregate("boomfin", 1) do
+          step { |ctx, v| }
+          finalize { |ctx| raise "final boom" }
+        end
+        res << (begin
+                  db.execute("SELECT boomfin(v) FROM t")
+                rescue StandardError => e
+                  [e.class.name, e.message]
+                end)
+        # Unaffected afterwards, and a working aggregate still runs.
+        res << db.execute("SELECT COUNT(*) FROM t")
+        db.create_aggregate("ok", 1) do
+          step { |ctx, v| ctx[:n] = (ctx[:n] || 0) + v.to_i }
+          finalize { |ctx| ctx.result = ctx[:n] }
+        end
+        res << db.execute("SELECT ok(v) FROM t")
+        db.close
+        res
+        "##,
+    );
+}
+
+/// Every group holds a live instance the collector must not reclaim,
+/// and a finished group's slot must be reused rather than leaked.
+#[test]
+fn sqlite3_aggregate_group_state() {
+    run_test_once(
+        r##"
+        require "rubygems"
+        require "sqlite3"
+        db = SQLite3::Database.new(":memory:")
+        db.execute("CREATE TABLE t (g, v)")
+        db.execute("BEGIN")
+        60.times { |i| 3.times { |j| db.execute("INSERT INTO t VALUES (?, ?)", ["g#{i}", j]) } }
+        db.execute("COMMIT")
+        # The block allocates on every row, so a collection can land
+        # between them while every group's instance is in flight.
+        db.create_aggregate("collect", 1) do
+          step { |ctx, v| (ctx[:a] ||= []) << ("y" * 30 + v.to_s) }
+          finalize { |ctx| ctx.result = (ctx[:a] || []).map(&:size).sum }
+        end
+        rows = db.execute("SELECT g, collect(v) FROM t GROUP BY g ORDER BY g")
+        res = [rows.size, rows.first, rows.last, rows.map { |r| r[1] }.uniq]
+        # Running it again must reuse the slots the first run released.
+        3.times { db.execute("SELECT g, collect(v) FROM t GROUP BY g") }
+        GC.start
+        res << db.execute("SELECT collect(v) FROM t").flatten
         db.close
         res
         "##,


### PR DESCRIPTION
`Database#define_aggregator2` registers a real aggregate, which is what `create_aggregate` and `create_aggregate_handler` are built on. The gem hands the native side a class rather than a block: it answers `arity`, and each aggregation group gets one instance whose `step` runs per row and whose `finalize` answers the result.

```ruby
db.create_aggregate("mysum", 1) do
  step { |ctx, n| ctx[:sum] = (ctx[:sum] || 0) + n }
  finalize { |ctx| ctx.result = ctx[:sum] || 0 }
end
db.execute("select k, mysum(v) from t group by k")
```

## Per-group state

The callbacks ride the machinery #1318 introduced: the per-connection call state, and an exception stashed rather than unwound through SQLite's C frames.

What is new is the per-group state. SQLite keeps that in `sqlite3_aggregate_context`, which is C memory the collector cannot see. So the context word holds a slot number and the instance itself lives in `DbHandle::aggregates`, where `mark` finds it. `xFinal` frees the slot for the next group, so a `GROUP BY` over many groups reuses slots rather than growing the table without bound.

## Three differences from a scalar function

All of them are the extension's behaviour rather than a choice here.

- The arity really is registered, so `mysum(a, b)` against an aggregate declared with one argument is refused by SQLite. The arity given to `create_function` never reaches SQLite at all.
- `xFinal` runs for a group that never stepped, an aggregate over no rows, and must answer what a fresh instance's `finalize` returns. One is created there.
- The result comes from `finalize`'s return value, not from a `FunctionProxy` the binding reads.

## Hot path

`stmt_step` is one call per row. The connection object an aggregate callback needs is read from the statement's `@connection` only when some function is defined on the connection. Reading it unconditionally cost activerecord about 2 %, which is what the instance-variable lookup and interning the name come to per row.

| benchmark | before | after |
| --- | --- | --- |
| activerecord | 191 ms | 186 ms |
| sequel | 86 ms | 85 ms |

Interleaved rounds, medians. Interleaving matters: absolute numbers drift with machine state, so alternating the two binaries within one run is the only comparison that holds.

## Verification

Diffed against the gem's real C extension throughout: grouped and ungrouped, empty groups, two aggregates in one query, an aggregate over a scalar function, `create_aggregate_handler`, and a raise from either callback with the connection still usable afterwards.

Separately, the callbacks are exercised with a JIT compile and a deopt taken inside them, with a nested query on the same connection, and under `gc-stress` with sixty groups' instances in flight at once. That last one is what pins the slot table's rooting.

A `collation` with a real comparator is still unsupported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013q5CpZ6eqZUJtPhSJHfjus

---
_Generated by [Claude Code](https://claude.ai/code/session_013q5CpZ6eqZUJtPhSJHfjus)_