### PR TITLE
JIT: load the float before the register it would clobber, in both inlined typed stores

### DIFF
--- a/monoruby/src/builtins/fiddle.rs
+++ b/monoruby/src/builtins/fiddle.rs
@@ -877,11 +877,14 @@ fn fiddle_write_inline(
     };
 
     let val_slot = args + 2usize;
-    state.load_fixnum(ir, args, GP::Rdi);
 
     match kind {
         WriteKind::F64 => {
+            // `load_fpr` destroys rdi: a value that is not already in an fpr
+            // is converted through it. So the value reaches its register
+            // before the address is put in rdi, never after.
             let xsrc = state.load_fpr(ir, val_slot);
+            state.load_fixnum(ir, args, GP::Rdi);
             let deopt = ir.new_deopt(state);
             ir.inline(move |r#gen, _, labels, base| {
                 let d = r#gen.deopt_label(labels, deopt, DeoptCause::Value(GP::Rdi));
@@ -889,6 +892,7 @@ fn fiddle_write_inline(
             });
         }
         _ => {
+            state.load_fixnum(ir, args, GP::Rdi);
             state.load_fixnum(ir, val_slot, GP::Rsi);
             let deopt = ir.new_deopt(state);
             let width = match kind {
@@ -1189,6 +1193,29 @@ mod tests {
               raise unless Fiddle.___read(ptr, TY_INT) == 0x41424344
               Fiddle.___write(ptr, TY_DOUBLE, 3.14)
               raise unless Fiddle.___read(ptr, TY_DOUBLE) == 3.14
+            ensure
+              Fiddle.___free(ptr)
+            end
+            :ok
+            "#
+        ));
+    }
+
+    // A double that arrives as a method argument is not already in an fpr,
+    // so the inlined `___write` converts it into one, and that conversion
+    // goes through rdi, where the address had been put. `Fiddle::Pointer`'s
+    // own `write_double` is exactly this shape. The literal in the test
+    // above never reaches it: a constant loads straight into an fpr.
+    #[test]
+    fn fiddle_write_double_argument() {
+        run_test_no_result_check(&format!(
+            r#"{TYPE_PRELUDE}
+            def store(ptr, v) = Fiddle.___write(ptr, TY_DOUBLE, v)
+            ptr = Fiddle.___malloc(8)
+            raise "malloc returned NULL" if ptr == 0
+            begin
+              1000.times {{ |i| store(ptr, i * 1.5) }}
+              raise unless Fiddle.___read(ptr, TY_DOUBLE) == 1498.5
             ensure
               Fiddle.___free(ptr)
             end

--- a/monoruby/src/builtins/io_buffer.rs
+++ b/monoruby/src/builtins/io_buffer.rs
@@ -544,11 +544,14 @@ fn set_value_inline(
     };
 
     let val_slot = args + 2usize;
-    state.load(ir, recv, GP::Rdi);
-    state.load_fixnum(ir, args + 1usize, GP::Rsi);
     match kind {
         ValKind::Float => {
+            // `load_fpr` destroys rdi: a value that is not already in an fpr
+            // is converted through it. So the value reaches its register
+            // before the receiver is put in rdi, never after.
             let xsrc = state.load_fpr(ir, val_slot);
+            state.load(ir, recv, GP::Rdi);
+            state.load_fixnum(ir, args + 1usize, GP::Rsi);
             let deopt = ir.new_deopt(state);
             ir.inline(move |r#gen, _, labels, base| {
                 let d = r#gen.deopt_label(labels, deopt, DeoptCause::Value(GP::Rsi));
@@ -556,6 +559,8 @@ fn set_value_inline(
             });
         }
         _ => {
+            state.load(ir, recv, GP::Rdi);
+            state.load_fixnum(ir, args + 1usize, GP::Rsi);
             let signed = kind == ValKind::Signed;
             // Read the value's link mode *before* `load_fixnum` materializes
             // it: a constant it can see settles the store's range window here
@@ -1845,6 +1850,25 @@ mod tests {
             20.times { |i| t.set_value(:u32, 0, i); res << t.get_value(:u32, 0) << er.call { b3.get_value(:u32, 0) } }
             [r, res]
 
+            "##,
+        );
+    }
+
+    /// A float that arrives as a method argument is not already in an fpr, so
+    /// the inlined `:f64` store converts it into one, and that conversion goes
+    /// through rdi. With the receiver loaded into rdi first, the store read
+    /// the float's bits as the buffer. The block above never reaches that
+    /// path: its own arithmetic leaves the value in an fpr already.
+    #[test]
+    fn io_buffer_set_value_f64_argument() {
+        run_test(
+            r##"
+            def store(b, off, v) = b.set_value(:f64, off, v)
+            def fetch(b, off) = b.get_value(:f64, off)
+            b = IO::Buffer.new(64)
+            sum = 0.0
+            1000.times { |i| store(b, (i % 8) * 8, i * 1.5); sum += fetch(b, (i % 8) * 8) }
+            [sum, fetch(b, 0), fetch(b, 56)]
             "##,
         );
     }

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -2427,6 +2427,7 @@ b074a58194d91b7b13d55025d23399ce	[nil, 2, 1, 1, nil, nil, 5, nil]	x = nil\n     
 b07897e1515470c5f367e6c838cd3ca3	true	h = {a: 1}.compare_by_identity\n            Marshal.load(Marshal.dum
 b0a6a8263e7c30eec12325762ab54dc5	[1, 2, nil, nil, 3, 1, nil, :from_block, [:a, :b, :c, :d, :e], [:a], [:a, :b, :d, :e]]	r = []\n        begin\n          r << 1\n          break if r.size == 1\n  
 b0fd99f84986028ca4c492df3405e97c	[1, true, true, [:autoindexes, :filter_hits, :filter_misses, :fullscan_steps, :reprepares, :runs, :sorts, :vm_steps], 1, [["ArgumentError", "unknown key: nope"], ["TypeError", "non-symbol given"], ["TypeError", "non-symbol given"]], 1, [:autoindexes, :filter_hits, :filter_misses, :fullscan_steps, :reprepares, :runs, :sorts, :vm_steps], "TypeError"]	require "rubygems"\n        require "sqlite3"\n        db = SQLite3::Data
+b10be18d4e367e7c54a931cb46aa1a17	[749250.0, 1488.0, 1498.5]	def store(b, off, v) = b.set_value(:f64, off, v)\n            def fe
 b127614a38e6a826e83df4733ad1c138	[true, true]	require "openssl"\n        [OpenSSL::Cipher::CipherError < OpenSSL::Open
 b13eb772180c210a5c10579da6ea6cfb	true	a = []\n            a << a\n            b = Marshal.load(Marshal.dump
 b15052c5abbd93a1a9004be3b57beb9c	[:foo, :bar]	$res = []\n            obj = Object.new\n            def obj.singleto


### PR DESCRIPTION
Two inlined typed stores loaded their value over the register that held the destination.

`set_value_inline` (`IO::Buffer#set_value`) put the receiver in rdi and only then asked for the value's fpr; `fiddle_write_inline` (`Fiddle.___write`) did the same with the address. `load_fpr` destroys rdi whenever the value is not already in an fpr: that arm, `FprLoad::FromStack`, emits `<load Rdi>; float_to_fpr(Rdi, ...)`, as its own doc comment states.

A float is in that state whenever it arrives as a method argument instead of being computed in the frame, which is exactly what the existing coverage never does: the `:f64` cases in `io_buffer_get_set_value_jit` compute the value in the block that stores it, and `fiddle_read_write_roundtrip` passes a literal, which loads straight into an fpr.

```ruby
def store(b, off, v) = b.set_value(:f64, off, v)
b = IO::Buffer.new(64)
1000.times { |i| store(b, 0, i * 1.5) }   # SIGSEGV once `store` is compiled
```

```ruby
def store(ptr, v) = Fiddle.___write(ptr, Fiddle::Types::DOUBLE, v)
ptr = Fiddle.___malloc(8)
1000.times { |i| store(ptr, i * 1.5) }    # SIGSEGV once `store` is compiled
```

`Fiddle::Pointer#write_double` is the second shape verbatim, so every JIT-compiled `write_double` call was affected.

The two differ in what the clobbered register was about to do. At the `IO::Buffer` fault, rip is in JIT code at `movq rdi, [rdi + 0x10]`, the first instruction of `emit_io_buffer_addr`, with `rdi = 0x404bc00000000000`: the double being stored, read as the buffer. `emit_fiddle_write_f64` instead untags rdi as the *destination*, so that one does not fault on a load at all. It stores the double to whatever address the float's bits name, and only crashes when that address happens to be unmapped.

## The change

Only the float arms move. In both sites the GP loads move into both match arms, so nothing is loaded before something can clobber it; the integer arms keep the order they had (and in `set_value_inline`, the `check_range` read before `load_fixnum`).

One test per site, `io_buffer_set_value_f64_argument` and `fiddle_write_double_argument`. Each dies with `signal: 11, SIGSEGV` against the unfixed code and passes against the fixed code; `cargo test -p monoruby --lib` is 2451 passed, 0 failed.