### PR TITLE
JIT: name the kwrest table by address, not PC-relatively

### DIFF
--- a/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
+++ b/monoruby/src/codegen/arch/aarch64/compile/method_call.rs
@@ -1127,22 +1127,21 @@ impl Codegen {
         );
     }
 
-    /// `RestKw`: build a const-data table of (name: i32, slot-id: i32) pairs
-    /// terminated by (0, 0), then call `correct_rest_kw(&table, lfp)` which
-    /// reads the listed slots and returns the `**kwrest` Hash in x0. Mirrors
-    /// the x86 `RestKw` arm; the const-table emission is arch-neutral and the
-    /// table address is taken with PC-relative `adr` (as in OptCase).
-    pub(in crate::codegen::jitgen) fn emit_rest_kw(&mut self, rest_kw: Vec<(SlotId, IdentId)>) {
-        let data = self.jit.const_align8();
-        for (i, name) in rest_kw.into_iter() {
-            self.jit.const_i32(name.get() as i32);
-            self.jit.const_i32(i.0 as i32);
-        }
-        self.jit.const_i32(0);
-        self.jit.const_i32(0);
+    /// `RestKw`: call `correct_rest_kw(&table, lfp)`, which reads the slots
+    /// the table lists and returns the `**kwrest` Hash in x0. The table of
+    /// (name: i32, slot-id: i32) pairs, terminated by (0, 0), was laid down
+    /// in the constant area by `Codegen::resolve_rest_kw_tables` before this
+    /// unit's code, so its address is known here and goes in as an immediate.
+    ///
+    /// PC-relative `adr` is what this cannot use: it reaches ±1 MiB, and the
+    /// constant area sits behind the whole unit, so a call site early in a
+    /// large one could not name its own table (`Codegen::far_branch_mode` is
+    /// the same reach, for branches). An absolute address has no range.
+    pub(in crate::codegen::jitgen) fn emit_rest_kw(&mut self, table: DestLabel) {
+        let data = self.jit.get_label_address(&table).as_ptr() as u64;
         let f = runtime::correct_rest_kw as *const () as u64;
         monoasm_arm64!(&mut self.jit,
-            adr x0, data;          // &table
+            mov x0, (data);        // &table
             mov x1, x22;           // lfp (R14)
             str x30, [sp, #-16]!;
             mov x9, (f);

--- a/monoruby/src/codegen/arch/x86_64/compile/mod.rs
+++ b/monoruby/src/codegen/arch/x86_64/compile/mod.rs
@@ -297,17 +297,9 @@ impl Codegen {
 
     /// `**kwrest` fixup: build a const table of (name, slot) pairs and call
     /// `correct_rest_kw(&table, lfp) -> kwrest Hash`.
-    pub(in crate::codegen::jitgen) fn emit_rest_kw(&mut self, rest_kw: Vec<(SlotId, IdentId)>) {
-        let data = self.jit.const_align8();
-        for (i, name) in rest_kw.into_iter() {
-            self.jit.const_i32(name.get() as i32);
-            self.jit.const_i32(i.0 as i32);
-        }
-        self.jit.const_i32(0);
-        self.jit.const_i32(0);
-
+    pub(in crate::codegen::jitgen) fn emit_rest_kw(&mut self, table: DestLabel) {
         monoasm!( &mut self.jit,
-            lea  rdi, [rip + data];
+            lea  rdi, [rip + table];
             movq rsi, r14;
             movq rax, (runtime::correct_rest_kw);
             call rax;

--- a/monoruby/src/codegen/jitgen.rs
+++ b/monoruby/src/codegen/jitgen.rs
@@ -608,6 +608,9 @@ impl Codegen {
         let const_version_label = (!const_folds.is_empty())
             .then(|| self.jit.const_i64(const_version as _));
         self.unit_const_version = const_version_label.clone();
+        // Every `**kwrest` call site's table, for the same reason: laid down
+        // now so the emission site can name it by address.
+        self.resolve_rest_kw_tables(&mut frame.asm_info);
         // Bind the fresh snapshot words now: the aarch64 lowering bakes their
         // *addresses* into the guard sequences as immediates, so the labels
         // must be resolved before `gen_machine_code` runs (x86 reads them
@@ -705,6 +708,49 @@ impl Codegen {
             bop_deps,
             const_map,
         ))
+    }
+
+    /// Lay down every `RestKw`'s (name, slot-id) table in the constant area
+    /// and record its label in the instruction, before any of the unit's
+    /// code is emitted.
+    ///
+    /// The emission site needs the table's *address*, and nothing else. On
+    /// aarch64 it cannot take that address PC-relatively: constants are
+    /// emitted at `finalize`, behind the whole unit, and `adr` reaches
+    /// ±1 MiB, so a call site early in a large unit could not name its own
+    /// table. Resolving the label first lets the backend bake an absolute
+    /// address instead, which has no range at all — what the unit's
+    /// class-version word beside this already does. x86 reads the table
+    /// rip-relative either way; building it here keeps one path.
+    fn resolve_rest_kw_tables(&mut self, info: &mut AsmInfo) {
+        for (_, ir) in info.iter_ir_mut() {
+            self.build_rest_kw_table_in(ir);
+        }
+        for (ir, _, _) in info.iter_outline_bridges_mut() {
+            self.build_rest_kw_table_in(ir);
+        }
+        for (ir, _) in info.iter_inline_bridges_mut() {
+            self.build_rest_kw_table_in(ir);
+        }
+        for context::SpecializeInfo { info, .. } in info.iter_specialized_methods_mut() {
+            self.resolve_rest_kw_tables(info);
+        }
+    }
+
+    fn build_rest_kw_table_in(&mut self, ir: &mut AsmIr) {
+        for inst in ir.inst_iter_mut() {
+            if let AsmInst::RestKw { rest_kw, table } = inst {
+                let data = self.jit.const_align8();
+                for (slot, name) in rest_kw.iter() {
+                    self.jit.const_i32(name.get() as i32);
+                    self.jit.const_i32(slot.0 as i32);
+                }
+                // Terminator: `correct_rest_kw` reads until a zero name.
+                self.jit.const_i32(0);
+                self.jit.const_i32(0);
+                *table = Some(data);
+            }
+        }
     }
 }
 

--- a/monoruby/src/codegen/jitgen/asmir.rs
+++ b/monoruby/src/codegen/jitgen/asmir.rs
@@ -846,7 +846,10 @@ impl AsmIr {
     }
 
     pub(super) fn kw_rest(&mut self, rest_kw: Vec<(SlotId, IdentId)>) {
-        self.push(AsmInst::RestKw { rest_kw });
+        self.push(AsmInst::RestKw {
+            rest_kw,
+            table: None,
+        });
     }
 
     ///
@@ -2833,8 +2836,14 @@ pub(super) enum AsmInst {
         src: SlotId,
         len: usize,
     },
+    /// Hand `correct_rest_kw` the `**kwrest` Hash built from the listed
+    /// slots. `table` is where those (name, slot-id) pairs live: it is
+    /// filled in by `Codegen::resolve_rest_kw_tables` before any of the
+    /// unit's code is emitted, so the emission site can name the table by
+    /// an absolute address rather than a PC-relative one.
     RestKw {
         rest_kw: Vec<(SlotId, IdentId)>,
+        table: Option<DestLabel>,
     },
 
     UndefMethod {

--- a/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
+++ b/monoruby/src/codegen/jitgen/asmir/compile_shared.rs
@@ -1608,9 +1608,12 @@ impl Codegen {
             }
             // Trap for statically-unreachable code: call the panicking helper.
             AsmInst::Unreachable => self.encode_linst(LInst::Unreachable),
-            // `**kwrest` fixup: build a (name, slot) const table and call
-            // `correct_rest_kw(&table, lfp) -> kwrest Hash`.
-            AsmInst::RestKw { rest_kw } => self.encode_linst(LInst::RestKw { rest_kw }),
+            // `**kwrest` fixup: call `correct_rest_kw(&table, lfp)`, which
+            // answers the Hash. The (name, slot) table was laid down before
+            // this unit's code (`Codegen::resolve_rest_kw_tables`).
+            AsmInst::RestKw { table, .. } => self.encode_linst(LInst::RestKw {
+                table: table.expect("kwrest table laid down before codegen"),
+            }),
             // Not a shared instruction: hand off to the per-arch backend.
             // (§9a-ii) Not-yet-LIR-ized arms still emit directly in the per-arch
             // `compile_asmir_arch`. During the buffering pass, defer them as
@@ -2126,8 +2129,8 @@ impl Codegen {
             LInst::Unreachable => {
                 self.emit_unreachable();
             }
-            LInst::RestKw { rest_kw } => {
-                self.emit_rest_kw(rest_kw);
+            LInst::RestKw { table } => {
+                self.emit_rest_kw(table);
             }
             LInst::GuardClassVersion {
                 class_version,

--- a/monoruby/src/codegen/jitgen/lir.rs
+++ b/monoruby/src/codegen/jitgen/lir.rs
@@ -1090,7 +1090,7 @@ pub(in crate::codegen) enum LInst {
     },
     Unreachable,
     RestKw {
-        rest_kw: Vec<(SlotId, IdentId)>,
+        table: DestLabel,
     },
     GuardClassVersion {
         class_version: DestLabel,

--- a/monoruby/tests/far_branch_relaxation.rs
+++ b/monoruby/tests/far_branch_relaxation.rs
@@ -51,6 +51,30 @@ fn an_opt_case_in_a_far_frame() {
     );
 }
 
+/// A `**kwrest` call site inside a far frame: the (name, slot-id) table it
+/// hands `correct_rest_kw` is constant-area data too, emitted behind the
+/// whole unit, so its address is baked in absolutely rather than reached
+/// with `adr`. It was the one const-area reference the relaxation did not
+/// cover, and a frame this size puts the table out of `adr`'s reach.
+///
+/// Unlike the shapes above this one goes through the *method* JIT, whose
+/// caller does not catch a panic from the emitter (the loop JIT's does,
+/// and simply leaves the loop interpreted), and it is sized to clear the
+/// ±1 MiB reach outright rather than merely cross the relaxation
+/// threshold: 120k AsmInsts, about 1.8 MiB of aarch64 code.
+#[test]
+fn a_kwrest_call_in_a_far_frame() {
+    run_test_once(
+        r#"
+        add = (0...40000).map { |k| "a = a + #{k % 7 + 1}" }.join("\n")
+        eval "def sink(x, **opts)\n x + opts.size\nend\ndef big(v)\n a = sink(v, k: 1, j: 2)\n #{add}\n a & 0xffffff\nend"
+        r = 0
+        40.times { r = big(r) }
+        r
+        "#,
+    );
+}
+
 /// Floats across the far split: the long form keeps the original fcmp
 /// condition (an inverted one flips the unordered/NaN direction), so the
 /// float compares must behave identically at either scale.

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -1103,6 +1103,7 @@
 4e91589759e06abf5967280f353d07c5	[9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError", 9, "ArgumentError"]	def g(a, b, c) = yield(a + b + c)\n        def f(...) = g(1, ...)\n      
 4e9433807c6ac2166e6457fd13ba0a0f	[nil, nil, nil, 6, 18, :back, 3000, 3000]	def run(h, k, n = 300)\n          r = nil; i = 0\n          while i < n; 
 4e9bfbcee73c693e57ccc4d38d0dfa34	["x", "y"]	base = "/tmp/monoruby_dir_eachchild_#{Process.pid}_#{rand(100000)}"
+4ebdeda32efe3cd6cc9c7246b7edb219	6399880	add = (0...40000).map { |k| "a = a + #{k % 7 + 1}" }.join("\\n")\n       
 4ebe3f743c44083475b01a20ac7c38bc	false	binding.local_variable_defined?(:_10)
 4edbac695b5ed45b538971de1ca0ed2c	[true, true, true, false]	f = File.open("Cargo.toml")\n            begin\n              [f.binm
 4edf4d45c190ed9014d06dda3424cfb3	[200, true]	parents = Array.new(200) { [] }\n            5.times { GC.start }\n  


### PR DESCRIPTION
`RestKw` hands `correct_rest_kw` a table of (name, slot-id) pairs, and on aarch64 that address went in with `adr`. It reaches ±1 MiB, and constants are emitted at finalize behind the whole compilation unit, so a `**kwrest` call site early in a large unit could not name its own table.

That is the overflow #1324 fixed for `opt_case`'s jump tables, in the one const-area reference the branch relaxation does not cover: `far_branch_mode` never gated this path, so a large frame aborts with `ADR displacement out of range` whether or not it is in far mode.

```ruby
def sink(x, **opts) = x + opts.size
def big(v)
  a = sink(v, k: 1, j: 2)   # its table ends up ~1.8 MiB away
  # ... a megabyte of body ...
end
```

## The fix

The one the unit's class-version word already uses: resolve the label before any of the unit's code is emitted, then bake an absolute address, which has no range at all.

Building the tables moves out of both backends into a single walk of the AsmIr tree, beside the other pre-codegen rewrites. The two backends now only reference a label. x86 reads it rip-relative exactly as before; aarch64 moves it as an immediate, two instructions more than the `adr` it replaces, on a path that then calls a runtime function.

## Why the test is shaped the way it is

It lives in `tests/far_branch_relaxation.rs` with the rest of the family, but differs from the three already there in two ways the bug requires.

- It goes through the **method** JIT. The loop JIT's caller catches a panic from the emitter and leaves the loop interpreted, so a loop-shaped test passes with or without the fix. The method JIT's caller does not catch it.
- It is sized to clear the ±1 MiB reach outright, not merely to cross the relaxation threshold. Measured at 120,039 AsmInsts in one unit, about 1.8 MiB of aarch64 code at the ratio #1324's case measured, with the call site at the top.

## Verification

Full suite on x86-64: 108 test binaries, 3,522 tests, no failures. The aarch64 compile and behaviour are for the darwin job, which is what exercises the changed instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013q5CpZ6eqZUJtPhSJHfjus

---
_Generated by [Claude Code](https://claude.ai/code/session_013q5CpZ6eqZUJtPhSJHfjus)_