### PR TITLE
bytecodegen: emit a loop's `break` at the depth its merge has

### DIFF
--- a/monoruby/src/bytecodegen.rs
+++ b/monoruby/src/bytecodegen.rs
@@ -352,6 +352,13 @@ struct LoopInfo {
     next_dest: Label,
     redo_dest: Label,
     ret: Option<BcReg>,
+    /// Stack depth at `break_dest`. A loop that produces a value has that
+    /// value pushed by the time the label is applied, while a `break` writes
+    /// the value slot (`ret`) without pushing anything, so a break exits one
+    /// slot short of the merge. It is emitted at this depth instead, which
+    /// keeps the value it just stored on the stack as far as the JIT's
+    /// per-instruction sp is concerned.
+    break_sp: BcTemp,
     /// Depth of the `ensure` stack when the loop was entered. A `break` /
     /// `next` that jumps out of `begin/ensure` blocks nested inside the
     /// loop body must run those `ensure` clauses (the ones at indices
@@ -967,12 +974,22 @@ impl<'a> BytecodeGen<'a> {
         redo_dest: Label,
         ret: Option<BcReg>,
     ) {
+        // The depth at `break_dest`: a loop that produces a value has that
+        // value in `ret`, and every construct applies the label with `ret`
+        // pushed (the prefix `while` pushes it before the loop, the postfix
+        // form and `for` push it just before the label). A `break` writes
+        // `ret` without pushing, so its own depth is one short of the merge's.
+        let break_sp = match ret {
+            Some(BcReg::Temp(BcTemp(slot))) => BcTemp(slot + 1),
+            _ => BcTemp(self.temp),
+        };
         self.loops.push(LoopInfo {
             break_dest,
             next_dest,
             redo_dest,
             ret,
             ensure_depth: self.ensure.len(),
+            break_sp,
         });
     }
 

--- a/monoruby/src/bytecodegen/expression.rs
+++ b/monoruby/src/bytecodegen/expression.rs
@@ -845,6 +845,7 @@ impl<'a> BytecodeGen<'a> {
                     break_dest,
                     ret,
                     ensure_depth,
+                    break_sp,
                     ..
                 } = match self.loops.last() {
                     Some(data) => data.clone(),
@@ -862,6 +863,15 @@ impl<'a> BytecodeGen<'a> {
                         }
                     }
                 };
