### PR TITLE
Fix an aarch64 JIT abort when a huge method inlines a dense case/when

### DIFF
--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -613,6 +613,22 @@ impl Codegen {
         // must be resolved before `gen_machine_code` runs (x86 reads them
         // rip-relative and doesn't care).
         self.jit.finalize();
+        // aarch64 branch relaxation (see `Codegen::far_branch_mode`): decided
+        // once for the whole unit, root and inlined callees together, from the
+        // unit's total AsmIr instruction count. 64 bytes per AsmInst is a
+        // generous per-instruction bound, so 8192 instructions stays
+        // comfortably inside the ±1 MiB Imm19/Adr reach even doubled by the
+        // long forms; anything larger emits BB edges in long form and inlines
+        // opt_case's jump tables. The reach that matters is not frame-local:
+        // constants — opt_case's near-form jump tables among them — are
+        // emitted at finalize behind the *entire* unit, so an `adr` in a
+        // small inlined frame still spans everything emitted after it. A
+        // per-frame decision let exactly that overflow (a generated sqlite
+        // module placed a jump table 1.55 MiB past its `adr`).
+        #[cfg(target_arch = "aarch64")]
+        {
+            self.far_branch_mode = unit_inst_len(&mut frame.asm_info) > 8192;
+        }
         // x86: collect this unit's class-version imm32 patch sites (one per
         // emitted guard, root and inlined children alike — one compilation
         // is atomic at one version). Cleared here so an earlier aborted
@@ -692,6 +708,28 @@ impl Codegen {
     }
 }
 
