### PR TITLE
sqlite3: free a refused registration's entry the way SQLite does

### DIFF
--- a/monoruby/src/builtins/sqlite3.rs
+++ b/monoruby/src/builtins/sqlite3.rs
@@ -1031,18 +1031,18 @@ fn db_authorizer_assign(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: B
 // User-defined functions
 // ---------------------------------------------------------------------
 
-/// One registered scalar function: the Proc `create_function` was given.
+/// One registered function: the Proc `create_function` was given, or the
+/// class `create_aggregate` was given. Which of the two it is follows
+/// from the callbacks registered beside it — `func_invoke` is only ever
+/// given a Proc, `agg_step` / `agg_final` only ever a class — so the
+/// entry does not carry the distinction a second time.
 ///
 /// SQLite keeps this as the function's `pApp` for as long as the function
 /// is defined, so it is a leaked `Box` freed by the `xDestroy` below. The
-/// same Proc is also held in `DbHandle::funcs`, which is what roots it
+/// same value is also held in `DbHandle::funcs`, which is what roots it
 /// for the collector — this copy is never the only reference.
-enum FuncEntry {
-    /// `create_function`: one block, run per row.
-    Scalar { block: Value },
-    /// `create_aggregate`: a class, instantiated once per group. Its
-    /// instances answer `step(*args)` per row and `finalize` once.
-    Aggregate { klass: Value },
+struct FuncEntry {
+    value: Value,
 }
 
 /// `xDestroy`: SQLite calls this when the function is replaced or its
@@ -1307,11 +1307,7 @@ unsafe extern "C" fn func_invoke(
             vm.temp_push(v);
             args.push(v);
         }
-        let FuncEntry::Scalar { block } = entry else {
-            result_error(ctx, "not a scalar function");
-            return;
-        };
-        let result = match block.is_proc() {
+        let result = match entry.value.is_proc() {
             Some(p) => vm.invoke_proc(globals, &p, &args),
             None => Err(err_sqlite3(vm, globals, "function block is not a Proc")),
         };
@@ -1331,11 +1327,11 @@ unsafe extern "C" fn func_invoke(
 
 /// The instance accumulating this group, creating it on the first row.
 ///
-/// SQLite's per-group memory is a slot number into the connection's
-/// instance table; zero means "not started", so slots are stored
-/// one-based. `n` is the size to allocate — zero asks without
-/// allocating, which is what `xFinal` does to tell an empty group from
-/// one that stepped.
+/// SQLite's per-group memory is four bytes holding a slot number into
+/// the connection's instance table; zero means "not started yet", so
+/// slots are stored one-based. The pointer to those bytes comes back
+/// with the instance, so `xFinal` can free the slot without asking for
+/// it a second time.
 ///
 /// # Safety
 /// A live context belonging to `state`'s connection.
@@ -1343,29 +1339,28 @@ unsafe fn aggregate_instance(
     state: &mut CallState,
     ctx: *mut sq::sqlite3_context,
     klass: Value,
-    create: bool,
-) -> Result<Option<Value>> {
+) -> Result<(Value, *mut u32)> {
     // SAFETY: the caller's contract.
-    let slot_ptr = unsafe {
-        sq::sqlite3_aggregate_context(ctx, if create { 4 } else { 0 }) as *mut u32
-    };
+    let slot_ptr = unsafe { sq::sqlite3_aggregate_context(ctx, 4) as *mut u32 };
     if slot_ptr.is_null() {
-        // Out of memory, or `xFinal` on a group that never stepped.
-        return Ok(None);
+        // The one failure SQLite reports this way.
+        return Err(MonorubyErr::runtimeerr("out of memory"));
     }
     // SAFETY: four bytes SQLite zeroed for us and keeps for this group.
     let slot = unsafe { *slot_ptr };
-    let vm = unsafe { &mut *state.vm };
-    let globals = unsafe { &mut *state.globals };
-    if slot != 0 {
-        let table = &native_mut::<DbHandle>(state.db_obj)?.aggregates;
-        return Ok(table.get(slot as usize - 1).copied().flatten());
-    }
-    if !create {
-        return Ok(None);
+    if slot != 0
+        && let Some(inst) = native_mut::<DbHandle>(state.db_obj)?
+            .aggregates
+            .get(slot as usize - 1)
+            .copied()
+            .flatten()
+    {
+        return Ok((inst, slot_ptr));
     }
     // First row of this group: one instance of the proxy class, which
     // holds the caller's `FunctionProxy` as its context.
+    let vm = unsafe { &mut *state.vm };
+    let globals = unsafe { &mut *state.globals };
     let inst = vm.invoke_method_inner(globals, IdentId::NEW, klass, &[], None, None)?;
     let table = &mut native_mut::<DbHandle>(state.db_obj)?.aggregates;
     let index = match table.iter().position(|e| e.is_none()) {
@@ -1381,24 +1376,16 @@ unsafe fn aggregate_instance(
     // SAFETY: as above; SQLite hands back the same four bytes for every
     // row of this group.
     unsafe { *slot_ptr = index as u32 + 1 };
-    Ok(Some(inst))
+    Ok((inst, slot_ptr))
 }
 
 /// Drop this group's instance, freeing its slot for the next group.
 ///
 /// # Safety
-/// As `aggregate_instance`.
-unsafe fn release_aggregate(state: &mut CallState, ctx: *mut sq::sqlite3_context) {
-    // SAFETY: the caller's contract; asking with 0 never allocates.
-    let slot_ptr = unsafe { sq::sqlite3_aggregate_context(ctx, 0) as *mut u32 };
-    if slot_ptr.is_null() {
-        return;
-    }
-    // SAFETY: four bytes SQLite kept for this group.
+/// The slot `aggregate_instance` handed back for a group still running.
+unsafe fn release_aggregate(state: &mut CallState, slot_ptr: *mut u32) {
+    // SAFETY: the caller's contract; the slot is one-based and non-zero.
     let slot = unsafe { *slot_ptr };
-    if slot == 0 {
-        return;
-    }
     if let Ok(h) = native_mut::<DbHandle>(state.db_obj)
         && let Some(e) = h.aggregates.get_mut(slot as usize - 1)
     {
@@ -1406,6 +1393,27 @@ unsafe fn release_aggregate(state: &mut CallState, ctx: *mut sq::sqlite3_context
     }
     // SAFETY: as above.
     unsafe { *slot_ptr = 0 };
+}
+
+/// Free a group's instance when `xFinal` cannot run normally — almost
+/// always because an earlier row raised and the step is unwinding. The
+/// group is over either way, so leaving the instance in the table would
+/// pin it, and its slot, for the life of the connection.
+///
+/// # Safety
+/// A live context, inside `xFinal`.
+unsafe fn release_aborted_aggregate(ctx: *mut sq::sqlite3_context) {
+    // SAFETY: the caller's contract; asking with 0 never allocates, so
+    // a group that never stepped answers null and has nothing to free.
+    let slot_ptr = unsafe { sq::sqlite3_aggregate_context(ctx, 0) as *mut u32 };
+    // SAFETY: as above.
+    let Some(state) = (unsafe { current_call(sq::sqlite3_context_db_handle(ctx)) }) else {
+        return;
+    };
+    if !slot_ptr.is_null() {
+        // SAFETY: the slot SQLite kept for this group, still one-based.
+        unsafe { release_aggregate(&mut *state, slot_ptr) };
+    }
 }
 
 /// Recover the running step and this function's registration, or report
@@ -1442,19 +1450,14 @@ unsafe extern "C" fn agg_step(
         let Some((state, entry)) = callback_state(ctx) else {
             return;
         };
-        let FuncEntry::Aggregate { klass } = entry else {
-            result_error(ctx, "not an aggregate function");
-            return;
-        };
+        let klass = entry.value;
         let vm = &mut *state.vm;
         let globals = &mut *state.globals;
         // The instance and the arguments stay rooted while the rest are
         // built: each is fresh, and allocating the next may collect.
         let len = vm.temp_len();
         let result = (|| -> Result<()> {
-            let Some(inst) = aggregate_instance(state, ctx, *klass, true)? else {
-                return Err(MonorubyErr::runtimeerr("out of memory"));
-            };
+            let (inst, _) = aggregate_instance(state, ctx, klass)?;
             let vm = &mut *state.vm;
             let globals = &mut *state.globals;
             vm.temp_push(inst);
@@ -1484,19 +1487,20 @@ unsafe extern "C" fn agg_final(ctx: *mut sq::sqlite3_context) {
     // SAFETY: SQLite passes a live context.
     unsafe {
         let Some((state, entry)) = callback_state(ctx) else {
+            release_aborted_aggregate(ctx);
             return;
         };
-        let FuncEntry::Aggregate { klass } = entry else {
-            result_error(ctx, "not an aggregate function");
-            return;
-        };
+        let klass = entry.value;
         let vm = &mut *state.vm;
         let len = vm.temp_len();
+        // The slot this group's instance sits in, so it can be freed
+        // below whether `finalize` answered or raised.
+        let mut slot_ptr: *mut u32 = std::ptr::null_mut();
         let result = (|| -> Result<()> {
-            // `create` here is what makes an empty group answer.
-            let Some(inst) = aggregate_instance(state, ctx, *klass, true)? else {
-                return Err(MonorubyErr::runtimeerr("out of memory"));
-            };
+            // A group that never stepped starts its instance here, which
+            // is what makes an aggregate over no rows answer.
+            let (inst, p) = aggregate_instance(state, ctx, klass)?;
+            slot_ptr = p;
             let vm = &mut *state.vm;
             let globals = &mut *state.globals;
             vm.temp_push(inst);
@@ -1508,7 +1512,9 @@ unsafe extern "C" fn agg_final(ctx: *mut sq::sqlite3_context) {
         let vm = &mut *state.vm;
         vm.temp_clear(len);
         // The group is over either way: its instance must not outlive it.
-        release_aggregate(state, ctx);
+        if !slot_ptr.is_null() {
+            release_aggregate(state, slot_ptr);
+        }
         if let Err(e) = result {
             let globals = &mut *state.globals;
             result_error(ctx, &e.get_error_message(&globals.store));
@@ -1544,7 +1550,7 @@ fn db_define_aggregator(
         .coerce_to_i64(globals)? as c_int;
     // Rooted for as long as SQLite may instantiate it.
     native_mut::<DbHandle>(lfp.self_val())?.funcs.push(klass);
-    let entry = Box::into_raw(Box::new(FuncEntry::Aggregate { klass }));
+    let entry = Box::into_raw(Box::new(FuncEntry { value: klass }));
     FUNC_COUNT.with(|n| n.set(n.get() + 1));
     // SAFETY: a live connection and a NUL-terminated name; `entry` goes
     // to SQLite, which gives it back to `func_destroy`.
@@ -1562,8 +1568,9 @@ fn db_define_aggregator(
         )
     };
     if rc != sq::SQLITE_OK {
-        // SAFETY: the box just leaked, still unshared.
-        drop(unsafe { Box::from_raw(entry) });
+        // `entry` is not ours to free: SQLite runs `xDestroy` on the
+        // application data when the registration itself fails, so the
+        // box has already been dropped by the time this is reached.
         FUNC_COUNT.with(|n| n.set(n.get() - 1));
         check(vm, globals, db, rc)?;
     }
@@ -1635,7 +1642,7 @@ fn register_function(
     if let Some(mut h) = funcs.try_hash_ty() {
         h.insert(Value::string_from_str(&name), block, vm, globals)?;
     }
-    let entry = Box::into_raw(Box::new(FuncEntry::Scalar { block }));
+    let entry = Box::into_raw(Box::new(FuncEntry { value: block }));
     // From here on `stmt_step` installs a guard: something can call back.
     FUNC_COUNT.with(|n| n.set(n.get() + 1));
     // SAFETY: a live connection and a NUL-terminated name; `entry` is
@@ -1654,10 +1661,8 @@ fn register_function(
         )
     };
     if rc != sq::SQLITE_OK {
-        // SQLite did not take the function, so `xDestroy` never runs and
-        // the box is ours to free.
-        // SAFETY: the box just leaked, still unshared.
-        drop(unsafe { Box::from_raw(entry) });
+        // As above: a failed registration still runs `xDestroy`, so the
+        // box is already gone and freeing it here would double-free.
         FUNC_COUNT.with(|n| n.set(n.get() - 1));
         check(vm, globals, db, rc)?;
     }

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -35,6 +35,7 @@
 01c4e0473295f086423b12e2cc1c13d8	"dd"	"foo" =~ /(o+)/\n            Enumerator.new { |y| "dd" =~ /(d+)/; y 
 01c75784b17e927119a6f718cf196d83	"missing keyword: :x"	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; def m(x:)
 01cdf73be52a73b5c8a772cfd2975bf0	[:pub, "Method", :priv_err, :prot_err, :missing_err]	class PubMethSpec\n              def pub; :pub; end\n              pr
+01cee626a438d39cf2c4e7fca7e9b8d5	[60, ["g0", 93], ["g9", 93], [93], [5580], [["g0", 3], ["g1", 3]]]	require "rubygems"\n        require "sqlite3"\n        db = SQLite3::Data
 01db1c6b4f58aff12e2dbade8652decf	"2.5e+00"	class HasToF; def to_f; 2.5; end; end\n            sprintf("%.1e", H
 01f5957c8d7059b4dc6d1a49e6890469	[:a, [:a, :b]]	m = Module.new do\n              def a; end\n              def b; end
 02383c606eb753dd897479b98e6e993a	[1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987]	fib = Enumerator::Generator.new do |y|\n                a = b = 1\n  
@@ -1221,6 +1222,7 @@
 58ae474979a8f24c46f6287c4ea2d27e	42	begin\n          exit(42)\n        rescue SystemExit => e\n          e.sta
 58e3d47261cf211685533a77ad92ecdd	[:lje, :m, :good]	res = []\n        # a return whose home chain crosses a class body is in
 58eabdb793930657cccdfdf8db5c2d99	[[1, 2], 3]	lambda { |((*a, b))| [a, b] }.call([[1, 2, 3]])
+590f817f96b25b6345b772998bf12eb1	[[["[[\\"Integer\\", 1], [\\"Float\\", 2.5], [\\"NilClass\\", nil], [\\"String\\", \\"\\\\x00\\\\xFF\\"], [\\"String\\", \\"txt\\"]]"]], [["int", [["integer", 7]]], ["big", [["real", 1.1805916207174113e+21]]], ["float", [["real", 1.5]]], ["nil", [["null", nil]]], ["text", [["text", "plain"]]], ["binary", [["blob", "bin"]]], ["blob", [["blob", "\\x00\\xFF"]]], ["bool", "RuntimeError", "can't return TrueClass"], ["obj", "RuntimeError", "can't return Object"]], [["got 1"]], [[[15]], [[0]]], ["ArgumentError", "tried to create Proc object without a block"], [[14]], ["a\\u0000b", "one", "ret", "triple", "types"], [[2]], ["SQLite3::MisuseException", "not an error"], [[3]]]	require "rubygems"\n        require "sqlite3"\n        db = SQLite3::Data
 59104be79a3c34af64f1252be7287e04	42	x = 1\n            binding.eval("x = 42")\n            x\n            
 591cc1df80c9acab4811bc6f380f4314	"<STDIN>"	$stdin.path
 5935b2a14b1389efa07807ca17f49618	true	f = File.open("Cargo.toml")\n            begin\n              f.flush
@@ -1229,6 +1231,7 @@
 59a5cb7a0c17abeadcdd4fb2b0ab7b76	1	case 9\n        when 0,4,8\n          0\n        when 1,5,9\n          1\n  
 59a6ce8e2915130ae9576712b5a0f444	[1.0, Infinity]	[1.0, 1.0 / 0.0]
 59b430ac9ae86f562aec95304e3961db	[:FOO]	$res = []\n            class C\n              def self.const_added(na
+59b749e32a062fc95a24e05a583a51f7	[[[63]], [["a", 3], ["b", 60]], [[0]], ["SQLite3::SQLException", "wrong number of arguments to function mysum():"], [[63, 68]], [[126]], ["SQLite3::MisuseException", "not an error"], [[30]]]	require "rubygems"\n        require "sqlite3"\n        db = SQLite3::Data
 59fe9d3049fb74a53b64cc5407966322	[[[:a, 300], [:b, 300], [:c, 270], [:d, 30]], :e, :d]	class Ra; def tag = :a; end\n            class Rb; def tag = :b; end
 5a20645aebc0d88e162feb3d416ba777	3	class Integer; alias __orig :/; def /(o); __orig(o); end; end; 12 / 4
 5a33fd783a7b98bc5a5ed1d31a52649b	[[1, 2, 3, 4], 1, [1, 3]]	class Wrap\n          def initialize(a) = @a = a\n          def +(...)\n  

--- a/monoruby/tests/sqlite3.rs
+++ b/monoruby/tests/sqlite3.rs
@@ -672,6 +672,15 @@ fn sqlite3_create_function() {
         # SQLITE_DETERMINISTIC passes through.
         db.define_function_with_flags("det", 0x800) { |v| v.to_i + 1 }
         res << db.execute("SELECT det(1)")
+        # A name SQLite refuses is reported, and the connection is
+        # unharmed: the registration SQLite dropped takes its own data
+        # with it.
+        res << (begin
+                  db.create_function("w" * 300, 1) { |fp, v| fp.result = 1 }
+                rescue SQLite3::Exception => e
+                  [e.class.name, e.message]
+                end)
+        res << db.execute("SELECT det(2)")
         db.close
         res
         "##,
@@ -775,6 +784,15 @@ fn sqlite3_create_aggregate() {
         # And one composed with a scalar function.
         db.create_function("dbl", 1) { |fp, v| fp.result = v.to_i * 2 }
         res << db.execute("SELECT mysum(dbl(v)) FROM t")
+        # A name SQLite refuses is reported, and leaves nothing behind.
+        res << (begin
+                  db.create_aggregate("z" * 300, 1) do
+                    step { |ctx, v| }
+                    finalize { |ctx| ctx.result = 1 }
+                  end
+                rescue SQLite3::Exception => e
+                  [e.class.name, e.message]
+                end)
         # `create_aggregate_handler` takes a class directly.
         handler = Class.new do
           def self.arity = 1
@@ -860,6 +878,15 @@ fn sqlite3_aggregate_group_state() {
         3.times { db.execute("SELECT g, collect(v) FROM t GROUP BY g") }
         GC.start
         res << db.execute("SELECT collect(v) FROM t").flatten
+        # A collection forced from inside `step` must find every group's
+        # instance live, including the ones not being stepped.
+        db.create_aggregate("gcsum", 1) do
+          step { |ctx, v| GC.start; ctx[:n] = (ctx[:n] || 0) + v.to_i }
+          finalize { |ctx| ctx.result = ctx[:n] || -1 }
+        end
+        res << db.execute(
+          "SELECT g, gcsum(v) FROM t WHERE g IN ('g0', 'g1') GROUP BY g ORDER BY g"
+        )
         db.close
         res
         "##,


### PR DESCRIPTION
Covering the failure path of `create_aggregate` found a double free, and the same mistake in the scalar path from #1318.

## The double free

SQLite runs `xDestroy` on the application data when `sqlite3_create_function_v2` itself fails:

> The destructor is also invoked if the call to `sqlite3_create_function_v2()` fails.

So freeing the box afterwards frees it twice, and the process aborts on the first refused registration:

```
free(): double free detected in tcache 2
```

The scalar path carried a comment asserting the opposite, and no test had ever reached it. A name over 255 bytes is the way in, and both paths now have a test for it.

## An aborted aggregate query leaked

`xFinal` still runs for every group while a failed statement unwinds. It returned early on the stashed exception without freeing that group's instance, so each aborted aggregate query pinned one Ruby object, and its slot, for the life of the connection.

## What the uncovered lines pointed at

- The registration entry no longer carries a scalar-or-aggregate tag. Which one it is already follows from the callbacks registered beside it, so the two arms that re-checked were unreachable.
- `aggregate_instance` hands back the slot it used, so `xFinal` frees the group without asking SQLite for the same four bytes again. The "ask without allocating" case disappears with it, along with the `create` flag that was always true.

## Tests

Two cases, both diffed against the gem's real C extension as the rest of the file is:

- a refused name for a function and for an aggregate, with the connection still working afterwards;
- a collection forced from inside `step`, so every group's instance is traced through the connection's table.

Patch coverage of the changed file goes from 89.13% to 98.37% locally, measured over `cargo llvm-cov --test sqlite3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013q5CpZ6eqZUJtPhSJHfjus

---
_Generated by [Claude Code](https://claude.ai/code/session_013q5CpZ6eqZUJtPhSJHfjus)_