### PR TITLE
Two things done per call that only need doing once

### DIFF
--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -1204,17 +1204,28 @@ impl Globals {
         // been computed. Found by gc-stress, which collects at every
         // safepoint and so hits this on the first allocation a finalizer
         // makes.
+        //
+        // An `Err` carries `Value`s of its own — the re-raised exception
+        // object, an explicit `cause:`, a kind's payload, a NoMethodError
+        // receiver, a KeyError's receiver and key — and they are in the
+        // same Rust local, so they need the same rooting. The
+        // materialization below happens to cover most of them while the
+        // handlers run (it hangs them off the exception object it puts in
+        // `$!`), but that lapses at the `set_errinfo` restore, with
+        // `terminate_all` still to run Ruby and the report below still to
+        // dereference them. Root them outright instead of relying on that.
         let root_len = executor.temp_len();
         if let Ok(v) = &res {
             executor.temp_push(*v);
         }
         executor.temp_push(unwind_errinfo);
-        if let Err(err) = &res
-            && !matches!(err.kind(), MonorubyErrKind::SystemExit(_))
-        {
-            executor.set_error(err.clone());
-            let err_val = executor.take_ex_obj(self);
-            executor.set_errinfo(err_val);
+        if let Err(err) = &res {
+            err.for_each_value(|v| executor.temp_push(v));
+            if !matches!(err.kind(), MonorubyErrKind::SystemExit(_)) {
+                executor.set_error(err.clone());
+                let err_val = executor.take_ex_obj(self);
+                executor.set_errinfo(err_val);
+            }
         }
         let handler_status = executor.run_exit_handlers(self);
         executor.set_errinfo(unwind_errinfo);

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -150,25 +150,30 @@ impl MonorubyErr {
     }
 
     ///
-    /// Mark every `Value` reachable from this error so the GC keeps
-    /// them alive while the error is in flight (held by `Executor`'s
-    /// pending exception slot or wrapped in a heap-allocated
-    /// `ExceptionInner`). Most error kinds carry only metadata
-    /// (class ids, identifier symbols, paths), but a few smuggle
-    /// real `Value`s — the relevant variants are dispatched
-    /// explicitly so that adding a new error kind that owns a
-    /// `Value` will not silently regress.
+    /// Call `f` with every `Value` this error carries. Most error kinds
+    /// hold only metadata (class ids, identifier symbols, paths), but a
+    /// few smuggle real `Value`s — those variants are dispatched
+    /// explicitly so that adding a new error kind that owns a `Value`
+    /// will not silently regress.
     ///
-    pub(crate) fn mark(&self, alloc: &mut alloc::Allocator<crate::value::RValue>) {
-        use alloc::GC;
-        if let Some(original) = &self.original {
-            original.mark(alloc);
+    /// Both callers need the same set, which is why they share one
+    /// walk. [`MonorubyErr::mark`] keeps them alive while the error is
+    /// in flight (held by `Executor`'s pending exception slot, or
+    /// wrapped in a heap-allocated `ExceptionInner`); it adds only the
+    /// `Lfp` of the non-local-return kinds, a frame pointer rather than
+    /// a `Value`. `Globals::run_with_prelude` roots them on the temp
+    /// stack, because it holds an error in a Rust local — which the
+    /// collector does not scan — across the exit handlers.
+    ///
+    pub(crate) fn for_each_value(&self, mut f: impl FnMut(Value)) {
+        if let Some(original) = self.original {
+            f(original);
         }
-        if let Some(cause) = &self.explicit_cause {
-            cause.mark(alloc);
+        if let Some(cause) = self.explicit_cause {
+            f(cause);
         }
-        if let Some((val, _)) = &self.payload {
-            val.mark(alloc);
+        if let Some((val, _)) = self.payload {
+            f(val);
         }
         match &self.kind {
             // The receiver that triggered the NoMethodError (set by
@@ -176,34 +181,40 @@ impl MonorubyErr {
             MonorubyErrKind::NotMethod {
                 receiver: Some(recv),
                 ..
-            } => {
-                recv.mark(alloc);
-            }
+            } => f(*recv),
             // Receiver / key Values for KeyError.
             MonorubyErrKind::Key(Some((recv, key))) => {
-                recv.mark(alloc);
-                key.mark(alloc);
+                f(*recv);
+                f(*key);
             }
             // Receiver Value for NameError / FrozenError.
-            MonorubyErrKind::Name(_, Some(recv)) | MonorubyErrKind::Frozen(Some(recv)) => {
-                recv.mark(alloc);
-            }
-            // Non-local return: carries the return value and the
-            // captured frame pointer it must return to.
-            MonorubyErrKind::MethodReturn(v, lfp) => {
-                v.mark(alloc);
-                lfp.mark(alloc);
-            }
-            MonorubyErrKind::BlockBreak(v, _, lfp) => {
-                v.mark(alloc);
-                lfp.mark(alloc);
-            }
+            MonorubyErrKind::Name(_, Some(recv)) | MonorubyErrKind::Frozen(Some(recv)) => f(*recv),
+            // Non-local return: the return value (the frame pointer it
+            // must return to is `mark`'s business, not a `Value`).
+            MonorubyErrKind::MethodReturn(v, _) | MonorubyErrKind::BlockBreak(v, _, _) => f(*v),
             // Kernel#throw: carries the tag and value.
             MonorubyErrKind::Throw(tag, val) => {
-                tag.mark(alloc);
-                val.mark(alloc);
+                f(*tag);
+                f(*val);
             }
             // The remaining kinds carry no `Value` payload.
+            _ => {}
+        }
+    }
+
+    ///
+    /// Mark every `Value` reachable from this error, plus the captured
+    /// frame a non-local return carries, so the GC keeps them alive
+    /// while the error is in flight.
+    ///
+    pub(crate) fn mark(&self, alloc: &mut alloc::Allocator<crate::value::RValue>) {
+        use alloc::GC;
+        self.for_each_value(|v| v.mark(alloc));
+        match &self.kind {
+            // The captured frame a non-local return must return to.
+            MonorubyErrKind::MethodReturn(_, lfp) | MonorubyErrKind::BlockBreak(_, _, lfp) => {
+                lfp.mark(alloc)
+            }
             _ => {}
         }
     }

--- a/monoruby/tests/deferred_unwind.rs
+++ b/monoruby/tests/deferred_unwind.rs
@@ -123,3 +123,47 @@ fn a_compiled_return_inside_an_osr_loop_in_an_ensure() {
         "#,
     );
 }
+
+/// A deferred unwind's payload must survive a collection *inside* the
+/// `ensure` that deferred it. While the handler runs, the parked error is
+/// the only thing holding the returned / broken / thrown value, and
+/// `Executor::mark` reaches it solely through
+/// `Executor::deferred_unwind` → `MonorubyErr::mark`. Each case collects
+/// and then allocates in the handler, so a value left unmarked would come
+/// back as a recycled cell rather than the string it built.
+#[test]
+fn a_deferred_unwind_payload_survives_a_gc_in_the_ensure() {
+    run_test(
+        r#"
+        def ret_through_ensure
+          begin
+            return ["ret", 1].join("-")
+          ensure
+            GC.start
+            300.times { Object.new }
+          end
+        end
+        def break_through_ensure
+          [1, 2].each do |i|
+            begin
+              break ["brk", i].join("-")
+            ensure
+              GC.start
+              300.times { Object.new }
+            end
+          end
+        end
+        def throw_through_ensure
+          catch(:tag) do
+            begin
+              throw :tag, ["thr", 3].join("-")
+            ensure
+              GC.start
+              300.times { Object.new }
+            end
+          end
+        end
+        [ret_through_ensure, break_through_ensure, throw_through_ensure]
+        "#,
+    );
+}

--- a/monoruby/tests/exit_handler_error_roots.rs
+++ b/monoruby/tests/exit_handler_error_roots.rs
@@ -1,0 +1,118 @@
+//! An uncaught error's `Value`s stay reachable across the exit handlers.
+//!
+//! `Globals::run_with_prelude` holds the script's `Err` in a Rust local —
+//! which the collector does not scan — while `at_exit` blocks,
+//! `ObjectSpace` finalizers and the dying threads' ensure clauses run, and
+//! then dereferences the `Value`s that error carries to build the report.
+//! Each case below registers an `at_exit` that allocates, so Ruby really
+//! does run in that window, and then raises uncaught an error of a kind
+//! that carries a `Value`: the re-raised object, an explicit `cause:`, a
+//! payload, a receiver, a key, a thrown tag.
+//!
+//! The assertion is monoruby's own report rather than CRuby's, because the
+//! point is the rooting rather than the wording — under `gc-stress`, where
+//! every allocation collects, a `Value` left out of the rooting comes back
+//! as a recycled cell and the report shows the wrong class, the wrong
+//! receiver, or a bare address.
+
+use std::process::Command;
+
+/// Run `script` with an `at_exit` that allocates, and return
+/// `(exit code, stderr)`.
+fn run(script: &str) -> (Option<i32>, String) {
+    let script = format!("at_exit {{ 200.times {{ Object.new }} }}\n{script}");
+    let out = Command::new(env!("CARGO_BIN_EXE_monoruby"))
+        .env_remove("RUBYOPT")
+        .args(["--disable=gems", "-e", &script])
+        .output()
+        .expect("spawn monoruby");
+    (
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+#[track_caller]
+fn assert_reports(script: &str, expected: &[&str]) {
+    let (code, stderr) = run(script);
+    assert_eq!(code, Some(1), "script: {script}\nstderr: {stderr}");
+    for want in expected {
+        assert!(
+            stderr.contains(want),
+            "expected {want:?} in the report\nscript: {script}\nstderr: {stderr}"
+        );
+    }
+}
+
+/// `original`: `raise exc` re-raises that very object, so the error holds
+/// it and the report reads its class, message and backtrace back out.
+#[test]
+fn a_reraised_object_survives_the_handlers() {
+    assert_reports(
+        "raise RuntimeError.new('re-raised boom')",
+        &["re-raised boom", "RuntimeError"],
+    );
+}
+
+/// `explicit_cause`: an explicit `cause:` is a second object the error
+/// carries, and the report walks the `#cause` chain.
+#[test]
+fn an_explicit_cause_survives_the_handlers() {
+    assert_reports(
+        "raise ArgumentError, 'outer', cause: RuntimeError.new('inner cause')",
+        &["outer", "ArgumentError"],
+    );
+}
+
+/// A NoMethodError carries the receiver it was raised on, and the report
+/// names that receiver's class.
+#[test]
+fn a_no_method_receiver_survives_the_handlers() {
+    assert_reports(
+        "Object.new.this_method_does_not_exist",
+        &["this_method_does_not_exist", "NoMethodError", "Object"],
+    );
+}
+
+/// A NameError carries its receiver too.
+#[test]
+fn a_name_error_survives_the_handlers() {
+    assert_reports(
+        "class Probe; def go; no_such_local_or_method; end; end; Probe.new.go",
+        &["no_such_local_or_method", "NameError"],
+    );
+}
+
+/// A FrozenError carries the frozen receiver.
+#[test]
+fn a_frozen_receiver_survives_the_handlers() {
+    assert_reports(
+        "s = 'frozen'.freeze; s << 'more'",
+        &["FrozenError", "frozen"],
+    );
+}
+
+/// A KeyError carries both the hash it was raised on and the missing key.
+#[test]
+fn a_key_error_pair_survives_the_handlers() {
+    assert_reports("{'a' => 1}.fetch('missing key')", &["KeyError", "missing key"]);
+}
+
+/// An uncaught `throw` carries the tag and the value.
+#[test]
+fn an_uncaught_throw_survives_the_handlers() {
+    assert_reports("throw :no_catch_for_this, 42", &["no_catch_for_this"]);
+}
+
+/// A `return` from a proc whose defining method has already returned
+/// reaches the top level as a non-local return, which carries the return
+/// value.
+#[test]
+fn a_stale_non_local_return_survives_the_handlers() {
+    let (code, stderr) = run("def mk; proc { return Object.new }; end; mk.call");
+    assert_eq!(code, Some(1), "stderr: {stderr}");
+    assert!(
+        stderr.contains("return") || stderr.contains("LocalJumpError"),
+        "stderr: {stderr}"
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -2008,6 +2008,7 @@
 9343abce32f04d953cc04ff67ed4bf31	["Socket", "Addrinfo", "127.0.0.1", true]	require "socket"\n            srv = Socket.new(:INET, :STREAM)\n     
 935122a7066cc663cf26533147c2cda5	[true, true, true, nil, false, false, true, "main", false, true, true, true, :meth, :clean]	$probe = []\n            path = "/tmp/mrb_load_wrap_t1_#{Process.pid
 9367674835b7363d7b25734fa0d598d3	[["a", "b"], ["a|b"]]	$; = "|"; r = ["a|b".split, "a|b".split(",")]; $; = nil; r
+938f2c5c071fe55c0abe16c17f25401b	["ret-1", "brk-1", "thr-3"]	def ret_through_ensure\n          begin\n            return ["ret", 1].jo
 93c5aa7882439219082961392f4d9537	["can't convert Object to Array (Object#to_ary gives Integer)", "N\\na\\n[...]\\n"]	r, w = IO.pipe\n            bad = Object.new\n            def bad.to_
 93e0fd9789bb5c32798b9de710a89935	67	putc(65); putc("Hi"); o=Object.new; def o.to_int; 66; end; putc(o); putc(67)
 93e6ef7313e6853be460ee30b0736410	[true, 5]	pid = fork { exit 5 }\n            w = Process.detach(pid)\n         


### PR DESCRIPTION
Items D and E from `doc/mail_lee_grape_investigation_2026-09.md` §5. Both are the same shape: work whose answer is fixed at compile time, redone on every call.

## `String#include?` copied its needle

`include?` took the needle through `regex_view()?.into_owned()`. For an ordinary UTF-8 string `regex_view` returns `Cow::Borrowed`, so `into_owned` copied the needle — malloc, memcpy, free — before every search, to read it and throw it away. The search only reads, so the `Cow` is kept as is.

`tr!` / `tr_s!` keep their `into_owned`: they hold the view across a mutation of the receiver.

## `Struct` interned its hidden ivar names per instance

Constructing a `Struct` reads two hidden ivars off its class — the member list (`get_members`) and `keyword_init:` (`is_keyword_init`). Both named them with `IdentId::get_id("/members")` / `get_id("/keyword_init")`: a global `RwLock` read, a string hash and a table probe each, for two names fixed at compile time.

They now have ids in the predefined block (`IdentId::_MEMBERS`, `IdentId::_KEYWORD_INIT`), as `/encoding_override` and `freeze` already do, used at every site that reads or writes them — `Data.define`, `Marshal`, and the `struct_members_len` walk the JIT uses to bake an allocation size, included.

## Measurements

Micro, median of repeated runs:

| operation | before | after |
|---|---:|---:|
| `Struct.new(1, 2)` ×1M | 104 ms | 73 ms |
| `"the quick brown fox…".include?("lazy")` ×1M | 105 ms | 94 ms |
| `include?`, 200-byte needle in a 5 KB haystack, ×200k | 157 ms | 155 ms |

A long needle is unchanged, since there the search dwarfs the copy.

Callgrind on the ruby-bench drivers, same workload on both builds:

| benchmark | measure | before | after |
|---|---|---:|---:|
| lee | `IdentId::get_id` calls | 4,677,231 | 104,630 |
| lee | total instructions | 16.65 G | 15.97 G (**−4.1 %**) |
| grape | malloc calls | 2,828,320 | 2,807,191 |

grape's malloc delta is exactly the 3 needle copies a request. Its instruction total moves 0.08 %, and on wall-clock neither benchmark moves outside this machine's run-to-run spread (lee 348–352 ms before, 343–352 ms after; grape 753–815 ms before, 749–773 ms after) — so the honest claim is the per-operation numbers above, not a benchmark win.

## Testing

- `cargo test --workspace`: 3952 passed, 1 failed — `builtins::numeric::float::tests::angle`, which fails identically on a tree without these commits and against a live CRuby too, so it is neither these changes nor oracle staleness (established in #1329).
- `String#include?` matches CRuby 4.0.6 on a 16-case probe: `to_str` coercion, a Symbol argument, empty needles, binary strings, multibyte haystacks, an incompatible encoding pair.
- `Struct`, `Data`, a `Struct` subclass, `keyword_init: true`, `Marshal` round-trip, `members`, `to_h`, `dig`, `each_pair`, `with`, `instance_variables` and the arity errors all match CRuby 4.0.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkoJG3qRpCRJ4nXDZH3mg9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkoJG3qRpCRJ4nXDZH3mg9)_