### PR TITLE
Chain deopt: convert the compilation unit's frames, not the whole stack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,6 +405,15 @@ External crates (fetched from git):
   `sqlite3_stmt*`. `Statement#step` steps and reads the whole row in one
   builtin call. Opening and closing a connection park the green thread on
   the native pool (`NativeOp::Sqlite3`); everything else runs inline.
+  `create_function` is a real user-defined function: SQLite calls back
+  into Ruby from inside `sqlite3_step`, as nokogiri's XPath handlers do.
+  A raised exception is stashed rather than unwound through the C frames
+  and re-raised once the step returns. The callback finds the running
+  `Executor` through a thread-local map keyed by **connection**, saved
+  and restored rather than pushed and popped: green-thread switches are
+  not LIFO, so a callback that parks would otherwise let another thread
+  pop its entry. `create_aggregate` and a `collation` with a real
+  comparator are still unsupported.
 
 ---
 

--- a/libsqlite3-src/src/lib.rs
+++ b/libsqlite3-src/src/lib.rs
@@ -200,6 +200,9 @@ unsafe extern "C" {
         x_destroy: Option<unsafe extern "C" fn(*mut c_void)>,
     ) -> c_int;
     pub fn sqlite3_user_data(ctx: *mut sqlite3_context) -> *mut c_void;
+    /// The connection a function is running on, which is how a callback
+    /// finds the step that invoked it.
+    pub fn sqlite3_context_db_handle(ctx: *mut sqlite3_context) -> *mut sqlite3;
     pub fn sqlite3_aggregate_context(ctx: *mut sqlite3_context, n: c_int) -> *mut c_void;
     pub fn sqlite3_result_null(ctx: *mut sqlite3_context);
     pub fn sqlite3_result_int64(ctx: *mut sqlite3_context, v: sqlite3_int64);