+                // A `break` writes the loop's value into `ret` instead of
+                // pushing it, so the generator's depth here is one short of
+                // the merge's at `break_dest`. Emit the whole exit at the
+                // merge's depth: the JIT discards every slot above an
+                // instruction's recorded sp, and the value slot is the one
+                // just above it, so at the lower depth the value is dropped
+                // the instant it is stored.
+                let saved_temp = self.temp;
+                self.temp = break_sp.0;
                 if let Some(reg) = ret {
                     self.gen_store_expr(reg, val)?;
                 } else {
@@ -869,7 +879,9 @@ impl<'a> BytecodeGen<'a> {
                 }
                 // Run `ensure` blocks nested inside the loop before exiting.
                 self.gen_loop_pending_ensures(ensure_depth)?;
+                self.add_merge(break_dest);
                 self.emit(BytecodeInst::Br(break_dest), loc);
+                self.temp = saved_temp;
                 if use_mode == UseMode2::Push {
                     self.push();
                 }

--- a/monoruby/src/bytecodegen/statement.rs
+++ b/monoruby/src/bytecodegen/statement.rs
@@ -1007,6 +1007,29 @@ mod test {
     }
 
     #[test]
+    fn break_keeps_the_loop_value() {
+        // A `break` stores the loop's value into the loop's `ret` slot
+        // instead of pushing it, so the generator's depth at the exit is one
+        // short of the merge's at `break_dest`. The JIT discards every slot
+        // above an instruction's recorded sp, so emitted at the lower depth
+        // the value is dropped the instant it is stored, and the merge then
+        // compiles a `ret` of an undefined slot. The calls before the result
+        // are what makes the method hot enough to be compiled.
+        run_test(
+            r##"
+            def a; begin; break; end while false; end
+            def b; begin; break 7; end while false; end
+            def c(x); begin; break 1 if x; break 2; end while false; end
+            def d; i = 0; while true; i += 1; break i if i > 3; end; end
+            def e; for i in 0..10; break i if i > 2; end; end
+            def g; begin; begin; break 8; ensure; $ens = 1; end; end while false; end
+            60.times { a; b; c(true); c(false); d; e; g }
+            [a, b, c(true), c(false), d, e, g, $ens]
+            "##,
+        );
+    }
+
+    #[test]
     fn redo_loop() {
         // `redo` restarts the loop body without re-evaluating the condition
         // (so a side-effecting condition like `(i += 1)` does not re-run).

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -2377,6 +2377,7 @@ acabc0312a822b618b976d7b03a36850	["a1e1ca65d05c669fd66fb42fca66bb467bf8c2531fe5f
 acaecec60e1d4df64f4888d1585ffb87	[[1, 5], [2, 6]]	[1, 2].each.with_index(5).to_a
 ace3583fa43b814b77f102993799e3b9	["Array", true, true, "nil", true]	res = []\n            t = Thread.new { sleep }\n            Thread.pa
 aced21e1e31e2ddc5465a70187f24f60	["para1a\\npara1b\\n\\npara2\\n", "para", "ASCII-8BIT", "ra1a", "para1b\\n\\npara2\\n", "para1a\\npara1b\\n\\npara2\\n", nil, "US-ASCII", ["para1a\\n", "para1b\\n", "\\n", "para2\\n"], ["para1a\\n", "para1b\\n\\npara2\\n"], ["para1a\\npara1b\\n\\npara2\\n"], ["para1a", "para1b", "", "para2"], ["para1a\\npara1b\\n\\n", "para2\\n"], ["pa", "ra", "1", "a\\n", "pa", "ra", "1", "b\\n", "\\np", "ar", "a2", "\\n"]]	require 'tmpdir'\n            f = File.join(Dir.tmpdir, "file_read_a
+ad063a5a7b5850775d75f6df196eaae1	[nil, 7, 1, 2, 4, 3, 8, 1]	def a; begin; break; end while false; end\n            def b; begin;
 ad1ae32a9a55d70e4730df3370a823db	[1, 2]	class C; def to_ary; [1, 2]; end; end\nArray.try_convert(C.new)
 ad3d114daa3fe697d3d65acf89424a99	[1, 2, 3]	c = Class.new\n            captured = nil\n            c.class_exec(1
 ad40135a1d283484c7b5cb46e05719d4	99	class C\n              X = 99\n            end\n            C.class_ev


### PR DESCRIPTION
```ruby
def f
  begin
    break
  end while false
end

50.times { f }
```

```
thread 'main' panicked at monoruby/src/codegen/jitgen/state/read_slot.rs:321:
internal error: entered unreachable code: load() %1 V: AbstractFrame {
  slot_state: { [%0: S(Class(ClassId(520)))] [%1: V] [%2: V] }, next_sp: %1, ... }
```

CRuby answers `nil`, and so does `--no-jit`; the abort needs the method to be compiled, which is what the 50 calls are for.

## What goes wrong

A `break` stores the loop's value into the loop's `ret` slot rather than pushing it, so the generator's stack depth at the exit is one short of the depth `break_dest` is applied at. Every loop that produces a value has that value pushed by the time the label goes down: the prefix `while` pushes it before the loop, the postfix form and `for` just before the label.

The JIT reads that depth per instruction and discards every slot above it, after each instruction (`clear_above_next_sp` at the end of `compile_basic_block`'s loop) and again when a branch is recorded (`new_branch`). At the lower depth the value slot is the one just above the recorded sp, so the value went away the instant the break stored it:

```
[:00001 sp=%1] %1 = nil      # the break's store, discarded at once
[:00002 sp=%2] br => BB2
[BB2 entry]    { [%0: ...] [%1: V] [%2: V] }
[:00004 sp=%1] ret %1        # panics: %1 is undefined
```

Two things kept it hidden. `into_bytecode`'s sp-consistency check never saw these edges, because the `break` emitted its `Br` directly instead of through `emit_br`, so no merge source was recorded for it. And a loop with a real back edge does not reach the bad state: the loop machinery rebuilds the exit's state, so only a loop the JIT sees as straight-line code (a `begin ... end while false`, or a `while` whose condition folds) exposes it.

Not a recent regression: the same panic reproduces at `origin/master~150` (2026-08-22), where the assert sits at `read_slot.rs:269`.

## The change

Emit the whole exit at the merge's depth: the store, any `ensure` bodies nested inside the loop, and the branch. `LoopInfo` carries that depth, derived from `ret` rather than from the depth at `loop_push` (the three constructs push the value at different points, so the latter is right for two of them and one too high for the prefix `while`).

The branch is now also recorded as a merge source, so the sp-consistency check covers break edges from here on. That check earned its keep immediately: it caught the first version of this patch getting the prefix `while` wrong, at `__range_step_numeric` during startup, instead of leaving a miscompile to find later.

## Checks

| | |
| --- | --- |
| `cargo test -p monoruby --lib` | 2452 passed, 0 failed |
| `cargo test -p monoruby` (30 integration binaries) | all ok, 0 failed |
| new test, against the unfixed code | `signal: 6, SIGABRT` |

The regression test sits in `bytecodegen::statement` and covers the shapes that reach the exit path: the postfix form with and without a value, two breaks in one block, the prefix `while`, `for`, and a break out of a nested `ensure`. Checked by hand against CRuby as well, including a break from inside an expression and a nested labeled block.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CreYezJ9tefe5BjESSzd7Q)_