+/// Total AsmIr instruction count of a whole compilation unit: the frame's
+/// blocks and bridges plus, recursively, every inlined specialized callee's.
+#[cfg(target_arch = "aarch64")]
+fn unit_inst_len(info: &mut AsmInfo) -> usize {
+    let mut total: usize = info
+        .iter_ir_mut()
+        .map(|(_, ir)| ir.inst_len())
+        .sum::<usize>()
+        + info
+            .iter_outline_bridges_mut()
+            .map(|(ir, _, _)| ir.inst_len())
+            .sum::<usize>()
+        + info
+            .iter_inline_bridges_mut()
+            .map(|(ir, _)| ir.inst_len())
+            .sum::<usize>();
+    for specialized in info.specialized_methods.iter_mut() {
+        total += unit_inst_len(&mut specialized.info);
+    }
+    total
+}
+
 impl Codegen {
     /// Arch-neutral driver: emit machine code for a whole method and its
     /// inlined specialized callees (recursively), calling the per-arch
@@ -767,30 +805,6 @@ impl Codegen {
         let pair = self.get_address_pair();
 
         let mut ir_vec = frame.detach_ir();
-
-        // aarch64 branch relaxation (see `Codegen::far_branch_mode`): decide
-        // from the frame's total AsmIr instruction count whether a BB-edge
-        // Imm19/Adr reference could exceed its ±1 MiB reach. 64 bytes per
-        // AsmInst is a generous per-instruction bound, so 8192 instructions
-        // stays comfortably inside 1 MiB even doubled by the long forms;
-        // anything larger emits BB edges in long form. The flag is saved and
-        // restored around this frame because `gen_machine_code` recursed into
-        // the inlined callees above — each frame decides for itself.
-        #[cfg(target_arch = "aarch64")]
-        let far_branch_saved = {
-            let total: usize = ir_vec.iter().map(|(_, ir)| ir.inst_len()).sum::<usize>()
-                + frame
-                    .iter_outline_bridges_mut()
-                    .map(|(ir, _, _)| ir.inst_len())
-                    .sum::<usize>()
-                + frame
-                    .iter_inline_bridges_mut()
-                    .map(|(ir, _)| ir.inst_len())
-                    .sum::<usize>();
-            let saved = self.far_branch_mode;
-            self.far_branch_mode = total > 8192;
-            saved
-        };
 
         // §21 — AsmIR optimization seam (Path 2). `inst` is the ordered,
         // replayable instruction stream; this is the arch-neutral layer where
@@ -898,10 +912,7 @@ impl Codegen {
         #[cfg(target_arch = "aarch64")]
         self.a64_drain_side_exits(&mut frame, !had_outline_bridges && fallthrough_in);
         #[cfg(target_arch = "aarch64")]
-        {
-            self.a64_patch_jump_tables();
-            self.far_branch_mode = far_branch_saved;
-        }
+        self.a64_patch_jump_tables();
         #[cfg(not(target_arch = "aarch64"))]
         let _ = had_outline_bridges;
 

--- a/monoruby/tests/opt_case_huge_unit.rs
+++ b/monoruby/tests/opt_case_huge_unit.rs
@@ -1,0 +1,46 @@
+//! Regression coverage for the aarch64 branch-relaxation decision: an
+//! `opt_case` inside a small *inlined* frame of a huge compilation unit.
+//!
+//! `far_branch_mode` used to be decided per frame, but near-form opt_case
+//! jump tables live in the constant area, which is emitted at finalize
+//! behind the *entire* unit — so a small inlined frame's `adr` had to reach
+//! past everything emitted after it, and in a unit past ±1 MiB it could
+//! not ("ADR displacement out of range", first hit by a dewasm-generated
+//! sqlite build). The decision is unit-wide now; this test builds the
+//! same shape synthetically.
+
+use monoruby::tests::*;
+
+#[test]
+fn opt_case_in_inlined_frame_of_huge_unit() {
+    // A dense-integer `case` that lowers to opt_case, in its own small
+    // method. The call site below passes a literal argument, which is what
+    // makes the site specializable (see `specialized_iseq`'s gate), so the
+    // body is inlined into `big`'s unit rather than compiled standalone.
+    let mut src = String::from("class Picker\n  def pick(n, mask)\n    case n & mask\n");
+    for i in 0..64 {
+        src.push_str(&format!("    when {i} then {}\n", i * 3 + 1));
+    }
+    src.push_str("    else -1\n    end\n  end\nend\n");
+
+    // A method big enough that its one compilation unit exceeds the ±1 MiB
+    // `adr` reach by a wide margin (30000 statements emit roughly 2.7 MiB
+    // of aarch64 code), with the inlined opt_case at the very top so its
+    // table reference spans the whole rest of the unit.
+    src.push_str("class Big\n  def initialize\n    @p = Picker.new\n  end\n");
+    src.push_str("  def big(a)\n    a = a + @p.pick(a, 63)\n");
+    for i in 0..30000 {
+        src.push_str(&format!("    a = a + {} - {}\n", i % 9, (i + 3) % 5));
+    }
+    src.push_str("    a & 0xffffff\n  end\nend\n");
+
+    // Enough calls to take `big` through the method JIT and then run the
+    // compiled code (the crash fired when the finished unit was finalized,
+    // so compiling at all is the point; the calls after it prove the
+    // inlined dispatch still computes the right thing). Integration tests
+    // link the library without cfg(test), so the production compile
+    // threshold (20 calls) applies, not the lowered test one.
+    src.push_str("b = Big.new\nr = 0\n40.times { r = b.big(r) }\nr\n");
+
+    run_test_once(&src);
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -2238,6 +2238,7 @@ a3c1f3715d0c4e66afd79ece55a249ad	[1, "c", Errno::EEXIST, [ArgumentError, "invali
 a3ee8370b62260dbe97cbc7ed605dd03	"missing keyword: :x"	def msg; yield; "no error"; rescue ArgumentError => e; e.message; end; def m(x:,
 a3fbe69a6d5dbf4f950d529b546578ff	[true, true]	def bar(x); x * 2; end\n        m = method(:bar)\n        loc = m.source_
 a40cda8b2c175e21feb1879eeb9ab44f	[]	def m\n              "foofoo" =~ /(?<matched>foo)/\n              loc
+a412e7cd426cce32db94f655f3ff9e81	2406136	class Picker\n  def pick(n, mask)\n    case n & mask\n    when 0 then 1\n    when 1 
 a4149a238fc4b1eb2b5d83d5a3a1df6e	[1, [2, 3, 4], 5]	->((a, *b, c)) { [a, b, c] }.call([1, 2, 3, 4, 5])
 a41897885873df2832ff2e4ca224faf4	true	class Foo\n              def initialize\n                @a = 1\n     
 a438a5b6095e3a044e9fc3a4b29764a8	[false, true, true, false, false, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true]	class StrMock\n          def to_str; "abc"; end\n          def ==(o); o =


### PR DESCRIPTION
On aarch64, the following code aborts with "ADR displacement out of range":

```ruby
src = "class Picker\n  def pick(n, mask)\n    case n & mask\n"
64.times { |i| src << "    when #{i} then #{i * 3 + 1}\n" }
src << "    else -1\n    end\n  end\nend\n"
src << "class Big\n  def initialize\n    @p = Picker.new\n  end\n"
src << "  def big(a)\n    a = a + @p.pick(a, 63)\n"
30000.times { |i| src << "    a = a + #{i % 9} - #{(i + 3) % 5}\n" }
src << "    a & 0xffffff\n  end\nend\n"
eval(src)

b = Big.new
r = 0
40.times { r = b.big(r) }
puts r
```

The near form of `opt_case` puts its jump table in the constant area, which is emitted behind the whole compilation unit, but `far_branch_mode` was decided per frame, so the small inlined `pick` frame chose the near form and its `adr` could not reach the table across the ~2.7 MiB of `big`.
The decision is now made once per unit, from the instruction total of the root frame and every inlined callee.

`tests/opt_case_huge_unit.rs` is the reproduction above as a differential test: it aborts without the fix and passes with it.