--- a/monoruby/src/builtins/sqlite3.rs
+++ b/monoruby/src/builtins/sqlite3.rs
@@ -23,7 +23,7 @@
 use super::*;
 use crate::alloc::GC;
 use libsqlite3_src as sq;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::ffi::{CStr, CString, c_char, c_int, c_void};
 
 pub(crate) fn init(globals: &mut Globals) {
@@ -109,8 +109,8 @@ fn sqlite3_init(_: &mut Executor, globals: &mut Globals, _: Lfp, _: BytecodePtr)
     globals.define_private_builtin_func(d, "load_extension_internal", db_load_extension, 1);
     globals.define_builtin_func_rest(d, "trace", db_trace);
     globals.define_builtin_func(d, "authorizer=", db_authorizer_assign, 1);
-    globals.define_builtin_func_rest(d, "define_function_with_flags", db_define_function);
-    globals.define_builtin_func_rest(d, "define_function", db_define_function_plain);
+    globals.define_builtin_func(d, "define_function_with_flags", db_define_function, 2);
+    globals.define_builtin_func(d, "define_function", db_define_function_plain, 1);
     globals.define_private_builtin_func(d, "define_aggregator2", db_define_aggregator, 2);
     globals.define_builtin_func(d, "collation", db_collation, 2);
     globals.define_builtin_func(d, "complete?", db_complete_p, 1);
@@ -938,8 +938,16 @@ fn db_exec_batch(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecode
         }
         let guard = StmtHandle { stmt, done: false };
         loop {
+            // A user function in this statement reaches the interpreter
+            // through this guard, as in `stmt_step`.
+            let mut call = CallGuard::new(vm, globals, db);
             // SAFETY: a live statement.
             let rc = unsafe { sq::sqlite3_step(stmt) };
+            let err = call.take_error();
+            drop(call);
+            if let Some(e) = err {
+                return Err(e);
+            }
             match rc {
                 // SAFETY: positioned on a row.
                 sq::SQLITE_ROW => rows.push(unsafe { row_value_as_text(stmt) }),
@@ -1006,15 +1014,376 @@ fn db_authorizer_assign(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: B
     Ok(Value::nil())
 }
 
-/// Database#define_function_with_flags(name, flags, &block) -> raises
+// ---------------------------------------------------------------------
+// User-defined functions
+// ---------------------------------------------------------------------
+
+/// One registered scalar function: the Proc `create_function` was given.
+///
+/// SQLite keeps this as the function's `pApp` for as long as the function
+/// is defined, so it is a leaked `Box` freed by the `xDestroy` below. The
+/// same Proc is also held in `DbHandle::funcs`, which is what roots it
+/// for the collector — this copy is never the only reference.
+struct FuncEntry {
+    block: Value,
+}
+
+/// `xDestroy`: SQLite calls this when the function is replaced or its
+/// connection closes.
+unsafe extern "C" fn func_destroy(app: *mut c_void) {
+    if !app.is_null() {
+        // SAFETY: the `Box` leaked at registration, handed back once.
+        drop(unsafe { Box::from_raw(app as *mut FuncEntry) });
+    }
+}
+
+/// What a callback needs to re-enter the interpreter, and where it leaves
+/// an exception for the step that caused it.
+///
+/// A Ruby exception must not unwind through SQLite's C frames, so the
+/// callback stashes it here, tells SQLite the function failed, and the
+/// builtin that called `sqlite3_step` re-raises it once control is back
+/// in Rust. This is how `nokogiri`'s XPath handlers work
+/// (`builtins/nokogiri/xpath.rs`).
+struct CallState {
+    vm: *mut Executor,
+    globals: *mut Globals,
+    error: Option<MonorubyErr>,
+}
+
+thread_local! {
+    /// The step in progress on each connection.
+    ///
+    /// Keyed by connection, and saved-and-restored rather than pushed
+    /// and popped, because green-thread switches are not LIFO: a
+    /// callback that parks (any `sleep` or IO in the block) lets another
+    /// green thread run, and it may finish its own step first. A plain
+    /// stack would then have one thread pop the other's entry and hand a
+    /// callback the wrong `Executor`. Per connection, two green threads
+    /// stepping two connections never meet; nesting on one connection —
+    /// which SQLite allows, and the C extension permits — still works,
+    /// since the inner guard restores the outer on the way out.
+    static CALLS: RefCell<HashMap<usize, *mut CallState>> =
+        RefCell::new(HashMap::default());
+}
+
+thread_local! {
+    /// Whether any user function has been defined on this thread.
+    ///
+    /// `stmt_step` is the hot path — one call per row — and installing a
+    /// guard costs an allocation and a map write. Almost no program
+    /// defines a function, so the guard is skipped entirely while this
+    /// is zero, leaving that path exactly as it was.
+    ///
+    /// It only ever grows: closing a connection drops its functions, but
+    /// SQLite frees them from whichever thread runs the close, and this
+    /// counter is per thread. Undercounting would skip a guard a
+    /// callback needs, so the count is deliberately never reduced except
+    /// when a registration fails outright. The cost of overcounting is
+    /// one guard per step in a program that used a function and then
+    /// stopped.
+    static FUNC_COUNT: Cell<usize> = const { Cell::new(0) };
+}
+
+/// Make `vm` / `globals` reachable from a callback for the duration of a
+/// step, and take back any exception a callback left behind.
+///
+/// `None` when no function is defined: there is then nothing that could
+/// call back, so there is nothing to guard.
+struct CallGuard {
+    inner: Option<CallGuardInner>,
+}
+
+struct CallGuardInner {
+    db: usize,
+    prev: Option<*mut CallState>,
+    state: Box<CallState>,
+}
+
+impl CallGuard {
+    fn new(vm: &mut Executor, globals: &mut Globals, db: *mut sq::sqlite3) -> Self {
+        if FUNC_COUNT.with(|n| n.get()) == 0 {
+            return Self { inner: None };
+        }
+        // Boxed so the address stays put however the map grows.
+        let mut state = Box::new(CallState {
+            vm,
+            globals,
+            error: None,
+        });
+        let p: *mut CallState = &mut *state;
+        let db = db as usize;
+        let prev = CALLS.with(|c| c.borrow_mut().insert(db, p));
+        Self {
+            inner: Some(CallGuardInner { db, prev, state }),
+        }
+    }
+
+    /// The exception a callback raised during this step, if any.
+    fn take_error(&mut self) -> Option<MonorubyErr> {
+        self.inner.as_mut().and_then(|i| i.state.error.take())
+    }
+}
+
+impl Drop for CallGuard {
+    fn drop(&mut self) {
+        let Some(i) = &self.inner else { return };
+        CALLS.with(|c| {
+            let mut c = c.borrow_mut();
+            match i.prev {
+                Some(p) => c.insert(i.db, p),
+                None => c.remove(&i.db),
+            };
+        });
+    }
+}
+
+/// The step running on `db`, or `None` when SQLite reached a callback
+/// from somewhere this binding does not guard.
+fn current_call(db: *mut sq::sqlite3) -> Option<*mut CallState> {
+    CALLS.with(|c| c.borrow().get(&(db as usize)).copied())
+}
+
+/// A function argument as Ruby, by the same mapping the row readers use.
+///
+/// # Safety
+/// `v` is a live `sqlite3_value` for the duration of the callback.
+unsafe fn arg_value(v: *mut sq::sqlite3_value) -> Value {
+    // SAFETY: the caller's contract.
+    unsafe {
+        match sq::sqlite3_value_type(v) {
+            sq::SQLITE_INTEGER => Value::integer(sq::sqlite3_value_int64(v)),
+            sq::SQLITE_FLOAT => Value::float(sq::sqlite3_value_double(v)),
+            sq::SQLITE_NULL => Value::nil(),
+            sq::SQLITE_BLOB => {
+                let ptr = sq::sqlite3_value_blob(v) as *const u8;
+                if ptr.is_null() {
+                    Value::bytes_from_slice(&[])
+                } else {
+                    let len = sq::sqlite3_value_bytes(v).max(0) as usize;
+                    Value::bytes_from_slice(std::slice::from_raw_parts(ptr, len))
+                }
+            }
+            _ => {
+                let ptr = sq::sqlite3_value_text(v) as *const c_char;
+                if ptr.is_null() {
+                    Value::nil()
+                } else {
+                    let len = sq::sqlite3_value_bytes(v).max(0) as usize;
+                    let bytes = std::slice::from_raw_parts(ptr as *const u8, len);
+                    Value::string_from_vec(bytes.to_vec())
+                }
+            }
+        }
+    }
+}
+
+/// Hand the block's answer back to SQLite, by the same rules `bind_param`
+/// uses for a bound value. The C extension refuses anything else with a
+/// RuntimeError rather than storing a NULL.
+fn set_result(
+    globals: &mut Globals,
+    ctx: *mut sq::sqlite3_context,
+    value: Value,
+) -> Result<()> {
+    // SAFETY: a live context, and buffers SQLite copies before returning
+    // (`SQLITE_TRANSIENT`).
+    unsafe {
+        match value.unpack() {
+            RV::Nil => sq::sqlite3_result_null(ctx),
+            RV::Fixnum(i) => sq::sqlite3_result_int64(ctx, i),
+            RV::Float(f) => sq::sqlite3_result_double(ctx, f),
+            RV::BigInt(b) => match num::ToPrimitive::to_i64(b) {
+                Some(i) => sq::sqlite3_result_int64(ctx, i),
+                None => sq::sqlite3_result_double(
+                    ctx,
+                    num::ToPrimitive::to_f64(b).unwrap_or(f64::INFINITY),
+                ),
+            },
+            RV::String(s) => {
+                let bytes = s.as_bytes();
+                if s.encoding() == crate::value::Encoding::Ascii8 || is_blob(globals, value) {
+                    sq::sqlite3_result_blob(
+                        ctx,
+                        bytes.as_ptr() as *const c_void,
+                        bytes.len() as c_int,
+                        sq::SQLITE_TRANSIENT(),
+                    )
+                } else {
+                    sq::sqlite3_result_text(
+                        ctx,
+                        bytes.as_ptr() as *const c_char,
+                        bytes.len() as c_int,
+                        sq::SQLITE_TRANSIENT(),
+                    )
+                }
+            }
+            _ => {
+                return Err(MonorubyErr::runtimeerr(format!(
+                    "can't return {}",
+                    value.get_real_class_name(&globals.store)
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Tell SQLite the function failed. The message is only what SQLite
+/// reports; the Ruby exception itself travels in `CallState::error`.
+fn result_error(ctx: *mut sq::sqlite3_context, msg: &str) {
+    if let Ok(c) = CString::new(msg) {
+        // SAFETY: a live context and a NUL-terminated string SQLite copies.
+        unsafe { sq::sqlite3_result_error(ctx, c.as_ptr(), -1) };
+    }
+}
+
+/// `xFunc`: SQLite calls this once per row the function appears in,
+/// from inside `sqlite3_step`.
+unsafe extern "C" fn func_invoke(
+    ctx: *mut sq::sqlite3_context,
+    argc: c_int,
+    argv: *mut *mut sq::sqlite3_value,
+) {
+    // SAFETY: SQLite passes a live context, and `argv` holds `argc` live
+    // values for the duration of the call.
+    unsafe {
+        let Some(state) = current_call(sq::sqlite3_context_db_handle(ctx)) else {
+            // No step of ours is running, so there is no interpreter to
+            // re-enter and nowhere to put an exception.
+            result_error(ctx, "sqlite3 function called outside a query");
+            return;
+        };
+        let state = &mut *state;
+        // A previous row already failed; this evaluation is being torn
+        // down, so do not run the block again.
+        if state.error.is_some() {
+            result_error(ctx, "aborted");
+            return;
+        }
+        let vm = &mut *state.vm;
+        let globals = &mut *state.globals;
+        let entry = &*(sq::sqlite3_user_data(ctx) as *const FuncEntry);
+
+        // The arguments stay rooted while they are built: each one is a
+        // fresh object, and allocating the next may collect.
+        let len = vm.temp_len();
+        let mut args = Vec::with_capacity(argc.max(0) as usize);
+        for i in 0..argc as isize {
+            let v = arg_value(*argv.offset(i));
+            vm.temp_push(v);
+            args.push(v);
+        }
+        let result = match entry.block.is_proc() {
+            Some(p) => vm.invoke_proc(globals, &p, &args),
+            None => Err(err_sqlite3(vm, globals, "function block is not a Proc")),
+        };
+        vm.temp_clear(len);
+
+        match result.and_then(|v| set_result(globals, ctx, v)) {
+            Ok(()) => {}
+            Err(e) => {
+                // Report a failure to SQLite so the step unwinds, and keep
+                // the exception for the builtin to re-raise.
+                result_error(ctx, &e.get_error_message(&globals.store));
+                state.error = Some(e);
+            }
+        }
+    }
+}
+
+/// Database#define_function_with_flags(name, flags, &block) -> self
+///
+/// The C-level half of `create_function`; the gem's Ruby half wraps the
+/// caller's block in one that builds a `FunctionProxy` and answers its
+/// `result`. Registered with an arity of -1, as the extension does: the
+/// arity passed to `create_function` never reaches SQLite, so
+/// `create_function("f", 1)` really does accept `f(1, 2)`.
 #[monoruby_builtin]
-fn db_define_function(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr) -> Result<Value> {
-    db_of(vm, globals, lfp.self_val())?;
-    Err(err_sqlite3(
-        vm,
-        globals,
-        "create_function is not supported by monoruby's sqlite3 binding",
-    ))
+fn db_define_function(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, pc: BytecodePtr) -> Result<Value> {
+    // The gem passes the text-rep flags straight through; UTF-8 is the
+    // only encoding this binding reads, and SQLITE_DETERMINISTIC is the
+    // one other bit worth honouring.
+    let flags = lfp.arg(1).coerce_to_i64(globals)? as c_int;
+    register_function(vm, globals, lfp, pc, flags)
+}
+
+/// Database#define_function(name, &block) -> self
+///
+/// `define_function_with_flags` with no flags.
+#[monoruby_builtin]
+fn db_define_function_plain(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    pc: BytecodePtr,
+) -> Result<Value> {
+    register_function(vm, globals, lfp, pc, 0)
+}
+
+/// Register `lfp.arg(0)` as a scalar function running `lfp`'s block.
+fn register_function(
+    vm: &mut Executor,
+    globals: &mut Globals,
+    lfp: Lfp,
+    pc: BytecodePtr,
+    flags: c_int,
+) -> Result<Value> {
+    let db = db_of(vm, globals, lfp.self_val())?;
+    let name = lfp.arg(0).expect_string(&globals.store)?;
+    // SQLite takes a NUL-terminated name, so a name holding a NUL byte
+    // registers only the part before it — which is what the C extension
+    // does, and `"a\0b"` really does define `a`.
+    let bytes = name.as_bytes();
+    let upto = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
+    let cname = CString::new(&bytes[..upto]).expect("no NUL before the first NUL");
+    let enc = sq::SQLITE_UTF8 | (flags & sq::SQLITE_DETERMINISTIC);
+    let Some(bh) = lfp.block() else {
+        // What `Proc.new` says, which is where the C extension ends up.
+        return Err(MonorubyErr::argumenterr(
+            "tried to create Proc object without a block",
+        ));
+    };
+    let block: Value = vm.generate_proc(globals, bh, pc)?.into();
+    // Rooted here for as long as SQLite may call it; the `FuncEntry`
+    // below holds the same Value but is invisible to the collector.
+    native_mut::<DbHandle>(lfp.self_val())?.funcs.push(block);
+    // The C extension also records it under the name the caller gave,
+    // which `Database#functions` exposes.
+    let funcs = globals
+        .store
+        .get_ivar(lfp.self_val(), IdentId::get_id("@functions"))
+        .unwrap_or_default();
+    if let Some(mut h) = funcs.try_hash_ty() {
+        h.insert(Value::string_from_str(&name), block, vm, globals)?;
+    }
+    let entry = Box::into_raw(Box::new(FuncEntry { block }));
+    // From here on `stmt_step` installs a guard: something can call back.
+    FUNC_COUNT.with(|n| n.set(n.get() + 1));
+    // SAFETY: a live connection and a NUL-terminated name; `entry` is
+    // handed to SQLite, which gives it back to `func_destroy`.
+    let rc = unsafe {
+        sq::sqlite3_create_function_v2(
+            db,
+            cname.as_ptr(),
+            -1,
+            enc,
+            entry as *mut c_void,
+            Some(func_invoke),
+            None,
+            None,
+            Some(func_destroy),
+        )
+    };
+    if rc != sq::SQLITE_OK {
+        // SQLite did not take the function, so `xDestroy` never runs and
+        // the box is ours to free.
+        // SAFETY: the box just leaked, still unshared.
+        drop(unsafe { Box::from_raw(entry) });
+        FUNC_COUNT.with(|n| n.set(n.get() - 1));
+        check(vm, globals, db, rc)?;
+    }
+    Ok(lfp.self_val())
 }
 
 /// Database#define_aggregator2(klass, name) -> raises
@@ -1042,26 +1411,6 @@ fn db_complete_p(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: Bytecode
     };
     // SAFETY: a NUL-terminated string that outlives the call.
     Ok(Value::bool(unsafe { sq::sqlite3_complete(c.as_ptr()) } != 0))
-}
-
-/// Database#define_function(name, &block) -> raises
-///
-/// The C-level half of `create_function`. Like it, and for the same
-/// reason (a SQLite callback would have to re-enter the interpreter),
-/// this refuses rather than pretending to register anything.
-#[monoruby_builtin]
-fn db_define_function_plain(
-    vm: &mut Executor,
-    globals: &mut Globals,
-    lfp: Lfp,
-    _: BytecodePtr,
-) -> Result<Value> {
-    db_of(vm, globals, lfp.self_val())?;
-    Err(err_sqlite3(
-        vm,
-        globals,
-        "create_function is not supported by monoruby's sqlite3 binding",
-    ))
 }
 
 /// Database#collation(name, comparator) -> self
@@ -1197,8 +1546,18 @@ fn stmt_step(vm: &mut Executor, globals: &mut Globals, lfp: Lfp, _: BytecodePtr)
         return Ok(Value::nil());
     }
     let stmt = h.stmt;
+    // A user function reaches the interpreter through this guard, and
+    // leaves an exception on it rather than unwinding through SQLite.
+    // SAFETY: a live statement.
+    let db = unsafe { sq::sqlite3_db_handle(stmt) };
+    let mut guard = CallGuard::new(vm, globals, db);
     // SAFETY: a live statement.
     let rc = unsafe { sq::sqlite3_step(stmt) };
+    if let Some(e) = guard.take_error() {
+        return Err(e);
+    }
+    drop(guard);
+    let h = native_mut::<StmtHandle>(lfp.self_val())?;
     match rc {
         sq::SQLITE_ROW => {
             h.done = false;

--- a/monoruby/src/globals.rs
+++ b/monoruby/src/globals.rs
@@ -1204,17 +1204,28 @@ impl Globals {
         // been computed. Found by gc-stress, which collects at every
         // safepoint and so hits this on the first allocation a finalizer
         // makes.
+        //
+        // An `Err` carries `Value`s of its own — the re-raised exception
+        // object, an explicit `cause:`, a kind's payload, a NoMethodError
+        // receiver, a KeyError's receiver and key — and they are in the
+        // same Rust local, so they need the same rooting. The
+        // materialization below happens to cover most of them while the
+        // handlers run (it hangs them off the exception object it puts in
+        // `$!`), but that lapses at the `set_errinfo` restore, with
+        // `terminate_all` still to run Ruby and the report below still to
+        // dereference them. Root them outright instead of relying on that.
         let root_len = executor.temp_len();
         if let Ok(v) = &res {
             executor.temp_push(*v);
         }
         executor.temp_push(unwind_errinfo);
-        if let Err(err) = &res
-            && !matches!(err.kind(), MonorubyErrKind::SystemExit(_))
-        {
-            executor.set_error(err.clone());
-            let err_val = executor.take_ex_obj(self);
-            executor.set_errinfo(err_val);
+        if let Err(err) = &res {
+            err.for_each_value(|v| executor.temp_push(v));
+            if !matches!(err.kind(), MonorubyErrKind::SystemExit(_)) {
+                executor.set_error(err.clone());
+                let err_val = executor.take_ex_obj(self);
+                executor.set_errinfo(err_val);
+            }
         }
         let handler_status = executor.run_exit_handlers(self);
         executor.set_errinfo(unwind_errinfo);

--- a/monoruby/src/globals/error.rs
+++ b/monoruby/src/globals/error.rs
@@ -150,25 +150,30 @@ impl MonorubyErr {
     }
 
     ///
-    /// Mark every `Value` reachable from this error so the GC keeps
-    /// them alive while the error is in flight (held by `Executor`'s
-    /// pending exception slot or wrapped in a heap-allocated
-    /// `ExceptionInner`). Most error kinds carry only metadata
-    /// (class ids, identifier symbols, paths), but a few smuggle
-    /// real `Value`s — the relevant variants are dispatched
-    /// explicitly so that adding a new error kind that owns a
-    /// `Value` will not silently regress.
+    /// Call `f` with every `Value` this error carries. Most error kinds
+    /// hold only metadata (class ids, identifier symbols, paths), but a
+    /// few smuggle real `Value`s — those variants are dispatched
+    /// explicitly so that adding a new error kind that owns a `Value`
+    /// will not silently regress.
     ///
-    pub(crate) fn mark(&self, alloc: &mut alloc::Allocator<crate::value::RValue>) {
-        use alloc::GC;
-        if let Some(original) = &self.original {
-            original.mark(alloc);
+    /// Both callers need the same set, which is why they share one
+    /// walk. [`MonorubyErr::mark`] keeps them alive while the error is
+    /// in flight (held by `Executor`'s pending exception slot, or
+    /// wrapped in a heap-allocated `ExceptionInner`); it adds only the
+    /// `Lfp` of the non-local-return kinds, a frame pointer rather than
+    /// a `Value`. `Globals::run_with_prelude` roots them on the temp
+    /// stack, because it holds an error in a Rust local — which the
+    /// collector does not scan — across the exit handlers.
+    ///
+    pub(crate) fn for_each_value(&self, mut f: impl FnMut(Value)) {
+        if let Some(original) = self.original {
+            f(original);
         }
-        if let Some(cause) = &self.explicit_cause {
-            cause.mark(alloc);
+        if let Some(cause) = self.explicit_cause {
+            f(cause);
         }
-        if let Some((val, _)) = &self.payload {
-            val.mark(alloc);
+        if let Some((val, _)) = self.payload {
+            f(val);
         }
         match &self.kind {
             // The receiver that triggered the NoMethodError (set by
@@ -176,34 +181,40 @@ impl MonorubyErr {
             MonorubyErrKind::NotMethod {
                 receiver: Some(recv),
                 ..
-            } => {
-                recv.mark(alloc);
-            }
+            } => f(*recv),
             // Receiver / key Values for KeyError.
             MonorubyErrKind::Key(Some((recv, key))) => {
-                recv.mark(alloc);
-                key.mark(alloc);
+                f(*recv);
+                f(*key);
             }
             // Receiver Value for NameError / FrozenError.
-            MonorubyErrKind::Name(_, Some(recv)) | MonorubyErrKind::Frozen(Some(recv)) => {
-                recv.mark(alloc);
-            }
-            // Non-local return: carries the return value and the
-            // captured frame pointer it must return to.
-            MonorubyErrKind::MethodReturn(v, lfp) => {
-                v.mark(alloc);
-                lfp.mark(alloc);
-            }
-            MonorubyErrKind::BlockBreak(v, _, lfp) => {
-                v.mark(alloc);
-                lfp.mark(alloc);
-            }
+            MonorubyErrKind::Name(_, Some(recv)) | MonorubyErrKind::Frozen(Some(recv)) => f(*recv),
+            // Non-local return: the return value (the frame pointer it
+            // must return to is `mark`'s business, not a `Value`).
+            MonorubyErrKind::MethodReturn(v, _) | MonorubyErrKind::BlockBreak(v, _, _) => f(*v),
             // Kernel#throw: carries the tag and value.
             MonorubyErrKind::Throw(tag, val) => {
-                tag.mark(alloc);
-                val.mark(alloc);
+                f(*tag);
+                f(*val);
             }
             // The remaining kinds carry no `Value` payload.
+            _ => {}
+        }
+    }
+
+    ///
+    /// Mark every `Value` reachable from this error, plus the captured
+    /// frame a non-local return carries, so the GC keeps them alive
+    /// while the error is in flight.
+    ///
+    pub(crate) fn mark(&self, alloc: &mut alloc::Allocator<crate::value::RValue>) {
+        use alloc::GC;
+        self.for_each_value(|v| v.mark(alloc));
+        match &self.kind {
+            // The captured frame a non-local return must return to.
+            MonorubyErrKind::MethodReturn(_, lfp) | MonorubyErrKind::BlockBreak(_, _, lfp) => {
+                lfp.mark(alloc)
+            }
             _ => {}
         }
     }

--- a/monoruby/tests/deferred_unwind.rs
+++ b/monoruby/tests/deferred_unwind.rs
@@ -123,3 +123,47 @@ fn a_compiled_return_inside_an_osr_loop_in_an_ensure() {
         "#,
     );
 }
+
+/// A deferred unwind's payload must survive a collection *inside* the
+/// `ensure` that deferred it. While the handler runs, the parked error is
+/// the only thing holding the returned / broken / thrown value, and
+/// `Executor::mark` reaches it solely through
+/// `Executor::deferred_unwind` → `MonorubyErr::mark`. Each case collects
+/// and then allocates in the handler, so a value left unmarked would come
+/// back as a recycled cell rather than the string it built.
+#[test]
+fn a_deferred_unwind_payload_survives_a_gc_in_the_ensure() {
+    run_test(
+        r#"
+        def ret_through_ensure
+          begin
+            return ["ret", 1].join("-")
+          ensure
+            GC.start
+            300.times { Object.new }
+          end
+        end
+        def break_through_ensure
+          [1, 2].each do |i|
+            begin
+              break ["brk", i].join("-")
+            ensure
+              GC.start
+              300.times { Object.new }
+            end
+          end
+        end
+        def throw_through_ensure
+          catch(:tag) do
+            begin
+              throw :tag, ["thr", 3].join("-")
+            ensure
+              GC.start
+              300.times { Object.new }
+            end
+          end
+        end
+        [ret_through_ensure, break_through_ensure, throw_through_ensure]
+        "#,
+    );
+}

--- a/monoruby/tests/exit_handler_error_roots.rs
+++ b/monoruby/tests/exit_handler_error_roots.rs
@@ -1,0 +1,118 @@
+//! An uncaught error's `Value`s stay reachable across the exit handlers.
+//!
+//! `Globals::run_with_prelude` holds the script's `Err` in a Rust local —
+//! which the collector does not scan — while `at_exit` blocks,
+//! `ObjectSpace` finalizers and the dying threads' ensure clauses run, and
+//! then dereferences the `Value`s that error carries to build the report.
+//! Each case below registers an `at_exit` that allocates, so Ruby really
+//! does run in that window, and then raises uncaught an error of a kind
+//! that carries a `Value`: the re-raised object, an explicit `cause:`, a
+//! payload, a receiver, a key, a thrown tag.
+//!
+//! The assertion is monoruby's own report rather than CRuby's, because the
+//! point is the rooting rather than the wording — under `gc-stress`, where
+//! every allocation collects, a `Value` left out of the rooting comes back
+//! as a recycled cell and the report shows the wrong class, the wrong
+//! receiver, or a bare address.
+
+use std::process::Command;
+
+/// Run `script` with an `at_exit` that allocates, and return
+/// `(exit code, stderr)`.
+fn run(script: &str) -> (Option<i32>, String) {
+    let script = format!("at_exit {{ 200.times {{ Object.new }} }}\n{script}");
+    let out = Command::new(env!("CARGO_BIN_EXE_monoruby"))
+        .env_remove("RUBYOPT")
+        .args(["--disable=gems", "-e", &script])
+        .output()
+        .expect("spawn monoruby");
+    (
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+#[track_caller]
+fn assert_reports(script: &str, expected: &[&str]) {
+    let (code, stderr) = run(script);
+    assert_eq!(code, Some(1), "script: {script}\nstderr: {stderr}");
+    for want in expected {
+        assert!(
+            stderr.contains(want),
+            "expected {want:?} in the report\nscript: {script}\nstderr: {stderr}"
+        );
+    }
+}
+
+/// `original`: `raise exc` re-raises that very object, so the error holds
+/// it and the report reads its class, message and backtrace back out.
+#[test]
+fn a_reraised_object_survives_the_handlers() {
+    assert_reports(
+        "raise RuntimeError.new('re-raised boom')",
+        &["re-raised boom", "RuntimeError"],
+    );
+}
+
+/// `explicit_cause`: an explicit `cause:` is a second object the error
+/// carries, and the report walks the `#cause` chain.
+#[test]
+fn an_explicit_cause_survives_the_handlers() {
+    assert_reports(
+        "raise ArgumentError, 'outer', cause: RuntimeError.new('inner cause')",
+        &["outer", "ArgumentError"],
+    );
+}
+
+/// A NoMethodError carries the receiver it was raised on, and the report
+/// names that receiver's class.
+#[test]
+fn a_no_method_receiver_survives_the_handlers() {
+    assert_reports(
+        "Object.new.this_method_does_not_exist",
+        &["this_method_does_not_exist", "NoMethodError", "Object"],
+    );
+}
+
+/// A NameError carries its receiver too.
+#[test]
+fn a_name_error_survives_the_handlers() {
+    assert_reports(
+        "class Probe; def go; no_such_local_or_method; end; end; Probe.new.go",
+        &["no_such_local_or_method", "NameError"],
+    );
+}
+
+/// A FrozenError carries the frozen receiver.
+#[test]
+fn a_frozen_receiver_survives_the_handlers() {
+    assert_reports(
+        "s = 'frozen'.freeze; s << 'more'",
+        &["FrozenError", "frozen"],
+    );
+}
+
+/// A KeyError carries both the hash it was raised on and the missing key.
+#[test]
+fn a_key_error_pair_survives_the_handlers() {
+    assert_reports("{'a' => 1}.fetch('missing key')", &["KeyError", "missing key"]);
+}
+
+/// An uncaught `throw` carries the tag and the value.
+#[test]
+fn an_uncaught_throw_survives_the_handlers() {
+    assert_reports("throw :no_catch_for_this, 42", &["no_catch_for_this"]);
+}
+
+/// A `return` from a proc whose defining method has already returned
+/// reaches the top level as a non-local return, which carries the return
+/// value.
+#[test]
+fn a_stale_non_local_return_survives_the_handlers() {
+    let (code, stderr) = run("def mk; proc { return Object.new }; end; mk.call");
+    assert_eq!(code, Some(1), "stderr: {stderr}");
+    assert!(
+        stderr.contains("return") || stderr.contains("LocalJumpError"),
+        "stderr: {stderr}"
+    );
+}

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -2008,6 +2008,7 @@
 9343abce32f04d953cc04ff67ed4bf31	["Socket", "Addrinfo", "127.0.0.1", true]	require "socket"\n            srv = Socket.new(:INET, :STREAM)\n     
 935122a7066cc663cf26533147c2cda5	[true, true, true, nil, false, false, true, "main", false, true, true, true, :meth, :clean]	$probe = []\n            path = "/tmp/mrb_load_wrap_t1_#{Process.pid
 9367674835b7363d7b25734fa0d598d3	[["a", "b"], ["a|b"]]	$; = "|"; r = ["a|b".split, "a|b".split(",")]; $; = nil; r
+938f2c5c071fe55c0abe16c17f25401b	["ret-1", "brk-1", "thr-3"]	def ret_through_ensure\n          begin\n            return ["ret", 1].jo
 93c5aa7882439219082961392f4d9537	["can't convert Object to Array (Object#to_ary gives Integer)", "N\\na\\n[...]\\n"]	r, w = IO.pipe\n            bad = Object.new\n            def bad.to_
 93e0fd9789bb5c32798b9de710a89935	67	putc(65); putc("Hi"); o=Object.new; def o.to_int; 66; end; putc(o); putc(67)
 93e6ef7313e6853be460ee30b0736410	[true, 5]	pid = fork { exit 5 }\n            w = Process.detach(pid)\n         

--- a/monoruby/tests/ruby_oracle.tsv
+++ b/monoruby/tests/ruby_oracle.tsv
@@ -183,6 +183,7 @@
 0b360a7151ca4646f547e0ecffd6cf13	[true, true, true, true, true, ArgumentError, ArgumentError, TypeError, TypeError, Hash, false]	(ENV["MONO_T_ZZ"]="hi"; a=ENV["MONO_T_ZZ"].frozen?; b=ENV.method(:has_key?)==ENV
 0b40f53074d9e48c2b4d7383337aaada	[[1, 1, 2, 3], ArgumentError, -2, nil]	class Diff\n          attr_reader :v\n          def initialize(v) = @v = 
 0b45e95b3c2f86584c9598881d58fac9	[42, 90, 15, "1/2", "7:8", "argerr"]	def a0; 42; end\n        def a1(x); x * 10; end\n        def a5(a, b, c, 
+0b4f45356eb0234401ec06e247eb53b6	[[["[[\\"Integer\\", 1], [\\"Float\\", 2.5], [\\"NilClass\\", nil], [\\"String\\", \\"\\\\x00\\\\xFF\\"], [\\"String\\", \\"txt\\"]]"]], [["int", [["integer", 7]]], ["big", [["real", 1.1805916207174113e+21]]], ["float", [["real", 1.5]]], ["nil", [["null", nil]]], ["text", [["text", "plain"]]], ["binary", [["blob", "bin"]]], ["blob", [["blob", "\\x00\\xFF"]]], ["bool", "RuntimeError", "can't return TrueClass"], ["obj", "RuntimeError", "can't return Object"]], [["got 1"]], [[[15]], [[0]]], ["ArgumentError", "tried to create Proc object without a block"], [[14]], ["a\\u0000b", "one", "ret", "triple", "types"], [[2]]]	require "rubygems"\n        require "sqlite3"\n        db = SQLite3::Data
 0b56e400524c40599f5741f2c015962d	7	class Foo\n              def method_missing(name, *args)\n           
 0b645df6fa816084c17746fbb8754151	-4	class Integer; alias __orig :~; def ~; __orig; end; end; ~(3)
 0b67f0becaeeca974d1e74004df4c680	[[:x], [1, :y]]	class C\n                 def initialize; @log = []; end\n                 def []=
@@ -631,6 +632,7 @@
 2c4fa500f8bcf950b28e5b25417f18be	"US-ASCII"	"z".encode("US-ASCII").next.encoding.to_s
 2c60a3b58b3cec1741ef306698cffc54	"missing: hello"	class C\n          def method_missing(name, *args)\n            "missing:
 2cbffbc78f3202b93258530c17eb3aec	[1200, "abcdefghij", true]	def app_piece2(s, piece, n)\n          i = 0\n          while i < n\n     
+2ce4c46a627e56a288d69bedcb54e67d	[["ArgumentError", "boom at 2"], ["ArgumentError", "boom at 2"], [[1], [2], [3]], [[11], [12], [13]]]	require "rubygems"\n        require "sqlite3"\n        db = SQLite3::Data
 2cf607598595d4b3f44991e7c7f960a0	[[:typeerr], [:typeerr], [:typeerr], [:ok]]	def t(x)\n              [x].map do |v|\n                begin\n       
 2d0977c7c034e1bbf8950d44e00c27b0	[1, 20, nil, 1, 2, nil, 1, nil]	def run(h, k, n = 300)\n          r = nil; i = 0\n          while i < n; 
 2d0f94c4757acfe87ab61946bc9adbbb	3	st = Process.detach(spawn("sh", "-c", "exit 3")).value; st.exitstatus
@@ -1207,6 +1209,7 @@
 581a9eeda65b4118ca39d22e6e34f801	[:caught, "boom"]	class C\n              def initialize; @h = {}; end\n              de
 582de92dfc668c66f3fca99c56ea0221	9	M = Data.define(:amount, :unit)\nM.new("amount" => 1, amount: 9, unit: "m").amoun
 58330bef80223af992dc7623e3ec3084	[312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3], 312, [1, 2, 3]]	def g(x, y, z)\n          x, y, z = z, x, y\n          x * 100 + y * 10 +
+5848d3c79a069c869e17a609e9eccaa1	[[[3]], [[3]], ["RuntimeError", "inner"], [[3]]]	require "rubygems"\n        require "sqlite3"\n        db = SQLite3::Data
 58536fdabdc310d1d4cdf2be1346caa2	[:broke, :b, ["0", "1", "2"]]	r1 = Array.new(4) { |i| break :broke if i == 2; i }\n        a = [9]\n   
 585f197f00dd5b3733ac8eba28e6e47d	[199, "v199"]	class P\n          attr_accessor :x, :y\n        end\n        p = P.new\n  
 58661de46a8dc941342a4319c35b9c90	1	obj = Object.new\n            def obj.infinite?; nil; end\n          
@@ -1645,6 +1648,7 @@
 78d0e78fc74998266ad2fd179077428d	[[4, 5, "s4"]]	class P\n          attr_accessor :x, :y, :z\n        end\n        def fill
 78d7ea39e2bafbf7649c9fc6b54bb309	[90300, 50, 50, [6, 6], [8, 8]]	class Base\n          def helper(x); x.succ; end\n          def m(v); [he
 7933b76f3fbc5da321278e1298f09b68	"1/2"	0.5.to_r.to_s
+793df4a57062ccad86195db16e27aa5f	[[["[[\\"Integer\\", 1], [\\"Float\\", 2.5], [\\"NilClass\\", nil], [\\"String\\", \\"\\\\x00\\\\xFF\\"], [\\"String\\", \\"txt\\"]]"]], [["int", [["integer", 7]]], ["big", [["real", 1.1805916207174113e+21]]], ["float", [["real", 1.5]]], ["nil", [["null", nil]]], ["text", [["text", "plain"]]], ["binary", [["blob", "bin"]]], ["blob", [["blob", "\\x00\\xFF"]]], ["bool", "RuntimeError", "can't return TrueClass"], ["obj", "RuntimeError", "can't return Object"]], [["got 1"]]]	require "rubygems"\n        require "sqlite3"\n        db = SQLite3::Data
 79444ab999b1bb6218ce359077c8b24d	true	$LOADED_FEATURES.class == Array\n            
 79670f7488f2c3d15c92d158fb9043d3	"ab20000c"	%Q(ab#{100*200}c#$a)
 797f4bcc2f336f9d89d45a2f223ea819	["Bar", "Foo"]	$a = []\n            class Foo\n                CONST = 'Foo'\n       

--- a/monoruby/tests/sqlite3.rs
+++ b/monoruby/tests/sqlite3.rs
@@ -446,13 +446,14 @@ fn sqlite3_statements_are_finalized_when_collected() {
     );
 }
 
-/// The entry points monoruby's binding does not implement, and the ones
-/// it accepts but ignores. Not oracle-checked: the C extension really
-/// registers these callbacks, and the whole point here is that this
-/// binding refuses instead — a SQLite callback would have to re-enter
-/// the interpreter. What is pinned is that each fails loudly, as a
-/// `SQLite3::Exception` naming the feature, rather than appearing to
-/// work.
+/// The entry points monoruby's binding still does not implement, and the
+/// ones it accepts but ignores. Not oracle-checked: the C extension
+/// really registers these callbacks, and the point here is that this
+/// binding refuses loudly instead, with a `SQLite3::Exception` naming
+/// the feature, rather than appearing to work.
+///
+/// `create_function` is no longer among them — see
+/// `sqlite3_create_function`.
 #[test]
 fn sqlite3_unsupported_callbacks_refuse() {
     let v = run_test_no_result_check(
@@ -466,14 +467,10 @@ fn sqlite3_unsupported_callbacks_refuse() {
           def finalize; 0; end
         end
         r = []
-        r << (begin; db.create_function("f", 1) { |c, v| c.result = v }; rescue => e; [e.class.name, e.message]; end)
-        r << (begin; db.define_function("g") { |v| v }; rescue => e; [e.class.name, e.message]; end)
         r << (begin; db.create_aggregate_handler(agg); rescue => e; [e.class.name, e.message]; end)
         r << (begin; db.collation("c", Object.new); rescue => e; [e.class.name, e.message]; end)
         r << (begin; db.load_extension("x"); rescue => e; [e.class.name, e.message]; end)
         expected = [
-          ["SQLite3::Exception", "create_function is not supported by monoruby's sqlite3 binding"],
-          ["SQLite3::Exception", "create_function is not supported by monoruby's sqlite3 binding"],
           ["SQLite3::Exception", "create_aggregate is not supported by monoruby's sqlite3 binding"],
           ["SQLite3::Exception", "collation is not supported by monoruby's sqlite3 binding"],
           ["SQLite3::Exception", "load_extension is not available: monoruby's SQLite is built without extension loading"],
@@ -496,7 +493,7 @@ fn sqlite3_unsupported_callbacks_refuse() {
         r.size + r2.size
         "##,
     );
-    assert_eq!(v.try_fixnum(), Some(10));
+    assert_eq!(v.try_fixnum(), Some(8));
 }
 
 /// The failure paths of opening a connection, and `open16`, which the
@@ -623,6 +620,130 @@ fn sqlite3_binding_and_accessor_edges() {
         db.interrupt
         db.execute("INSERT INTO t (a, b) VALUES (1, 'x')")
         res << db.execute("SELECT * FROM t")
+        db.close
+        res
+        "##,
+    );
+}
+
+/// `create_function` over the native binding. The gem's Ruby half wraps
+/// the caller's block in one that fills a `FunctionProxy`; the block
+/// below it runs inside `sqlite3_step`, reached from SQLite's C
+/// callback, which is what every case here exercises.
+#[test]
+fn sqlite3_create_function() {
+    run_test_once(
+        r##"
+        require "rubygems"
+        require "sqlite3"
+        db = SQLite3::Database.new(":memory:")
+        res = []
+        # Arguments arrive by the same mapping the row readers use.
+        db.create_function("types", -1) { |fp, *a| fp.result = a.map { |x| [x.class.name, x] }.inspect }
+        res << db.execute("SELECT types(1, 2.5, NULL, x'00ff', 'txt')")
+        # Results: the classes SQLite can store, and the refusal for the rest.
+        db.create_function("ret", 1) { |fp, kind|
+          fp.result = case kind
+            when "int" then 7
+            when "big" then 2**70
+            when "float" then 1.5
+            when "nil" then nil
+            when "text" then "plain"
+            when "binary" then "bin".dup.force_encoding("BINARY")
+            when "blob" then SQLite3::Blob.new("\x00\xff")
+            when "bool" then true
+            when "obj" then Object.new
+            end
+        }
+        res << %w[int big float nil text binary blob bool obj].map { |k|
+          begin
+            [k, db.execute("SELECT typeof(ret(?)), ret(?)", [k, k])]
+          rescue StandardError => e
+            [k, e.class.name, e.message]
+          end
+        }
+        # The arity given to create_function never reaches SQLite, so a
+        # call with a different count still runs.
+        db.create_function("one", 1) { |fp, a| fp.result = "got #{a.inspect}" }
+        res << db.execute("SELECT one(1, 2)")
+        # `define_function` is the same thing without flags, and hands
+        # the block the arguments directly rather than a FunctionProxy.
+        db.define_function("triple") { |v| v.to_i * 3 }
+        res << [db.execute("SELECT triple(5)"), db.execute("SELECT triple(NULL)")]
+        res << (begin; db.define_function("nb"); rescue StandardError => e; [e.class.name, e.message]; end)
+        # SQLite takes a NUL-terminated name, so a name holding a NUL
+        # defines only the part before it — while the registry the
+        # extension keeps is keyed by the whole string.
+        db.define_function("a\0b") { |v| v.to_i * 7 }
+        res << db.execute("SELECT a(2)")
+        res << db.instance_variable_get(:@functions).keys.sort
+        # SQLITE_DETERMINISTIC passes through.
+        db.define_function_with_flags("det", 0x800) { |v| v.to_i + 1 }
+        res << db.execute("SELECT det(1)")
+        db.close
+        res
+        "##,
+    );
+}
+
+/// A block that raises must not unwind through SQLite's C frames: the
+/// exception is carried out of the step and re-raised unchanged, the
+/// scan stops, and the connection stays usable.
+#[test]
+fn sqlite3_function_exceptions() {
+    run_test_once(
+        r##"
+        require "rubygems"
+        require "sqlite3"
+        db = SQLite3::Database.new(":memory:")
+        db.execute("CREATE TABLE t (a)")
+        db.execute("INSERT INTO t VALUES (1), (2), (3)")
+        res = []
+        db.create_function("failat", 1) { |fp, v| raise ArgumentError, "boom at #{v}" if v.to_i == 2; fp.result = v }
+        res << (begin
+                  db.execute("SELECT failat(a) FROM t ORDER BY a")
+                rescue StandardError => e
+                  [e.class.name, e.message]
+                end)
+        # The same through the batch executor, which steps on its own.
+        res << (begin
+                  db.execute_batch2("SELECT failat(a) FROM t ORDER BY a")
+                rescue StandardError => e
+                  [e.class.name, e.message]
+                end)
+        # Unaffected afterwards.
+        res << db.execute("SELECT a FROM t ORDER BY a")
+        db.create_function("ok", 1) { |fp, v| fp.result = v.to_i + 10 }
+        res << db.execute("SELECT ok(a) FROM t ORDER BY a")
+        db.close
+        res
+        "##,
+    );
+}
+
+/// SQLite lets a function callback run another statement on the same
+/// connection, and the C extension allows it, so the call state a
+/// callback finds has to nest.
+#[test]
+fn sqlite3_function_reentrancy() {
+    run_test_once(
+        r##"
+        require "rubygems"
+        require "sqlite3"
+        db = SQLite3::Database.new(":memory:")
+        db.execute("CREATE TABLE t (a)")
+        db.execute("INSERT INTO t VALUES (1), (2), (3)")
+        res = []
+        db.create_function("count_rows", 0) { |fp| fp.result = db.execute("SELECT COUNT(*) FROM t").flatten.first }
+        res << db.execute("SELECT count_rows()")
+        # A function whose block calls a query that calls another function.
+        db.create_function("outer", 0) { |fp| fp.result = db.execute("SELECT count_rows()").flatten.first }
+        res << db.execute("SELECT outer()")
+        # A raise from the inner one still reaches the caller.
+        db.create_function("inner_bad", 0) { |fp| raise "inner" }
+        db.create_function("wrap", 0) { |fp| fp.result = db.execute("SELECT inner_bad()").flatten.first }
+        res << (begin; db.execute("SELECT wrap()"); rescue StandardError => e; [e.class.name, e.message]; end)
+        res << db.execute("SELECT COUNT(*) FROM t")
         db.close
         res
         "##,


### PR DESCRIPTION
Item F of `doc/railsbench_investigation_2026-09.md`, and it came out of @sisshiki1969's observation that the compiler already knows every frame size in a compilation unit, so deopt has no business chasing the stack by indirection.

## What the walk was doing

An escalated side exit walked the control-frame chain to the bottom, hash-looking-up every frame's return address on the way. Counters over 2,000 railsbench requests:

| | /walk | /req |
|---|---:|---:|
| frames visited | 76.39 | 1,033 |
| conversions **in the deopting unit** | **1.85** | 25 |
| conversions in **other** units | **13.03** | **176** |

So 87.6 % of the conversions were other compilations' frames, each one dropping a still-valid compiled body to the interpreter for nothing the mechanism needs. §8.5 of `doc/chain_deopt.md` calls this out as "strictly more conversion than the speculation will need, which is sound" — this is what it cost.

## Why the unit is the right boundary

`escalate_side_exits` already made the argument; it is why a root-frame exit does not escalate at all:

> Both things escalation buys are confined to a single compilation unit … Type information never crosses a unit boundary … an unboxed local is only ever read across a frame boundary *inside* the unit.

This carries it one step further. The number of frames to convert is the site's own depth in the compilation — a constant the compiler already has. `JitContext::chain_deopt_frames` returns it in place of the boolean, `AsmIr` stamps it onto every side exit as before (the single consultation point §6 asks for), the handler passes it to `runtime::chain_deopt`, and the walk stops there. Measured depth on railsbench is 1, 2 or 4 — three values over 27,057 walks, which is what a compile-time constant per site looks like.

`check_bop_redefine` passes `None` and still walks to the bottom: a redefined basic op does invalidate compiled code across units, exactly as its comment says.

## The four things that had to hold, and how they were checked

**Static depth matches the runtime chain.** `do_specialized_call` emits `set_lfp; push_frame; call entry; pop_frame` — one real control frame and one real `call` per specialized frame — and `trace_contexts` documents the 1:1 with `stack_frame`. A `debug_assert!` in the bounded loop re-checks it on every escalation: inside the unit a frame's return address must either convert or read as VM code (an earlier walk's work); anything else means the two have drifted and the walk would stop short of the root. It never fired across the suite.

**A heap-promoted frame is still converted correctly.** `move_frame_to_heap` redirects `cfp.lfp()` and tombstones the stack copy, but the walk reads the LFP from the frame's own slot — the same read `restore_lfp` (`movq r14, [rbp-16]`) does on every JIT return — so a promoted frame is followed to its live copy. The stub's other two pointers are plain machine-stack addresses that promotion cannot move (`frame_bytes` copies only the Ruby local area, not the spill or FprSave regions).

**A captured frame is safe.** Promotion walks outward from the frame a block literal or binding is anchored to, and a block literal's outer is the frame it is written in — so whatever triggers a promotion is promoted itself, and its post-call `guard_capture` (`testb [r14 - …], 0b1000_1000`) sees the dirty meta. Measured on a shape that provably emits `store_dyn_var_specialized`: a capture on the first iteration followed by 62,499 specialized writes still reads back correctly through the captured Proc, as do writes through the Proc interleaved with the block's, `local_variable_set` from outside, and two levels of nesting.

**An `Error` exit's unwind needs nothing outside the unit.** `entry_raise` unwinds by `leave; ret` with the error signal in rax, through the return-address slot — so an unrewritten slot lands in the caller's compiled post-call error check, which is exactly what a root-frame raise has always done. §8.4 only establishes that a *converted* frame behaves correctly when the unwind passes through it. `method_caller_specialized_ids` says the out-of-unit half outright: the static non-local-return teardown flies over every inlined frame and returns "to its dynamic caller, whose post-call frame pop is rbp-derived and therefore correct no matter how many inlined frames were flown over".

## Measured

railsbench under callgrind, freshly paired:

| | Ir/req |
|---|---:|
| base | 3,084,280 |
| this change | **3,004,061** (**−2.60 %**) |

| | before | after |
|---|---:|---:|
| `chain_deopt_into` self | 32,175 | **3,336** |
| `CodePtr::add` | 8,319 | **456** |
| generated code, all of it | 526,629 | 506,766 |
| `runtime::vm_get_constant` | 4,137 | 1,146 |
| `Executor::const_lexical_self_key` | 1,493 | 410 |
| `runtime::args::fill_positional_args` | 31,584 | 30,021 |
| `GlobalMethodCache::get` | 23,216 | 22,253 |

The walk going away is the first two rows. The interpreter's own helpers falling alongside it is the 176 needless conversions a request showing up as cost: those frames now keep running compiled instead of re-entering the VM and re-doing const lookups, method lookups and argument filling. Wall clock moves 1.751 → 1.658 ms/req median, which is inside this machine's ±5 %.

## Testing

Every number below matches the baseline binary exactly — no new failure anywhere.

- `cargo test --workspace --release`, and again with `-C debug-assertions=yes` so the new assertion is live: 4010 passed, 1 failed — `builtins::numeric::float::tests::angle`, which fails identically without these commits and against a live CRuby (established in #1329, #1331, #1339, #1341).
- `cargo check --target aarch64-unknown-linux-gnu`.
- ruby/spec `core/`: array, hash, string, proc, method, enumerable, exception, range, integer, float, binding, kernel, class, module — failure counts identical to the baseline binary in every category.
- Every `benchmark/*.rb`, byte-compared between the two binaries. The two that differ are non-deterministic by construction: `app_aobench` has `srand(0)` commented out (with it restored, baseline, this change and CRuby agree on md5), and `trick` is an animation cut off by the timeout.
- Exception and non-local-exit behaviour through inlined frames (raise/rescue at every level, `ensure`, `retry`, method-return and break from blocks, `throw`/`catch`, `ensure` + `return`) matches CRuby, as does the capture battery above and the forwarding-trampoline `forward_rest` path with the caller's frame promoted mid-loop.

## What is left

The remaining `d` table lookups can become rbp-relative constants, the way `store_dyn_var_specialized` already reaches an outer frame's slot with one `movq [rbp + const]`; that would retire `chain_deopt_table`, `check_vm_address` and `runtime::chain_deopt` from this path entirely. With `d` down to 1–4 the remaining cost is small, so the doc records it as low priority rather than doing it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkoJG3qRpCRJ4nXDZH3mg9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkoJG3qRpCRJ4nXDZH3mg9)_